### PR TITLE
Update README.md maptools link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ repo forall -p -c 'git checkout $REPO_RREV'
 > **_NOTE:_**  DWPAL is currently private (will be public in a week's time), which will cause repo init to fail on fetch. To workaround that, `no-dwpal.xml` is provided - so use the following repo init command instead: `repo init -u https://github.com/prplfoundation/intel_multiap_manifest.git -m no-dwpal.xml`. Note that without DWPAL, only DUMMY mode is supported.
 
 ## Build Instructions
-Each component can be built with CMAKE, or use the [tools/maptools.py](tools/maptools.py) build command.
+Each component can be built with CMAKE, or use the [tools/maptools.py](tools/README.md) build command.


### PR DESCRIPTION
The link previously pointed to the maptools source file instead of the 
maptools GIT page. All the documentation can be found in the .md file
of the maptools repo