### PR TITLE
tools: set GID as well as UID

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -24,8 +24,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ARG uid
+ARG gid
 ARG topdir
 
-USER $uid
+USER $uid:$gid
 WORKDIR $topdir
 ENTRYPOINT ["./prplMesh/tools/maptools.py", "build"]

--- a/tools/docker/builder/image-build.sh
+++ b/tools/docker/builder/image-build.sh
@@ -9,7 +9,12 @@ scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*/*}"
 
 main() {
-    run docker image build --build-arg topdir=$topdir --build-arg uid=${SUDO_UID:-0} --tag prplmesh-build ${scriptdir}
+    run docker image build \
+        --build-arg topdir=$topdir \
+        --build-arg uid=${SUDO_UID:-0} \
+        --build-arg gid=${SUDO_GID:-0} \
+        --tag prplmesh-build \
+        ${scriptdir}
 }
 
 main $@


### PR DESCRIPTION
Commit 5e83aec7ec made sure that the build is done as the current user
instead of as root. However, it did not make sure that the group is also
set to the user's group. Thus, the AutoGenerated files and the files in
the build/ directory will belong to group 'root'.

Similar to what we do for uid, add a variable gid and set it based on
SUDO_GID, and use it in the USER directive.