### PR TITLE
 framework: transport: fix cmdu fragmentation/reassembly

### DIFF
--- a/framework/transport/ieee1905_transport/ieee1905_transport_packet_processing.cpp
+++ b/framework/transport/ieee1905_transport/ieee1905_transport_packet_processing.cpp
@@ -225,6 +225,11 @@ bool Ieee1905Transport::de_fragment_packet(Packet &packet)
 
     // concat the fragment body (excluding the IEEE1905 header)
     size_t fragmentTlvsLength = packet.payload.iov_len - sizeof(Ieee1905CmduHeader);
+    // Only count end of message TLV for the last fragment
+    if (ch->GetLastFragmentIndicator() == 0) {
+        fragmentTlvsLength -= sizeof(Tlv);
+    }
+
     if (val.bufIndex + fragmentTlvsLength >= kMaximumDeFragmentionSize) {
         MAPF_WARN("defragmentation buffer overflow - dropping fragment");
         return false;


### PR DESCRIPTION
Current state in the transport code for fragmented packets is to send
each fragment as is, so the first fragment will not include end of
message TLV. Found out by functional testing with containers and
sniffing using wireshark, this is not in par with the ieee1905
specification.

The actual reason that end of message TLV must exist for each CMDU, is
due to the simple fact that there is no message length in the CMDU
header, hence it is impossible for a receiver to know when the fragment
ends without end of message TLV.

This change fixes this by initially allocating and zeroing out the last
3 bytes of each fragment, thus enforcing end of message TLV for each
transmitted fragment.
(In addition, add a workaround not to drop fragment if there is a
mismatch with the fragment length (more bytes after end of message TLV).
Currently the last fragment has this issue, so make that a warning for
now)

On reassembly, simply ignore the last 3 bytes (size of TLV header) for every fragment but the last.
