### PR TITLE
tools: remove paramiko dependency

### DIFF
--- a/tools/commands/deploy.py
+++ b/tools/commands/deploy.py
@@ -6,7 +6,6 @@ import subprocess
 import collections
 import shutil
 import yaml
-import paramiko
 import glob
 import hashlib
 import errno
@@ -26,7 +25,8 @@ class mapconnect(object):
     
     def __connect__(self):
         ''' connect sftp and ssh clients '''
-       
+
+        import paramiko
         # start sftp connection
         t = paramiko.Transport((self.proxy['ip'], 22))
         t.connect(username=self.proxy['user'], password=self.proxy['pass'])

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,1 @@
-paramiko==2.4.2
 PyYAML==5.1


### PR DESCRIPTION
paramiko is used only for deploy, so remove it from the dependency and
wrap the call with try / except.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>