### PR TITLE
Hotfix/cmdu tx message id fix

### DIFF
--- a/common/beerocks/btl/btl_local_bus.cpp
+++ b/common/beerocks/btl/btl_local_bus.cpp
@@ -229,9 +229,10 @@ bool transport_socket_thread::bus_send(ieee1905_1::CmduMessage &cmdu, const std:
     net::network_utils::mac_from_string(msg.metadata()->src, src_mac);
     net::network_utils::mac_from_string(msg.metadata()->dst, dst_mac);
 
-    msg.metadata()->ether_type = ETH_P_1905_1;
-    msg.metadata()->length     = length;
-    msg.metadata()->msg_type   = static_cast<uint16_t>(cmdu.getMessageType());
+    msg.metadata()->ether_type        = ETH_P_1905_1;
+    msg.metadata()->length            = length;
+    msg.metadata()->msg_type          = static_cast<uint16_t>(cmdu.getMessageType());
+    msg.metadata()->preset_message_id = cmdu.getMessageId() ? 1 : 0;
 
     std::copy_n((uint8_t *)cmdu.getMessageBuff(), msg.metadata()->length, (uint8_t *)msg.data());
     return bus->publisher().Send(msg);

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -73,6 +73,7 @@ public:
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
     eMessageType getMessageType();
+    uint16_t getMessageId();
 
 protected:
     void reset();

--- a/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
@@ -132,3 +132,14 @@ eMessageType CmduMessage::getMessageType()
 
     return (eMessageType)msgValue;
 }
+
+uint16_t CmduMessage::getMessageId()
+{
+    uint16_t mid = getCmduHeader()->message_id();
+
+    if (m_swap && !m_swapped) {
+        swap_16((uint16_t &)mid);
+    }
+
+    return mid;
+}

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -70,6 +70,7 @@ public:
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
     eMessageType getMessageType();
+    uint16_t getMessageId();
 
 protected:
     void reset();

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -129,3 +129,14 @@ eMessageType CmduMessage::getMessageType()
 
     return (eMessageType)msgValue;
 }
+
+uint16_t CmduMessage::getMessageId()
+{
+    uint16_t mid = getCmduHeader()->message_id();
+
+    if (m_swap && !m_swapped) {
+        swap_16((uint16_t &)mid);
+    }
+
+    return mid;
+}


### PR DESCRIPTION
When parsing a CmduMessageRx, the CMDU header is never swapped (CmduMessageRx::parse)
since it may be parsed multiple times when forwarded over UDS.
For that reason, any CMDU header field needs to have a special getter function that will handle endianness.
Currently, there is a single such getter - `CmduMessage::getMessageType()`.

This PR adds `CmduMessage::getMessageId()` which is needed when the upper layer needs to reply with a CMDU with the same MID.

In addition, update BTL to set the preset_message_id to be true if there is a none
zero MID in the CMDU header.