### PR TITLE
tools: docker runner - add sources mapping for gdb

### DIFF
--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -15,6 +15,7 @@ run() {
 
 scriptdir="$(cd "${0%/*}"; pwd)"
 installdir="${scriptdir%/*/*/*}/build/install"
+sourcesdir="${scriptdir%/*/*}"
 
 usage() {
     echo "usage: $(basename $0) [-hvd] [-i ip] [-n name] [-N network]"
@@ -86,6 +87,7 @@ main() {
                 --privileged
                 --network ${NETWORK}
                 -v ${installdir}:${installdir}
+                -v ${sourcesdir}:${sourcesdir}
                 --name ${NAME}"
 
     if [ "$DETACH" = "false" ]; then


### PR DESCRIPTION
Add sources mapping for runner containers so that it will be possible to
debug the containers with gdb.