### PR TITLE
TLVF - Fix tlv type size from 16 bit to 8 bit

### DIFF
--- a/common/beerocks/bcl/include/beerocks/bcl/beerocks_message_structs.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/beerocks_message_structs.h
@@ -21,7 +21,7 @@ typedef struct {
     uint8_t src_bridge_mac[net::MAC_ADDR_LEN] = {};
     uint16_t length                           = 0;
     uint8_t swap_needed                       = 0;
-} sUdsHeader;
+} __attribute__((packed)) sUdsHeader;
 
 //////////////////// tlvf includes /////////////////////////////
 
@@ -91,7 +91,7 @@ typedef struct sRadioCapabilities {
         cell_capa            = 0;
         cap_flag             = 0;
     }
-} sRadioCapabilities;
+} __attribute__((packed)) sRadioCapabilities;
 
 //////////////////// tlvf includes - END/////////////////////////////
 

--- a/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
@@ -29,7 +29,7 @@ typedef struct sIpv4Addr {
             oct[i] = 0;
         }
     }
-} sIpv4Addr;
+} __attribute__((packed)) sIpv4Addr;
 
 typedef struct sMacAddr {
     uint8_t oct[MAC_ADDR_LEN];
@@ -44,7 +44,7 @@ typedef struct sMacAddr {
         channel = 0;
         rssi    = 0;
     }
-} sMacAddr;
+} __attribute__((packed)) sMacAddr;
 }
 }
 

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -18,9 +18,9 @@
 using namespace beerocks;
 
 typedef struct sTlvHeader {
-    uint16_t type;
+    uint8_t type;
     uint16_t length;
-} sTlvHeader;
+}  __attribute__((packed)) sTlvHeader;
 
 #define DEFAULT_MAX_SOCKET_CONNECTIONS 10
 #define TX_BUFFER_UDS (tx_buffer + sizeof(beerocks::message::sUdsHeader))
@@ -192,13 +192,12 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
 
     bool ret = true;
 
-    uint16_t type   = tlv->type;
+    uint8_t type   = tlv->type;
     uint16_t length = tlv->length;
 
     do {
 
         if (uds_header->swap_needed) {
-            swap_16(type);
             swap_16(length);
         }
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli_net_map.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli_net_map.h
@@ -31,7 +31,7 @@ typedef struct sCliNetworkMapNodeAp {
     void struct_init(){
         mac.struct_init();
     }
-} sCliNetworkMapNodeAp;
+} __attribute__((packed)) sCliNetworkMapNodeAp;
 
 typedef struct sCliNetworkMapNodeSta {
     beerocks::net::sMacAddr mac;
@@ -43,7 +43,7 @@ typedef struct sCliNetworkMapNodeSta {
     void struct_init(){
         mac.struct_init();
     }
-} sCliNetworkMapNodeSta;
+} __attribute__((packed)) sCliNetworkMapNodeSta;
 
 typedef struct sCliNetworkMapsNodeInfo {
     beerocks::net::sMacAddr mac;
@@ -75,7 +75,7 @@ typedef struct sCliNetworkMapsNodeInfo {
         mac.struct_init();
         ipv4.struct_init();
     }
-} sCliNetworkMapsNodeInfo;
+} __attribute__((packed)) sCliNetworkMapsNodeInfo;
 
 
 }; // close namespace: beerocks_message

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -46,7 +46,7 @@ typedef struct sVapInfo {
     void struct_init(){
         mac.struct_init();
     }
-} sVapInfo;
+} __attribute__((packed)) sVapInfo;
 
 typedef struct sSonConfig {
     uint8_t monitor_total_ch_load_notification_lo_th_percent;
@@ -70,7 +70,7 @@ typedef struct sSonConfig {
     }
     void struct_init(){
     }
-} sSonConfig;
+} __attribute__((packed)) sSonConfig;
 
 typedef struct sPlatformSettings {
     char front_ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
@@ -107,7 +107,7 @@ typedef struct sPlatformSettings {
                 (backhaul_vaps_bssid[i]).struct_init();
             }
     }
-} sPlatformSettings;
+} __attribute__((packed)) sPlatformSettings;
 
 typedef struct sWlanSettings {
     uint8_t band_enabled;
@@ -120,7 +120,7 @@ typedef struct sWlanSettings {
     }
     void struct_init(){
     }
-} sWlanSettings;
+} __attribute__((packed)) sWlanSettings;
 
 typedef struct sApSetRestrictedFailsafe {
     uint8_t failsafe_channel;
@@ -132,7 +132,7 @@ typedef struct sApSetRestrictedFailsafe {
     }
     void struct_init(){
     }
-} sApSetRestrictedFailsafe;
+} __attribute__((packed)) sApSetRestrictedFailsafe;
 
 typedef struct sApChannelSwitch {
     uint8_t channel;
@@ -146,7 +146,7 @@ typedef struct sApChannelSwitch {
     }
     void struct_init(){
     }
-} sApChannelSwitch;
+} __attribute__((packed)) sApChannelSwitch;
 
 typedef struct sDfsCacCompleted {
     uint32_t timeout;
@@ -160,7 +160,7 @@ typedef struct sDfsCacCompleted {
     }
     void struct_init(){
     }
-} sDfsCacCompleted;
+} __attribute__((packed)) sDfsCacCompleted;
 
 typedef struct sDfsChannelAvailable {
     uint32_t frequency;
@@ -173,7 +173,7 @@ typedef struct sDfsChannelAvailable {
     }
     void struct_init(){
     }
-} sDfsChannelAvailable;
+} __attribute__((packed)) sDfsChannelAvailable;
 
 typedef struct sWifiChannel {
     uint8_t channel;
@@ -187,7 +187,7 @@ typedef struct sWifiChannel {
     }
     void struct_init(){
     }
-} sWifiChannel;
+} __attribute__((packed)) sWifiChannel;
 
 typedef struct sClientAssociationParams {
     beerocks::net::sMacAddr mac;
@@ -204,7 +204,7 @@ typedef struct sClientAssociationParams {
         bssid.struct_init();
         capabilities.struct_init();
     }
-} sClientAssociationParams;
+} __attribute__((packed)) sClientAssociationParams;
 
 typedef struct sClientDisconnectionParams {
     beerocks::net::sMacAddr mac;
@@ -221,7 +221,7 @@ typedef struct sClientDisconnectionParams {
         mac.struct_init();
         bssid.struct_init();
     }
-} sClientDisconnectionParams;
+} __attribute__((packed)) sClientDisconnectionParams;
 
 typedef struct sClientMonitoringParams {
     beerocks::net::sMacAddr mac;
@@ -240,7 +240,7 @@ typedef struct sClientMonitoringParams {
         bridge_4addr_mac.struct_init();
         ipv4.struct_init();
     }
-} sClientMonitoringParams;
+} __attribute__((packed)) sClientMonitoringParams;
 
 typedef struct sConfigVapInfo {
     uint8_t type;
@@ -255,7 +255,7 @@ typedef struct sConfigVapInfo {
     }
     void struct_init(){
     }
-} sConfigVapInfo;
+} __attribute__((packed)) sConfigVapInfo;
 
 typedef struct sStaStatsParams {
     beerocks::net::sMacAddr mac;
@@ -284,7 +284,7 @@ typedef struct sStaStatsParams {
     void struct_init(){
         mac.struct_init();
     }
-} sStaStatsParams;
+} __attribute__((packed)) sStaStatsParams;
 
 typedef struct sApStatsParams {
     uint32_t rx_packets;
@@ -313,7 +313,7 @@ typedef struct sApStatsParams {
     }
     void struct_init(){
     }
-} sApStatsParams;
+} __attribute__((packed)) sApStatsParams;
 
 typedef struct sApLoadNotificationParams {
     uint16_t stats_delta_ms;
@@ -327,7 +327,7 @@ typedef struct sApLoadNotificationParams {
     }
     void struct_init(){
     }
-} sApLoadNotificationParams;
+} __attribute__((packed)) sApLoadNotificationParams;
 
 typedef struct sApActivityNotificationParams {
     uint8_t ap_activity_mode;
@@ -335,7 +335,7 @@ typedef struct sApActivityNotificationParams {
     }
     void struct_init(){
     }
-} sApActivityNotificationParams;
+} __attribute__((packed)) sApActivityNotificationParams;
 
 typedef struct sNodeRssiMeasurementRequest {
     beerocks::net::sMacAddr mac;
@@ -355,7 +355,7 @@ typedef struct sNodeRssiMeasurementRequest {
         mac.struct_init();
         ipv4.struct_init();
     }
-} sNodeRssiMeasurementRequest;
+} __attribute__((packed)) sNodeRssiMeasurementRequest;
 
 typedef struct sNodeRssiMeasurement {
     beerocks::net::sMacAddr mac;
@@ -374,7 +374,7 @@ typedef struct sNodeRssiMeasurement {
     void struct_init(){
         mac.struct_init();
     }
-} sNodeRssiMeasurement;
+} __attribute__((packed)) sNodeRssiMeasurement;
 
 typedef struct sNodeHostap {
     char iface_name[beerocks::message::IFACE_NAME_LENGTH];
@@ -398,7 +398,7 @@ typedef struct sNodeHostap {
                 (supported_channels[i]).struct_init();
             }
     }
