### PR TITLE
Hotfix/fix installed scripts

### DIFF
--- a/common/beerocks/scripts/CMakeLists.txt
+++ b/common/beerocks/scripts/CMakeLists.txt
@@ -4,12 +4,12 @@ configure_file(
         @ONLY
         )
 
-set(scripts
-    ${CMAKE_CURRENT_BINARY_DIR}/prplmesh_utils.sh
-    beerocks_utils.sh
-    beerocks_endurance_test.sh
-    beerocks_watchdog.sh
+set(scripts ${CMAKE_CURRENT_BINARY_DIR}/prplmesh_utils.sh)
+if (NOT TARGET_PLATFORM STREQUAL "linux")
+list(APPEND scripts beerocks_utils.sh
+    beerocks_endurance_test.sh beerocks_watchdog.sh
     udhcpc.script.alt)
+endif()
 
 install(PROGRAMS ${scripts} DESTINATION scripts)
 file(COPY ${scripts} DESTINATION ${CMAKE_MULTIAP_OUTPUT_DIRECTORY}/scripts)


### PR DESCRIPTION
Currently we install scripts which are only used by cross platforms
(RDKB, UGW) such as beerocks_utils.sh, beerocks_watchdog.sh, etc.

On the Linux platform, only install prplmesh_utils.sh. The other scripts are
still installed for UGW and RDKB. Although the intention is to also replace these
with prplmesh_utils.sh, we'll do that once that script is ready for it.