### PR TITLE
framework/tlvf: re-instate tlvf test

### DIFF
--- a/framework/tlvf/CMakeLists.txt
+++ b/framework/tlvf/CMakeLists.txt
@@ -62,6 +62,6 @@ install(DIRECTORY ${TLVF_OUT}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT TlvfConfig DESTINATION lib/cmake/Tlvf)
 install(PROGRAMS ${TLVF_DIR}/tlvf.py DESTINATION host/bin)
 
-# add_subdirectory(test)
+add_subdirectory(test)
 message("-- Done")
 

--- a/framework/tlvf/test/CMakeLists.txt
+++ b/framework/tlvf/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(BUILD_TESTS)
     add_executable(tlvf_test main.cpp)
-    target_link_libraries(tlvf_test common tlvf common ieee1905_transport_lib ieee1905_transport_messages)
+    target_link_libraries(tlvf_test mapf::elpp common tlvf common ieee1905_transport_lib ieee1905_transport_messages)
     install(TARGETS tlvf_test DESTINATION bin/tests)
     add_test(tlvf_test tlvf_test)
 endif()

--- a/framework/tlvf/test/CMakeLists.txt
+++ b/framework/tlvf/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(BUILD_TESTS)
     add_executable(tlvf_test main.cpp)
-    target_link_libraries(tlvf_test mapf::elpp common tlvf common ieee1905_transport_lib ieee1905_transport_messages)
+    target_link_libraries(tlvf_test mapf::elpp common tlvf common)
     install(TARGETS tlvf_test DESTINATION bin/tests)
     add_test(tlvf_test tlvf_test)
 endif()

--- a/framework/tlvf/test/main.cpp
+++ b/framework/tlvf/test/main.cpp
@@ -18,7 +18,7 @@
 #include "tlvf/wfa_map/tlvApCapability.h"
 
 #include <mapf/common/logger.h>
-#include <mapf/transport/ieee1905_transport.h>
+#include <mapf/common/err.h>
 #include <tlvf/wfa_map/tlvApCapability.h>
 
 #include <stdio.h>
@@ -33,20 +33,13 @@ using namespace mapf;
 int main(int argc, char *argv[])
 {
     mapf::Logger::Instance().LoggerInit("TLVF example");
+    uint8_t tx_buffer[256];
 
     //START BUILDING THE MESSAGE HERE
-    CmduTxMessage cmdu_tx_msg;
-
-    //setting metadata, not related to tlvf
-    memcpy(cmdu_tx_msg.metadata()->dst, "\x01\x80\xc2\x00\x00\x13", 6);
-    cmdu_tx_msg.metadata()->ether_type = ETH_P_1905_1;
-    cmdu_tx_msg.metadata()->msg_type   = 0x8019;
-    cmdu_tx_msg.metadata()->length =
-        256; //buffer size, needs to be bigger for longer messages, otherwise segfault or memory leak might occur
-    memset(cmdu_tx_msg.data(), 0x00, cmdu_tx_msg.metadata()->length);
+    memset(tx_buffer, 0, sizeof(tx_buffer));
 
     //creating cmdu message class and setting the header
-    CmduMessageTx msg = CmduMessageTx(cmdu_tx_msg.data(), cmdu_tx_msg.metadata()->length);
+    CmduMessageTx msg = CmduMessageTx(tx_buffer, sizeof(tx_buffer));
 
     //create method initializes the buffer and returns shared pointer to the message header
     auto header = msg.create(0, eMessageType::BACKHAUL_STEERING_REQUEST_MESSAGE);
@@ -123,7 +116,7 @@ int main(int argc, char *argv[])
     //MANDATORY - swaps to little indian.
     msg.finalize(true);
     uint8_t recv_buffer[256];
-    memcpy(recv_buffer, cmdu_tx_msg.data(), 256);
+    memcpy(recv_buffer, tx_buffer, 256);
 
     CmduMessageRx received_message;
     received_message.parse(recv_buffer, 256, true);

--- a/framework/tlvf/test/main.cpp
+++ b/framework/tlvf/test/main.cpp
@@ -18,8 +18,6 @@
 #include "tlvf/wfa_map/tlvApCapability.h"
 
 #include <mapf/common/logger.h>
-#include <mapf/common/poller.h>
-#include <mapf/local_bus.h>
 #include <mapf/transport/ieee1905_transport.h>
 #include <tlvf/wfa_map/tlvApCapability.h>
 
@@ -35,10 +33,6 @@ using namespace mapf;
 int main(int argc, char *argv[])
 {
     mapf::Logger::Instance().LoggerInit("TLVF example");
-
-    MAPF_INFO("initializing local bus interface");
-    LocalBusInterface bus(Context::Instance());
-    bus.Init();
 
     //START BUILDING THE MESSAGE HERE
     CmduTxMessage cmdu_tx_msg;
@@ -130,10 +124,6 @@ int main(int argc, char *argv[])
     msg.finalize(true);
     uint8_t recv_buffer[256];
     memcpy(recv_buffer, cmdu_tx_msg.data(), 256);
-    MAPF_INFO("sending CmduTxMessage: " << std::endl << cmdu_tx_msg);
-    bus.publisher().Send(cmdu_tx_msg);
-
-    MAPF_INFO("DONE");
 
     CmduMessageRx received_message;
     received_message.parse(recv_buffer, 256, true);


### PR DESCRIPTION
The tlvf test was disabled in CMake, and also no longer built.
Re-instate it now.

Remove the debug messages in the beginning (the beerocks part didn't
build, hlen is anyway not used, and the other message is not very
useful).

NOTE: this test runs into the same issue as the ieee1905_transport test:
it doesn't terminate if using nng as the msglib.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>