-} sNodeHostap;
+} __attribute__((packed)) sNodeHostap;
 
 typedef struct sVapsList {
     sVapInfo vaps[beerocks::IFACE_TOTAL_VAPS];
@@ -412,7 +412,7 @@ typedef struct sVapsList {
                 (vaps[i]).struct_init();
             }
     }
-} sVapsList;
+} __attribute__((packed)) sVapsList;
 
 typedef struct sArpMonitorData {
     beerocks::net::sMacAddr mac;
@@ -430,7 +430,7 @@ typedef struct sArpMonitorData {
         mac.struct_init();
         ipv4.struct_init();
     }
-} sArpMonitorData;
+} __attribute__((packed)) sArpMonitorData;
 
 typedef struct sArpQuery {
     beerocks::net::sMacAddr mac;
@@ -443,7 +443,7 @@ typedef struct sArpQuery {
         mac.struct_init();
         ipv4.struct_init();
     }
-} sArpQuery;
+} __attribute__((packed)) sArpQuery;
 
 typedef struct sNodeBssSteerTarget {
     beerocks::net::sMacAddr mac;
@@ -454,7 +454,7 @@ typedef struct sNodeBssSteerTarget {
     void struct_init(){
         mac.struct_init();
     }
-} sNodeBssSteerTarget;
+} __attribute__((packed)) sNodeBssSteerTarget;
 
 typedef struct sNodeBssSteerRequest {
     beerocks::net::sMacAddr mac;
@@ -470,7 +470,7 @@ typedef struct sNodeBssSteerRequest {
         mac.struct_init();
         bssid.struct_init();
     }
-} sNodeBssSteerRequest;
+} __attribute__((packed)) sNodeBssSteerRequest;
 
 typedef struct sNodeBssSteerResponse {
     beerocks::net::sMacAddr mac;
@@ -481,7 +481,7 @@ typedef struct sNodeBssSteerResponse {
     void struct_init(){
         mac.struct_init();
     }
-} sNodeBssSteerResponse;
+} __attribute__((packed)) sNodeBssSteerResponse;
 
 typedef struct sNeighborSetParams11k {
     beerocks::net::sMacAddr bssid;
@@ -510,7 +510,7 @@ typedef struct sNeighborSetParams11k {
     void struct_init(){
         bssid.struct_init();
     }
-} sNeighborSetParams11k;
+} __attribute__((packed)) sNeighborSetParams11k;
 
 typedef struct sNeighborRemoveParams11k {
     beerocks::net::sMacAddr bssid;
@@ -522,7 +522,7 @@ typedef struct sNeighborRemoveParams11k {
     void struct_init(){
         bssid.struct_init();
     }
-} sNeighborRemoveParams11k;
+} __attribute__((packed)) sNeighborRemoveParams11k;
 
 typedef struct sStaChannelLoadRequest11k {
     uint8_t channel;
@@ -555,7 +555,7 @@ typedef struct sStaChannelLoadRequest11k {
     void struct_init(){
         sta_mac.struct_init();
     }
-} sStaChannelLoadRequest11k;
+} __attribute__((packed)) sStaChannelLoadRequest11k;
 
 typedef struct sStaChannelLoadResponse11k {
     uint8_t channel;
@@ -582,7 +582,7 @@ typedef struct sStaChannelLoadResponse11k {
     void struct_init(){
         sta_mac.struct_init();
     }
-} sStaChannelLoadResponse11k;
+} __attribute__((packed)) sStaChannelLoadResponse11k;
 
 typedef struct sBeaconRequest11k {
     uint8_t measurement_mode;
@@ -624,7 +624,7 @@ typedef struct sBeaconRequest11k {
         sta_mac.struct_init();
         bssid.struct_init();
     }
-} sBeaconRequest11k;
+} __attribute__((packed)) sBeaconRequest11k;
 
 typedef struct sBeaconResponse11k {
     uint8_t channel;
@@ -660,7 +660,7 @@ typedef struct sBeaconResponse11k {
         sta_mac.struct_init();
         bssid.struct_init();
     }
-} sBeaconResponse11k;
+} __attribute__((packed)) sBeaconResponse11k;
 
 typedef struct sStatisticsRequest11k {
     beerocks::net::sMacAddr sta_mac;
@@ -718,7 +718,7 @@ typedef struct sStatisticsRequest11k {
         sta_mac.struct_init();
         peer_mac_addr.struct_init();
     }
-} sStatisticsRequest11k;
+} __attribute__((packed)) sStatisticsRequest11k;
 
 typedef struct sStatisticsResponse11k {
     uint8_t dialog_token;
@@ -744,7 +744,7 @@ typedef struct sStatisticsResponse11k {
     void struct_init(){
         sta_mac.struct_init();
     }
-} sStatisticsResponse11k;
+} __attribute__((packed)) sStatisticsResponse11k;
 
 typedef struct sLinkMeasurementsResponse11k {
     uint8_t dialog_token;
@@ -773,7 +773,7 @@ typedef struct sLinkMeasurementsResponse11k {
     void struct_init(){
         sta_mac.struct_init();
     }
-} sLinkMeasurementsResponse11k;
+} __attribute__((packed)) sLinkMeasurementsResponse11k;
 
 typedef struct sBackhaulParams {
     beerocks::net::sIpv4Addr gw_ipv4;
@@ -816,7 +816,7 @@ typedef struct sBackhaulParams {
                 (backhaul_scan_measurement_list[i]).struct_init();
             }
     }
