### PR TITLE
documentation: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of conduct
+
+The [prpl Foundation Code of Conduct](https://prplfoundation.org/about/code-of-conduct/) applies to all communication about prplMesh.
+
+If you encounter a problem with someone's conduct, contact the prpl Community Manager Mirko Lindner by emailing Mirko.Lindner [at] prplfoundation.org.


### PR DESCRIPTION
Github's "community profile" page under the "insights" tab shows that
prplMesh doesn't have a code of conduct, since it expects a
CODE_OF_CONDUCT.md file at the root of the repository.

Add CODE_OF_CONDUCT.md which points to prpl foundation's code of
conduct.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>