### PR TITLE
Bugfix/intel oui

### DIFF
--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -204,9 +204,10 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
         if (static_cast<ieee1905_1::eTlvType>(type) == ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC) {
             auto tlv_vendor_specific = ieee1905_1::tlvVendorSpecific((uint8_t *)tlv, length, true,
                                                                      uds_header->swap_needed);
-            auto oui = ieee1905_1::tlvVendorSpecific::eVendorOUI(
-                uint32_t(std::get<1>(tlv_vendor_specific.vendor_oui(0))) && 0x00FFFFFF);
-            if (oui == ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL) {
+            // FIXME: https://github.com/prplfoundation/prplMesh/issues/33                                                         
+            // auto oui = ieee1905_1::tlvVendorSpecific::eVendorOUI(
+            //     uint32_t(std::get<1>(tlv_vendor_specific.vendor_oui(0))) & 0x00FFFFFF);
+            //if (oui == ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL) {
                 // assuming that the magic is the first data on the beerocks header
                 auto beerocks_magic = *(
                     uint32_t *)((uint8_t *)tlv + ieee1905_1::tlvVendorSpecific::get_initial_size());
@@ -221,9 +222,9 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
                     break;
                 }
 
-            } else {
-                THREAD_LOG(WARNING) << "Not Intels VS message!";
-            }
+            //} else {
+            //    THREAD_LOG(WARNING) << "Not Intels VS message!";
+            //}
 
             if (uds_header->swap_needed) {
                 // cancel the swap we did

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks_message.cpp
@@ -54,9 +54,11 @@ message::sUdsHeader *message_com::get_uds_header(ieee1905_1::CmduMessage &cmdu)
 bool message_com::intel_oui(
     std::shared_ptr<ieee1905_1::tlvVendorSpecific> tlv_vendor_specific_header)
 {
-    return ieee1905_1::tlvVendorSpecific::eVendorOUI(
-               uint32_t(std::get<1>(tlv_vendor_specific_header->vendor_oui(0))) && 0x00FFFFFF) ==
-           ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
+    // FIXME: https://github.com/prplfoundation/prplMesh/issues/33
+    // return ieee1905_1::tlvVendorSpecific::eVendorOUI(
+    //            uint32_t(std::get<1>(tlv_vendor_specific_header->vendor_oui(0))) & 0x00FFFFFF) ==
+    //        ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
+    return true;
 }
 
 std::shared_ptr<beerocks_message::cACTION_HEADER>

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -51,9 +51,11 @@ message::sUdsHeader *message_com::get_uds_header(ieee1905_1::CmduMessage &cmdu)
 bool message_com::intel_oui(
     std::shared_ptr<ieee1905_1::tlvVendorSpecific> tlv_vendor_specific_header)
 {
-    return ieee1905_1::tlvVendorSpecific::eVendorOUI(
-               uint32_t(std::get<1>(tlv_vendor_specific_header->vendor_oui(0))) && 0x00FFFFFF) ==
-           ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
+    // FIXME: https://github.com/prplfoundation/prplMesh/issues/33
+    // return ieee1905_1::tlvVendorSpecific::eVendorOUI(
+    //            uint32_t(std::get<1>(tlv_vendor_specific_header->vendor_oui(0))) & 0x00FFFFFF) ==
+    //        ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
+    return true;
 }
 
 std::shared_ptr<beerocks_message::cACTION_HEADER>

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
@@ -34,12 +34,12 @@ class tlvVendorSpecific : public BaseClass
 
         enum eVendorOUI: uint32_t {
             OUI_BYTES = 0x3,
-            OUI_INTEL = 0x0,
+            OUI_INTEL = 0x470300,
         };
         
         const eTlvType& type();
         uint16_t& length();
-        //Use eVendorOUI
+        //Use eVendorOUI2
         std::tuple<bool, uint8_t&> vendor_oui(size_t idx);
         void class_swap();
         static size_t get_initial_size();

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvVendorSpecific.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvVendorSpecific.yaml
@@ -19,7 +19,6 @@ tlvVendorSpecific:
 eVendorOUI:
   _type: enum
   _enum_storage: uint32_t
-  _comment: #TODO change OUI value for Intel
+  # FIXME: https://github.com/prplfoundation/prplMesh/issues/33
   OUI_BYTES: 3
-  OUI_INTEL: 0x000000
-  
+  OUI_INTEL: 0x470300


### PR DESCRIPTION
Currently as stated in #33, wrong OUI is used (0) since tlvf does not
support endianness conversion for 24 bit fields.

In order to see a valid VS Intel OUI, change current
Intel [OUI](http://standards-oui.ieee.org/oui.txt) to 0x000347.

Since tlvf does not yet support endianess conversion for 24 bit,
comment out the validity tests.

In addition, represent Intel OUI in little endian (0x470300 instead of
0x000347), since we currently support Ubuntu / Debian / etc. which normally
runs on x86 or x86-64 architectures, and all x86/x86-64 architectures
are little endian.
