### PR TITLE
tools: reduce pip requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ repo init -u https://github.com/prplfoundation/prplMesh-manifest.git
 repo sync
 repo forall -p -c 'git checkout $REPO_RREV'
 ```
-> **_NOTE:_**  DWPAL is currently private (will be public in a week's time), which will cause repo init to fail on fetch. To workaround that, `no-dwpal.xml` is provided - so use the following repo init command instead: `repo init -u https://github.com/prplfoundation/intel_multiap_manifest.git -m no-dwpal.xml`. Note that without DWPAL, only DUMMY mode is supported.
 
 ## Build Instructions
 Each component can be built with CMAKE, or use the [tools/maptools.py](tools/README.md) build command.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Optional - to avoid ssh keys and password reprompt, add the following to ~/.gitc
 ```
 Then run the following commands to fetch the code:
 ```
-repo init -u https://github.com/prplfoundation/intel_multiap_manifest.git
+repo init -u https://github.com/prplfoundation/prplMesh-manifest.git
 repo sync
 repo forall -p -c 'git checkout $REPO_RREV'
 ```

--- a/tools/beerocks_analyzer/requirements.txt
+++ b/tools/beerocks_analyzer/requirements.txt
@@ -1,0 +1,7 @@
+paramiko==2.4.2
+pip==1.5.4
+PySide==1.2.4
+matplotlib==3.0.3
+networkx==2.3
+numpy==1.16.3
+PyYAML==5.1

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,7 +1,2 @@
 paramiko==2.4.2
-pip==1.5.4
-PySide==1.2.4
-matplotlib==3.0.3
-networkx==2.3
-numpy==1.16.3
 PyYAML==5.1


### PR DESCRIPTION
Most of the requirements are only needed for beerocks_analyzer. So move
requirements.txt to that directory, and limit the real maptools
requirements to paramiko and PyYAML.