### PR TITLE
bcl: string_utils: define __builtin_FILE/LINE

### DIFF
--- a/common/beerocks/bcl/include/beerocks/bcl/beerocks_string_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/beerocks_string_utils.h
@@ -65,6 +65,11 @@ public:
     static void copy_string(char *dst, const char *src, size_t dst_len);
 
     static std::vector<std::string> str_split(const std::string &s, char delim);
+    
+#ifndef __GCC__
+#define __builtin_FILE() __FILE__
+#define __builtin_LINE() __LINE__
+#endif
 
     static int64_t stoi(std::string str, const char *calling_file = __builtin_FILE(),
                         int calling_line = __builtin_LINE());


### PR DESCRIPTION
`__builtin_FILE()` and `__builtin_LINE()` are GCC extensions that are not
supported by clang. This confuses clang-based tools, e.g. some IDEs and
clang-tidy.

Give these macros a definition in non-GCC builds. We define them as
`__FILE__` and `__LINE__`, which is not terribly helpful, but the best we
can do in the given circumstances. Anyway, for static analysis the exact
value doesn't matter much.

NOTE Maybe it would have been better to do define them as static inline
functions.