-} sBackhaulParams;
+} __attribute__((packed)) sBackhaulParams;
 
 typedef struct sBackhaulRoam {
     beerocks::net::sMacAddr bssid;
@@ -827,7 +827,7 @@ typedef struct sBackhaulRoam {
     void struct_init(){
         bssid.struct_init();
     }
-} sBackhaulRoam;
+} __attribute__((packed)) sBackhaulRoam;
 
 typedef struct sBackhaulRssi {
     int8_t rssi;
@@ -835,7 +835,7 @@ typedef struct sBackhaulRssi {
     }
     void struct_init(){
     }
-} sBackhaulRssi;
+} __attribute__((packed)) sBackhaulRssi;
 
 typedef struct sLoggingLevelChange {
     beerocks::net::sMacAddr mac;
@@ -848,7 +848,7 @@ typedef struct sLoggingLevelChange {
     void struct_init(){
         mac.struct_init();
     }
-} sLoggingLevelChange;
+} __attribute__((packed)) sLoggingLevelChange;
 
 typedef struct sVersions {
     char master_version[beerocks::message::VERSION_LENGTH];
@@ -857,7 +857,7 @@ typedef struct sVersions {
     }
     void struct_init(){
     }
-} sVersions;
+} __attribute__((packed)) sVersions;
 
 typedef struct sWifiCredentials {
     eWiFiSec wifi_sec;
@@ -871,7 +871,7 @@ typedef struct sWifiCredentials {
     }
     void struct_init(){
     }
-} sWifiCredentials;
+} __attribute__((packed)) sWifiCredentials;
 
 typedef struct sOnboarding {
     uint8_t onboarding;
@@ -879,7 +879,7 @@ typedef struct sOnboarding {
     }
     void struct_init(){
     }
-} sOnboarding;
+} __attribute__((packed)) sOnboarding;
 
 typedef struct sAdminCredentials {
     char user_password[beerocks::message::USER_PASS_LEN];
@@ -887,7 +887,7 @@ typedef struct sAdminCredentials {
     }
     void struct_init(){
     }
-} sAdminCredentials;
+} __attribute__((packed)) sAdminCredentials;
 
 typedef struct sDeviceInfo {
     char manufacturer[beerocks::message::DEV_INFO_STR_MAX_LEN];
@@ -907,7 +907,7 @@ typedef struct sDeviceInfo {
     }
     void struct_init(){
     }
-} sDeviceInfo;
+} __attribute__((packed)) sDeviceInfo;
 
 typedef struct sRestrictedChannels {
     beerocks::net::sMacAddr hostap_mac;
@@ -919,7 +919,7 @@ typedef struct sRestrictedChannels {
     void struct_init(){
         hostap_mac.struct_init();
     }
-} sRestrictedChannels;
+} __attribute__((packed)) sRestrictedChannels;
 
 typedef struct sSteeringApConfig {
     beerocks::net::sMacAddr bssid;
@@ -937,7 +937,7 @@ typedef struct sSteeringApConfig {
     void struct_init(){
         bssid.struct_init();
     }
-} sSteeringApConfig;
+} __attribute__((packed)) sSteeringApConfig;
 
 typedef struct sSteeringClientConfig {
     uint32_t snrProbeHWM;
@@ -960,7 +960,7 @@ typedef struct sSteeringClientConfig {
     }
     void struct_init(){
     }
-} sSteeringClientConfig;
+} __attribute__((packed)) sSteeringClientConfig;
 
 typedef struct sSteeringSetGroupRequest {
     uint32_t steeringGroupIndex;
@@ -973,7 +973,7 @@ typedef struct sSteeringSetGroupRequest {
     void struct_init(){
         cfg.struct_init();
     }
-} sSteeringSetGroupRequest;
+} __attribute__((packed)) sSteeringSetGroupRequest;
 
 typedef struct sSteeringSetGroupResponse {
     int32_t error_code;
@@ -982,7 +982,7 @@ typedef struct sSteeringSetGroupResponse {
     }
     void struct_init(){
     }
-} sSteeringSetGroupResponse;
+} __attribute__((packed)) sSteeringSetGroupResponse;
 
 typedef struct sSteeringClientSetRequest {
     uint32_t steeringGroupIndex;
@@ -1001,7 +1001,7 @@ typedef struct sSteeringClientSetRequest {
         client_mac.struct_init();
         config.struct_init();
     }
-} sSteeringClientSetRequest;
+} __attribute__((packed)) sSteeringClientSetRequest;
 
 typedef struct sSteeringClientSetResponse {
     int32_t error_code;
@@ -1010,7 +1010,7 @@ typedef struct sSteeringClientSetResponse {
     }
     void struct_init(){
     }
-} sSteeringClientSetResponse;
+} __attribute__((packed)) sSteeringClientSetResponse;
 
 typedef struct sSteeringEvProbeReq {
     beerocks::net::sMacAddr client_mac;
@@ -1026,7 +1026,7 @@ typedef struct sSteeringEvProbeReq {
         client_mac.struct_init();
         bssid.struct_init();
     }
-} sSteeringEvProbeReq;
+} __attribute__((packed)) sSteeringEvProbeReq;
 
 typedef struct sSteeringEvAuthFail {
     beerocks::net::sMacAddr client_mac;
@@ -1043,7 +1043,7 @@ typedef struct sSteeringEvAuthFail {
         client_mac.struct_init();
         bssid.struct_init();
     }
-} sSteeringEvAuthFail;
+} __attribute__((packed)) sSteeringEvAuthFail;
 
 typedef struct sClientDisconnectResponse {
     int32_t error_code;
@@ -1052,7 +1052,7 @@ typedef struct sClientDisconnectResponse {
     }
     void struct_init(){
     }
-} sClientDisconnectResponse;
+} __attribute__((packed)) sClientDisconnectResponse;
 
 typedef struct sSteeringDatarateInfo {
     uint8_t maxChwidth;
@@ -1066,7 +1066,7 @@ typedef struct sSteeringDatarateInfo {
     }
     void struct_init(){
     }
-} sSteeringDatarateInfo;
+} __attribute__((packed)) sSteeringDatarateInfo;
 
 typedef struct sSteeringRrmCaps {
     uint8_t linkMeas;
@@ -1080,7 +1080,7 @@ typedef struct sSteeringRrmCaps {
     }
     void struct_init(){
     }
-} sSteeringRrmCaps;
+} __attribute__((packed)) sSteeringRrmCaps;
 
 enum eDisconnectSource: uint8_t {
     eDisconnect_Source_Unknown = 0x0,
@@ -1133,7 +1133,7 @@ typedef struct sSteeringEvConnect {
         datarateInfo.struct_init();
         rrmCaps.struct_init();
     }
-} sSteeringEvConnect;
+} __attribute__((packed)) sSteeringEvConnect;
 
 typedef struct sSteeringEvDisconnect {
     beerocks::net::sMacAddr client_mac;
@@ -1150,7 +1150,7 @@ typedef struct sSteeringEvDisconnect {
         client_mac.struct_init();
         bssid.struct_init();
     }
-} sSteeringEvDisconnect;
+} __attribute__((packed)) sSteeringEvDisconnect;
 
 typedef struct sSteeringEvActivity {
     beerocks::net::sMacAddr client_mac;
@@ -1164,7 +1164,7 @@ typedef struct sSteeringEvActivity {
         client_mac.struct_init();
         bssid.struct_init();
     }
-} sSteeringEvActivity;
+} __attribute__((packed)) sSteeringEvActivity;
 
 typedef struct sSteeringEvSnrXing {
     beerocks::net::sMacAddr client_mac;
@@ -1182,7 +1182,7 @@ typedef struct sSteeringEvSnrXing {
         client_mac.struct_init();
         bssid.struct_init();
     }
-} sSteeringEvSnrXing;
+} __attribute__((packed)) sSteeringEvSnrXing;
 
 typedef struct sSteeringEvSnr {
     beerocks::net::sMacAddr client_mac;
@@ -1197,7 +1197,7 @@ typedef struct sSteeringEvSnr {
         client_mac.struct_init();
         bssid.struct_init();
     }
-} sSteeringEvSnr;
+} __attribute__((packed)) sSteeringEvSnr;
 
 
 }; // close namespace: beerocks_message

