### PR TITLE
common: Fix README.md wrong license mention

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -5,5 +5,5 @@ The MultiAP controller and agent are external to this project.
 
 ## License
 <a name="license"></a>
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+This project is licensed under the BSD+Patent License - see the [LICENSE](LICENSE) file for details
 


### PR DESCRIPTION
Fix the wrong license mention found in https://github.com/prplfoundation/prplMesh/issues/13