### PR TITLE
CMakeLists: add -Wno-address-of-packed-member CFLAG

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -47,7 +47,7 @@ if (BUILD_PATENTS)
 endif()
 
 # Default Compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pthread -std=c++11 -Wno-unused-parameter -Wno-missing-field-initializers -fpermissive")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pthread -std=c++11 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-address-of-packed-member -fpermissive")
 
 option(STANDALONE "Standalone build" OFF)
 

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -58,7 +58,7 @@ message(STATUS "CMAKE_PROGRAM_PATH - ${CMAKE_PROGRAM_PATH}")
 message(STATUS "CMAKE_MULTIAP_OUTPUT_DIRECTORY - ${CMAKE_MULTIAP_OUTPUT_DIRECTORY}")
 
 # Default Compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pthread -Wno-comment -Wno-unused-parameter -Wno-missing-field-initializers -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pthread -Wno-comment -Wno-unused-parameter -Wno-missing-field-initializers -Wno-address-of-packed-member -fPIC")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -std=c++11 -fpermissive")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wl,-S -fPIE -fPIC")
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)

--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -32,7 +32,7 @@ if (BUILD_PATENTS)
 endif()
 
 # Default Compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pthread -std=c++11 -Wno-unused-parameter -Wno-missing-field-initializers -fpermissive")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pthread -std=c++11 -Wno-unused-parameter -Wno-missing-field-initializers -Wno-address-of-packed-member -fpermissive")
 
 option(STANDALONE "Standalone build" OFF)
 

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -22,7 +22,7 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 message("-- prefix=${CMAKE_INSTALL_PREFIX}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -pthread -Wall -Wextra -Werror -Wno-comment -Wno-unused-parameter -Wno-missing-field-initializers -fpermissive" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -pthread -Wall -Wextra -Werror -Wno-comment -Wno-unused-parameter -Wno-missing-field-initializers -Wno-address-of-packed-member -fpermissive" CACHE STRING "" FORCE)
 if(CMAKE_VERSION VERSION_LESS "3.1")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 else()


### PR DESCRIPTION
Recent GCC (at least GCC 9, maybe already earlier) adds a warning for
taking a possibly unaligned address of a member of a packed struct.
Since we use packed structs all over the place now, we hit this warning
in a few places.

However, all the platforms we target (x86, ARM, MIPS) support unaligned
accesses. So this warning is not really important.

Therefore, suppress it with the -Wno-address-of-packed-member flag. Even
though only the agent and common components really need it, apply it
globally.

Note that older GCC versions don't know this flag. However, GCC silently
ignores and -Wno- flag it doesn't know about.