--- a/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
@@ -38,7 +38,7 @@ protected:
     const bool m_parse__;
     const bool m_swap__;
     bool m_init_succeeded;
-    static const size_t kMinimumLength = 4; // tlv header length
+    static const size_t kMinimumLength = 3; // tlv header length
 };
 
 #endif //_BaseClass_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -87,7 +87,7 @@ protected:
     std::shared_ptr<cCmduHeader> m_cmdu_header;
     std::vector<std::shared_ptr<BaseClass>> m_class_vector;
     static const uint16_t kCmduHeaderLength = 8;
-    static const uint16_t kTlvHeaderLength  = 4;
+    static const uint16_t kTlvHeaderLength  = 3;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -44,7 +44,7 @@ typedef struct sWscAttrVersion {
         data_length = 0x1;
         data = WSC_VERSION;
     }
-} sWscAttrVersion;
+} __attribute__((packed)) sWscAttrVersion;
 
 typedef struct sWscAttrMessageType {
     eWscAttributes attribute_type;
@@ -59,7 +59,7 @@ typedef struct sWscAttrMessageType {
         data_length = 0x1;
         data = WSC_MSG_TYPE_M1;
     }
-} sWscAttrMessageType;
+} __attribute__((packed)) sWscAttrMessageType;
 
 typedef struct sWscAttrUuidE {
     eWscAttributes attribute_type;
@@ -73,7 +73,7 @@ typedef struct sWscAttrUuidE {
         attribute_type = ATTR_UUID_E;
         data_length = WSC_UUID_LENGTH;
     }
-} sWscAttrUuidE;
+} __attribute__((packed)) sWscAttrUuidE;
 
 typedef struct sWscAttrUuidR {
     eWscAttributes attribute_type;
@@ -87,7 +87,7 @@ typedef struct sWscAttrUuidR {
         attribute_type = ATTR_UUID_E;
         data_length = WSC_UUID_LENGTH;
     }
-} sWscAttrUuidR;
+} __attribute__((packed)) sWscAttrUuidR;
 
 typedef struct sWscAttrMac {
     eWscAttributes attribute_type;
@@ -103,7 +103,7 @@ typedef struct sWscAttrMac {
         data_length = WSC_MAC_LENGTH;
         data.struct_init();
     }
-} sWscAttrMac;
+} __attribute__((packed)) sWscAttrMac;
 
 typedef struct sWscAttrEnroleeNonce {
     eWscAttributes attribute_type;
@@ -117,7 +117,7 @@ typedef struct sWscAttrEnroleeNonce {
         attribute_type = ATTR_ENROLLEE_NONCE;
         data_length = WSC_NONCE_LENGTH;
     }
-} sWscAttrEnroleeNonce;
+} __attribute__((packed)) sWscAttrEnroleeNonce;
 
 typedef struct sWscAttrRegistrarNonce {
     eWscAttributes attribute_type;
@@ -131,7 +131,7 @@ typedef struct sWscAttrRegistrarNonce {
         attribute_type = ATTR_REGISTRAR_NONCE;
         data_length = WSC_NONCE_LENGTH;
     }
-} sWscAttrRegistrarNonce;
+} __attribute__((packed)) sWscAttrRegistrarNonce;
 
 typedef struct sWscAttrPublicKey {
     eWscAttributes attribute_type;
@@ -145,7 +145,7 @@ typedef struct sWscAttrPublicKey {
         attribute_type = ATTR_PUBLIC_KEY;
         data_length = WSC_PUBLIC_KEY_LENGTH;
     }
-} sWscAttrPublicKey;
+} __attribute__((packed)) sWscAttrPublicKey;
 
 typedef struct sWscAttrAuthenticationTypeFlags {
     eWscAttributes attribute_type;
@@ -160,7 +160,7 @@ typedef struct sWscAttrAuthenticationTypeFlags {
         attribute_type = ATTR_AUTH_TYPE_FLAGS;
         data_length = 0x2;
     }
-} sWscAttrAuthenticationTypeFlags;
+} __attribute__((packed)) sWscAttrAuthenticationTypeFlags;
 
 typedef struct sWscAttrEncryptionTypeFlags {
     eWscAttributes attribute_type;
@@ -175,7 +175,7 @@ typedef struct sWscAttrEncryptionTypeFlags {
         attribute_type = ATTR_ENCR_TYPE_FLAGS;
         data_length = 0x2;
     }
-} sWscAttrEncryptionTypeFlags;
+} __attribute__((packed)) sWscAttrEncryptionTypeFlags;
 
 typedef struct sWscAttrConnectionTypeFlags {
     eWscAttributes attribute_type;
@@ -190,7 +190,7 @@ typedef struct sWscAttrConnectionTypeFlags {
         data_length = 0x1;
         data = WSC_CONN_ESS;
     }
-} sWscAttrConnectionTypeFlags;
+} __attribute__((packed)) sWscAttrConnectionTypeFlags;
 
 typedef struct sWscAttrConfigurationMethods {
     eWscAttributes attribute_type;
@@ -206,7 +206,7 @@ typedef struct sWscAttrConfigurationMethods {
         data_length = 0x2;
         data = (WSC_CONFIG_PHY_PUSHBUTTON | WSC_CONFIG_VIRT_PUSHBUTTON);
     }
-} sWscAttrConfigurationMethods;
+} __attribute__((packed)) sWscAttrConfigurationMethods;
 
 typedef struct sWscAttrWscState {
     eWscAttributes attribute_type;
@@ -221,7 +221,7 @@ typedef struct sWscAttrWscState {
         data_length = 0x1;
         data = WSC_STATE_NOT_CONFIGURED;
     }
-} sWscAttrWscState;
+} __attribute__((packed)) sWscAttrWscState;
 
 typedef struct sWscAttrManufacturer {
     eWscAttributes attribute_type;
@@ -235,7 +235,7 @@ typedef struct sWscAttrManufacturer {
         attribute_type = ATTR_MANUFACTURER;
         data_length = WSC_MAX_NAME_LENGTH;
     }
-} sWscAttrManufacturer;
+} __attribute__((packed)) sWscAttrManufacturer;
 
 typedef struct sWscAttrModelName {
     eWscAttributes attribute_type;
@@ -249,7 +249,7 @@ typedef struct sWscAttrModelName {
         attribute_type = ATTR_MODEL_NAME;
         data_length = WSC_MAX_NAME_LENGTH;
     }
-} sWscAttrModelName;
+} __attribute__((packed)) sWscAttrModelName;
 
 typedef struct sWscAttrModelNumber {
     eWscAttributes attribute_type;
@@ -263,7 +263,7 @@ typedef struct sWscAttrModelNumber {
         attribute_type = ATTR_MODEL_NUMBER;
         data_length = WSC_MAX_NAME_LENGTH;
     }
-} sWscAttrModelNumber;
+} __attribute__((packed)) sWscAttrModelNumber;
 
 typedef struct sWscAttrSerialNumber {
     eWscAttributes attribute_type;
@@ -277,7 +277,7 @@ typedef struct sWscAttrSerialNumber {
         attribute_type = ATTR_SERIAL_NUMBER;
         data_length = WSC_MAX_NAME_LENGTH;
     }
-} sWscAttrSerialNumber;
+} __attribute__((packed)) sWscAttrSerialNumber;
 
 typedef struct sWscAttrPrimaryDeviceType {
     eWscAttributes attribute_type;
@@ -296,7 +296,7 @@ typedef struct sWscAttrPrimaryDeviceType {
         attribute_type = ATTR_PRIMARY_DEV_TYPE;
         data_length = WSC_PRIMARY_DEV_TYPE_LENGTH;
     }
-} sWscAttrPrimaryDeviceType;
+} __attribute__((packed)) sWscAttrPrimaryDeviceType;
 
 typedef struct sWscAttrDeviceName {
     eWscAttributes attribute_type;
@@ -310,7 +310,7 @@ typedef struct sWscAttrDeviceName {
         attribute_type = ATTR_DEV_NAME;
         data_length = WSC_MAX_NAME_LENGTH;
     }
-} sWscAttrDeviceName;
+} __attribute__((packed)) sWscAttrDeviceName;
 
 typedef struct sWscAttrRfBands {
     eWscAttributes attribute_type;
@@ -324,7 +324,7 @@ typedef struct sWscAttrRfBands {
         attribute_type = ATTR_RF_BANDS;
         data_length = 0x1;
     }
-} sWscAttrRfBands;
+} __attribute__((packed)) sWscAttrRfBands;
 
 typedef struct sWscAttrAssociationState {
     eWscAttributes attribute_type;
@@ -339,7 +339,7 @@ typedef struct sWscAttrAssociationState {
         data_length = 0x1;
         data = WSC_ASSOC_NOT_ASSOC;
     }
-} sWscAttrAssociationState;
+} __attribute__((packed)) sWscAttrAssociationState;
 
 typedef struct sWscAttrDevicePasswordID {
     eWscAttributes attribute_type;
@@ -355,7 +355,7 @@ typedef struct sWscAttrDevicePasswordID {
         data_length = 0x2;
         data = DEV_PW_PUSHBUTTON;
     }
-} sWscAttrDevicePasswordID;
+} __attribute__((packed)) sWscAttrDevicePasswordID;
 
 typedef struct sWscAttrConfigurationError {
     eWscAttributes attribute_type;
@@ -371,7 +371,7 @@ typedef struct sWscAttrConfigurationError {
         data_length = 0x2;
         data = WSC_CFG_NO_ERROR;
     }
-} sWscAttrConfigurationError;
+} __attribute__((packed)) sWscAttrConfigurationError;
 
 typedef struct sWscAttrOsVersion {
     eWscAttributes attribute_type;
@@ -387,7 +387,7 @@ typedef struct sWscAttrOsVersion {
         data_length = WSC_OS_VERSION_LENGTH;
         data = 0x80000001;
     }
-} sWscAttrOsVersion;
+} __attribute__((packed)) sWscAttrOsVersion;
 
 typedef struct sWscAttrVersionExtension {
     eWscAttributes attribute_type;
@@ -401,7 +401,7 @@ typedef struct sWscAttrVersionExtension {
         attribute_type = ATTR_VENDOR_EXTENSION;
         data_length = WSC_VENDOR_EXTENSIONS_LENGTH;
     }
-} sWscAttrVersionExtension;
+} __attribute__((packed)) sWscAttrVersionExtension;
 
 typedef struct sWscAttrKeyWrapAuthenticator {
     eWscAttributes attribute_type;
@@ -415,7 +415,7 @@ typedef struct sWscAttrKeyWrapAuthenticator {
         attribute_type = ATTR_KEY_WRAP_AUTH;
         data_length = WSC_KEY_WRAP_AUTH_LENGTH;
     }
-} sWscAttrKeyWrapAuthenticator;
+} __attribute__((packed)) sWscAttrKeyWrapAuthenticator;
 
 typedef struct sWscAttrSsid {
     eWscAttributes attribute_type;
@@ -429,7 +429,7 @@ typedef struct sWscAttrSsid {
         attribute_type = ATTR_SSID;
         data_length = WSC_MAX_NAME_LENGTH;
     }
-} sWscAttrSsid;
+} __attribute__((packed)) sWscAttrSsid;
 
 typedef struct sWscAttrAuthenticationType {
     eWscAttributes attribute_type;
@@ -444,7 +444,7 @@ typedef struct sWscAttrAuthenticationType {
         attribute_type = ATTR_AUTH_TYPE;
         data_length = 0x2;
     }
-} sWscAttrAuthenticationType;
+} __attribute__((packed)) sWscAttrAuthenticationType;
 
 typedef struct sWscAttrEncryptionType {
     eWscAttributes attribute_type;
@@ -459,7 +459,7 @@ typedef struct sWscAttrEncryptionType {
         attribute_type = ATTR_ENCR_TYPE;
         data_length = 0x2;
     }
-} sWscAttrEncryptionType;
+} __attribute__((packed)) sWscAttrEncryptionType;
 
 typedef struct sWscAttrNetworkKey {
     eWscAttributes attribute_type;
@@ -473,7 +473,7 @@ typedef struct sWscAttrNetworkKey {
         attribute_type = ATTR_NETWORK_KEY;
         data_length = WSC_MAX_NETWORK_KEY_LENGTH;
     }
-} sWscAttrNetworkKey;
+} __attribute__((packed)) sWscAttrNetworkKey;
 
 typedef struct sWscAttrBssid {
     eWscAttributes attribute_type;
@@ -488,7 +488,7 @@ typedef struct sWscAttrBssid {
         attribute_type = ATTR_MAC_ADDR;
         data_length = WSC_MAC_LENGTH;
     }
-} sWscAttrBssid;
+} __attribute__((packed)) sWscAttrBssid;
 
 typedef struct sWscAttrEncryptedSettings {
     eWscAttributes attribute_type;
@@ -523,7 +523,7 @@ typedef struct sWscAttrEncryptedSettings {
         bssid_attr.struct_init();
         key_wrap_auth_attr.struct_init();
     }
-} sWscAttrEncryptedSettings;
+} __attribute__((packed)) sWscAttrEncryptedSettings;
 
 
 }; // close namespace: WSC

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM1.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM1.h
@@ -94,7 +94,7 @@ typedef struct sM1 {
         os_version_attr.struct_init();
         vendor_extensions_attr.struct_init();
     }
