### PR TITLE
Fixes for GCC 9 warnings

### DIFF
--- a/common/beerocks/bcl/include/beerocks/bcl/beerocks_logging.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/beerocks_logging.h
@@ -37,6 +37,7 @@ public:
 
     log_levels()  = default;
     ~log_levels() = default;
+    log_levels(const log_levels&)  = default;
     log_levels(const std::set<std::string> &log_levels);
     log_levels(const std::string &log_level_str);
     log_levels &operator=(const log_levels &rhs);

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -138,7 +138,7 @@ static bool get_sta_caps(SRadioCapabilitiesStrings &caps_strings,
     std::string item;
     uint8_t i = 0;
 
-    memset(&sta_caps, 0, sizeof(beerocks::message::sRadioCapabilities));
+    sta_caps = beerocks::message::sRadioCapabilities();
     sta_caps.ht_bw  = 0xFF;
     sta_caps.vht_bw = 0xFF;
 
@@ -1030,7 +1030,7 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         LOG_IF(!msg, FATAL) << "Memory allocation failed!";
         // Initialize the message
         memset(msg_buff.get(), 0, sizeof(sACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION));
-        memset(&msg->params.capabilities, 0, sizeof(msg->params.capabilities));
+        msg->params.capabilities = beerocks::message::sRadioCapabilities();
 
         char VAP[SSID_MAX_SIZE]        = {0};
         char MACAddress[MAC_ADDR_SIZE] = {0};


### PR DESCRIPTION
I recently upgraded my system to using GCC 9, which brings a new set of warnings with it.

Two patches are needed to fix those warnings.