### PR TITLE
 tools: move build folder outside of prplMesh repo

### DIFF
--- a/tools/commands/build.py
+++ b/tools/commands/build.py
@@ -72,7 +72,7 @@ class mapbuild(object):
         commands = args.commands
         modules = build_modules if 'all' in args.modules else [m for m in build_modules if m in args.modules]
         modules_dir = os.path.realpath(args.map_path)
-        build_dir = os.path.realpath(modules_dir + '/build')
+        build_dir = os.path.realpath(modules_dir + '/../build')
         install_dir = os.path.realpath(build_dir + '/install')
 
         if 'distclean' in commands and os.path.exists(build_dir):

--- a/tools/prplMesh.code-workspace
+++ b/tools/prplMesh.code-workspace
@@ -1,0 +1,83 @@
+{
+	"folders": [
+		{
+			"path": "../"
+		},
+		{
+			"path": "../../hostap"
+		},
+		{
+			"path": "../../hostap/dwpal"
+		},
+		{
+			"path": "../../3rdparty/nng"
+		},
+		{
+			"path": "../../3rdparty/safeclib"
+		}
+	],
+	"settings": {
+		"files.exclude": {
+			"**/.git": true,
+			"**/.svn": true,
+			"**/.hg": true,
+			"**/CVS": true,
+			"**/.DS_Store": true,
+			"**/*.pyc": true,
+		},
+		"files.associations": {
+			"cctype": "cpp",
+			"cmath": "cpp",
+			"csignal": "cpp",
+			"cstdarg": "cpp",
+			"cstddef": "cpp",
+			"cstdio": "cpp",
+			"cstdlib": "cpp",
+			"cstring": "cpp",
+			"ctime": "cpp",
+			"cwchar": "cpp",
+			"strstream": "cpp",
+			"chrono": "cpp",
+			"condition_variable": "cpp",
+			"cstdint": "cpp",
+			"initializer_list": "cpp",
+			"iosfwd": "cpp",
+			"mutex": "cpp",
+			"ratio": "cpp",
+			"system_error": "cpp",
+			"thread": "cpp",
+			"cinttypes": "cpp",
+			"typeindex": "cpp",
+			"array": "cpp",
+			"*.tcc": "cpp",
+			"bitset": "cpp",
+			"clocale": "cpp",
+			"cwctype": "cpp",
+			"deque": "cpp",
+			"list": "cpp",
+			"unordered_map": "cpp",
+			"unordered_set": "cpp",
+			"vector": "cpp",
+			"exception": "cpp",
+			"fstream": "cpp",
+			"functional": "cpp",
+			"iomanip": "cpp",
+			"iostream": "cpp",
+			"istream": "cpp",
+			"limits": "cpp",
+			"new": "cpp",
+			"ostream": "cpp",
+			"numeric": "cpp",
+			"sstream": "cpp",
+			"stdexcept": "cpp",
+			"streambuf": "cpp",
+			"type_traits": "cpp",
+			"tuple": "cpp",
+			"typeinfo": "cpp",
+			"utility": "cpp",
+			"atomic": "cpp",
+			"codecvt": "cpp",
+			"memory": "cpp"
+		}
+	}
+}


### PR DESCRIPTION
Before merging prplMesh repos into one repository, the build folder was
created in the top directory, where .repo folder exists.
This was done in order to prevent accidental removal when using git
clean -xdf, and to prevent having untracked folders.

Now that we have a single repository (prplMesh), the build folder is
created in prplMesh repo - so update build.py to create the folder in
the parent directory.