-} sM1;
+} __attribute__((packed)) sM1;
 
 
 }; // close namespace: WSC

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM2.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM2.h
@@ -91,7 +91,7 @@ typedef struct sM2 {
         vendor_extensions_attr.struct_init();
         encrypted_settings_attr.struct_init();
     }
-} sM2;
+} __attribute__((packed)) sM2;
 
 
 }; // close namespace: WSC

--- a/framework/tlvf/AutoGenerated/include/tlvf/common/sMacAddress.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/common/sMacAddress.h
@@ -25,7 +25,7 @@ typedef struct sMacAddress {
                 mac[i] = 0x0;
             }
     }
-} sMacAddress;
+} __attribute__((packed)) sMacAddress;
 
 
 #endif //_TLVF/COMMON_SMACADDRESS_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/cCmduHeader.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/cCmduHeader.h
@@ -51,7 +51,7 @@ class cCmduHeader : public BaseClass
                 relay_indicator = 0x0;
                 reserved = 0x0;
             }
-        } sFlags;
+        } __attribute__((packed)) sFlags;
         
         const uint8_t& message_version();
         const uint8_t& reserved();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/eTlvType.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/eTlvType.h
@@ -19,7 +19,7 @@
 
 namespace ieee1905_1 {
 
-enum class eTlvType : uint16_t {
+enum class eTlvType : uint8_t {
     TLV_END_OF_MESSAGE = 0x0,
     TLV_AL_MAC_ADDRESS_TYPE = 0x1,
     TLV_MAC_ADDRESS = 0x2,
@@ -42,7 +42,7 @@ enum class eTlvType : uint16_t {
 };
 class eTlvTypeValidate {
 public:
-    static bool check(uint16_t value) {
+    static bool check(uint8_t value) {
         bool ret = false;
         switch (value) {
         case 0x0:

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/s802_11SpecificInformation.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/s802_11SpecificInformation.h
@@ -43,7 +43,7 @@ typedef struct s802_11SpecificInformation {
     void struct_init(){
         network_membership.struct_init();
     }
-} s802_11SpecificInformation;
+} __attribute__((packed)) s802_11SpecificInformation;
 
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
@@ -47,7 +47,7 @@ class tlv1905NeighborDevice : public BaseClass
             void struct_init(){
                 mac.struct_init();
             }
-        } sMacAl1905Device;
+        } __attribute__((packed)) sMacAl1905Device;
         
         const eTlvType& type();
         const uint16_t& length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceInformation.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceInformation.h
@@ -45,7 +45,7 @@ class tlvDeviceInformation : public BaseClass
             void struct_init(){
                 mac.struct_init();
             }
-        } sInfo;
+        } __attribute__((packed)) sInfo;
         
         const eTlvType& type();
         const uint16_t& length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonEventNotification.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonEventNotification.h
@@ -44,7 +44,7 @@ class tlvPushButtonEventNotification : public BaseClass
             void struct_init(){
                 media_specific_information.struct_init();
             }
-        } sMediaType;
+        } __attribute__((packed)) sMediaType;
         
         const eTlvType& type();
         const uint16_t& length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
