### PR TITLE
CONTRIBUTING.md: extend the workflow section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,20 @@ git config --global user.email "my@email.address"
 
 This section describes the workflow followed by core contributors and maintainers.
 It is advised to follow a similar workflow for your own contributions.
+This section describes the full workflow.
+For smaller contributions, you may take shortcuts.
+
+The workflow is explained in detail below. In summary, it consists of these steps.
+1. Create a branch
+2. Create a draft pull request
+3. Make the changes, commit with amend and rebase
+4. Push regularly
+5. Clean up the commits, push, and set pull request to "Ready for review"
+6. Review is done.
+7. Address review comments in additional fixup commits.
+8. Review is approved by maintainers.
+9. Use `git rebase -i --autosquash master` to clean up the pull request.
+10. Pull request is merged by maintainers.
 
 Start by creating a branch.
 We give branches a name following `<type>/<subject>`.
@@ -165,6 +179,86 @@ This draft pull request signals the others that someone is working on this featu
 It allows others to see what you're doing before it is completed, and to give early feedback and suggestions.
 For such a draft pull request, it is not yet necessary that the commits are nicely split up.
 
+Continue developing the code.
+Push your work regularly.
+You can make separate commits, or amend a single commit, or rebase and sort it into different commits, at your option.
+Every time you push, CI will run on the code and you will be informed of any issues with it.
+Also, even if the pull request is still draft, maintainers may start giving comments on it.
+The purpose of these comments is to make sure your work is aligned with expectations.
+It avoids that after a lot of work, you are asked to still make major changes.
+
+Once your feature is ready, use `git rebase -i` to organise it in clean commits and add a proper commit message to every commit, including a Signed-off-by.
+Force-push the branch and change the pull request state from "Draft" to "Ready for review".
+
+Other contributors will start reviewing your change and make suggestions for improvements.
+The review has the following goals:
+* Make sure maintainers stay aware of all the changes happening in the code.
+* Identify opportunities for refactoring, code reuse, optimisation, ...
+* Make sure the coding style and patterns stay consistent.
+* Make sure the code remains maintainable and easy to understand.
+* Brainstorm about better ways to write code or better architectural approaches.
+* Identify potential bugs.
+* Identify missing tests.
+
+Very often, the review will lead to comments that don't really need to be addressed for the pull request to be accepted.
+Many of the review goals are more about having a discussion than about really forcing changes.
+Unfortunately, github doesn't have an easy way to make such a distinction, so reviewers have to mention explicitly when a suggestion is optional.
+If there are review comments that need to be addressed, the pull request will be marked as "Changes requested".
+
+If you make more changes after a pull request is marked as "Ready for review", do not rebase or amend.
+This will allow reviewers to easily see the differences compared to their previous review.
+Instead, create additional commits with `git commit --fixup <sha1 of commit to fix> -e`.
+Do _not_ add a Signed-off-by to these commits.
+This will block merging due to the DCO check, but that is intended because the fixup commits need to be applied first (see below).
+In the fixup commit message, explain which review comments are addressed by the change - but don't change the subject line, since that is used by autosquash (see below).
+If the commit message itself needs to be changed, use `git commit --squash <sha1 of commit to fix> -e`.
+Below the subject line, add a second subject line, followed by the complete commit message and the Signed-off-by.
+During the autosquash rebase, we'll only retain the second commit message (see below).
+
+In the pull request's web interface, mark the comments that have been addressed as Resolved.
+Also mark the comments that are optional as Resolved.
+If you don't take the suggestion directly or you disagree or only apply it in part, don't mark it as Resolved.
+Regularly push your branch.
+
+There may be several iterations in the review.
+Finally, the pull-request is marked as Approved by the maintainers.
+However, it cannot be applied as is because the commits are still "dirty".
+The last step is to perform `git rebase -i --autosquash master`.
+This will apply the fixup commits automatically.
+For the squash commits, it will stop in an editor to allow you to update the commit message.
+Just use the last commit message, remove all the rest.
+Finally, force-push the branch.
+The DCO check will now succeed and the pull request is ready for merging.
+
+Note that there are a few cases where it is not possible to use fixup commits.
+In these cases, use rebase and create a clean series of commits again.
+Add a comment in the pull request why this was done.
+This is needed at least in the following cases:
+* If you need to pull in changes from master or another branch or pull request.
+* If you need to reorder the commits.
+* If you need to move a subset of the changes from one commit to another commit.
+
+If you are working on a big feature, you often encounter something small that needs to be fixed or improved that is relatively independent of the feature.
+Such a change can be included as one of the first commits in the pull request.
+However, often it's useful to create a separate pull request for it, so it can be applied more quickly.
+The typical workflow for this is:
+* Make the fix and commit it with a proper commit message.
+* Check out a new branch `hotfix/<description>` based on master.
+* Cherry-pick the fix commit.
+* Push and create a pull request.
+* Check out the development branch and rebase on the hotfix branch. This will automatically remove th fix commit.
+
+### Definition of done
+
+Before a pull request can be merged, it must be considered "Done".
+That means the following conditions must hold.
+* All commits have a Signed-off-by. Automatic with the DCO check.
+* At least one maintainer has reviewed and approvied.
+* Code builds on Ubuntu, with `MSGLIB=zmq` and `BWL_TYPE=DUMMY`. Automatic with Travis CI.
+* Unit tests run successfully. Automatic with Travis CI.
+* Controller and agent go to operational. Manual, by starting `local_bus`, `ieee1905_transport`, `beerocks_controller` and `beerocks_agent` and verifying that the agent log reports OPERATIONAL.
+* Run clang-format.sh. If it fixes lines you did not change, commit that separately. TODO handle this in Travis CI.
+* TODO valgrind / klockwork / clang-tidy / etc
 
 ### Coding style
 


### PR DESCRIPTION
Addresses most of @tomereli's review feedback on the first PR, except for this one:

> This gets me to the next section I think should be here - Code Review. We want contributors to participate, so some best code reviewing practices can be helpful. Especially regarding reviewing commits instead of pull requests, so that the fixups will go smoother (I'm not sure I know till now if that works:) )