### PR TITLE
tools: docker - add 'runner' docker support

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -75,11 +75,9 @@ prplmesh_agent_stop() {
 
 start_function() {
     echo "$0: start"
-    if [ `id -u` -ne 0 ]; then
-        err "$0: This command must be run as root"
-        exit 1
-    fi
-    [ "@BWL_TYPE@" = "DUMMY" ] && platform_init_dummy
+    [ `id -u` -ne 0 ] && echo "$0: warning - this commands needs root privileges so might not work (are you root?)"
+
+    [ "@BWL_TYPE@" = "DUMMY" ] && [ "$PLATFORM_INIT" == "true" ] && platform_init_dummy
     [ "@BTL_TYPE@" = "LOCAL_BUS" ] && prplmesh_framework_init
     [ "$PRPLMESH_MODE" = "CA" -o "$PRPLMESH_MODE" = "C" ] && prplmesh_controller_start
     [ "$PRPLMESH_MODE" = "CA" -o "$PRPLMESH_MODE" = "A" ] && prplmesh_agent_start
@@ -87,11 +85,9 @@ start_function() {
 
 stop_function() {
     echo "$0: stop"
-    if [ `id -u` -ne 0 ]; then
-        err "$0: This script must be run as root"
-        exit 1
-    fi
-    [ "@BWL_TYPE@" = "DUMMY" ] && platform_deinit_dummy
+    [ `id -u` -ne 0 ] && echo "$0: warning - this commands needs root privileges so might not work (are you root?)"
+
+    [ "@BWL_TYPE@" = "DUMMY" ] && [ "$PLATFORM_INIT" == "true" ] && platform_deinit_dummy
     [ "@BTL_TYPE@" = "LOCAL_BUS" ] && prplmesh_framework_deinit
     [ "$PRPLMESH_MODE" = "CA" -o "$PRPLMESH_MODE" = "C" ] && prplmesh_controller_stop
     [ "$PRPLMESH_MODE" = "CA" -o "$PRPLMESH_MODE" = "A" ] && prplmesh_agent_stop
@@ -105,11 +101,11 @@ status_function() {
 }
 
 usage() {
-    echo "usage: $(basename $0) {start|stop|restart|status} [-hv]"
+    echo "usage: $(basename $0) {start|stop|restart|status} [-hvsm]"
 }
 
 main() {
-    OPTS=`getopt -o 'hvm:' --long verbose,help,mode: -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvm:s' --long verbose,help,mode:skip-platform -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -117,15 +113,17 @@ main() {
 
     while true; do
         case "$1" in
-            -v | --verbose)      VERBOSE=true; shift ;;
-            -h | --help)         usage; exit 0; shift ;;
-            -m | --mode)         PRPLMESH_MODE="$2"; shift; shift ;;
+            -v | --verbose)       VERBOSE=true; shift ;;
+            -h | --help)          usage; exit 0; shift ;;
+            -m | --mode)          PRPLMESH_MODE="$2"; shift; shift ;;
+            -s | --skip-platform) PLATFORM_INIT=false; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
     done
 
     dbg VERBOSE=$VERBOSE
+    dbg PLATFORM_INIT=$PLATFORM_INIT
 
     case $1 in
         "start")
@@ -147,6 +145,7 @@ main() {
 }
 
 VERBOSE=false
+PLATFORM_INIT=true
 PRPLMESH_MODE="CA" # CA = Controller & Agent, A = Agent only, C = Controller only
 
 main $@

--- a/tools/docker/runner/Dockerfile
+++ b/tools/docker/runner/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+
+# Update Software repository
+RUN apt-get update && apt-get install -y \
+	binutils \
+	libreadline-dev \
+	libncurses-dev \
+	libssl-dev \
+	libjson-c-dev \
+	libnl-genl-3-dev \
+	libzmq3-dev \
+	python \
+	python-yaml \
+	vim \
+	net-tools \
+	bridge-utils \
+	iputils-ping \
+	iproute2 \
+	psmisc \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG installdir
+ARG bridgeip
+
+WORKDIR $installdir
+ADD entrypoint.sh /root/
+ADD start-controller /usr/bin
+ADD start-agent /usr/bin
+ADD start-controller-agent /usr/bin
+
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/tools/docker/runner/README.md
+++ b/tools/docker/runner/README.md
@@ -1,0 +1,25 @@
+# Docker builder image
+
+This folder includes a Dockerfile which can be used to build prplMesh from a container by running maptools.py from the container.
+
+It includes 2 helper scripts - one to generate the image `image-build.sh` and one to actually run `maptools.py build` from the container - `build.sh`.
+
+## Usage
+
+Build the initial image (one time):
+
+```bash
+sudo ./image-build.sh
+```
+
+Build prplMesh in container:
+
+```bash
+sudo ./build.sh <maptools.py build arguments>
+```
+
+---
+
+Proxy settings - the recommended way to work with docker behind a proxy is by [configuring the docker client to pass proxy information to containers automatically](https://docs.docker.com/network/proxy/).
+
+---

--- a/tools/docker/runner/README.md
+++ b/tools/docker/runner/README.md
@@ -1,22 +1,80 @@
-# Docker builder image
+# Docker runner image
 
-This folder includes a Dockerfile which can be used to build prplMesh from a container by running maptools.py from the container.
+This folder includes a Dockerfile and helper scripts which can be used to run prplMesh inside containers.
+It relies on an already built prplMesh by mapping the `build/install` directory to the container.
 
-It includes 2 helper scripts - one to generate the image `image-build.sh` and one to actually run `maptools.py build` from the container - `build.sh`.
+It includes 2 helper scripts - one to generate the image `image-build.sh` and one to actually run the container - `run.sh`.
 
 ## Usage
 
-Build the initial image (one time):
+Using this Dockerfile, you can run 2 containers, one with a controller+agent, the
+other with an agent only.
+The 2 containers are connected using a docker network (bridge), so can
+communicate + sniffed by running wireshark / tcpdump on the bridge from the host to see 1905
+packets.
+
+### Prerequisites
+
+build prplMesh (build/install directory will be the only directory mapped to the
+containers).
 
 ```bash
-sudo ./image-build.sh
+./maptools.py build map -f MSGLIB=zmq BUILD_TESTS=ON CMAKE_BUILD_TYPE=Debug
 ```
 
-Build prplMesh in container:
+Next, build the docker image using `./image-build.sh`.
+
+### Run the Containers
+
+Finally, run 2 containers - we will run one controller, naming it "controller", and one "agent".
+Naming is important to be able to attach to the container easily from other shells (for tailing the logs).
+
+Helper scripts for running controller and agent are provided in the image for running in detached mode.
+In this mode, the container entry command is to run the prplMesh controller / agent / controller & agent.
+After running, we can connect to the container with a new shell using `docker container exec -it <name> bash`.
+
+#### Run Agent+Controller container (detached)
 
 ```bash
-sudo ./build.sh <maptools.py build arguments>
+# start controller+agent in a new container named 'controller' in detached mode
+sudo ./run.sh -n controller -d start-controller-agent
+# attach the controller container and open new bash shell
+sudo docker container exec -it controller bash
+# Now we are inside the container and can tail the controller log
+tail -F /tmp/beerocks/logs/beerocks_controller.log
 ```
+
+#### Run Agent container (detached)
+
+```bash
+# start agent in a new container named 'agent' in detached mode
+sudo ./run.sh -n agent -d start-agent
+# attach the agent container and open new bash shell
+sudo docker container exec -it agent bash
+# Now we are inside the container and can tail the agent log
+tail -F /tmp/beerocks/logs/beerocks_agent.log
+```
+
+#### Running container interactive
+
+If needed, run the container interactively without specifying the daemon to run:
+
+```bash
+# start container named <name> and start interactive session using bash (supplied by the image)
+sudo ./run.sh -n <name>
+```
+
+---
+
+Notes
+
+1. The script automatically selects an IP based on the network, but its not 100% full proof - it generates a random IP in the network subnet, except for the gateway. If more than one container is created on the same network **they might get the same IP** (very rare but keep in mind)
+2. List all running containers `sudo docker container ls`
+3. Connect to any running container using `sudo docker container attach <name>`
+4. Connect to any running container opening a new shell using `docker container exec -it <name> bash`
+5. Kill all containers (running and stopped) `sudo docker rm -f $(sudo docker ps -a -q)` 
+
+---
 
 ---
 

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+run() {
+    echo "$*"
+    "$@" || exit $?
+}
+
+run ip link add br-lan type bridge
+run ip link add wlan0 type dummy up
+run ip link add wlan2 type dummy up
+run ip link set eth0 master br-lan
+run ip link set wlan0 master br-lan
+run ip link set wlan2 master br-lan
+run ifconfig eth0 0.0.0.0
+run ifconfig br-lan ${1} up
+
+shift
+echo $@
+
+#$@
+exec /bin/bash "$@"

--- a/tools/docker/runner/image-build.sh
+++ b/tools/docker/runner/image-build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+run() {
+    echo "$*"
+    "$@" || exit $?
+}
+
+scriptdir="$(cd "${0%/*}"; pwd)"
+installdir="${scriptdir%/*/*/*/*}/build/install"
+
+main() {
+    run docker image build \
+        --build-arg installdir=$installdir \
+        --tag prplmesh-runner \
+        ${scriptdir}
+}
+
+main $@

--- a/tools/docker/runner/run.sh
+++ b/tools/docker/runner/run.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+dbg() {
+    [ "$VERBOSE" = "true" ] && echo "$*"
+}
+
+err() {
+	echo -e '\033[1;31m'"$@"'\033[0m'
+}
+
+run() {
+    dbg "$*"
+    "$@" || exit $?
+}
+
+scriptdir="$(cd "${0%/*}"; pwd)"
+installdir="${scriptdir%/*/*/*/*}/build/install"
+
+usage() {
+    echo "usage: $(basename $0) [-hvd] [-i ip] [-n name] [-N network]"
+    echo "  options:"
+    echo "      -h|--help - show this help menu"
+    echo "      -v|--verbose - verbosity on"
+    echo "      -d|--detach - run in background"
+    echo "      -i|--ipaddr - ipaddr for container br-lan (should be in network subnet)"
+    echo "      -n|--name - container name (for later easy attach)"
+    echo "      -N|--network - docker network to which to attach the container"
+}
+
+iprand(){
+    ipaddr=$1
+    rand=`shuf -i 2-254 -n 1`
+    ip_hex=$(printf '%.2X%.2X%.2X%.2X\n' `echo $ipaddr | sed -e 's/\./ /g'`)
+    ip_hex_rand=$(printf %.8X `echo $(( 0x$ip_hex + $rand ))`)
+    ip_rand=$(printf '%d.%d.%d.%d\n' `echo $ip_hex_rand | sed -r 's/(..)/0x\1 /g'`)
+    echo "$ip_rand"
+}
+
+generate_container_random_ip() {
+    gateway_ip=$(docker network inspect $1 | jq -r '.[0].IPAM.Config'[0].Gateway)
+    echo $(iprand ${gateway_ip})
+}
+
+main() {
+    OPTS=`getopt -o 'hvdi:n:N:o:' --long verbose,help,detach,ipaddr:,name:,network:,options: -n 'parse-options' -- "$@"`
+
+    if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
+
+    eval set -- "$OPTS"
+
+    while true; do
+        case "$1" in
+            -v | --verbose) VERBOSE=true; shift ;;
+            -h | --help)    usage; exit 0; shift ;;
+            -d | --detach)  DETACH=true; shift ;;
+            -i | --ipaddr)  IPADDR="$2"; shift; shift ;;
+            -n | --name)    NAME="$2"; shift; shift ;;
+            -N | --network) NETWORK="$2"; shift; shift ;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1 ;;
+        esac
+    done
+
+    docker network inspect ${NETWORK} >/dev/null 2>&1 || {
+        dbg "Network $NETWORK does not exist, creating..."
+        run docker network create ${NETWORK} >/dev/null 2>&1
+    }
+
+    [ -z "$IPADDR" -a -n "$NETWORK" ] && {
+        dbg "Generate random IP for container $NAME for network $NETWORK"
+        IPADDR=$(generate_container_random_ip $NETWORK)
+    }
+    dbg "VERBOSE=${VERBOSE}"
+    dbg "DETACH=${DETACH}"
+    dbg "NETWORK=${NETWORK}"
+    dbg "IPADDR=${IPADDR}"
+    dbg "NAME=${NAME}"
+
+    DOCKEROPTS="-e USER=${SUDO_USER}
+                --privileged
+                --network ${NETWORK}
+                -v ${installdir}:${installdir}
+                --name ${NAME}"
+
+    if [ "$DETACH" = "false" ]; then
+        DOCKEROPTS="$DOCKEROPTS --interactive --tty --rm"
+    else
+        DOCKEROPTS="$DOCKEROPTS -d"
+    fi
+    
+    run docker container run ${DOCKEROPTS} prplmesh-runner $IPADDR "$@"
+}
+
+VERBOSE=false
+DETACH=false
+NETWORK=prplMesh-net
+IPADDR=
+NAME=prplMesh
+
+main $@

--- a/tools/docker/runner/start-agent
+++ b/tools/docker/runner/start-agent
@@ -1,0 +1,3 @@
+./bin/local_bus &
+./bin/ieee1905_transport &
+./bin/beerocks_agent

--- a/tools/docker/runner/start-controller
+++ b/tools/docker/runner/start-controller
@@ -1,0 +1,3 @@
+./bin/local_bus &
+./bin/ieee1905_transport &
+./bin/beerocks_controller

--- a/tools/docker/runner/start-controller-agent
+++ b/tools/docker/runner/start-controller-agent
@@ -1,0 +1,4 @@
+./bin/local_bus &
+./bin/ieee1905_transport &
+./bin/beerocks_controller &
+./bin/beerocks_agent


### PR DESCRIPTION
# Docker runner image

Dockerfile and helper scripts which can be used to run prplMesh inside containers.
It relies on an already built prplMesh by mapping the `build/install` directory to the container.

It includes 2 helper scripts - one to generate the image `image-build.sh` and one to actually run the container - `run.sh`.

## Usage

Using this Dockerfile, you can run 2 containers, one with a controller+agent, the
other with an agent only.
The 2 containers are connected using a docker network (bridge), so can
communicate + sniffed by running wireshark / tcpdump on the bridge from the host to see 1905
packets.

### Prerequisites

build prplMesh (build/install directory will be the only directory mapped to the
containers).

```bash
./maptools.py build map -f MSGLIB=zmq BUILD_TESTS=ON CMAKE_BUILD_TYPE=Debug
```

Next, build the docker image using `./image-build.sh`.

### Run the Containers

Finally, run 2 containers - we will run one controller, naming it "controller", and one "agent".
Naming is important to be able to attach to the container easily from other shells (for tailing the logs).

Helper scripts for running controller and agent are provided in the image for running in detached mode.
In this mode, the container entry command is to run the prplMesh controller / agent / controller & agent.
After running, we can connect to the container with a new shell using `docker container exec -it <name> bash`.

#### Run Agent+Controller container (detached)

```bash
# start controller+agent in a new container named 'controller' in detached mode
sudo ./run.sh -n controller -d start-controller-agent
# attach the controller container and open new bash shell
sudo docker container exec -it controller bash
# Now we are inside the container and can tail the controller log
tail -F /tmp/beerocks/logs/beerocks_controller.log
```

#### Run Agent container (detached)

```bash
# start agent in a new container named 'agent' in detached mode
sudo ./run.sh -n agent -d start-agent
# attach the agent container and open new bash shell
sudo docker container exec -it agent bash
# Now we are inside the container and can tail the agent log
tail -F /tmp/beerocks/logs/beerocks_agent.log
```

#### Running container interactive

If needed, run the container interactively without specifying the daemon to run:

```bash
# start container named <name> and start interactive session using bash (supplied by the image)
sudo ./run.sh -n <name>
```

---

Notes

1. The script automatically selects an IP based on the network, but its not 100% full proof - it generates a random IP in the network subnet, except for the gateway. If more than one container is created on the same network **they might get the same IP** (very rare but keep in mind)
2. Connect to any running container using `sudo docker container attach <name>`
3. Connect to any running container opening a new shell using `docker container exec -it <name> bash`
4. Kill all containers (running and stopped) `sudo docker rm -f $(sudo docker ps -a -q)` 

---

---

Proxy settings - the recommended way to work with docker behind a proxy is by [configuring the docker client to pass proxy information to containers automatically](https://docs.docker.com/network/proxy/).

---
