### PR TITLE
build: docker: add support to run as current user

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -23,5 +23,9 @@ RUN apt-get update && apt-get install -y \
 	vim \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /root/prplMesh
-ENTRYPOINT ["/root/prplMesh/tools/maptools.py", "build"]
+ARG uid
+ARG topdir
+
+USER $uid
+WORKDIR $topdir
+ENTRYPOINT ["./prplMesh/tools/maptools.py", "build"]

--- a/tools/docker/builder/build.sh
+++ b/tools/docker/builder/build.sh
@@ -9,7 +9,7 @@ scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*/*}"
 
 main() {
-    run docker container run -v ${topdir}:/root --interactive --tty --rm prplmesh-build $@
+    run docker container run -v ${topdir}:${topdir} --interactive --tty --rm prplmesh-build $@
 }
 
 main $@

--- a/tools/docker/builder/image-build.sh
+++ b/tools/docker/builder/image-build.sh
@@ -9,7 +9,7 @@ scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*/*}"
 
 main() {
-    run docker image build --tag prplmesh-build ${scriptdir}
+    run docker image build --build-arg topdir=$topdir --build-arg uid=${SUDO_UID:-0} --tag prplmesh-build ${scriptdir}
 }
 
 main $@


### PR DESCRIPTION
This commit adds support for building from docker container with the
current user and current paths.
This allows running output binaries from the host, rebuilding as needed,
and removes the annoying fact that new files are generated with root
permissions, thus can't be accessed without sudo from the host user.

The way it works is by adding the following arguments to the image
generation:
- user - user name
- uid - user group id
- topdir - top directory (where .repo/ is)

Then we add a new user in the image with the same group id as the host
user. The image-build.sh is updated accordingly (The reason this works is
because the Filesystem doesn't really care if the user is called "user"
or "deni" or "jenkins". It only cares about the UID attached to that user,
so the permissions will be preserved and various applications will not
complain that there is no user with that UID. Reference -
https://denibertovic.com/posts/handling-permissions-with-docker-volumes/)

The topdir is needed so that all the paths that are generated in the
container are aligned with the real paths. So we provide the topdir path
in the container run command (build.sh).

One small note - this will only work if the host has the same
dependencies installed. For example, since the docker image contains
latest ZMQ, the host has to have the same ZMQ version installed
(provided we are building with ZMQ).

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>