### PR TITLE
Add CODEOWNERS file for default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @tomereli @rammarzin @arnout


### PR DESCRIPTION
Initial CODEOWNERS file for default reviewers - @tomereli, @arnout,
@rammarzin.

Reference - https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file

Later we will add code owners for specific modules, once we have
maintaners per component.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>