### PR TITLE
maptools.py: build safelibc with larger strings

### DIFF
--- a/tools/commands/build.py
+++ b/tools/commands/build.py
@@ -87,8 +87,9 @@ class cmakebuilder(builder):
         subprocess.check_call(cmd, env=self.env)
 
 class acbuilder(builder):
-    def __init__(self, name, modules_dir, build_dir, install_dir, make_verbose=False):
+    def __init__(self, name, modules_dir, build_dir, install_dir, make_verbose=False, extra_config_args=():
         self.make_verbose = make_verbose
+        self.extra_config_args = extra_config_args
         super(acbuilder, self).__init__(name, modules_dir, build_dir, install_dir)
 
     def clean(self):
@@ -113,6 +114,7 @@ class acbuilder(builder):
 
         cmd = [self.src_path + "/configure",
                "--prefix=" + self.install_path]
+        cmd.extend(self.extra_config_args)
         logger.info("configuring {}: {}".format(self.name, " ".join(cmd)))
         subprocess.check_call(cmd, env=self.env)
 
@@ -149,7 +151,8 @@ class mapbuild(object):
                     args.cmake_flags, args.generator)
 
             if name == 'safeclib':
-                builder = acbuilder('safeclib', modules_dir, build_dir, install_dir, args.make_verbose)
+                builder = acbuilder('safeclib', modules_dir, build_dir, install_dir, args.make_verbose,
+                                    ['--enable-strmax=65536'])
 
             self.run_command(builder, commands)
 


### PR DESCRIPTION
safelibc puts an artificial limit on the maximum string size. This limit
is set at configuration time and defaults to 4K. However, we need to
handle much larger strings - dwpal's `HOSTAPD_TO_DWPAL_MSG_LENGTH` is set
to 16K.

For a bit of safety margin, set the maximum string size to 64K.

In order to do this, the acbuilder class is extended with an additional
field `extra_config_args` with extra arguments to be passed to the
configure script.