@@ -54,7 +54,7 @@ class tlvReceiverLinkMetric : public BaseClass
             void struct_init(){
                 rssi_db = 0xff;
             }
-        } sLinkMetricInfo;
+        } __attribute__((packed)) sLinkMetricInfo;
         
         typedef struct sInterfacePairInfo {
             sMacAddress mac_of_an_interface_in_the_receiving_al;
@@ -70,7 +70,7 @@ class tlvReceiverLinkMetric : public BaseClass
                 mac_of_an_interface_in_the_neighbor_al.struct_init();
                 link_metric_info.struct_init();
             }
-        } sInterfacePairInfo;
+        } __attribute__((packed)) sInterfacePairInfo;
         
         const eTlvType& type();
         const uint16_t& length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
@@ -65,7 +65,7 @@ class tlvTransmitterLinkMetric : public BaseClass
             void struct_init(){
                 phy_rate = 0xffff;
             }
-        } sLinkMetricInfo;
+        } __attribute__((packed)) sLinkMetricInfo;
         
         typedef struct sInterfacePairInfo {
             sMacAddress mac_of_an_interface_in_the_receiving_al;
@@ -81,7 +81,7 @@ class tlvTransmitterLinkMetric : public BaseClass
                 mac_of_an_interface_in_the_neighbor_al.struct_init();
                 link_metric_info.struct_init();
             }
-        } sInterfacePairInfo;
+        } __attribute__((packed)) sInterfacePairInfo;
         
         const eTlvType& type();
         const uint16_t& length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/eTlvTypeMap.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/eTlvTypeMap.h
@@ -19,7 +19,7 @@
 
 namespace wfa_map {
 
-enum eTlvTypeMap: uint16_t {
+enum eTlvTypeMap: uint8_t {
     TLV_SUPPORTED_SERVICE = 0x80,
     TLV_SEARCHED_SERVICE = 0x81,
     TLV_AP_RADIO_IDENTIFIER = 0x82,

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApCapability.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApCapability.h
@@ -51,7 +51,7 @@ class tlvApCapability : public BaseClass
             void struct_init(){
                 reserved = 0x0;
             }
-        } sValue;
+        } __attribute__((packed)) sValue;
         
         const eTlvTypeMap& type();
         const uint16_t& length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
@@ -93,7 +93,7 @@ class cOperatingClasses : public BaseClass
             }
             void struct_init(){
             }
