### PR TITLE
prplMesh-platform-init.sh: use the built hostapd

### DIFF
--- a/tools/scripts/prplMesh-platform-init.sh
+++ b/tools/scripts/prplMesh-platform-init.sh
@@ -92,7 +92,7 @@ main() {
 
 VERBOSE=false
 HELP=false
-HOSTAPD=`which hostapd 2>/dev/null`
+HOSTAPD=$(realpath ${0%/*}/../../../build/install/bin/hostapd)
 HOSTAPD_CONF=$(realpath ${0%/*}/hostapd.conf)
 HOSTAPD_PID=/var/run/hostapd.pid
 


### PR DESCRIPTION
Instead of looking for hostapd in $PATH, use the one from the build
directory by default.

It is still possible to override with the -H option.