### PR TITLE
tools: docker - add initial builder Dockerfile

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:18.04
+
+# Update Software repository
+RUN apt-get update && apt-get install -y \
+	curl \
+	gcc \
+	cmake \
+	ninja-build \
+	binutils \
+	git \
+	autoconf \
+	autogen \
+	libtool \
+	pkg-config \
+	libreadline-dev \
+	libncurses-dev \
+	libssl-dev \
+	libjson-c-dev \
+	libnl-genl-3-dev \
+	libzmq3-dev \
+	python \
+	python-yaml \
+	vim \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/prplMesh
+ENTRYPOINT ["/root/prplMesh/tools/maptools.py", "build"]

--- a/tools/docker/builder/README.md
+++ b/tools/docker/builder/README.md
@@ -1,0 +1,25 @@
+# Docker builder image
+
+This folder includes a Dockerfile which can be used to build prplMesh from a container by running maptools.py from the container.
+
+It includes 2 helper scripts - one to generate the image `image-build.sh` and one to actually run `maptools.py build` from the container - `build.sh`.
+
+## Usage
+
+Build the initial image (one time):
+
+```bash
+sudo ./image-build.sh
+```
+
+Build prplMesh in container:
+
+```bash
+sudo ./build.sh <maptools.py build arguments>
+```
+
+---
+
+Proxy settings - the recommended way to work with docker behind a proxy is by [configuring the docker client to pass proxy information to containers automatically](https://docs.docker.com/network/proxy/).
+
+---

--- a/tools/docker/builder/build.sh
+++ b/tools/docker/builder/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+run() {
+    echo "$*"
+    "$@" || exit $?
+}
+
+scriptdir="$(cd "${0%/*}"; pwd)"
+topdir="${scriptdir%/*/*/*/*}"
+
+main() {
+    run docker container run -v ${topdir}:/root --interactive --tty --rm prplmesh-build $@
+}
+
+main $@

--- a/tools/docker/builder/image-build.sh
+++ b/tools/docker/builder/image-build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+run() {
+    echo "$*"
+    "$@" || exit $?
+}
+
+scriptdir="$(cd "${0%/*}"; pwd)"
+topdir="${scriptdir%/*/*/*/*}"
+
+main() {
+    run docker image build --tag prplmesh-build ${scriptdir}
+}
+
+main $@


### PR DESCRIPTION
Add initial Dockerfile and instructions for building docker image and
running a container which builds and exists.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>
Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