-        } sFlags;
+        } __attribute__((packed)) sFlags;
         
         uint8_t& operating_class();
         uint8_t& channel_list_length();

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -68,7 +68,6 @@ bool tlv1905NeighborDevice::alloc_mac_al_1905_device(size_t count) {
 
 void tlv1905NeighborDevice::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_mac_local_iface->struct_swap();
     for (size_t i = 0; i < m_mac_al_1905_device_idx__; i++){
@@ -94,10 +93,8 @@ bool tlv1905NeighborDevice::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_1905_NEIGHBOR_DEVICE;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_1905_NEIGHBOR_DEVICE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_1905_NEIGHBOR_DEVICE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_1905_NEIGHBOR_DEVICE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_1905_NEIGHBOR_DEVICE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -39,7 +39,6 @@ sMacAddress& tlvAlMacAddressType::mac() {
 
 void tlvAlMacAddressType::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_mac->struct_swap();
 }
@@ -62,10 +61,8 @@ bool tlvAlMacAddressType::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AL_MAC_ADDRESS_TYPE;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_AL_MAC_ADDRESS_TYPE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AL_MAC_ADDRESS_TYPE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_AL_MAC_ADDRESS_TYPE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AL_MAC_ADDRESS_TYPE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -39,7 +39,6 @@ tlvAutoconfigFreqBand::eValue& tlvAutoconfigFreqBand::value() {
 
 void tlvAutoconfigFreqBand::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -61,10 +60,8 @@ bool tlvAutoconfigFreqBand::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AUTOCONFIG_FREQ_BAND;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_AUTOCONFIG_FREQ_BAND) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AUTOCONFIG_FREQ_BAND) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_AUTOCONFIG_FREQ_BAND) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AUTOCONFIG_FREQ_BAND) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -92,7 +92,6 @@ bool tlvDeviceBridgingCapability::add_bridging_tuples_list(std::shared_ptr<cMacL
 
 void tlvDeviceBridgingCapability::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     for (size_t i = 0; i < (size_t)*m_bridging_tuples_list_length; i++){
         std::get<1>(bridging_tuples_list(i)).class_swap();
@@ -117,10 +116,8 @@ bool tlvDeviceBridgingCapability::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -73,7 +73,6 @@ bool tlvDeviceInformation::alloc_info(size_t count) {
 
 void tlvDeviceInformation::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_mac->struct_swap();
     for (size_t i = 0; i < (size_t)*m_info_length; i++){
@@ -100,10 +99,8 @@ bool tlvDeviceInformation::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_INFORMATION;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_DEVICE_INFORMATION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_INFORMATION) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_DEVICE_INFORMATION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_INFORMATION) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -35,7 +35,6 @@ const uint16_t& tlvEndOfMessage::length() {
 
 void tlvEndOfMessage::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -56,10 +55,8 @@ bool tlvEndOfMessage::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_END_OF_MESSAGE;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_END_OF_MESSAGE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_END_OF_MESSAGE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_END_OF_MESSAGE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_END_OF_MESSAGE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -47,7 +47,6 @@ tlvLinkMetricQuery::eLinkMetricsType& tlvLinkMetricQuery::link_metrics() {
 
 void tlvLinkMetricQuery::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_mac_al_1905_device->struct_swap();
 }
@@ -72,10 +71,8 @@ bool tlvLinkMetricQuery::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_QUERY;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_LINK_METRIC_QUERY) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_QUERY) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_LINK_METRIC_QUERY) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_QUERY) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -39,7 +39,6 @@ tlvLinkMetricResultCode::eValue& tlvLinkMetricResultCode::value() {
 
 void tlvLinkMetricResultCode::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -61,10 +60,8 @@ bool tlvLinkMetricResultCode::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_RESULT_CODE;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_LINK_METRIC_RESULT_CODE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_RESULT_CODE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_LINK_METRIC_RESULT_CODE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_RESULT_CODE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -44,7 +44,6 @@ std::tuple<bool, uint8_t&> tlvMacAddress::mac(size_t idx) {
 
 void tlvMacAddress::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -66,10 +65,8 @@ bool tlvMacAddress::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_MAC_ADDRESS;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_MAC_ADDRESS) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_MAC_ADDRESS) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_MAC_ADDRESS) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_MAC_ADDRESS) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -68,7 +68,6 @@ bool tlvNon1905neighborDeviceList::alloc_mac_non_1905_device(size_t count) {
 
 void tlvNon1905neighborDeviceList::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_mac_local_iface->struct_swap();
     for (size_t i = 0; i < m_mac_non_1905_device_idx__; i++){
@@ -94,10 +93,8 @@ bool tlvNon1905neighborDeviceList::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -69,7 +69,6 @@ bool tlvPushButtonEventNotification::alloc_media_type_list(size_t count) {
 
 void tlvPushButtonEventNotification::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     for (size_t i = 0; i < (size_t)*m_media_type_list_length; i++){
         m_media_type_list[i].struct_swap();
@@ -94,10 +93,8 @@ bool tlvPushButtonEventNotification::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -51,7 +51,6 @@ sMacAddress& tlvPushButtonJoinNotification::iface_mac_of_new_device_joined() {
 
 void tlvPushButtonJoinNotification::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_al_mac_notification_src->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_mid_of_the_notification));
@@ -80,10 +79,8 @@ bool tlvPushButtonJoinNotification::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -72,7 +72,6 @@ bool tlvReceiverLinkMetric::alloc_interface_pair_info(size_t count) {
 
 void tlvReceiverLinkMetric::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_al_mac_of_the_device_that_transmits->struct_swap();
     m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_swap();
@@ -100,10 +99,8 @@ bool tlvReceiverLinkMetric::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_RECEIVER_LINK_METRIC;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_RECEIVER_LINK_METRIC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_RECEIVER_LINK_METRIC) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_RECEIVER_LINK_METRIC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_RECEIVER_LINK_METRIC) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -39,7 +39,6 @@ tlvSearchedRole::eValue& tlvSearchedRole::value() {
 
 void tlvSearchedRole::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -61,10 +60,8 @@ bool tlvSearchedRole::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SEARCHED_ROLE;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_SEARCHED_ROLE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SEARCHED_ROLE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_SEARCHED_ROLE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SEARCHED_ROLE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -39,7 +39,6 @@ tlvSupportedFreqBand::eValue& tlvSupportedFreqBand::value() {
 
 void tlvSupportedFreqBand::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -61,10 +60,8 @@ bool tlvSupportedFreqBand::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_FREQ_BAND;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_SUPPORTED_FREQ_BAND) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_FREQ_BAND) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_SUPPORTED_FREQ_BAND) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_FREQ_BAND) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -39,7 +39,6 @@ tlvSupportedRole::eValue& tlvSupportedRole::value() {
 
 void tlvSupportedRole::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -61,10 +60,8 @@ bool tlvSupportedRole::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_ROLE;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_SUPPORTED_ROLE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_ROLE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_SUPPORTED_ROLE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_ROLE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -72,7 +72,6 @@ bool tlvTransmitterLinkMetric::alloc_interface_pair_info(size_t count) {
 
 void tlvTransmitterLinkMetric::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_al_mac_of_the_device_that_transmits->struct_swap();
     m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_swap();
@@ -100,10 +99,8 @@ bool tlvTransmitterLinkMetric::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_TRANSMITTER_LINK_METRIC;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_TRANSMITTER_LINK_METRIC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_TRANSMITTER_LINK_METRIC) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_TRANSMITTER_LINK_METRIC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_TRANSMITTER_LINK_METRIC) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -44,7 +44,6 @@ std::tuple<bool, uint8_t&> tlvVendorSpecific::vendor_oui(size_t idx) {
 
 void tlvVendorSpecific::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -39,7 +39,6 @@ WSC::sM1& tlvWscM1::M1Frame() {
 
 void tlvWscM1::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_M1Frame->struct_swap();
 }
@@ -62,10 +61,8 @@ bool tlvWscM1::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_WSC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_WSC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -39,7 +39,6 @@ WSC::sM2& tlvWscM2::M2Frame() {
 
 void tlvWscM2::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_M2Frame->struct_swap();
 }
@@ -62,10 +61,8 @@ bool tlvWscM2::init()
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
     else {
-        eTlvType swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvType::TLV_WSC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvType::TLV_WSC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
@@ -39,7 +39,6 @@ tlvApCapability::sValue& tlvApCapability::value() {
 
 void tlvApCapability::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_value->struct_swap();
 }
@@ -62,10 +61,8 @@ bool tlvApCapability::init()
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_CAPABILITY;
     else {
-        eTlvTypeMap swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvTypeMap::TLV_AP_CAPABILITY) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_CAPABILITY) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvTypeMap::TLV_AP_CAPABILITY) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_CAPABILITY) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -100,7 +100,6 @@ bool tlvApRadioBasicCapabilities::add_operating_classes_info_list(std::shared_pt
 
 void tlvApRadioBasicCapabilities::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
     for (size_t i = 0; i < (size_t)*m_operating_classes_info_list_length; i++){
@@ -128,10 +127,8 @@ bool tlvApRadioBasicCapabilities::init()
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES;
     else {
-        eTlvTypeMap swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -39,7 +39,6 @@ sMacAddress& tlvApRadioIdentifier::radio_uid() {
 
 void tlvApRadioIdentifier::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
 }
@@ -62,10 +61,8 @@ bool tlvApRadioIdentifier::init()
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER;
     else {
-        eTlvTypeMap swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -96,7 +96,6 @@ bool tlvChannelPreference::add_operating_classes_list(std::shared_ptr<cOperating
 
 void tlvChannelPreference::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
     for (size_t i = 0; i < (size_t)*m_operating_classes_list_length; i++){
@@ -123,10 +122,8 @@ bool tlvChannelPreference::init()
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_PREFERENCE;
     else {
-        eTlvTypeMap swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvTypeMap::TLV_CHANNEL_PREFERENCE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_PREFERENCE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvTypeMap::TLV_CHANNEL_PREFERENCE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_PREFERENCE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -66,7 +66,6 @@ bool tlvSearchedService::alloc_searched_service_list(size_t count) {
 
 void tlvSearchedService::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -88,10 +87,8 @@ bool tlvSearchedService::init()
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SEARCHED_SERVICE;
     else {
-        eTlvTypeMap swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SEARCHED_SERVICE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SEARCHED_SERVICE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -66,7 +66,6 @@ bool tlvSupportedService::alloc_supported_service_list(size_t count) {
 
 void tlvSupportedService::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
@@ -88,10 +87,8 @@ bool tlvSupportedService::init()
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SUPPORTED_SERVICE;
     else {
-        eTlvTypeMap swapped_type = *m_type;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }
-            if (swapped_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SUPPORTED_SERVICE) << ", received value: " << int(swapped_type);
+            if (*m_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SUPPORTED_SERVICE) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -35,7 +35,7 @@ protected:
     const bool m_parse__;
     const bool m_swap__;
     bool m_init_succeeded;
-    static const size_t kMinimumLength = 4; // tlv header length
+    static const size_t kMinimumLength = 3; // tlv header length
 };
 
 #endif //_BaseClass_H_

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -84,7 +84,7 @@ protected:
     std::shared_ptr<cCmduHeader> m_cmdu_header;
     std::vector<std::shared_ptr<BaseClass>> m_class_vector;
     static const uint16_t kCmduHeaderLength = 8;
-    static const uint16_t kTlvHeaderLength  = 4;
+    static const uint16_t kTlvHeaderLength  = 3;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -626,10 +626,8 @@ class TlvF:
                     lines_cpp.append("if (!m_%s__) *m_%s = %s;" % ( self.MEMBER_PARSE, param_name, param_val_const) )
                     if self.is_tlv_class and param_name == MetaData.TLV_TYPE_TYPE:
                         lines_cpp.append( "else {" )
-                        lines_cpp.append( "%s%s swapped_type = *m_%s;" % ( self.getIndentation(1), param_type, param_name ) )
-                        lines_cpp.append( "%sif (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&swapped_type)); }" % self.getIndentation(1) )
-                        lines_cpp.append( "%sif (swapped_type != %s) {" % ( self.getIndentation(2), param_val_const ) )
-                        lines_cpp.append( '%sTLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(%s) << ", received value: " << int(swapped_type);' %  (self.getIndentation(2), param_val_const) )
+                        lines_cpp.append( "%sif (*m_type != %s) {" % ( self.getIndentation(2), param_val_const ) )
+                        lines_cpp.append( '%sTLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(%s) << ", received value: " << int(*m_type);' %  (self.getIndentation(2), param_val_const) )
                         lines_cpp.append( "%sreturn false;" % self.getIndentation(2))
                         lines_cpp.append( "%s}" % self.getIndentation(1) )
                         lines_cpp.append( "}" )
@@ -1127,7 +1125,7 @@ class TlvF:
         self.insertLineH(insert_name, insert_marker, "%s%s_%s" % (self.getIndentation(2), self.CODE_STRUCT_INIT_FUNC_INSERT, name))
         self.insertLineH(insert_name, insert_marker, "%s}" % (self.getIndentation(1)) )
 
-        self.insertLineH(insert_name, insert_marker, "} %s;" % (name))
+        self.insertLineH(insert_name, insert_marker, "} __attribute__((packed)) %s;" % (name))
         self.insertLineH(insert_name, insert_marker, "")
 
     def addEnumCode(self, insert_name, insert_marker, name, enum_storage):

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/eTlvType.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/eTlvType.yaml
@@ -4,7 +4,7 @@ _namespace: ieee1905_1
 
 eTlvType:
   _type: enum_class
-  _enum_storage: uint16_t
+  _enum_storage: uint8_t
   TLV_END_OF_MESSAGE: 0x00
   TLV_AL_MAC_ADDRESS_TYPE: 0x01
   TLV_MAC_ADDRESS: 0x02
@@ -24,4 +24,4 @@ eTlvType:
   TLV_WSC: 0x11
   TLV_PUSH_BUTTON_EVENT_NOTIFICATION: 0x12
   TLV_PUSH_BUTTON_JOIN_NOTIFICATION: 0x13
-  
+

--- a/framework/tlvf/yaml/tlvf/wfa_map/eTlvTypeMap.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/eTlvTypeMap.yaml
@@ -4,7 +4,7 @@ _namespace: wfa_map
 
 eTlvTypeMap:
   _type: enum
-  _enum_storage: uint16_t
+  _enum_storage: uint8_t
   TLV_SUPPORTED_SERVICE: 0x80
   TLV_SEARCHED_SERVICE: 0x81
   TLV_AP_RADIO_IDENTIFIER: 0x82


### PR DESCRIPTION
IEEE 1905.1 defines the TLV as a 1-byte type, 2-byte length and
variable-length value. However, the TLV definition in the prplMesh
source code used 2 bytes (uint16_t) for the type.

With the 'type' field at 1 byte, the default struct packing is incorrect
(the compiler will insert an extra byte to make sure the length field is
16-bit aligned). Therefore, we also must make sure the structs are
packed correctly, by adding the 'packed' attribute (cfr. #18).

Also, the TLV structure layout is repeated in a few places, so all of
these have to be fixed.

With this fix, the demo can work:
 Tested with ZMQ using 2 VMs. Wireshark capture for autoconfig response in a remote agent:
![image](https://user-images.githubusercontent.com/13386849/59556324-17ae2d00-8fc9-11e9-92c7-65414b0a0e2e.png)
