### PR TITLE
tlvf: CmduMessage::getNextTlvType(): TLV type is 8 bit

### DIFF
--- a/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
@@ -36,18 +36,16 @@ bool CmduMessage::getNextTlvType(eTlvType &tlvType) const
     }
 
     if (m_class_vector.size() == 0) {
-        tlvValue = *((uint16_t *)m_cmdu_header->getBuffPtr());
+        tlvValue = *m_cmdu_header->getBuffPtr();
     } else {
-        tlvValue = *((uint16_t *)m_class_vector.back()->getBuffPtr());
-    }
-    if (m_swap) {
-        swap_16((uint16_t &)tlvValue);
+        tlvValue = *m_class_vector.back()->getBuffPtr();
     }
     if (eTlvTypeValidate::check(tlvValue)) {
         tlvType = (eTlvType)tlvValue;
+        return true;
+    } else {
+        return false;
     }
-
-    return true;
 }
 
 uint16_t CmduMessage::getNextTlvLength() const
@@ -55,9 +53,9 @@ uint16_t CmduMessage::getNextTlvLength() const
     uint16_t tlvLength;
     if (m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() > kTlvHeaderLength)) {
         if (m_class_vector.size() == 0) {
-            tlvLength = *((uint16_t *)(m_cmdu_header->getBuffPtr() + sizeof(uint16_t)));
+            tlvLength = *((uint16_t *)(m_cmdu_header->getBuffPtr() + sizeof(uint8_t)));
         } else {
-            tlvLength = *((uint16_t *)(m_class_vector.back()->getBuffPtr() + sizeof(uint16_t)));
+            tlvLength = *((uint16_t *)(m_class_vector.back()->getBuffPtr() + sizeof(uint8_t)));
         }
 
         if (m_swap) {

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -33,18 +33,16 @@ bool CmduMessage::getNextTlvType(eTlvType &tlvType) const
     }
 
     if (m_class_vector.size() == 0) {
-        tlvValue = *((uint16_t *)m_cmdu_header->getBuffPtr());
+        tlvValue = *m_cmdu_header->getBuffPtr();
     } else {
-        tlvValue = *((uint16_t *)m_class_vector.back()->getBuffPtr());
-    }
-    if (m_swap) {
-        swap_16((uint16_t &)tlvValue);
+        tlvValue = *m_class_vector.back()->getBuffPtr();
     }
     if (eTlvTypeValidate::check(tlvValue)) {
         tlvType = (eTlvType)tlvValue;
+        return true;
+    } else {
+        return false;
     }
-
-    return true;
 }
 
 uint16_t CmduMessage::getNextTlvLength() const
@@ -52,9 +50,9 @@ uint16_t CmduMessage::getNextTlvLength() const
     uint16_t tlvLength;
     if (m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() > kTlvHeaderLength)) {
         if (m_class_vector.size() == 0) {
-            tlvLength = *((uint16_t *)(m_cmdu_header->getBuffPtr() + sizeof(uint16_t)));
+            tlvLength = *((uint16_t *)(m_cmdu_header->getBuffPtr() + sizeof(uint8_t)));
         } else {
-            tlvLength = *((uint16_t *)(m_class_vector.back()->getBuffPtr() + sizeof(uint16_t)));
+            tlvLength = *((uint16_t *)(m_class_vector.back()->getBuffPtr() + sizeof(uint8_t)));
         }
 
         if (m_swap) {


### PR DESCRIPTION
Commit 4136c80f8ee76 fixed the IEEE1905 TLV 'type' field from 16 bits to 8
bits. However, parsing the TLV 'type' field is also open-coded in 
CmduMessage::getNextTlvType(). It reads 16 bits from the buffer and swaps
them.

Similarly, CmduMessage::getNextTlvLength() takes an offset of 2 bytes into
the buffer, which should be only 1 byte.

The tlvf_test breaks because of this. This was not detected since it is not
yet executed in CI.

Fix both CmduMessage::getNextTlvType() and CmduMessage::getNextTlvLength()
to use only one byte for the TLV `type' field.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>