### PR TITLE
common: bwl: dummy - add dummy acs_report

### DIFF
--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -161,7 +161,51 @@ bool ap_wlan_hal_dummy::restricted_channels_set(char *channel_list) { return tru
 
 bool ap_wlan_hal_dummy::restricted_channels_get(char *channel_list) { return false; }
 
-bool ap_wlan_hal_dummy::read_acs_report() { return true; }
+bool ap_wlan_hal_dummy::read_acs_report()
+{
+    uint8_t idx = 0;
+    if (m_radio_info.is_5ghz == false) {
+        // 2.4G simulated report
+        for (uint16_t ch = 1; ch <= 11; ch++) {
+            m_radio_info.supported_channels[idx].channel     = ch;
+            m_radio_info.supported_channels[idx].bandwidth   = 20;
+            m_radio_info.supported_channels[idx].bss_overlap = 10;
+            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            idx++;
+        }
+    } else {
+        // 5G simulated report
+        for (uint16_t ch = 36; ch <= 64; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                idx++;
+            }
+        }
+        for (uint16_t ch = 100; ch <= 144; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                idx++;
+            }
+        }
+        for (uint16_t ch = 149; ch <= 165; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                idx++;
+            }
+        }
+    }
+
+    return true;
+}
 
 bool ap_wlan_hal_dummy::set_vap_enable(const std::string &iface_name, const bool enable)
 {

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -105,7 +105,13 @@ bool base_wlan_hal_dummy::dummy_send_cmd(const std::string &cmd) { return false;
 
 bool base_wlan_hal_dummy::dummy_send_cmd(const std::string &cmd, char **reply) { return false; }
 
-bool base_wlan_hal_dummy::refresh_radio_info() { return true; }
+bool base_wlan_hal_dummy::refresh_radio_info()
+{
+    if (get_iface_name() == "wlan2") {
+        m_radio_info.is_5ghz = true;
+    }
+    return true;
+}
 
 bool base_wlan_hal_dummy::refresh_vap_info(int vap_id) { return true; }
 


### PR DESCRIPTION
Add dummy acs_report for 2.4G so that channel selection FSM will
complete and the agent will get operational (simulate ACS and CSA).

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>