### PR TITLE
framework: tlvf: refactor to use single sMacAddr

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.h
+++ b/agent/src/beerocks/slave/ap_manager_thread.h
@@ -30,7 +30,7 @@ public:
         beerocks::eIfaceType hostap_iface_type;
         bool acs_enabled;
         bool iface_filter_low;
-        beerocks::net::sMacAddr *backhaul_vaps_bssid; // array
+        sMacAddr *backhaul_vaps_bssid; // array
     };
 
     void ap_manager_config(ap_manager_conf_t &conf);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -817,7 +817,7 @@ bool main_thread::send_autoconfig_search_message(std::shared_ptr<SSlaveSockets> 
         LOG(ERROR) << "addClass ieee1905_1::tlvAlMacAddressType failed";
         return false;
     }
-    network_utils::mac_from_string(tlvAlMacAddressType->mac().mac, bridge_info.mac);
+    network_utils::mac_from_string(tlvAlMacAddressType->mac().oct, bridge_info.mac);
 
     auto tlvSearchedRole = cmdu_tx.addClass<ieee1905_1::tlvSearchedRole>();
     if (!tlvSearchedRole) {

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
@@ -74,7 +74,7 @@ private:
 
     Socket *get_backhaul_socket();
     void load_iface_params(const std::string &strIface, beerocks::eArpSource eType);
-    std::string bridge_iface_from_mac(const net::sMacAddr &sMac);
+    std::string bridge_iface_from_mac(const sMacAddr &sMac);
     void send_dhcp_notification(std::string op, std::string mac, std::string ip,
                                 std::string hostname);
     void arp_entries_cleanup();

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3808,8 +3808,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             LOG(ERROR) << "Error creating TLV_AP_RADIO_BASIC_CAPABILITIES";
             return false;
         }
-        std::copy_n(network_utils::mac_from_string(config.radio_identifier).oct,
-                    beerocks::net::MAC_ADDR_LEN, tlvAp->radio_uid().mac);
+        std::copy_n(network_utils::mac_from_string(config.radio_identifier).oct, sizeof(sMacAddr),
+                    tlvAp->radio_uid().oct);
         tlvAp->maximum_number_of_bsss_supported() =
             beerocks::IFACE_TOTAL_VAPS; //TODO get maximum supported VAPs from DWPAL
 
@@ -3845,8 +3845,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             return false;
         }
 
-        std::copy_n(hostap_params.iface_mac.oct, beerocks::net::MAC_ADDR_LEN,
-                    tlvWscM1->M1Frame().mac_attr.data.mac);
+        std::copy_n(hostap_params.iface_mac.oct, sizeof(sMacAddr),
+                    tlvWscM1->M1Frame().mac_attr.data.oct);
         // TODO: read manufactured, name, model and device name from BPL
         string_utils::copy_string(tlvWscM1->M1Frame().manufacturer_attr.data, "prpl", 5);
         string_utils::copy_string(tlvWscM1->M1Frame().model_name_attr.data, "Ubuntu", 7);

--- a/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
@@ -13,6 +13,15 @@
 #include <stdint.h>
 #include <string>
 
+#include <tlvf/common/sMacAddr.h>
+
+inline bool operator==(sMacAddr const &lhs, sMacAddr const &rhs)
+{
+    return (0 == std::memcmp(lhs.oct, rhs.oct, sizeof(sMacAddr)));
+}
+
+inline bool operator!=(sMacAddr const &lhs, sMacAddr const &rhs) { return !(rhs == lhs); }
+
 namespace beerocks {
 namespace net {
 
@@ -31,18 +40,6 @@ typedef struct sIpv4Addr {
     }
     bool operator!=(sIpv4Addr const &rhs) const { return !(rhs == *this); }
 } __attribute__((packed)) sIpv4Addr;
-
-typedef struct sMacAddr {
-    uint8_t oct[MAC_ADDR_LEN];
-
-    void struct_swap() {}
-    void struct_init() { std::memset(oct, 0, MAC_ADDR_LEN); }
-    bool operator==(sMacAddr const &rhs) const
-    {
-        return (0 == std::memcmp(this->oct, rhs.oct, MAC_ADDR_LEN));
-    }
-    bool operator!=(sMacAddr const &rhs) const { return !(rhs == *this); }
-} __attribute__((packed)) sMacAddr;
 
 typedef struct sScanResult {
     sMacAddr mac;

--- a/common/beerocks/bwl/common/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/common/base_wlan_hal_types.h
@@ -111,7 +111,7 @@ typedef struct {
 
 typedef struct {
     uint32_t disconnect_reason;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr bssid;
 } sACTION_BACKHAUL_DISCONNECT_REASON_NOTIFICATION;
 
 typedef struct {
@@ -157,8 +157,8 @@ typedef struct {
 } sACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE;
 
 typedef struct {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint8_t rx_snr;
     uint8_t blocked;   // True if response blocked.
     uint8_t broadcast; // True if broadcast probe.
@@ -169,8 +169,8 @@ typedef struct {
 } sACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION;
 
 typedef struct {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint8_t rx_snr;
     uint8_t reason;
     uint8_t blocked; // True if response blocked.
@@ -182,7 +182,7 @@ typedef struct {
 } sACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION;
 
 typedef struct {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     beerocks::message::sRadioCapabilities capabilities;
     int8_t vap_id;
     uint8_t reserved1;
@@ -191,7 +191,7 @@ typedef struct {
 } sClientAssociationParams;
 
 typedef struct {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     int8_t vap_id;
     uint8_t reason;
     uint8_t source;
@@ -207,7 +207,7 @@ typedef struct {
 } sACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION;
 
 typedef struct {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint8_t status_code;
     uint8_t reserved1;
     uint8_t reserved2;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -35,16 +35,16 @@ class cACTION_APMANAGER_4ADDR_STA_JOINED : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_4ADDR_STA_JOINED);
         }
-        beerocks::net::sMacAddr& src_mac();
-        beerocks::net::sMacAddr& dst_mac();
+        sMacAddr& src_mac();
+        sMacAddr& dst_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_src_mac = nullptr;
-        beerocks::net::sMacAddr* m_dst_mac = nullptr;
+        sMacAddr* m_src_mac = nullptr;
+        sMacAddr* m_dst_mac = nullptr;
 };
 
 class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
@@ -360,14 +360,14 @@ class cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE : public BaseClass
@@ -380,14 +380,14 @@ class cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
@@ -480,7 +480,7 @@ class cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         int8_t& vap_id();
         uint32_t& type();
         uint32_t& reason();
@@ -490,7 +490,7 @@ class cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         int8_t* m_vap_id = nullptr;
         uint32_t* m_type = nullptr;
         uint32_t* m_reason = nullptr;
@@ -526,7 +526,7 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_DISALLOW_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         uint8_t& reject_sta();
         void class_swap();
         static size_t get_initial_size();
@@ -534,7 +534,7 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         uint8_t* m_reject_sta = nullptr;
 };
 
@@ -548,7 +548,7 @@ class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_ALLOW_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         beerocks::net::sIpv4Addr& ipv4();
         void class_swap();
         static size_t get_initial_size();
@@ -556,7 +556,7 @@ class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
 };
 
@@ -610,14 +610,14 @@ class cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST : public BaseClass
@@ -670,14 +670,14 @@ class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseCla
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -116,7 +116,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         bool set_bridge_iface(std::string& str);
         bool set_bridge_iface(const std::string& str);
         bool set_bridge_iface(char buffer[], size_t size);
-        beerocks::net::sMacAddr& iface_mac();
+        sMacAddr& iface_mac();
         uint8_t& iface_is_5ghz();
         char* wire_iface(size_t length = 0);
         bool set_wire_iface(std::string& str);
@@ -139,7 +139,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         bool set_pass(const std::string& str);
         bool set_pass(char buffer[], size_t size);
         uint32_t& security_type();
-        beerocks::net::sMacAddr& preferred_bssid();
+        sMacAddr& preferred_bssid();
         uint8_t& wire_iface_type();
         uint8_t& wireless_iface_type();
         uint8_t& wired_backhaul();
@@ -151,7 +151,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         eActionOp_BACKHAUL* m_action_op = nullptr;
         char* m_bridge_iface = nullptr;
         size_t m_bridge_iface_idx__ = 0;
-        beerocks::net::sMacAddr* m_iface_mac = nullptr;
+        sMacAddr* m_iface_mac = nullptr;
         uint8_t* m_iface_is_5ghz = nullptr;
         char* m_wire_iface = nullptr;
         size_t m_wire_iface_idx__ = 0;
@@ -164,7 +164,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         char* m_pass = nullptr;
         size_t m_pass_idx__ = 0;
         uint32_t* m_security_type = nullptr;
-        beerocks::net::sMacAddr* m_preferred_bssid = nullptr;
+        sMacAddr* m_preferred_bssid = nullptr;
         uint8_t* m_wire_iface_type = nullptr;
         uint8_t* m_wireless_iface_type = nullptr;
         uint8_t* m_wired_backhaul = nullptr;
@@ -278,14 +278,14 @@ class cACTION_BACKHAUL_4ADDR_CONNECTED : public BaseClass
         static eActionOp_BACKHAUL get_action_op(){
             return (eActionOp_BACKHAUL)(ACTION_BACKHAUL_4ADDR_CONNECTED);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_BACKHAUL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION : public BaseClass
@@ -378,14 +378,14 @@ class cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClas
         static eActionOp_BACKHAUL get_action_op(){
             return (eActionOp_BACKHAUL)(ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_BACKHAUL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 }; // close namespace: beerocks_message

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -1325,8 +1325,8 @@ class cACTION_BML_STEERING_CLIENT_SET_REQUEST : public BaseClass
             return (eActionOp_BML)(ACTION_BML_STEERING_CLIENT_SET_REQUEST);
         }
         uint32_t& steeringGroupIndex();
-        beerocks::net::sMacAddr& bssid();
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& bssid();
+        sMacAddr& client_mac();
         sSteeringClientConfig& config();
         uint8_t& remove();
         void class_swap();
@@ -1336,8 +1336,8 @@ class cACTION_BML_STEERING_CLIENT_SET_REQUEST : public BaseClass
         bool init();
         eActionOp_BML* m_action_op = nullptr;
         uint32_t* m_steeringGroupIndex = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_client_mac = nullptr;
         sSteeringClientConfig* m_config = nullptr;
         uint8_t* m_remove = nullptr;
 };
@@ -1413,8 +1413,8 @@ class cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST : public BaseClass
             return (eActionOp_BML)(ACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST);
         }
         uint32_t& steeringGroupIndex();
-        beerocks::net::sMacAddr& bssid();
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& bssid();
+        sMacAddr& client_mac();
         eDisconnectType& type();
         uint32_t& reason();
         void class_swap();
@@ -1424,8 +1424,8 @@ class cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST : public BaseClass
         bool init();
         eActionOp_BML* m_action_op = nullptr;
         uint32_t* m_steeringGroupIndex = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_client_mac = nullptr;
         eDisconnectType* m_type = nullptr;
         uint32_t* m_reason = nullptr;
 };
@@ -1461,8 +1461,8 @@ class cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST : public BaseClass
             return (eActionOp_BML)(ACTION_BML_STEERING_CLIENT_MEASURE_REQUEST);
         }
         uint32_t& steeringGroupIndex();
-        beerocks::net::sMacAddr& bssid();
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& bssid();
+        sMacAddr& client_mac();
         void class_swap();
         static size_t get_initial_size();
 
@@ -1470,8 +1470,8 @@ class cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST : public BaseClass
         bool init();
         eActionOp_BML* m_action_op = nullptr;
         uint32_t* m_steeringGroupIndex = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_client_mac = nullptr;
 };
 
 class cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE : public BaseClass
@@ -1531,16 +1531,16 @@ class cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST);
         }
-        beerocks::net::sMacAddr& al_mac();
-        beerocks::net::sMacAddr& ruid();
+        sMacAddr& al_mac();
+        sMacAddr& ruid();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_BML* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_al_mac = nullptr;
-        beerocks::net::sMacAddr* m_ruid = nullptr;
+        sMacAddr* m_al_mac = nullptr;
+        sMacAddr* m_ruid = nullptr;
 };
 
 }; // close namespace: beerocks_message

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli.h
@@ -166,8 +166,8 @@ class cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CROSS_RX_RSSI_MEASUREMENT);
         }
-        beerocks::net::sMacAddr& client_mac();
-        beerocks::net::sMacAddr& hostap_mac();
+        sMacAddr& client_mac();
+        sMacAddr& hostap_mac();
         uint16_t& center_frequency();
         void class_swap();
         static size_t get_initial_size();
@@ -175,8 +175,8 @@ class cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
-        beerocks::net::sMacAddr* m_hostap_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_hostap_mac = nullptr;
         uint16_t* m_center_frequency = nullptr;
 };
 
@@ -190,14 +190,14 @@ class cACTION_CLI_OPTIMAL_PATH_TASK : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_OPTIMAL_PATH_TASK);
         }
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& client_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
 };
 
 class cACTION_CLI_LOAD_BALANCER_TASK : public BaseClass
@@ -210,14 +210,14 @@ class cACTION_CLI_LOAD_BALANCER_TASK : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_LOAD_BALANCER_TASK);
         }
-        beerocks::net::sMacAddr& ap_mac();
+        sMacAddr& ap_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_ap_mac = nullptr;
+        sMacAddr* m_ap_mac = nullptr;
 };
 
 class cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK : public BaseClass
@@ -248,14 +248,14 @@ class cACTION_CLI_DUMP_NODE_INFO : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_DUMP_NODE_INFO);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CLI_PING_SLAVE_REQUEST : public BaseClass
@@ -268,7 +268,7 @@ class cACTION_CLI_PING_SLAVE_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_PING_SLAVE_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         uint16_t& num_of_req();
         uint16_t& size();
         void class_swap();
@@ -277,7 +277,7 @@ class cACTION_CLI_PING_SLAVE_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         uint16_t* m_num_of_req = nullptr;
         uint16_t* m_size = nullptr;
 };
@@ -314,14 +314,14 @@ class cACTION_CLI_BACKHAUL_SCAN_RESULTS : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_BACKHAUL_SCAN_RESULTS);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CLI_BACKHAUL_ROAM_REQUEST : public BaseClass
@@ -334,16 +334,16 @@ class cACTION_CLI_BACKHAUL_ROAM_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_BACKHAUL_ROAM_REQUEST);
         }
-        beerocks::net::sMacAddr& slave_mac();
-        beerocks::net::sMacAddr& bssid();
+        sMacAddr& slave_mac();
+        sMacAddr& bssid();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_slave_mac = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_slave_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
 };
 
 class cACTION_CLI_CLIENT_ALLOW_REQUEST : public BaseClass
@@ -356,16 +356,16 @@ class cACTION_CLI_CLIENT_ALLOW_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_ALLOW_REQUEST);
         }
-        beerocks::net::sMacAddr& client_mac();
-        beerocks::net::sMacAddr& hostap_mac();
+        sMacAddr& client_mac();
+        sMacAddr& hostap_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
-        beerocks::net::sMacAddr* m_hostap_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_hostap_mac = nullptr;
 };
 
 class cACTION_CLI_CLIENT_DISALLOW_REQUEST : public BaseClass
@@ -378,16 +378,16 @@ class cACTION_CLI_CLIENT_DISALLOW_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_DISALLOW_REQUEST);
         }
-        beerocks::net::sMacAddr& client_mac();
-        beerocks::net::sMacAddr& hostap_mac();
+        sMacAddr& client_mac();
+        sMacAddr& hostap_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
-        beerocks::net::sMacAddr* m_hostap_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_hostap_mac = nullptr;
 };
 
 class cACTION_CLI_CLIENT_DISCONNECT_REQUEST : public BaseClass
@@ -400,7 +400,7 @@ class cACTION_CLI_CLIENT_DISCONNECT_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_DISCONNECT_REQUEST);
         }
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& client_mac();
         uint32_t& type();
         uint32_t& reason();
         void class_swap();
@@ -409,7 +409,7 @@ class cACTION_CLI_CLIENT_DISCONNECT_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
         uint32_t* m_type = nullptr;
         uint32_t* m_reason = nullptr;
 };
@@ -424,8 +424,8 @@ class cACTION_CLI_CLIENT_BSS_STEER_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_BSS_STEER_REQUEST);
         }
-        beerocks::net::sMacAddr& client_mac();
-        beerocks::net::sMacAddr& bssid();
+        sMacAddr& client_mac();
+        sMacAddr& bssid();
         uint32_t& disassoc_timer();
         void class_swap();
         static size_t get_initial_size();
@@ -433,8 +433,8 @@ class cACTION_CLI_CLIENT_BSS_STEER_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
         uint32_t* m_disassoc_timer = nullptr;
 };
 
@@ -448,16 +448,16 @@ class cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& hostap_mac();
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& hostap_mac();
+        sMacAddr& client_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_hostap_mac = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_hostap_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
 };
 
 class cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
@@ -470,8 +470,8 @@ class cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& hostap_mac();
-        beerocks::net::sMacAddr& client_mac();
+        sMacAddr& hostap_mac();
+        sMacAddr& client_mac();
         uint8_t& channel();
         void class_swap();
         static size_t get_initial_size();
@@ -479,8 +479,8 @@ class cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_hostap_mac = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_hostap_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
         uint8_t* m_channel = nullptr;
 };
 
@@ -494,8 +494,8 @@ class cACTION_CLI_CLIENT_BEACON_11K_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_BEACON_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& client_mac();
-        beerocks::net::sMacAddr& bssid();
+        sMacAddr& client_mac();
+        sMacAddr& bssid();
         std::tuple<bool, uint8_t&> ssid(size_t idx);
         uint8_t& use_optional_ssid();
         uint8_t& channel();
@@ -510,8 +510,8 @@ class cACTION_CLI_CLIENT_BEACON_11K_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
         uint8_t* m_ssid = nullptr;
         size_t m_ssid_idx__ = 0;
         uint8_t* m_use_optional_ssid = nullptr;
@@ -533,9 +533,9 @@ class cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_CLIENT_STATISTICS_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& hostap_mac();
-        beerocks::net::sMacAddr& client_mac();
-        beerocks::net::sMacAddr& peer_mac();
+        sMacAddr& hostap_mac();
+        sMacAddr& client_mac();
+        sMacAddr& peer_mac();
         uint8_t& group_identity();
         void class_swap();
         static size_t get_initial_size();
@@ -543,9 +543,9 @@ class cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_hostap_mac = nullptr;
-        beerocks::net::sMacAddr* m_client_mac = nullptr;
-        beerocks::net::sMacAddr* m_peer_mac = nullptr;
+        sMacAddr* m_hostap_mac = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+        sMacAddr* m_peer_mac = nullptr;
         uint8_t* m_group_identity = nullptr;
 };
 
@@ -559,7 +559,7 @@ class cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         sApChannelSwitch& cs_params();
         void class_swap();
         static size_t get_initial_size();
@@ -567,7 +567,7 @@ class cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
 };
 
@@ -581,14 +581,14 @@ class cACTION_CLI_HOSTAP_TX_ON_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_HOSTAP_TX_ON_REQUEST);
         }
-        beerocks::net::sMacAddr& ap_mac();
+        sMacAddr& ap_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_ap_mac = nullptr;
+        sMacAddr* m_ap_mac = nullptr;
 };
 
 class cACTION_CLI_HOSTAP_TX_OFF_REQUEST : public BaseClass
@@ -601,14 +601,14 @@ class cACTION_CLI_HOSTAP_TX_OFF_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_HOSTAP_TX_OFF_REQUEST);
         }
-        beerocks::net::sMacAddr& ap_mac();
+        sMacAddr& ap_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_ap_mac = nullptr;
+        sMacAddr* m_ap_mac = nullptr;
 };
 
 class cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
@@ -621,8 +621,8 @@ class cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& ap_mac();
-        beerocks::net::sMacAddr& bssid();
+        sMacAddr& ap_mac();
+        sMacAddr& bssid();
         uint8_t& channel();
         int8_t& vap_id();
         void class_swap();
@@ -631,8 +631,8 @@ class cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_ap_mac = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_ap_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
         uint8_t* m_channel = nullptr;
         int8_t* m_vap_id = nullptr;
 };
@@ -647,8 +647,8 @@ class cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& ap_mac();
-        beerocks::net::sMacAddr& bssid();
+        sMacAddr& ap_mac();
+        sMacAddr& bssid();
         int8_t& vap_id();
         void class_swap();
         static size_t get_initial_size();
@@ -656,8 +656,8 @@ class cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_ap_mac = nullptr;
-        beerocks::net::sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_ap_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
         int8_t* m_vap_id = nullptr;
 };
 
@@ -671,14 +671,14 @@ class cACTION_CLI_HOSTAP_STATS_MEASUREMENT : public BaseClass
         static eActionOp_CLI get_action_op(){
             return (eActionOp_CLI)(ACTION_CLI_HOSTAP_STATS_MEASUREMENT);
         }
-        beerocks::net::sMacAddr& ap_mac();
+        sMacAddr& ap_mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CLI* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_ap_mac = nullptr;
+        sMacAddr* m_ap_mac = nullptr;
 };
 
 }; // close namespace: beerocks_message

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli_net_map.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli_net_map.h
@@ -21,7 +21,7 @@
 namespace beerocks_message {
 
 typedef struct sCliNetworkMapNodeAp {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint16_t length;
     uint8_t hierarchy;
     void struct_swap(){
@@ -34,7 +34,7 @@ typedef struct sCliNetworkMapNodeAp {
 } __attribute__((packed)) sCliNetworkMapNodeAp;
 
 typedef struct sCliNetworkMapNodeSta {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint8_t type;
     int8_t rx_rssi;
     void struct_swap(){
@@ -46,7 +46,7 @@ typedef struct sCliNetworkMapNodeSta {
 } __attribute__((packed)) sCliNetworkMapNodeSta;
 
 typedef struct sCliNetworkMapsNodeInfo {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     beerocks::net::sIpv4Addr ipv4;
     char name[beerocks::message::NODE_NAME_LENGTH];
     uint8_t type;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -37,7 +37,7 @@ enum eDHCPOp: uint8_t {
 };
 
 typedef struct sVapInfo {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
     uint8_t backhaul_vap;
     void struct_swap(){
@@ -96,7 +96,7 @@ typedef struct sPlatformSettings {
     uint8_t backhaul_max_vaps;
     uint8_t backhaul_network_enabled;
     uint8_t backhaul_prefered_radio_band;
-    beerocks::net::sMacAddr backhaul_vaps_bssid[12];
+    sMacAddr backhaul_vaps_bssid[12];
     void struct_swap(){
         for (size_t i = 0; i < 12; i++){
             (backhaul_vaps_bssid[i]).struct_swap();
@@ -190,8 +190,8 @@ typedef struct sWifiChannel {
 } __attribute__((packed)) sWifiChannel;
 
 typedef struct sClientAssociationParams {
-    beerocks::net::sMacAddr mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr mac;
+    sMacAddr bssid;
     beerocks::message::sRadioCapabilities capabilities;
     int8_t vap_id;
     void struct_swap(){
@@ -207,8 +207,8 @@ typedef struct sClientAssociationParams {
 } __attribute__((packed)) sClientAssociationParams;
 
 typedef struct sClientDisconnectionParams {
-    beerocks::net::sMacAddr mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr mac;
+    sMacAddr bssid;
     int8_t vap_id;
     uint8_t reason;
     uint8_t source;
@@ -224,8 +224,8 @@ typedef struct sClientDisconnectionParams {
 } __attribute__((packed)) sClientDisconnectionParams;
 
 typedef struct sClientMonitoringParams {
-    beerocks::net::sMacAddr mac;
-    beerocks::net::sMacAddr bridge_4addr_mac;
+    sMacAddr mac;
+    sMacAddr bridge_4addr_mac;
     beerocks::net::sIpv4Addr ipv4;
     uint8_t channel;
     int8_t vap_id;
@@ -258,7 +258,7 @@ typedef struct sConfigVapInfo {
 } __attribute__((packed)) sConfigVapInfo;
 
 typedef struct sStaStatsParams {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint32_t rx_packets;
     uint32_t tx_packets;
     uint32_t tx_bytes;
@@ -338,7 +338,7 @@ typedef struct sApActivityNotificationParams {
 } __attribute__((packed)) sApActivityNotificationParams;
 
 typedef struct sNodeRssiMeasurementRequest {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     beerocks::net::sIpv4Addr ipv4;
     uint8_t channel;
     uint8_t cross;
@@ -379,7 +379,7 @@ typedef struct sNodeRssiMeasurement {
 typedef struct sNodeHostap {
     char iface_name[beerocks::message::IFACE_NAME_LENGTH];
     uint8_t iface_type;
-    beerocks::net::sMacAddr iface_mac;
+    sMacAddr iface_mac;
     uint8_t iface_is_5ghz;
     uint8_t ant_num;
     uint8_t ant_gain;
@@ -415,7 +415,7 @@ typedef struct sVapsList {
 } __attribute__((packed)) sVapsList;
 
 typedef struct sArpMonitorData {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     beerocks::net::sIpv4Addr ipv4;
     uint32_t iface_idx;
     uint8_t state;
@@ -433,7 +433,7 @@ typedef struct sArpMonitorData {
 } __attribute__((packed)) sArpMonitorData;
 
 typedef struct sArpQuery {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     beerocks::net::sIpv4Addr ipv4;
     void struct_swap(){
         mac.struct_swap();
@@ -446,7 +446,7 @@ typedef struct sArpQuery {
 } __attribute__((packed)) sArpQuery;
 
 typedef struct sNodeBssSteerTarget {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint8_t channel;
     void struct_swap(){
         mac.struct_swap();
@@ -457,7 +457,7 @@ typedef struct sNodeBssSteerTarget {
 } __attribute__((packed)) sNodeBssSteerTarget;
 
 typedef struct sNodeBssSteerRequest {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint16_t disassoc_timer;
     uint8_t disassoc_imminent;
     sNodeBssSteerTarget bssid;
@@ -473,7 +473,7 @@ typedef struct sNodeBssSteerRequest {
 } __attribute__((packed)) sNodeBssSteerRequest;
 
 typedef struct sNodeBssSteerResponse {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint8_t status_code;
     void struct_swap(){
         mac.struct_swap();
@@ -484,7 +484,7 @@ typedef struct sNodeBssSteerResponse {
 } __attribute__((packed)) sNodeBssSteerResponse;
 
 typedef struct sNeighborSetParams11k {
-    beerocks::net::sMacAddr bssid;
+    sMacAddr bssid;
     char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
     uint8_t op_class;
     uint8_t channel;
@@ -513,7 +513,7 @@ typedef struct sNeighborSetParams11k {
 } __attribute__((packed)) sNeighborSetParams11k;
 
 typedef struct sNeighborRemoveParams11k {
-    beerocks::net::sMacAddr bssid;
+    sMacAddr bssid;
     char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
     int8_t vap_id;
     void struct_swap(){
@@ -530,7 +530,7 @@ typedef struct sStaChannelLoadRequest11k {
     uint16_t repeats;
     uint16_t rand_ival;
     uint16_t duration;
-    beerocks::net::sMacAddr sta_mac;
+    sMacAddr sta_mac;
     uint8_t parallel;
     uint8_t enable;
     uint8_t request;
@@ -566,7 +566,7 @@ typedef struct sStaChannelLoadResponse11k {
     uint8_t measurement_token;
     uint16_t duration;
     uint64_t start_time;
-    beerocks::net::sMacAddr sta_mac;
+    sMacAddr sta_mac;
     uint8_t use_optional_wide_band_ch_switch;
     uint32_t new_ch_width;
     uint32_t new_ch_center_freq_seg_0;
@@ -591,8 +591,8 @@ typedef struct sBeaconRequest11k {
     uint16_t repeats;
     uint16_t rand_ival;
     uint16_t duration;
-    beerocks::net::sMacAddr sta_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr sta_mac;
+    sMacAddr bssid;
     uint8_t parallel;
     uint8_t enable;
     uint8_t request;
@@ -640,8 +640,8 @@ typedef struct sBeaconResponse11k {
     uint16_t duration;
     uint32_t parent_tsf;
     uint64_t start_time;
-    beerocks::net::sMacAddr sta_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr sta_mac;
+    sMacAddr bssid;
     uint32_t new_ch_width;
     uint32_t new_ch_center_freq_seg_0;
     uint32_t new_ch_center_freq_seg_1;
@@ -663,8 +663,8 @@ typedef struct sBeaconResponse11k {
 } __attribute__((packed)) sBeaconResponse11k;
 
 typedef struct sStatisticsRequest11k {
-    beerocks::net::sMacAddr sta_mac;
-    beerocks::net::sMacAddr peer_mac_addr;
+    sMacAddr sta_mac;
+    sMacAddr peer_mac_addr;
     uint8_t group_identity;
     uint8_t parallel;
     uint8_t enable;
@@ -728,7 +728,7 @@ typedef struct sStatisticsResponse11k {
     uint16_t statistics_group_data_size;
     uint16_t duration;
     uint32_t statistics_group_data[13];
-    beerocks::net::sMacAddr sta_mac;
+    sMacAddr sta_mac;
     uint8_t use_optional_rep_reason;
     uint8_t average_trigger;
     uint8_t consecutive_trigger;
@@ -755,7 +755,7 @@ typedef struct sLinkMeasurementsResponse11k {
     uint8_t rsni;
     uint8_t transmit_power;
     uint8_t link_margin;
-    beerocks::net::sMacAddr sta_mac;
+    sMacAddr sta_mac;
     uint8_t use_optional_dmg_link_margin;
     uint8_t dmg_link_margin_activity;
     uint8_t dmg_link_margin_mcs;
@@ -777,13 +777,13 @@ typedef struct sLinkMeasurementsResponse11k {
 
 typedef struct sBackhaulParams {
     beerocks::net::sIpv4Addr gw_ipv4;
-    beerocks::net::sMacAddr gw_bridge_mac;
-    beerocks::net::sMacAddr controller_bridge_mac;
-    beerocks::net::sMacAddr bridge_mac;
+    sMacAddr gw_bridge_mac;
+    sMacAddr controller_bridge_mac;
+    sMacAddr bridge_mac;
     beerocks::net::sIpv4Addr bridge_ipv4;
-    beerocks::net::sMacAddr backhaul_mac;
+    sMacAddr backhaul_mac;
     beerocks::net::sIpv4Addr backhaul_ipv4;
-    beerocks::net::sMacAddr backhaul_bssid;
+    sMacAddr backhaul_bssid;
     uint8_t backhaul_channel;
     uint8_t backhaul_is_wireless;
     uint8_t backhaul_iface_type;
@@ -819,7 +819,7 @@ typedef struct sBackhaulParams {
 } __attribute__((packed)) sBackhaulParams;
 
 typedef struct sBackhaulRoam {
-    beerocks::net::sMacAddr bssid;
+    sMacAddr bssid;
     uint8_t channel;
     void struct_swap(){
         bssid.struct_swap();
@@ -838,7 +838,7 @@ typedef struct sBackhaulRssi {
 } __attribute__((packed)) sBackhaulRssi;
 
 typedef struct sLoggingLevelChange {
-    beerocks::net::sMacAddr mac;
+    sMacAddr mac;
     uint8_t module_name;
     uint8_t log_level;
     uint8_t enable;
@@ -910,7 +910,7 @@ typedef struct sDeviceInfo {
 } __attribute__((packed)) sDeviceInfo;
 
 typedef struct sRestrictedChannels {
-    beerocks::net::sMacAddr hostap_mac;
+    sMacAddr hostap_mac;
     uint8_t restricted_channels[beerocks::message::RESTRICTED_CHANNEL_LENGTH];
     uint8_t is_global;
     void struct_swap(){
@@ -922,7 +922,7 @@ typedef struct sRestrictedChannels {
 } __attribute__((packed)) sRestrictedChannels;
 
 typedef struct sSteeringApConfig {
-    beerocks::net::sMacAddr bssid;
+    sMacAddr bssid;
     uint32_t utilCheckIntervalSec;
     uint32_t utilAvgCount;
     uint32_t inactCheckIntervalSec;
@@ -986,8 +986,8 @@ typedef struct sSteeringSetGroupResponse {
 
 typedef struct sSteeringClientSetRequest {
     uint32_t steeringGroupIndex;
-    beerocks::net::sMacAddr bssid;
-    beerocks::net::sMacAddr client_mac;
+    sMacAddr bssid;
+    sMacAddr client_mac;
     sSteeringClientConfig config;
     uint8_t remove;
     void struct_swap(){
@@ -1013,8 +1013,8 @@ typedef struct sSteeringClientSetResponse {
 } __attribute__((packed)) sSteeringClientSetResponse;
 
 typedef struct sSteeringEvProbeReq {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint8_t rx_snr;
     uint8_t blocked;
     uint8_t broadcast;
@@ -1029,8 +1029,8 @@ typedef struct sSteeringEvProbeReq {
 } __attribute__((packed)) sSteeringEvProbeReq;
 
 typedef struct sSteeringEvAuthFail {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint8_t rx_snr;
     uint8_t blocked;
     uint8_t reject;
@@ -1111,8 +1111,8 @@ enum eSteeringEventType: uint8_t {
 };
 
 typedef struct sSteeringEvConnect {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint32_t isBTMSupported;
     uint32_t isRRMSupported;
     uint8_t bandCap2G;
@@ -1136,8 +1136,8 @@ typedef struct sSteeringEvConnect {
 } __attribute__((packed)) sSteeringEvConnect;
 
 typedef struct sSteeringEvDisconnect {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint32_t reason;
     eDisconnectSource source;
     eDisconnectType type;
@@ -1153,8 +1153,8 @@ typedef struct sSteeringEvDisconnect {
 } __attribute__((packed)) sSteeringEvDisconnect;
 
 typedef struct sSteeringEvActivity {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint8_t active;
     void struct_swap(){
         client_mac.struct_swap();
@@ -1167,8 +1167,8 @@ typedef struct sSteeringEvActivity {
 } __attribute__((packed)) sSteeringEvActivity;
 
 typedef struct sSteeringEvSnrXing {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint32_t snr;
     eSteeringSnrChange inactveXing;
     eSteeringSnrChange highXing;
@@ -1185,8 +1185,8 @@ typedef struct sSteeringEvSnrXing {
 } __attribute__((packed)) sSteeringEvSnrXing;
 
 typedef struct sSteeringEvSnr {
-    beerocks::net::sMacAddr client_mac;
-    beerocks::net::sMacAddr bssid;
+    sMacAddr client_mac;
+    sMacAddr bssid;
     uint32_t snr;
     void struct_swap(){
         client_mac.struct_swap();

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -48,7 +48,7 @@ class cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION : public BaseClass
         uint8_t& platform();
         uint8_t& low_pass_filter_on();
         uint8_t& enable_repeater_mode();
-        beerocks::net::sMacAddr& radio_identifier();
+        sMacAddr& radio_identifier();
         uint8_t& is_slave_reconf();
         void class_swap();
         static size_t get_initial_size();
@@ -66,7 +66,7 @@ class cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION : public BaseClass
         uint8_t* m_platform = nullptr;
         uint8_t* m_low_pass_filter_on = nullptr;
         uint8_t* m_enable_repeater_mode = nullptr;
-        beerocks::net::sMacAddr* m_radio_identifier = nullptr;
+        sMacAddr* m_radio_identifier = nullptr;
         uint8_t* m_is_slave_reconf = nullptr;
 };
 
@@ -108,9 +108,9 @@ class cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& backhaul_iface_mac();
+        sMacAddr& backhaul_iface_mac();
         beerocks::net::sIpv4Addr& backhaul_ipv4();
-        beerocks::net::sMacAddr& bridge_iface_mac();
+        sMacAddr& bridge_iface_mac();
         beerocks::net::sIpv4Addr& bridge_ipv4();
         sNodeHostap& hostap();
         void class_swap();
@@ -119,9 +119,9 @@ class cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_backhaul_iface_mac = nullptr;
+        sMacAddr* m_backhaul_iface_mac = nullptr;
         beerocks::net::sIpv4Addr* m_backhaul_ipv4 = nullptr;
-        beerocks::net::sMacAddr* m_bridge_iface_mac = nullptr;
+        sMacAddr* m_bridge_iface_mac = nullptr;
         beerocks::net::sIpv4Addr* m_bridge_ipv4 = nullptr;
         sNodeHostap* m_hostap = nullptr;
 };
@@ -328,7 +328,7 @@ class cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& bridge_mac();
+        sMacAddr& bridge_mac();
         uint8_t& operational();
         void class_swap();
         static size_t get_initial_size();
@@ -336,7 +336,7 @@ class cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_bridge_mac = nullptr;
+        sMacAddr* m_bridge_mac = nullptr;
         uint8_t* m_operational = nullptr;
 };
 
@@ -1045,14 +1045,14 @@ class cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
@@ -1105,14 +1105,14 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public Bas
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
@@ -1125,14 +1125,14 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION : public BaseClass
@@ -1165,14 +1165,14 @@ class cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
@@ -1185,14 +1185,14 @@ class cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CONTROL_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
@@ -1245,7 +1245,7 @@ class cACTION_CONTROL_CLIENT_DISALLOW_REQUEST : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_DISALLOW_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         uint8_t& reject_sta();
         void class_swap();
         static size_t get_initial_size();
@@ -1253,7 +1253,7 @@ class cACTION_CONTROL_CLIENT_DISALLOW_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         uint8_t* m_reject_sta = nullptr;
 };
 
@@ -1267,7 +1267,7 @@ class cACTION_CONTROL_CLIENT_ALLOW_REQUEST : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_ALLOW_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         beerocks::net::sIpv4Addr& ipv4();
         void class_swap();
         static size_t get_initial_size();
@@ -1275,7 +1275,7 @@ class cACTION_CONTROL_CLIENT_ALLOW_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
 };
 
@@ -1289,7 +1289,7 @@ class cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_DISCONNECT_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         int8_t& vap_id();
         uint32_t& type();
         uint32_t& reason();
@@ -1299,7 +1299,7 @@ class cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         int8_t* m_vap_id = nullptr;
         uint32_t* m_type = nullptr;
         uint32_t* m_reason = nullptr;
@@ -1375,7 +1375,7 @@ class cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         beerocks::net::sIpv4Addr& ipv4();
         char* name(size_t length = 0);
         bool set_name(std::string& str);
@@ -1387,7 +1387,7 @@ class cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
         char* m_name = nullptr;
         size_t m_name_idx__ = 0;
@@ -1543,14 +1543,14 @@ class cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_header.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_header.h
@@ -38,7 +38,7 @@ class cACTION_HEADER : public BaseClass
         //need to cast eActionOp_XXXX to uint8_t
         uint8_t& action_op();
         uint8_t& direction();
-        beerocks::net::sMacAddr& radio_mac();
+        sMacAddr& radio_mac();
         uint8_t& last();
         uint16_t& id();
         uint16_t& length();
@@ -52,7 +52,7 @@ class cACTION_HEADER : public BaseClass
         eAction* m_action = nullptr;
         uint8_t* m_action_op = nullptr;
         uint8_t* m_direction = nullptr;
-        beerocks::net::sMacAddr* m_radio_mac = nullptr;
+        sMacAddr* m_radio_mac = nullptr;
         uint8_t* m_last = nullptr;
         uint16_t* m_id = nullptr;
         uint16_t* m_length = nullptr;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_monitor.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_monitor.h
@@ -189,14 +189,14 @@ class cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
@@ -229,7 +229,7 @@ class cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_DISCONNECT_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         beerocks::net::sIpv4Addr& ipv4();
         uint8_t& channel();
         void class_swap();
@@ -238,7 +238,7 @@ class cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
         uint8_t* m_channel = nullptr;
 };
@@ -293,14 +293,14 @@ class cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public BaseClass
@@ -313,14 +313,14 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public Bas
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
@@ -333,14 +333,14 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
@@ -353,14 +353,14 @@ class cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION : public BaseClass
@@ -601,14 +601,14 @@ class cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST);
         }
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 class cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_platform.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_platform.h
@@ -190,7 +190,7 @@ class cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION : public BaseClass
         }
         eDHCPOp& dhcp_op();
         uint32_t& op();
-        beerocks::net::sMacAddr& mac();
+        sMacAddr& mac();
         beerocks::net::sIpv4Addr& ipv4();
         char* hostname(size_t length = 0);
         bool set_hostname(std::string& str);
@@ -204,7 +204,7 @@ class cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION : public BaseClass
         eActionOp_PLATFORM* m_action_op = nullptr;
         eDHCPOp* m_dhcp_op = nullptr;
         uint32_t* m_op = nullptr;
-        beerocks::net::sMacAddr* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
         char* m_hostname = nullptr;
         size_t m_hostname_idx__ = 0;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -25,12 +25,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_4ADDR_STA_JOINED::~cACTION_APMANAGER_4ADDR_STA_JOINED() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_4ADDR_STA_JOINED::src_mac() {
-    return (beerocks::net::sMacAddr&)(*m_src_mac);
+sMacAddr& cACTION_APMANAGER_4ADDR_STA_JOINED::src_mac() {
+    return (sMacAddr&)(*m_src_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_APMANAGER_4ADDR_STA_JOINED::dst_mac() {
-    return (beerocks::net::sMacAddr&)(*m_dst_mac);
+sMacAddr& cACTION_APMANAGER_4ADDR_STA_JOINED::dst_mac() {
+    return (sMacAddr&)(*m_dst_mac);
 }
 
 void cACTION_APMANAGER_4ADDR_STA_JOINED::class_swap()
@@ -42,8 +42,8 @@ void cACTION_APMANAGER_4ADDR_STA_JOINED::class_swap()
 size_t cACTION_APMANAGER_4ADDR_STA_JOINED::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // src_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // dst_mac
+    class_size += sizeof(sMacAddr); // src_mac
+    class_size += sizeof(sMacAddr); // dst_mac
     return class_size;
 }
 
@@ -53,11 +53,11 @@ bool cACTION_APMANAGER_4ADDR_STA_JOINED::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_src_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_src_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_src_mac->struct_init(); }
-    m_dst_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_dst_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_dst_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -735,8 +735,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::~cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::class_swap()
@@ -747,7 +747,7 @@ void cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::class_swap()
 size_t cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -757,8 +757,8 @@ bool cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -778,8 +778,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::~cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::class_swap()
@@ -790,7 +790,7 @@ void cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::class_swap()
 size_t cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -800,8 +800,8 @@ bool cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -993,8 +993,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::~cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 int8_t& cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::vap_id() {
@@ -1019,7 +1019,7 @@ void cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::class_swap()
 size_t cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(int8_t); // vap_id
     class_size += sizeof(uint32_t); // type
     class_size += sizeof(uint32_t); // reason
@@ -1032,8 +1032,8 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(int8_t) * 1;
@@ -1102,8 +1102,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::~cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 uint8_t& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::reject_sta() {
@@ -1118,7 +1118,7 @@ void cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::class_swap()
 size_t cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(uint8_t); // reject_sta
     return class_size;
 }
@@ -1129,8 +1129,8 @@ bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_reject_sta = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -1152,8 +1152,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::~cACTION_APMANAGER_CLIENT_ALLOW_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::ipv4() {
@@ -1169,7 +1169,7 @@ void cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::class_swap()
 size_t cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
     return class_size;
 }
@@ -1180,8 +1180,8 @@ bool cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
@@ -1290,8 +1290,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::~cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::class_swap()
@@ -1302,7 +1302,7 @@ void cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::class_swap()
 size_t cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -1312,8 +1312,8 @@ bool cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -1419,8 +1419,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
 }
-beerocks::net::sMacAddr& cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
@@ -1431,7 +1431,7 @@ void cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 size_t cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -1441,8 +1441,8 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -281,8 +281,8 @@ bool cACTION_BACKHAUL_ENABLE::set_bridge_iface(char str[], size_t size) {
     m_bridge_iface[size] = '\0';
     return true;
 }
-beerocks::net::sMacAddr& cACTION_BACKHAUL_ENABLE::iface_mac() {
-    return (beerocks::net::sMacAddr&)(*m_iface_mac);
+sMacAddr& cACTION_BACKHAUL_ENABLE::iface_mac() {
+    return (sMacAddr&)(*m_iface_mac);
 }
 
 uint8_t& cACTION_BACKHAUL_ENABLE::iface_is_5ghz() {
@@ -478,8 +478,8 @@ uint32_t& cACTION_BACKHAUL_ENABLE::security_type() {
     return (uint32_t&)(*m_security_type);
 }
 
-beerocks::net::sMacAddr& cACTION_BACKHAUL_ENABLE::preferred_bssid() {
-    return (beerocks::net::sMacAddr&)(*m_preferred_bssid);
+sMacAddr& cACTION_BACKHAUL_ENABLE::preferred_bssid() {
+    return (sMacAddr&)(*m_preferred_bssid);
 }
 
 uint8_t& cACTION_BACKHAUL_ENABLE::wire_iface_type() {
@@ -505,7 +505,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
 {
     size_t class_size = 0;
     class_size += beerocks::message::IFACE_NAME_LENGTH * sizeof(char); // bridge_iface
-    class_size += sizeof(beerocks::net::sMacAddr); // iface_mac
+    class_size += sizeof(sMacAddr); // iface_mac
     class_size += sizeof(uint8_t); // iface_is_5ghz
     class_size += beerocks::message::IFACE_NAME_LENGTH * sizeof(char); // wire_iface
     class_size += beerocks::message::IFACE_NAME_LENGTH * sizeof(char); // sta_iface
@@ -513,7 +513,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
     class_size += beerocks::message::WIFI_SSID_MAX_LENGTH * sizeof(char); // ssid
     class_size += beerocks::message::WIFI_PASS_MAX_LENGTH * sizeof(char); // pass
     class_size += sizeof(uint32_t); // security_type
-    class_size += sizeof(beerocks::net::sMacAddr); // preferred_bssid
+    class_size += sizeof(sMacAddr); // preferred_bssid
     class_size += sizeof(uint8_t); // wire_iface_type
     class_size += sizeof(uint8_t); // wireless_iface_type
     class_size += sizeof(uint8_t); // wired_backhaul
@@ -529,8 +529,8 @@ bool cACTION_BACKHAUL_ENABLE::init()
     m_bridge_iface = (char*)m_buff_ptr__;
     m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
     m_bridge_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
-    m_iface_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_iface_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_iface_mac->struct_init(); }
     m_iface_is_5ghz = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -551,8 +551,8 @@ bool cACTION_BACKHAUL_ENABLE::init()
     m_pass_idx__  = beerocks::message::WIFI_PASS_MAX_LENGTH;
     m_security_type = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
-    m_preferred_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_preferred_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_preferred_bssid->struct_init(); }
     m_wire_iface_type = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -780,8 +780,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_BACKHAUL_4ADDR_CONNECTED::~cACTION_BACKHAUL_4ADDR_CONNECTED() {
 }
-beerocks::net::sMacAddr& cACTION_BACKHAUL_4ADDR_CONNECTED::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_BACKHAUL_4ADDR_CONNECTED::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_BACKHAUL_4ADDR_CONNECTED::class_swap()
@@ -792,7 +792,7 @@ void cACTION_BACKHAUL_4ADDR_CONNECTED::class_swap()
 size_t cACTION_BACKHAUL_4ADDR_CONNECTED::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -802,8 +802,8 @@ bool cACTION_BACKHAUL_4ADDR_CONNECTED::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -994,8 +994,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
 }
-beerocks::net::sMacAddr& cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
@@ -1006,7 +1006,7 @@ void cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 size_t cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -1016,8 +1016,8 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -2835,12 +2835,12 @@ uint32_t& cACTION_BML_STEERING_CLIENT_SET_REQUEST::steeringGroupIndex() {
     return (uint32_t&)(*m_steeringGroupIndex);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_STEERING_CLIENT_SET_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_BML_STEERING_CLIENT_SET_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_STEERING_CLIENT_SET_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_BML_STEERING_CLIENT_SET_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 sSteeringClientConfig& cACTION_BML_STEERING_CLIENT_SET_REQUEST::config() {
@@ -2863,8 +2863,8 @@ size_t cACTION_BML_STEERING_CLIENT_SET_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(uint32_t); // steeringGroupIndex
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // client_mac
     class_size += sizeof(sSteeringClientConfig); // config
     class_size += sizeof(uint8_t); // remove
     return class_size;
@@ -2878,11 +2878,11 @@ bool cACTION_BML_STEERING_CLIENT_SET_REQUEST::init()
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_config = (sSteeringClientConfig*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(sSteeringClientConfig) * 1;
@@ -3036,12 +3036,12 @@ uint32_t& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::steeringGroupIndex() {
     return (uint32_t&)(*m_steeringGroupIndex);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 eDisconnectType& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::type() {
@@ -3064,8 +3064,8 @@ size_t cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(uint32_t); // steeringGroupIndex
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // client_mac
     class_size += sizeof(eDisconnectType); // type
     class_size += sizeof(uint32_t); // reason
     return class_size;
@@ -3079,11 +3079,11 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::init()
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_type = (eDisconnectType*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(eDisconnectType) * 1;
@@ -3153,12 +3153,12 @@ uint32_t& cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::steeringGroupIndex() {
     return (uint32_t&)(*m_steeringGroupIndex);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 void cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::class_swap()
@@ -3172,8 +3172,8 @@ size_t cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(uint32_t); // steeringGroupIndex
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // client_mac
     return class_size;
 }
 
@@ -3185,11 +3185,11 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::init()
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -3345,12 +3345,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::~cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::al_mac() {
-    return (beerocks::net::sMacAddr&)(*m_al_mac);
+sMacAddr& cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::al_mac() {
+    return (sMacAddr&)(*m_al_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::ruid() {
-    return (beerocks::net::sMacAddr&)(*m_ruid);
+sMacAddr& cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::ruid() {
+    return (sMacAddr&)(*m_ruid);
 }
 
 void cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::class_swap()
@@ -3362,8 +3362,8 @@ void cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::class_swap()
 size_t cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // al_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // ruid
+    class_size += sizeof(sMacAddr); // al_mac
+    class_size += sizeof(sMacAddr); // ruid
     return class_size;
 }
 
@@ -3373,11 +3373,11 @@ bool cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_al_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_al_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_al_mac->struct_init(); }
-    m_ruid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ruid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ruid->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -332,12 +332,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::~cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::hostap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_hostap_mac);
+sMacAddr& cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::hostap_mac() {
+    return (sMacAddr&)(*m_hostap_mac);
 }
 
 uint16_t& cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::center_frequency() {
@@ -354,8 +354,8 @@ void cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::class_swap()
 size_t cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // hostap_mac
+    class_size += sizeof(sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // hostap_mac
     class_size += sizeof(uint16_t); // center_frequency
     return class_size;
 }
@@ -366,11 +366,11 @@ bool cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
-    m_hostap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_hostap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_center_frequency = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_center_frequency = 0x0;
@@ -393,8 +393,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_OPTIMAL_PATH_TASK::~cACTION_CLI_OPTIMAL_PATH_TASK() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_OPTIMAL_PATH_TASK::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_OPTIMAL_PATH_TASK::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 void cACTION_CLI_OPTIMAL_PATH_TASK::class_swap()
@@ -405,7 +405,7 @@ void cACTION_CLI_OPTIMAL_PATH_TASK::class_swap()
 size_t cACTION_CLI_OPTIMAL_PATH_TASK::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // client_mac
     return class_size;
 }
 
@@ -415,8 +415,8 @@ bool cACTION_CLI_OPTIMAL_PATH_TASK::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -436,8 +436,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_LOAD_BALANCER_TASK::~cACTION_CLI_LOAD_BALANCER_TASK() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_LOAD_BALANCER_TASK::ap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_ap_mac);
+sMacAddr& cACTION_CLI_LOAD_BALANCER_TASK::ap_mac() {
+    return (sMacAddr&)(*m_ap_mac);
 }
 
 void cACTION_CLI_LOAD_BALANCER_TASK::class_swap()
@@ -448,7 +448,7 @@ void cACTION_CLI_LOAD_BALANCER_TASK::class_swap()
 size_t cACTION_CLI_LOAD_BALANCER_TASK::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // ap_mac
+    class_size += sizeof(sMacAddr); // ap_mac
     return class_size;
 }
 
@@ -458,8 +458,8 @@ bool cACTION_CLI_LOAD_BALANCER_TASK::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ap_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -513,8 +513,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_DUMP_NODE_INFO::~cACTION_CLI_DUMP_NODE_INFO() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_DUMP_NODE_INFO::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CLI_DUMP_NODE_INFO::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CLI_DUMP_NODE_INFO::class_swap()
@@ -525,7 +525,7 @@ void cACTION_CLI_DUMP_NODE_INFO::class_swap()
 size_t cACTION_CLI_DUMP_NODE_INFO::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -535,8 +535,8 @@ bool cACTION_CLI_DUMP_NODE_INFO::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -556,8 +556,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_PING_SLAVE_REQUEST::~cACTION_CLI_PING_SLAVE_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_PING_SLAVE_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CLI_PING_SLAVE_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 uint16_t& cACTION_CLI_PING_SLAVE_REQUEST::num_of_req() {
@@ -578,7 +578,7 @@ void cACTION_CLI_PING_SLAVE_REQUEST::class_swap()
 size_t cACTION_CLI_PING_SLAVE_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(uint16_t); // num_of_req
     class_size += sizeof(uint16_t); // size
     return class_size;
@@ -590,8 +590,8 @@ bool cACTION_CLI_PING_SLAVE_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_num_of_req = (uint16_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
@@ -665,8 +665,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_BACKHAUL_SCAN_RESULTS::~cACTION_CLI_BACKHAUL_SCAN_RESULTS() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_BACKHAUL_SCAN_RESULTS::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CLI_BACKHAUL_SCAN_RESULTS::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CLI_BACKHAUL_SCAN_RESULTS::class_swap()
@@ -677,7 +677,7 @@ void cACTION_CLI_BACKHAUL_SCAN_RESULTS::class_swap()
 size_t cACTION_CLI_BACKHAUL_SCAN_RESULTS::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -687,8 +687,8 @@ bool cACTION_CLI_BACKHAUL_SCAN_RESULTS::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -708,12 +708,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_BACKHAUL_ROAM_REQUEST::~cACTION_CLI_BACKHAUL_ROAM_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_BACKHAUL_ROAM_REQUEST::slave_mac() {
-    return (beerocks::net::sMacAddr&)(*m_slave_mac);
+sMacAddr& cACTION_CLI_BACKHAUL_ROAM_REQUEST::slave_mac() {
+    return (sMacAddr&)(*m_slave_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_BACKHAUL_ROAM_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_CLI_BACKHAUL_ROAM_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
 void cACTION_CLI_BACKHAUL_ROAM_REQUEST::class_swap()
@@ -725,8 +725,8 @@ void cACTION_CLI_BACKHAUL_ROAM_REQUEST::class_swap()
 size_t cACTION_CLI_BACKHAUL_ROAM_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // slave_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // slave_mac
+    class_size += sizeof(sMacAddr); // bssid
     return class_size;
 }
 
@@ -736,11 +736,11 @@ bool cACTION_CLI_BACKHAUL_ROAM_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_slave_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_slave_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_slave_mac->struct_init(); }
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -760,12 +760,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_ALLOW_REQUEST::~cACTION_CLI_CLIENT_ALLOW_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_ALLOW_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_ALLOW_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_ALLOW_REQUEST::hostap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_hostap_mac);
+sMacAddr& cACTION_CLI_CLIENT_ALLOW_REQUEST::hostap_mac() {
+    return (sMacAddr&)(*m_hostap_mac);
 }
 
 void cACTION_CLI_CLIENT_ALLOW_REQUEST::class_swap()
@@ -777,8 +777,8 @@ void cACTION_CLI_CLIENT_ALLOW_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_ALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // hostap_mac
+    class_size += sizeof(sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // hostap_mac
     return class_size;
 }
 
@@ -788,11 +788,11 @@ bool cACTION_CLI_CLIENT_ALLOW_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
-    m_hostap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_hostap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -812,12 +812,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_DISALLOW_REQUEST::~cACTION_CLI_CLIENT_DISALLOW_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_DISALLOW_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_DISALLOW_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_DISALLOW_REQUEST::hostap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_hostap_mac);
+sMacAddr& cACTION_CLI_CLIENT_DISALLOW_REQUEST::hostap_mac() {
+    return (sMacAddr&)(*m_hostap_mac);
 }
 
 void cACTION_CLI_CLIENT_DISALLOW_REQUEST::class_swap()
@@ -829,8 +829,8 @@ void cACTION_CLI_CLIENT_DISALLOW_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_DISALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // hostap_mac
+    class_size += sizeof(sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // hostap_mac
     return class_size;
 }
 
@@ -840,11 +840,11 @@ bool cACTION_CLI_CLIENT_DISALLOW_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
-    m_hostap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_hostap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -864,8 +864,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_DISCONNECT_REQUEST::~cACTION_CLI_CLIENT_DISCONNECT_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_DISCONNECT_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_DISCONNECT_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 uint32_t& cACTION_CLI_CLIENT_DISCONNECT_REQUEST::type() {
@@ -886,7 +886,7 @@ void cACTION_CLI_CLIENT_DISCONNECT_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // client_mac
     class_size += sizeof(uint32_t); // type
     class_size += sizeof(uint32_t); // reason
     return class_size;
@@ -898,8 +898,8 @@ bool cACTION_CLI_CLIENT_DISCONNECT_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_type = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
@@ -923,12 +923,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_BSS_STEER_REQUEST::~cACTION_CLI_CLIENT_BSS_STEER_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_BSS_STEER_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_BSS_STEER_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_BSS_STEER_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_CLI_CLIENT_BSS_STEER_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
 uint32_t& cACTION_CLI_CLIENT_BSS_STEER_REQUEST::disassoc_timer() {
@@ -945,8 +945,8 @@ void cACTION_CLI_CLIENT_BSS_STEER_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_BSS_STEER_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // bssid
     class_size += sizeof(uint32_t); // disassoc_timer
     return class_size;
 }
@@ -957,11 +957,11 @@ bool cACTION_CLI_CLIENT_BSS_STEER_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
     m_disassoc_timer = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
@@ -983,12 +983,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::~cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::hostap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_hostap_mac);
+sMacAddr& cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::hostap_mac() {
+    return (sMacAddr&)(*m_hostap_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 void cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
@@ -1000,8 +1000,8 @@ void cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // hostap_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // hostap_mac
+    class_size += sizeof(sMacAddr); // client_mac
     return class_size;
 }
 
@@ -1011,11 +1011,11 @@ bool cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_hostap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_hostap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -1035,12 +1035,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::~cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::hostap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_hostap_mac);
+sMacAddr& cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::hostap_mac() {
+    return (sMacAddr&)(*m_hostap_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
 uint8_t& cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::channel() {
@@ -1056,8 +1056,8 @@ void cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // hostap_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // hostap_mac
+    class_size += sizeof(sMacAddr); // client_mac
     class_size += sizeof(uint8_t); // channel
     return class_size;
 }
@@ -1068,11 +1068,11 @@ bool cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_hostap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_hostap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -1094,12 +1094,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_BEACON_11K_REQUEST::~cACTION_CLI_CLIENT_BEACON_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
 std::tuple<bool, uint8_t&> cACTION_CLI_CLIENT_BEACON_11K_REQUEST::ssid(size_t idx) {
@@ -1152,8 +1152,8 @@ void cACTION_CLI_CLIENT_BEACON_11K_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_BEACON_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // bssid
     class_size += beerocks::message::WIFI_SSID_MAX_LENGTH * sizeof(uint8_t); // ssid
     class_size += sizeof(uint8_t); // use_optional_ssid
     class_size += sizeof(uint8_t); // channel
@@ -1171,11 +1171,11 @@ bool cACTION_CLI_CLIENT_BEACON_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
     m_ssid = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += (sizeof(uint8_t) * beerocks::message::WIFI_SSID_MAX_LENGTH);
@@ -1212,16 +1212,16 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::~cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::hostap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_hostap_mac);
+sMacAddr& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::hostap_mac() {
+    return (sMacAddr&)(*m_hostap_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::client_mac() {
-    return (beerocks::net::sMacAddr&)(*m_client_mac);
+sMacAddr& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::peer_mac() {
-    return (beerocks::net::sMacAddr&)(*m_peer_mac);
+sMacAddr& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::peer_mac() {
+    return (sMacAddr&)(*m_peer_mac);
 }
 
 uint8_t& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::group_identity() {
@@ -1238,9 +1238,9 @@ void cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::class_swap()
 size_t cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // hostap_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // client_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // peer_mac
+    class_size += sizeof(sMacAddr); // hostap_mac
+    class_size += sizeof(sMacAddr); // client_mac
+    class_size += sizeof(sMacAddr); // peer_mac
     class_size += sizeof(uint8_t); // group_identity
     return class_size;
 }
@@ -1251,14 +1251,14 @@ bool cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_hostap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_hostap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    m_client_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_client_mac->struct_init(); }
-    m_peer_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_peer_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_peer_mac->struct_init(); }
     m_group_identity = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -1280,8 +1280,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::~cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 sApChannelSwitch& cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::cs_params() {
@@ -1297,7 +1297,7 @@ void cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::class_swap()
 size_t cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(sApChannelSwitch); // cs_params
     return class_size;
 }
@@ -1308,8 +1308,8 @@ bool cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
@@ -1332,8 +1332,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_HOSTAP_TX_ON_REQUEST::~cACTION_CLI_HOSTAP_TX_ON_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_TX_ON_REQUEST::ap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_ap_mac);
+sMacAddr& cACTION_CLI_HOSTAP_TX_ON_REQUEST::ap_mac() {
+    return (sMacAddr&)(*m_ap_mac);
 }
 
 void cACTION_CLI_HOSTAP_TX_ON_REQUEST::class_swap()
@@ -1344,7 +1344,7 @@ void cACTION_CLI_HOSTAP_TX_ON_REQUEST::class_swap()
 size_t cACTION_CLI_HOSTAP_TX_ON_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // ap_mac
+    class_size += sizeof(sMacAddr); // ap_mac
     return class_size;
 }
 
@@ -1354,8 +1354,8 @@ bool cACTION_CLI_HOSTAP_TX_ON_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ap_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -1375,8 +1375,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_HOSTAP_TX_OFF_REQUEST::~cACTION_CLI_HOSTAP_TX_OFF_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_TX_OFF_REQUEST::ap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_ap_mac);
+sMacAddr& cACTION_CLI_HOSTAP_TX_OFF_REQUEST::ap_mac() {
+    return (sMacAddr&)(*m_ap_mac);
 }
 
 void cACTION_CLI_HOSTAP_TX_OFF_REQUEST::class_swap()
@@ -1387,7 +1387,7 @@ void cACTION_CLI_HOSTAP_TX_OFF_REQUEST::class_swap()
 size_t cACTION_CLI_HOSTAP_TX_OFF_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // ap_mac
+    class_size += sizeof(sMacAddr); // ap_mac
     return class_size;
 }
 
@@ -1397,8 +1397,8 @@ bool cACTION_CLI_HOSTAP_TX_OFF_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ap_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -1418,12 +1418,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::~cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::ap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_ap_mac);
+sMacAddr& cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::ap_mac() {
+    return (sMacAddr&)(*m_ap_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
 uint8_t& cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::channel() {
@@ -1443,8 +1443,8 @@ void cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::class_swap()
 size_t cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // ap_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // ap_mac
+    class_size += sizeof(sMacAddr); // bssid
     class_size += sizeof(uint8_t); // channel
     class_size += sizeof(int8_t); // vap_id
     return class_size;
@@ -1456,11 +1456,11 @@ bool cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -1484,12 +1484,12 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::~cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::ap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_ap_mac);
+sMacAddr& cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::ap_mac() {
+    return (sMacAddr&)(*m_ap_mac);
 }
 
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::bssid() {
-    return (beerocks::net::sMacAddr&)(*m_bssid);
+sMacAddr& cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
 int8_t& cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::vap_id() {
@@ -1505,8 +1505,8 @@ void cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::class_swap()
 size_t cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // ap_mac
-    class_size += sizeof(beerocks::net::sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // ap_mac
+    class_size += sizeof(sMacAddr); // bssid
     class_size += sizeof(int8_t); // vap_id
     return class_size;
 }
@@ -1517,11 +1517,11 @@ bool cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    m_bssid = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bssid->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(int8_t) * 1;
@@ -1543,8 +1543,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CLI_HOSTAP_STATS_MEASUREMENT::~cACTION_CLI_HOSTAP_STATS_MEASUREMENT() {
 }
-beerocks::net::sMacAddr& cACTION_CLI_HOSTAP_STATS_MEASUREMENT::ap_mac() {
-    return (beerocks::net::sMacAddr&)(*m_ap_mac);
+sMacAddr& cACTION_CLI_HOSTAP_STATS_MEASUREMENT::ap_mac() {
+    return (sMacAddr&)(*m_ap_mac);
 }
 
 void cACTION_CLI_HOSTAP_STATS_MEASUREMENT::class_swap()
@@ -1555,7 +1555,7 @@ void cACTION_CLI_HOSTAP_STATS_MEASUREMENT::class_swap()
 size_t cACTION_CLI_HOSTAP_STATS_MEASUREMENT::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // ap_mac
+    class_size += sizeof(sMacAddr); // ap_mac
     return class_size;
 }
 
@@ -1565,8 +1565,8 @@ bool cACTION_CLI_HOSTAP_STATS_MEASUREMENT::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_ap_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_ap_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -94,8 +94,8 @@ uint8_t& cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::enable_repeater_mode() {
     return (uint8_t&)(*m_enable_repeater_mode);
 }
 
-beerocks::net::sMacAddr& cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::radio_identifier() {
-    return (beerocks::net::sMacAddr&)(*m_radio_identifier);
+sMacAddr& cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::radio_identifier() {
+    return (sMacAddr&)(*m_radio_identifier);
 }
 
 uint8_t& cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::is_slave_reconf() {
@@ -124,7 +124,7 @@ size_t cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::get_initial_size()
     class_size += sizeof(uint8_t); // platform
     class_size += sizeof(uint8_t); // low_pass_filter_on
     class_size += sizeof(uint8_t); // enable_repeater_mode
-    class_size += sizeof(beerocks::net::sMacAddr); // radio_identifier
+    class_size += sizeof(sMacAddr); // radio_identifier
     class_size += sizeof(uint8_t); // is_slave_reconf
     return class_size;
 }
@@ -159,8 +159,8 @@ bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::init()
     m_buff_ptr__ += sizeof(uint8_t) * 1;
     m_enable_repeater_mode = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
-    m_radio_identifier = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_radio_identifier = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_radio_identifier->struct_init(); }
     m_is_slave_reconf = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -273,16 +273,16 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::~cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::backhaul_iface_mac() {
-    return (beerocks::net::sMacAddr&)(*m_backhaul_iface_mac);
+sMacAddr& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::backhaul_iface_mac() {
+    return (sMacAddr&)(*m_backhaul_iface_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::backhaul_ipv4() {
     return (beerocks::net::sIpv4Addr&)(*m_backhaul_ipv4);
 }
 
-beerocks::net::sMacAddr& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::bridge_iface_mac() {
-    return (beerocks::net::sMacAddr&)(*m_bridge_iface_mac);
+sMacAddr& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::bridge_iface_mac() {
+    return (sMacAddr&)(*m_bridge_iface_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::bridge_ipv4() {
@@ -305,9 +305,9 @@ void cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::class_swap()
 size_t cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // backhaul_iface_mac
+    class_size += sizeof(sMacAddr); // backhaul_iface_mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // backhaul_ipv4
-    class_size += sizeof(beerocks::net::sMacAddr); // bridge_iface_mac
+    class_size += sizeof(sMacAddr); // bridge_iface_mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // bridge_ipv4
     class_size += sizeof(sNodeHostap); // hostap
     return class_size;
@@ -319,14 +319,14 @@ bool cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_backhaul_iface_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_backhaul_iface_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_backhaul_iface_mac->struct_init(); }
     m_backhaul_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
     if (!m_parse__) { m_backhaul_ipv4->struct_init(); }
-    m_bridge_iface_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bridge_iface_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bridge_iface_mac->struct_init(); }
     m_bridge_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
@@ -860,8 +860,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::~cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::bridge_mac() {
-    return (beerocks::net::sMacAddr&)(*m_bridge_mac);
+sMacAddr& cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::bridge_mac() {
+    return (sMacAddr&)(*m_bridge_mac);
 }
 
 uint8_t& cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::operational() {
@@ -876,7 +876,7 @@ void cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::class_swap()
 size_t cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // bridge_mac
+    class_size += sizeof(sMacAddr); // bridge_mac
     class_size += sizeof(uint8_t); // operational
     return class_size;
 }
@@ -887,8 +887,8 @@ bool cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_bridge_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_bridge_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_bridge_mac->struct_init(); }
     m_operational = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -2403,8 +2403,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::~cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::class_swap()
@@ -2415,7 +2415,7 @@ void cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::class_swap()
 size_t cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -2425,8 +2425,8 @@ bool cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -2532,8 +2532,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::class_swap()
@@ -2544,7 +2544,7 @@ void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::class_swap()
 size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -2554,8 +2554,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -2575,8 +2575,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
@@ -2587,7 +2587,7 @@ void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -2597,8 +2597,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -2661,8 +2661,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::~cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::class_swap()
@@ -2673,7 +2673,7 @@ void cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::class_swap()
 size_t cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -2683,8 +2683,8 @@ bool cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -2704,8 +2704,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::~cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::class_swap()
@@ -2716,7 +2716,7 @@ void cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::class_swap()
 size_t cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -2726,8 +2726,8 @@ bool cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -2833,8 +2833,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::~cACTION_CONTROL_CLIENT_DISALLOW_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 uint8_t& cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::reject_sta() {
@@ -2849,7 +2849,7 @@ void cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::class_swap()
 size_t cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(uint8_t); // reject_sta
     return class_size;
 }
@@ -2860,8 +2860,8 @@ bool cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_reject_sta = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
@@ -2883,8 +2883,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_ALLOW_REQUEST::~cACTION_CONTROL_CLIENT_ALLOW_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_ALLOW_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_ALLOW_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_CONTROL_CLIENT_ALLOW_REQUEST::ipv4() {
@@ -2900,7 +2900,7 @@ void cACTION_CONTROL_CLIENT_ALLOW_REQUEST::class_swap()
 size_t cACTION_CONTROL_CLIENT_ALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
     return class_size;
 }
@@ -2911,8 +2911,8 @@ bool cACTION_CONTROL_CLIENT_ALLOW_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
@@ -2935,8 +2935,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::~cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 int8_t& cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::vap_id() {
@@ -2961,7 +2961,7 @@ void cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::class_swap()
 size_t cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(int8_t); // vap_id
     class_size += sizeof(uint32_t); // type
     class_size += sizeof(uint32_t); // reason
@@ -2974,8 +2974,8 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(int8_t) * 1;
@@ -3130,8 +3130,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::~cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::ipv4() {
@@ -3184,7 +3184,7 @@ void cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::class_swap()
 size_t cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
     class_size += beerocks::message::NODE_NAME_LENGTH * sizeof(char); // name
     return class_size;
@@ -3196,8 +3196,8 @@ bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
@@ -3524,8 +3524,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::~cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
@@ -3536,7 +3536,7 @@ void cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
 size_t cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -3546,8 +3546,8 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
@@ -45,8 +45,8 @@ uint8_t& cACTION_HEADER::direction() {
     return (uint8_t&)(*m_direction);
 }
 
-beerocks::net::sMacAddr& cACTION_HEADER::radio_mac() {
-    return (beerocks::net::sMacAddr&)(*m_radio_mac);
+sMacAddr& cACTION_HEADER::radio_mac() {
+    return (sMacAddr&)(*m_radio_mac);
 }
 
 uint8_t& cACTION_HEADER::last() {
@@ -77,7 +77,7 @@ size_t cACTION_HEADER::get_initial_size()
     class_size += sizeof(eAction); // action
     class_size += sizeof(uint8_t); // action_op
     class_size += sizeof(uint8_t); // direction
-    class_size += sizeof(beerocks::net::sMacAddr); // radio_mac
+    class_size += sizeof(sMacAddr); // radio_mac
     class_size += sizeof(uint8_t); // last
     class_size += sizeof(uint16_t); // id
     class_size += sizeof(uint16_t); // length
@@ -103,8 +103,8 @@ bool cACTION_HEADER::init()
     m_direction = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_direction = 0x1;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
-    m_radio_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_radio_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_radio_mac->struct_init(); }
     m_last = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_last = 0x0;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -339,8 +339,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::~cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::class_swap()
@@ -351,7 +351,7 @@ void cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::class_swap()
 size_t cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -361,8 +361,8 @@ bool cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -425,8 +425,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::~cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::ipv4() {
@@ -446,7 +446,7 @@ void cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::class_swap()
 size_t cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
     class_size += sizeof(uint8_t); // channel
     return class_size;
@@ -458,8 +458,8 @@ bool cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
@@ -570,8 +570,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::~cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::class_swap()
@@ -582,7 +582,7 @@ void cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::class_swap()
 size_t cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -592,8 +592,8 @@ bool cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -613,8 +613,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::class_swap()
@@ -625,7 +625,7 @@ void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::class_swap()
 size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -635,8 +635,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -656,8 +656,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
@@ -668,7 +668,7 @@ void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -678,8 +678,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -699,8 +699,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::~cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::class_swap()
@@ -711,7 +711,7 @@ void cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::class_swap()
 size_t cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -721,8 +721,8 @@ bool cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
@@ -1261,8 +1261,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::~cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST() {
 }
-beerocks::net::sMacAddr& cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
@@ -1273,7 +1273,7 @@ void cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
 size_t cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -1283,8 +1283,8 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -411,8 +411,8 @@ uint32_t& cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::op() {
     return (uint32_t&)(*m_op);
 }
 
-beerocks::net::sMacAddr& cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::mac() {
-    return (beerocks::net::sMacAddr&)(*m_mac);
+sMacAddr& cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 beerocks::net::sIpv4Addr& cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::ipv4() {
@@ -468,7 +468,7 @@ size_t cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eDHCPOp); // dhcp_op
     class_size += sizeof(uint32_t); // op
-    class_size += sizeof(beerocks::net::sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
     class_size += beerocks::message::NODE_NAME_LENGTH * sizeof(char); // hostname
     return class_size;
@@ -484,8 +484,8 @@ bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::init()
     m_buff_ptr__ += sizeof(eDHCPOp) * 1;
     m_op = (uint32_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint32_t) * 1;
-    m_mac = (beerocks::net::sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sMacAddr) * 1;
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -15,8 +15,8 @@ _multi_class_auto_insert:
 ###FIXME temp###
 cACTION_APMANAGER_4ADDR_STA_JOINED:
   _type: class
-  src_mac: beerocks::net::sMacAddr
-  dst_mac: beerocks::net::sMacAddr
+  src_mac: sMacAddr
+  dst_mac: sMacAddr
 ################
  
 cACTION_APMANAGER_JOINED_NOTIFICATION:
@@ -84,11 +84,11 @@ cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION:
 
 cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST:
   _type: class
@@ -108,7 +108,7 @@ cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION:
 
 cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   vap_id: int8_t
   type: uint32_t
   reason: uint32_t
@@ -119,12 +119,12 @@ cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE:
 
 cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   reject_sta: uint8_t
 
 cACTION_APMANAGER_CLIENT_ALLOW_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   ipv4: beerocks::net::sIpv4Addr
 
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
@@ -137,7 +137,7 @@ cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE:
 
 cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST:
   _type: class
@@ -149,7 +149,7 @@ cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE:
 
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -37,7 +37,7 @@ cACTION_BACKHAUL_ENABLE:
   bridge_iface:
     _type: char
     _length: [ "beerocks::message::IFACE_NAME_LENGTH"  ]
-  iface_mac: beerocks::net::sMacAddr
+  iface_mac: sMacAddr
   iface_is_5ghz: uint8_t
   wire_iface:
     _type: char
@@ -55,7 +55,7 @@ cACTION_BACKHAUL_ENABLE:
     _type: char
     _length: [ "beerocks::message::WIFI_PASS_MAX_LENGTH" ]
   security_type: uint32_t # bwl::sta_wlan_hal::Security
-  preferred_bssid: beerocks::net::sMacAddr
+  preferred_bssid: sMacAddr
   wire_iface_type: uint8_t  
   wireless_iface_type: uint8_t  
   wired_backhaul: uint8_t  
@@ -81,7 +81,7 @@ cACTION_BACKHAUL_RESET:
 
 cACTION_BACKHAUL_4ADDR_CONNECTED:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION:
   _type: class
@@ -101,4 +101,4 @@ cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE:
 
 cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -289,8 +289,8 @@ cACTION_BML_STEERING_SET_GROUP_RESPONSE:
 cACTION_BML_STEERING_CLIENT_SET_REQUEST:
   _type: class
   steeringGroupIndex: uint32_t
-  bssid: beerocks::net::sMacAddr
-  client_mac: beerocks::net::sMacAddr
+  bssid: sMacAddr
+  client_mac: sMacAddr
   config: sSteeringClientConfig
   remove: uint8_t
 
@@ -309,8 +309,8 @@ cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE:
 cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST:
   _type: class
   steeringGroupIndex: uint32_t
-  bssid: beerocks::net::sMacAddr
-  client_mac: beerocks::net::sMacAddr
+  bssid: sMacAddr
+  client_mac: sMacAddr
   type: eDisconnectType
   reason: uint32_t
 
@@ -321,8 +321,8 @@ cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE:
 cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST:
   _type: class
   steeringGroupIndex: uint32_t
-  bssid: beerocks::net::sMacAddr
-  client_mac: beerocks::net::sMacAddr
+  bssid: sMacAddr
+  client_mac: sMacAddr
 
 cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE:
   _type: class  
@@ -343,5 +343,5 @@ cACTION_BML_STEERING_EVENTS_UPDATE:
 
 cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST:
   _type: class
-  al_mac: beerocks::net::sMacAddr
-  ruid: beerocks::net::sMacAddr
+  al_mac: sMacAddr
+  ruid: sMacAddr

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_cli.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_cli.yaml
@@ -47,30 +47,30 @@ cACTION_CLI_RESPONSE_STR:
 
 cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT:
   _type: class
-  client_mac: beerocks::net::sMacAddr
-  hostap_mac: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  hostap_mac: sMacAddr
   center_frequency:
     _type: uint16_t
     _value: 0
 
 cACTION_CLI_OPTIMAL_PATH_TASK:
   _type: class
-  client_mac: beerocks::net::sMacAddr
+  client_mac: sMacAddr
 
 cACTION_CLI_LOAD_BALANCER_TASK:
   _type: class
-  ap_mac: beerocks::net::sMacAddr
+  ap_mac: sMacAddr
 
 cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK:
   _type: class
 
 cACTION_CLI_DUMP_NODE_INFO:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_CLI_PING_SLAVE_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   num_of_req: uint16_t
   size: uint16_t
 
@@ -81,12 +81,12 @@ cACTION_CLI_PING_ALL_SLAVES_REQUEST:
 
 cACTION_CLI_BACKHAUL_SCAN_RESULTS:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_CLI_BACKHAUL_ROAM_REQUEST:
   _type: class
-  slave_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  slave_mac: sMacAddr
+  bssid: sMacAddr
 
 #################################################
 # CLIENT
@@ -94,41 +94,41 @@ cACTION_CLI_BACKHAUL_ROAM_REQUEST:
 
 cACTION_CLI_CLIENT_ALLOW_REQUEST:
   _type: class
-  client_mac: beerocks::net::sMacAddr
-  hostap_mac: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  hostap_mac: sMacAddr
 
 cACTION_CLI_CLIENT_DISALLOW_REQUEST:
   _type: class
-  client_mac: beerocks::net::sMacAddr
-  hostap_mac: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  hostap_mac: sMacAddr
 
 cACTION_CLI_CLIENT_DISCONNECT_REQUEST:
   _type: class
-  client_mac: beerocks::net::sMacAddr
+  client_mac: sMacAddr
   type: uint32_t
   reason: uint32_t
 
 cACTION_CLI_CLIENT_BSS_STEER_REQUEST:
   _type: class
-  client_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  bssid: sMacAddr
   disassoc_timer: uint32_t
 
 cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST:
   _type: class
-  hostap_mac: beerocks::net::sMacAddr
-  client_mac: beerocks::net::sMacAddr
+  hostap_mac: sMacAddr
+  client_mac: sMacAddr
 
 cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST:
   _type: class
-  hostap_mac: beerocks::net::sMacAddr
-  client_mac: beerocks::net::sMacAddr
+  hostap_mac: sMacAddr
+  client_mac: sMacAddr
   channel: uint8_t
 
 cACTION_CLI_CLIENT_BEACON_11K_REQUEST:
   _type: class
-  client_mac: beerocks::net::sMacAddr 
-  bssid: beerocks::net::sMacAddr 
+  client_mac: sMacAddr 
+  bssid: sMacAddr 
   ssid:
     _type: uint8_t 
     _length: [ "beerocks::message::WIFI_SSID_MAX_LENGTH" ]
@@ -142,9 +142,9 @@ cACTION_CLI_CLIENT_BEACON_11K_REQUEST:
 
 cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST:
   _type: class
-  hostap_mac: beerocks::net::sMacAddr 
-  client_mac: beerocks::net::sMacAddr
-  peer_mac: beerocks::net::sMacAddr
+  hostap_mac: sMacAddr 
+  client_mac: sMacAddr
+  peer_mac: sMacAddr
   group_identity: uint8_t
 
 #################################################
@@ -153,30 +153,30 @@ cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST:
 
 cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   cs_params: sApChannelSwitch
 
 cACTION_CLI_HOSTAP_TX_ON_REQUEST:
   _type: class
-  ap_mac: beerocks::net::sMacAddr
+  ap_mac: sMacAddr
 
 cACTION_CLI_HOSTAP_TX_OFF_REQUEST:
   _type: class
-  ap_mac: beerocks::net::sMacAddr
+  ap_mac: sMacAddr
 
 cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST:
   _type: class
-  ap_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  ap_mac: sMacAddr
+  bssid: sMacAddr
   channel: uint8_t
   vap_id: int8_t
 
 cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST:
   _type: class
-  ap_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  ap_mac: sMacAddr
+  bssid: sMacAddr
   vap_id: int8_t
 
 cACTION_CLI_HOSTAP_STATS_MEASUREMENT:
   _type: class
-  ap_mac: beerocks::net::sMacAddr
+  ap_mac: sMacAddr

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_cli_net_map.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_cli_net_map.yaml
@@ -5,19 +5,19 @@ _namespace: beerocks_message
 
 sCliNetworkMapNodeAp:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   length: uint16_t
   hierarchy: uint8_t
 
 sCliNetworkMapNodeSta:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   type: uint8_t
   rx_rssi: int8_t
 
 sCliNetworkMapsNodeInfo:
   _type: struct
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   ipv4: beerocks::net::sIpv4Addr 
   name:
     _type: char 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -26,7 +26,7 @@ eDHCPOp:
 
 sVapInfo:
   _type: struct
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   ssid: 
     _type: char 
     _length: [ "beerocks::message::WIFI_SSID_MAX_LENGTH" ]
@@ -93,7 +93,7 @@ sPlatformSettings:
   backhaul_network_enabled: uint8_t 
   backhaul_prefered_radio_band: uint8_t 
   backhaul_vaps_bssid:
-    _type: beerocks::net::sMacAddr 
+    _type: sMacAddr 
     _length: [ 12 ]
     _comment: # 4 groups of 3 bssid in each group
 
@@ -158,15 +158,15 @@ sWifiChannel:
 
 sClientAssociationParams:
   _type: struct
-  mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  mac: sMacAddr
+  bssid: sMacAddr
   capabilities: beerocks::message::sRadioCapabilities
   vap_id: int8_t
 
 sClientDisconnectionParams:
   _type: struct
-  mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  mac: sMacAddr
+  bssid: sMacAddr
   vap_id: int8_t
   reason: uint8_t
   source: uint8_t
@@ -174,8 +174,8 @@ sClientDisconnectionParams:
 
 sClientMonitoringParams:
   _type: struct
-  mac: beerocks::net::sMacAddr
-  bridge_4addr_mac: beerocks::net::sMacAddr
+  mac: sMacAddr
+  bridge_4addr_mac: sMacAddr
   ipv4: beerocks::net::sIpv4Addr
   channel: uint8_t 
   vap_id: int8_t
@@ -205,7 +205,7 @@ sConfigVapInfo:
 
 sStaStatsParams:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   rx_packets: uint32_t
   tx_packets: uint32_t
   tx_bytes: uint32_t
@@ -250,7 +250,7 @@ sApActivityNotificationParams:
 
 sNodeRssiMeasurementRequest:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   ipv4: beerocks::net::sIpv4Addr
   channel: uint8_t 
   cross: uint8_t 
@@ -276,7 +276,7 @@ sNodeHostap:
     _type: char  
     _length: [ "beerocks::message::IFACE_NAME_LENGTH" ]
   iface_type: uint8_t    #beerocks::eIfaceType
-  iface_mac: beerocks::net::sMacAddr
+  iface_mac: sMacAddr
   iface_is_5ghz: uint8_t
   ant_num: uint8_t 
   ant_gain: uint8_t 
@@ -296,7 +296,7 @@ sVapsList:
 
 sArpMonitorData:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   ipv4: beerocks::net::sIpv4Addr
   iface_idx: uint32_t
   state: uint8_t 
@@ -305,29 +305,29 @@ sArpMonitorData:
 
 sArpQuery:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   ipv4: beerocks::net::sIpv4Addr
 
 sNodeBssSteerTarget:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   channel: uint8_t 
 
 sNodeBssSteerRequest:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   disassoc_timer: uint16_t
   disassoc_imminent: uint8_t 
   bssid: sNodeBssSteerTarget 
 
 sNodeBssSteerResponse:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   status_code: uint8_t 
 
 sNeighborSetParams11k:
   _type: struct
-  bssid: beerocks::net::sMacAddr   #ap mac
+  bssid: sMacAddr   #ap mac
   ssid:
     _type: char
     _length: [ "beerocks::message::WIFI_SSID_MAX_LENGTH" ]
@@ -354,7 +354,7 @@ sNeighborSetParams11k:
 
 sNeighborRemoveParams11k:
   _type: struct
-  bssid: beerocks::net::sMacAddr     #ap mac
+  bssid: sMacAddr     #ap mac
   ssid:
     _type: char 
     _length: [ "beerocks::message::WIFI_SSID_MAX_LENGTH" ]
@@ -367,7 +367,7 @@ sStaChannelLoadRequest11k:
   repeats: uint16_t   # '0' = once, '65535' = repeats until cancel request, other (1-65534) = specific num of repeats
   rand_ival: uint16_t # random interval - specifies the upper bound of the random delay to be used prior to making the measurement, expressed in units of TUs [=1024usec]
   duration: uint16_t  # measurement duration, expressed in units of TUs [=1024usec]
-  sta_mac: beerocks::net::sMacAddr
+  sta_mac: sMacAddr
 
   # Measurement request mode booleans:
   parallel: uint8_t            # (for multiple requests)'0' - measurements are to be performed in sequence, 
@@ -398,7 +398,7 @@ sStaChannelLoadResponse11k:
   measurement_token: uint8_t 
   duration: uint16_t    # measurement duration, expressed in units of TUs [=1024usec]
   start_time: uint64_t 
-  sta_mac: beerocks::net::sMacAddr
+  sta_mac: sMacAddr
 
   # Optinal fields:
   use_optional_wide_band_ch_switch: uint8_t    # bool
@@ -415,8 +415,8 @@ sBeaconRequest11k:
   repeats: uint16_t         # '0' = once, '65535' = repeats until cancel request, other (1-65534) = specific num of repeats
   rand_ival: uint16_t         # random interval - specifies the upper bound of the random delay to be used prior to making the measurement, expressed in units of TUs [=1024usec]
   duration: uint16_t          # measurement duration, expressed in units of TUs [=1024usec]
-  sta_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr             # the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
+  sta_mac: sMacAddr
+  bssid: sMacAddr             # the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
 
   # Measurement request mode booleans:
   parallel: uint8_t            # (for multiple requests)'0' - measurements are to be performed in sequence, 
@@ -464,8 +464,8 @@ sBeaconResponse11k:
   duration: uint16_t      # measurement duration, expressed in units of TUs [=1024usec]
   parent_tsf: uint32_t           # see IEEE part11, page 42
   start_time: uint64_t
-  sta_mac: beerocks::net::sMacAddr       # mac to send response
-  bssid: beerocks::net::sMacAddr      # the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
+  sta_mac: sMacAddr       # mac to send response
+  bssid: sMacAddr      # the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
 
   #optional:
   new_ch_width: uint32_t                      # not sure if this type is most fit
@@ -475,8 +475,8 @@ sBeaconResponse11k:
 
 sStatisticsRequest11k:
   _type: struct
-  sta_mac: beerocks::net::sMacAddr
-  peer_mac_addr: beerocks::net::sMacAddr # the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
+  sta_mac: sMacAddr
+  peer_mac_addr: sMacAddr # the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
 
   group_identity: uint8_t 
 
@@ -543,7 +543,7 @@ sStatisticsResponse11k:
   statistics_group_data:
     _type: uint32_t 
     _length: [ 13 ] # different data for each group identity, 4 octets counters with commas between them
-  sta_mac: beerocks::net::sMacAddr             # mac to send the request to
+  sta_mac: sMacAddr             # mac to send the request to
   
   # Optional:
   use_optional_rep_reason: uint8_t 
@@ -562,7 +562,7 @@ sLinkMeasurementsResponse11k:
   rsni: uint8_t 
   transmit_power: uint8_t 
   link_margin: uint8_t 
-  sta_mac: beerocks::net::sMacAddr  # mac to send the request to
+  sta_mac: sMacAddr  # mac to send the request to
 
   #Optional:
   use_optional_dmg_link_margin: uint8_t            # bool
@@ -579,13 +579,13 @@ sLinkMeasurementsResponse11k:
 sBackhaulParams:
   _type: struct
   gw_ipv4: beerocks::net::sIpv4Addr
-  gw_bridge_mac: beerocks::net::sMacAddr
-  controller_bridge_mac: beerocks::net::sMacAddr
-  bridge_mac: beerocks::net::sMacAddr
+  gw_bridge_mac: sMacAddr
+  controller_bridge_mac: sMacAddr
+  bridge_mac: sMacAddr
   bridge_ipv4: beerocks::net::sIpv4Addr
-  backhaul_mac: beerocks::net::sMacAddr
+  backhaul_mac: sMacAddr
   backhaul_ipv4: beerocks::net::sIpv4Addr
-  backhaul_bssid: beerocks::net::sMacAddr
+  backhaul_bssid: sMacAddr
   # uint32_t  backhaul_freq # HACK temp disabled because of a bug on endian converter
   backhaul_channel: uint8_t 
   backhaul_is_wireless: uint8_t 
@@ -598,7 +598,7 @@ sBackhaulParams:
 
 sBackhaulRoam:
   _type: struct
-  bssid: beerocks::net::sMacAddr
+  bssid: sMacAddr
   channel: uint8_t 
 
 sBackhaulRssi:
@@ -607,7 +607,7 @@ sBackhaulRssi:
 
 sLoggingLevelChange:
   _type: struct
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   module_name: uint8_t  # beerocks::eBeeRocksModules
   log_level: uint8_t    # beerocks::eLogLevel
   enable: uint8_t 
@@ -672,7 +672,7 @@ sDeviceInfo:
 
 sRestrictedChannels:
   _type: struct
-  hostap_mac: beerocks::net::sMacAddr
+  hostap_mac: sMacAddr
   restricted_channels:
     _type: uint8_t 
     _length: [ "beerocks::message::RESTRICTED_CHANNEL_LENGTH" ]
@@ -680,7 +680,7 @@ sRestrictedChannels:
 
 sSteeringApConfig:
   _type: struct
-  bssid: beerocks::net::sMacAddr
+  bssid: sMacAddr
   utilCheckIntervalSec: uint32_t
   utilAvgCount: uint32_t
   inactCheckIntervalSec: uint32_t 
@@ -710,8 +710,8 @@ sSteeringSetGroupResponse:
 sSteeringClientSetRequest:
   _type: struct
   steeringGroupIndex: uint32_t
-  bssid: beerocks::net::sMacAddr
-  client_mac: beerocks::net::sMacAddr
+  bssid: sMacAddr
+  client_mac: sMacAddr
   config: sSteeringClientConfig
   remove : uint8_t
 
@@ -721,16 +721,16 @@ sSteeringClientSetResponse:
 
 sSteeringEvProbeReq:
   _type: struct
-  client_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  bssid: sMacAddr
   rx_snr: uint8_t
   blocked: uint8_t
   broadcast: uint8_t
 
 sSteeringEvAuthFail:
   _type: struct
-  client_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  bssid: sMacAddr
   rx_snr: uint8_t
   blocked: uint8_t
   reject: uint8_t
@@ -796,8 +796,8 @@ eSteeringEventType:
 
 sSteeringEvConnect:
   _type: struct
-  client_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  bssid: sMacAddr
   isBTMSupported: uint32_t 
   isRRMSupported: uint32_t
   bandCap2G: uint8_t
@@ -807,22 +807,22 @@ sSteeringEvConnect:
 
 sSteeringEvDisconnect:
   _type: struct
-  client_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  bssid: sMacAddr
   reason: uint32_t
   source: eDisconnectSource
   type: eDisconnectType
 
 sSteeringEvActivity:
   _type: struct
-  client_mac: beerocks::net::sMacAddr
-  bssid: beerocks::net::sMacAddr
+  client_mac: sMacAddr
+  bssid: sMacAddr
   active: uint8_t 
 
 sSteeringEvSnrXing:
  _type: struct
- client_mac: beerocks::net::sMacAddr
- bssid: beerocks::net::sMacAddr
+ client_mac: sMacAddr
+ bssid: sMacAddr
  snr: uint32_t
  inactveXing: eSteeringSnrChange
  highXing: eSteeringSnrChange
@@ -830,7 +830,7 @@ sSteeringEvSnrXing:
 
 sSteeringEvSnr:
  _type: struct
- client_mac: beerocks::net::sMacAddr
- bssid: beerocks::net::sMacAddr
+ client_mac: sMacAddr
+ bssid: sMacAddr
  snr: uint32_t
                 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
@@ -29,7 +29,7 @@ cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION:
   platform: uint8_t            # configuration, beerocks::ePlatform
   low_pass_filter_on: uint8_t  # configuration
   enable_repeater_mode: uint8_t 
-  radio_identifier: beerocks::net::sMacAddr
+  radio_identifier: sMacAddr
   is_slave_reconf: uint8_t
 
 cACTION_CONTROL_SLAVE_JOINED_RESPONSE:
@@ -42,9 +42,9 @@ cACTION_CONTROL_SLAVE_JOINED_RESPONSE:
 
 cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION:
   _type: class
-  backhaul_iface_mac: beerocks::net::sMacAddr 
+  backhaul_iface_mac: sMacAddr 
   backhaul_ipv4: beerocks::net::sIpv4Addr 
-  bridge_iface_mac: beerocks::net::sMacAddr 
+  bridge_iface_mac: sMacAddr 
   bridge_ipv4: beerocks::net::sIpv4Addr 
   hostap: sNodeHostap 
 
@@ -102,7 +102,7 @@ cACTION_CONTROL_VERSION_MISMATCH_NOTIFICATION:
 
 cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION:
   _type: class
-  bridge_mac: beerocks::net::sMacAddr 
+  bridge_mac: sMacAddr 
   operational: uint8_t 
 
 cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION:
@@ -257,7 +257,7 @@ cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST:
 
 cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
   _type: class
@@ -269,11 +269,11 @@ cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE:
 
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION:
   _type: class
@@ -281,11 +281,11 @@ cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION:
 
 cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_CONTROL_CLIENT_ASSOCIATED_NOTIFICATION:
   _type: class
@@ -297,17 +297,17 @@ cACTION_CONTROL_CLIENT_DISCONNECTED_NOTIFICATION:
 
 cACTION_CONTROL_CLIENT_DISALLOW_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
   reject_sta: uint8_t
 
 cACTION_CONTROL_CLIENT_ALLOW_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   ipv4: beerocks::net::sIpv4Addr 
 
 cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   vap_id: int8_t
   type: uint32_t
   reason: uint32_t
@@ -326,7 +326,7 @@ cACTION_CONTROL_CLIENT_BSS_STEER_RESPONSE:
 
 cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   ipv4: beerocks::net::sIpv4Addr 
   name: 
     _type: char 
@@ -362,7 +362,7 @@ cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE:
 
 cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_header.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_header.yaml
@@ -21,7 +21,7 @@ cACTION_HEADER:
   direction: 
     _type: uint8_t
     _value: 1 #BEEROCKS_DIRECTION_AGENT
-  radio_mac: beerocks::net::sMacAddr
+  radio_mac: sMacAddr
   last:
     _type: uint8_t
     _value: 0

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_monitor.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_monitor.yaml
@@ -46,7 +46,7 @@ cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST:
 
 cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr
+  mac: sMacAddr
 
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
   _type: class
@@ -54,7 +54,7 @@ cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
 
 cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   ipv4: beerocks::net::sIpv4Addr 
   channel: uint8_t 
 
@@ -68,19 +68,19 @@ cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE:
 
 cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
  
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION:
   _type: class
@@ -139,7 +139,7 @@ cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE:
 
 cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST:
   _type: class
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
 
 cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_platform.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_platform.yaml
@@ -53,7 +53,7 @@ cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION:
   _type: class
   dhcp_op: eDHCPOp
   op: uint32_t 
-  mac: beerocks::net::sMacAddr 
+  mac: sMacAddr 
   ipv4: beerocks::net::sIpv4Addr 
   hostname: 
     _type: char 

--- a/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.cpp
+++ b/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.cpp
@@ -49,13 +49,13 @@ int bml_rdkb_internal::steering_set_group(uint32_t steeringGroupIndex,
     if (cfg_2 && cfg_5) {
         request->remove() = 0;
 
-        std::copy_n(cfg_2->bssid, sizeof(beerocks::net::sMacAddr::oct), request->cfg_2().bssid.oct);
+        std::copy_n(cfg_2->bssid, sizeof(sMacAddr::oct), request->cfg_2().bssid.oct);
         request->cfg_2().utilCheckIntervalSec   = cfg_2->utilCheckIntervalSec;
         request->cfg_2().utilAvgCount           = cfg_2->utilAvgCount;
         request->cfg_2().inactCheckIntervalSec  = cfg_2->inactCheckIntervalSec;
         request->cfg_2().inactCheckThresholdSec = cfg_2->inactCheckThresholdSec;
 
-        std::copy_n(cfg_5->bssid, sizeof(beerocks::net::sMacAddr::oct), request->cfg_5().bssid.oct);
+        std::copy_n(cfg_5->bssid, sizeof(sMacAddr::oct), request->cfg_5().bssid.oct);
         request->cfg_5().utilCheckIntervalSec   = cfg_5->utilCheckIntervalSec;
         request->cfg_5().utilAvgCount           = cfg_5->utilAvgCount;
         request->cfg_5().inactCheckIntervalSec  = cfg_5->inactCheckIntervalSec;
@@ -120,8 +120,8 @@ int bml_rdkb_internal::steering_client_set(uint32_t steeringGroupIndex, const BM
     }
 
     request->steeringGroupIndex() = steeringGroupIndex;
-    std::copy_n(bssid, sizeof(beerocks::net::sMacAddr::oct), request->bssid().oct);
-    std::copy_n(client_mac, sizeof(beerocks::net::sMacAddr::oct), request->client_mac().oct);
+    std::copy_n(bssid, sizeof(sMacAddr::oct), request->bssid().oct);
+    std::copy_n(client_mac, sizeof(sMacAddr::oct), request->client_mac().oct);
     request->remove() = 1;
     if (config) {
         request->config().snrProbeHWM      = config->snrProbeHWM;
@@ -248,7 +248,7 @@ int bml_rdkb_internal::steering_client_measure(uint32_t steeringGroupIndex,
 
     std::copy_n(client_mac, BML_MAC_ADDR_LEN, request->client_mac().oct);
     request->steeringGroupIndex() = steeringGroupIndex;
-    std::copy_n(bssid, sizeof(beerocks::net::sMacAddr::oct), request->bssid().oct);
+    std::copy_n(bssid, sizeof(sMacAddr::oct), request->bssid().oct);
 
     if (!message_com::send_cmdu(m_sockMaster, cmdu_tx)) {
         LOG(ERROR) << "Failed sending cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST message!";
@@ -298,7 +298,7 @@ int bml_rdkb_internal::steering_client_disconnect(uint32_t steeringGroupIndex,
 
     std::copy_n(client_mac, BML_MAC_ADDR_LEN, request->client_mac().oct);
     request->steeringGroupIndex() = steeringGroupIndex;
-    std::copy_n(bssid, sizeof(beerocks::net::sMacAddr::oct), request->bssid().oct);
+    std::copy_n(bssid, sizeof(sMacAddr::oct), request->bssid().oct);
     request->type()   = beerocks_message::eDisconnectType(type);
     request->reason() = reason;
 

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -453,10 +453,10 @@ static void steering_set_group_string_to_struct(const std::string &str_cfg_2,
     cfg2.inactCheckThresholdSec = string_utils::stoi(v_str_cfg_2[4]);
     cfg5.inactCheckThresholdSec = string_utils::stoi(v_str_cfg_5[4]);
 
-    beerocks::net::sMacAddr bssid2;
-    beerocks::net::sMacAddr bssid5;
-    std::copy_n(cfg2.bssid, sizeof(beerocks::net::sMacAddr::oct), bssid2.oct);
-    std::copy_n(cfg5.bssid, sizeof(beerocks::net::sMacAddr::oct), bssid5.oct);
+    sMacAddr bssid2;
+    sMacAddr bssid5;
+    std::copy_n(cfg2.bssid, sizeof(sMacAddr::oct), bssid2.oct);
+    std::copy_n(cfg5.bssid, sizeof(sMacAddr::oct), bssid5.oct);
 
     std::cout << "cfg2.bssid = " << network_utils::mac_to_string(bssid2) << std::endl
               << "cfg2.utilCheckIntervalSec = " << cfg2.utilCheckIntervalSec << std::endl

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -226,7 +226,7 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_search(Socket *sd,
     auto tlvAlMacAddressType = cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
     if (tlvAlMacAddressType) {
         al_mac =
-            network_utils::mac_to_string((const unsigned char *)tlvAlMacAddressType->mac().mac);
+            network_utils::mac_to_string((const unsigned char *)tlvAlMacAddressType->mac().oct);
         LOG(DEBUG) << "mac=" << al_mac;
     } else {
         LOG(ERROR) << "tlvAlMacAddressType missing - ignoring autconfig search message";
@@ -398,7 +398,7 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         return false;
     }
 
-    std::copy_n(tlvWscM1->M1Frame().mac_attr.data.mac, beerocks::net::MAC_ADDR_LEN,
+    std::copy_n(tlvWscM1->M1Frame().mac_attr.data.oct, beerocks::net::MAC_ADDR_LEN,
                 beerocks_header->radio_mac().oct);
     LOG(INFO) << "Handle slave join, radio mac "
               << network_utils::mac_to_string(beerocks_header->radio_mac());

--- a/controller/src/beerocks/master/tasks/channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.h
@@ -33,30 +33,30 @@ public:
     virtual ~channel_selection_task() {}
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
     } sHostapChannelRequest_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         uint8_t success;
     } sRestrictedChannelResponse_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         beerocks_message::sApChannelSwitch cs_params;
     } sCsa_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         beerocks_message::sDfsCacCompleted params;
     } sCacCompleted_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         beerocks_message::sDfsChannelAvailable params;
     } sDfsChannelAvailable_event;
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         beerocks_message::sApChannelSwitch cs_params;
 
         beerocks_message::sWifiChannel
@@ -64,7 +64,7 @@ public:
     } sAcsResponse_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         bool low_pass_filter_on;
         bool backhaul_is_wireless;
         uint8_t backhaul_channel;
@@ -77,27 +77,27 @@ public:
     } sSlaveJoined_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
     } sTxOnResponse_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
     } sApActivityIdle_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         std::chrono::steady_clock::time_point timestamp;
         bool timeout_expired;
     } sDfsReEntrySampleSteeredClients_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         std::chrono::steady_clock::time_point timestamp;
         bool timeout_expired;
     } sDfsCacPendinghostap_event;
 
     typedef struct {
-        beerocks::net::sMacAddr hostap_mac;
+        sMacAddr hostap_mac;
         uint8_t restricted_channels[beerocks::message::RESTRICTED_CHANNEL_LENGTH];
     } sConfiguredRestrictedChannels_event;
 

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.h
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.h
@@ -39,7 +39,7 @@ public:
         Socket *sd;
         uint32_t steeringGroupIndex;
         std::string bssid;
-        beerocks::net::sMacAddr client_mac;
+        sMacAddr client_mac;
         beerocks_message::sSteeringClientConfig config;
         uint8_t remove;
     };
@@ -62,7 +62,7 @@ public:
         Socket *sd;
         uint32_t steeringGroupIndex;
         std::string bssid;
-        beerocks::net::sMacAddr client_mac;
+        sMacAddr client_mac;
         beerocks_message::eDisconnectType type;
         uint32_t reason;
     };

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -27,7 +27,7 @@
 #include "tlvf/WSC/eWscAuth.h"
 #include "tlvf/WSC/eWscEncr.h"
 #include "tlvf/WSC/eWscLengths.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace WSC {
 
@@ -92,7 +92,7 @@ typedef struct sWscAttrUuidR {
 typedef struct sWscAttrMac {
     eWscAttributes attribute_type;
     uint16_t data_length;
-    sMacAddress data;
+    sMacAddr data;
     void struct_swap(){
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&attribute_type));
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&data_length));
@@ -478,7 +478,7 @@ typedef struct sWscAttrNetworkKey {
 typedef struct sWscAttrBssid {
     eWscAttributes attribute_type;
     uint16_t data_length;
-    sMacAddress data;
+    sMacAddr data;
     void struct_swap(){
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&attribute_type));
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&data_length));

--- a/framework/tlvf/AutoGenerated/include/tlvf/common/sMacAddr.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/common/sMacAddr.h
@@ -1,0 +1,31 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_COMMON_SMACADDR_H_
+#define _TLVF_COMMON_SMACADDR_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+typedef struct sMacAddr {
+    uint8_t oct[6];
+    void struct_swap(){
+    }
+    void struct_init(){
+            for (size_t i = 0; i < 6; i++) {
+                oct[i] = 0x0;
+            }
+    }
+} __attribute__((packed)) sMacAddr;
+
+
+#endif //_TLVF/COMMON_SMACADDR_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/s802_11SpecificInformation.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/s802_11SpecificInformation.h
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <stdint.h>
 #include <tlvf/swap.h>
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace ieee1905_1 {
 
@@ -29,7 +29,7 @@ enum eRole: uint8_t {
 };
 
 typedef struct s802_11SpecificInformation {
-    sMacAddress network_membership;
+    sMacAddr network_membership;
     eRole role;
     //Hex value of dot11CurrentChannelBandwidth
     uint8_t ap_channel_band;

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 
 namespace ieee1905_1 {
@@ -39,7 +39,7 @@ class tlv1905NeighborDevice : public BaseClass
         };
         
         typedef struct sMacAl1905Device {
-            sMacAddress mac;
+            sMacAddr mac;
             eBridgesExist bridges_exist;
             void struct_swap(){
                 mac.struct_swap();
@@ -51,7 +51,7 @@ class tlv1905NeighborDevice : public BaseClass
         
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& mac_local_iface();
+        sMacAddr& mac_local_iface();
         std::tuple<bool, sMacAl1905Device&> mac_al_1905_device(size_t idx);
         bool alloc_mac_al_1905_device(size_t count = 1);
         void class_swap();
@@ -61,7 +61,7 @@ class tlv1905NeighborDevice : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_mac_local_iface = nullptr;
+        sMacAddr* m_mac_local_iface = nullptr;
         sMacAl1905Device* m_mac_al_1905_device = nullptr;
         size_t m_mac_al_1905_device_idx__ = 0;
 };

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvAlMacAddressType.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvAlMacAddressType.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace ieee1905_1 {
 
@@ -34,7 +34,7 @@ class tlvAlMacAddressType : public BaseClass
 
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& mac();
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
@@ -42,7 +42,7 @@ class tlvAlMacAddressType : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h
@@ -22,7 +22,7 @@
 #include "tlvf/ieee_1905_1/eTlvType.h"
 #include <tuple>
 #include <vector>
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace ieee1905_1 {
 
@@ -63,7 +63,7 @@ class cMacList : public BaseClass
         ~cMacList();
 
         uint8_t& mac_list_length();
-        std::tuple<bool, sMacAddress&> mac_list(size_t idx);
+        std::tuple<bool, sMacAddr&> mac_list(size_t idx);
         bool alloc_mac_list(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
@@ -71,7 +71,7 @@ class cMacList : public BaseClass
     private:
         bool init();
         uint8_t* m_mac_list_length = nullptr;
-        sMacAddress* m_mac_list = nullptr;
+        sMacAddr* m_mac_list = nullptr;
         size_t m_mac_list_idx__ = 0;
 };
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceInformation.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceInformation.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 #include "tlvf/ieee_1905_1/eMediaType.h"
 
@@ -35,7 +35,7 @@ class tlvDeviceInformation : public BaseClass
         ~tlvDeviceInformation();
 
         typedef struct sInfo {
-            sMacAddress mac;
+            sMacAddr mac;
             eMediaType media_type;
             uint8_t media_info_length;
             eMediaType media_info;
@@ -49,7 +49,7 @@ class tlvDeviceInformation : public BaseClass
         
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& mac();
+        sMacAddr& mac();
         uint8_t& info_length();
         std::tuple<bool, sInfo&> info(size_t idx);
         bool alloc_info(size_t count = 1);
@@ -60,7 +60,7 @@ class tlvDeviceInformation : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_mac = nullptr;
+        sMacAddr* m_mac = nullptr;
         uint8_t* m_info_length = nullptr;
         sInfo* m_info = nullptr;
         size_t m_info_idx__ = 0;

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvLinkMetricQuery.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvLinkMetricQuery.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace ieee1905_1 {
 
@@ -46,7 +46,7 @@ class tlvLinkMetricQuery : public BaseClass
         const eTlvType& type();
         const uint16_t& length();
         eNeighborType& neighbor_type();
-        sMacAddress& mac_al_1905_device();
+        sMacAddr& mac_al_1905_device();
         eLinkMetricsType& link_metrics();
         void class_swap();
         static size_t get_initial_size();
@@ -56,7 +56,7 @@ class tlvLinkMetricQuery : public BaseClass
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
         eNeighborType* m_neighbor_type = nullptr;
-        sMacAddress* m_mac_al_1905_device = nullptr;
+        sMacAddr* m_mac_al_1905_device = nullptr;
         eLinkMetricsType* m_link_metrics = nullptr;
 };
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 
 namespace ieee1905_1 {
@@ -35,8 +35,8 @@ class tlvNon1905neighborDeviceList : public BaseClass
 
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& mac_local_iface();
-        std::tuple<bool, sMacAddress&> mac_non_1905_device(size_t idx);
+        sMacAddr& mac_local_iface();
+        std::tuple<bool, sMacAddr&> mac_non_1905_device(size_t idx);
         bool alloc_mac_non_1905_device(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
@@ -45,8 +45,8 @@ class tlvNon1905neighborDeviceList : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_mac_local_iface = nullptr;
-        sMacAddress* m_mac_non_1905_device = nullptr;
+        sMacAddr* m_mac_local_iface = nullptr;
+        sMacAddr* m_mac_non_1905_device = nullptr;
         size_t m_mac_non_1905_device_idx__ = 0;
 };
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace ieee1905_1 {
 
@@ -34,14 +34,14 @@ class tlvPushButtonJoinNotification : public BaseClass
 
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& al_mac_notification_src();
+        sMacAddr& al_mac_notification_src();
         uint16_t& mid_of_the_notification();
         //Interface-specific MAC address of the interface of the transmitting device
         //belonging to the medium on which a new device joined.
-        sMacAddress& transmitter_iface_mac_of_new_device_joined();
+        sMacAddr& transmitter_iface_mac_of_new_device_joined();
         //Interface-specific MAC address of the interface of the new device that was
         //joined to the network as a result of the push button configuration sequence.
-        sMacAddress& iface_mac_of_new_device_joined();
+        sMacAddr& iface_mac_of_new_device_joined();
         void class_swap();
         static size_t get_initial_size();
 
@@ -49,10 +49,10 @@ class tlvPushButtonJoinNotification : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_al_mac_notification_src = nullptr;
+        sMacAddr* m_al_mac_notification_src = nullptr;
         uint16_t* m_mid_of_the_notification = nullptr;
-        sMacAddress* m_transmitter_iface_mac_of_new_device_joined = nullptr;
-        sMacAddress* m_iface_mac_of_new_device_joined = nullptr;
+        sMacAddr* m_transmitter_iface_mac_of_new_device_joined = nullptr;
+        sMacAddr* m_iface_mac_of_new_device_joined = nullptr;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 #include "tlvf/ieee_1905_1/eMediaType.h"
 
@@ -57,8 +57,8 @@ class tlvReceiverLinkMetric : public BaseClass
         } __attribute__((packed)) sLinkMetricInfo;
         
         typedef struct sInterfacePairInfo {
-            sMacAddress mac_of_an_interface_in_the_receiving_al;
-            sMacAddress mac_of_an_interface_in_the_neighbor_al;
+            sMacAddr mac_of_an_interface_in_the_receiving_al;
+            sMacAddr mac_of_an_interface_in_the_neighbor_al;
             sLinkMetricInfo link_metric_info;
             void struct_swap(){
                 mac_of_an_interface_in_the_receiving_al.struct_swap();
@@ -74,8 +74,8 @@ class tlvReceiverLinkMetric : public BaseClass
         
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& al_mac_of_the_device_that_transmits();
-        sMacAddress& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
+        sMacAddr& al_mac_of_the_device_that_transmits();
+        sMacAddr& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
         //The following fields shall be repeated for each connected interface pair between the
         //receiving 1905.1 AL and the neighbor 1905.1 AL.
         std::tuple<bool, sInterfacePairInfo&> interface_pair_info(size_t idx);
@@ -87,8 +87,8 @@ class tlvReceiverLinkMetric : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_al_mac_of_the_device_that_transmits = nullptr;
-        sMacAddress* m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = nullptr;
+        sMacAddr* m_al_mac_of_the_device_that_transmits = nullptr;
+        sMacAddr* m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = nullptr;
         sInterfacePairInfo* m_interface_pair_info = nullptr;
         size_t m_interface_pair_info_idx__ = 0;
 };

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 #include "tlvf/ieee_1905_1/eMediaType.h"
 
@@ -68,8 +68,8 @@ class tlvTransmitterLinkMetric : public BaseClass
         } __attribute__((packed)) sLinkMetricInfo;
         
         typedef struct sInterfacePairInfo {
-            sMacAddress mac_of_an_interface_in_the_receiving_al;
-            sMacAddress mac_of_an_interface_in_the_neighbor_al;
+            sMacAddr mac_of_an_interface_in_the_receiving_al;
+            sMacAddr mac_of_an_interface_in_the_neighbor_al;
             sLinkMetricInfo link_metric_info;
             void struct_swap(){
                 mac_of_an_interface_in_the_receiving_al.struct_swap();
@@ -85,8 +85,8 @@ class tlvTransmitterLinkMetric : public BaseClass
         
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddress& al_mac_of_the_device_that_transmits();
-        sMacAddress& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
+        sMacAddr& al_mac_of_the_device_that_transmits();
+        sMacAddr& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
         //The fields shall be repeated for each connected interface pair between the receiving
         //905.1 AL and the neighbor 1905.1 AL.
         std::tuple<bool, sInterfacePairInfo&> interface_pair_info(size_t idx);
@@ -98,8 +98,8 @@ class tlvTransmitterLinkMetric : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_al_mac_of_the_device_that_transmits = nullptr;
-        sMacAddress* m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = nullptr;
+        sMacAddr* m_al_mac_of_the_device_that_transmits = nullptr;
+        sMacAddr* m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = nullptr;
         sInterfacePairInfo* m_interface_pair_info = nullptr;
         size_t m_interface_pair_info_idx__ = 0;
 };

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioBasicCapabilities.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioBasicCapabilities.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/wfa_map/eTlvTypeMap.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 #include <vector>
 
@@ -37,7 +37,7 @@ class tlvApRadioBasicCapabilities : public BaseClass
 
         const eTlvTypeMap& type();
         const uint16_t& length();
-        sMacAddress& radio_uid();
+        sMacAddr& radio_uid();
         uint8_t& maximum_number_of_bsss_supported();
         uint8_t& operating_classes_info_list_length();
         std::tuple<bool, cOperatingClassesInfo&> operating_classes_info_list(size_t idx);
@@ -50,7 +50,7 @@ class tlvApRadioBasicCapabilities : public BaseClass
         bool init();
         eTlvTypeMap* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_radio_uid = nullptr;
+        sMacAddr* m_radio_uid = nullptr;
         uint8_t* m_maximum_number_of_bsss_supported = nullptr;
         uint8_t* m_operating_classes_info_list_length = nullptr;
         cOperatingClassesInfo* m_operating_classes_info_list = nullptr;

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioIdentifier.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioIdentifier.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/wfa_map/eTlvTypeMap.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 
 namespace wfa_map {
 
@@ -34,7 +34,7 @@ class tlvApRadioIdentifier : public BaseClass
 
         const eTlvTypeMap& type();
         const uint16_t& length();
-        sMacAddress& radio_uid();
+        sMacAddr& radio_uid();
         void class_swap();
         static size_t get_initial_size();
 
@@ -42,7 +42,7 @@ class tlvApRadioIdentifier : public BaseClass
         bool init();
         eTlvTypeMap* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_radio_uid = nullptr;
+        sMacAddr* m_radio_uid = nullptr;
 };
 
 }; // close namespace: wfa_map

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/wfa_map/eTlvTypeMap.h"
-#include "tlvf/common/sMacAddress.h"
+#include "tlvf/common/sMacAddr.h"
 #include <tuple>
 #include <vector>
 #include <asm/byteorder.h>
@@ -38,7 +38,7 @@ class tlvChannelPreference : public BaseClass
 
         const eTlvTypeMap& type();
         const uint16_t& length();
-        sMacAddress& radio_uid();
+        sMacAddr& radio_uid();
         uint8_t& operating_classes_list_length();
         std::tuple<bool, cOperatingClasses&> operating_classes_list(size_t idx);
         std::shared_ptr<cOperatingClasses> create_operating_classes_list();
@@ -50,7 +50,7 @@ class tlvChannelPreference : public BaseClass
         bool init();
         eTlvTypeMap* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddress* m_radio_uid = nullptr;
+        sMacAddr* m_radio_uid = nullptr;
         uint8_t* m_operating_classes_list_length = nullptr;
         cOperatingClasses* m_operating_classes_list = nullptr;
         size_t m_operating_classes_list_idx__ = 0;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -33,8 +33,8 @@ const uint16_t& tlv1905NeighborDevice::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlv1905NeighborDevice::mac_local_iface() {
-    return (sMacAddress&)(*m_mac_local_iface);
+sMacAddr& tlv1905NeighborDevice::mac_local_iface() {
+    return (sMacAddr&)(*m_mac_local_iface);
 }
 
 std::tuple<bool, tlv1905NeighborDevice::sMacAl1905Device&> tlv1905NeighborDevice::mac_al_1905_device(size_t idx) {
@@ -80,7 +80,7 @@ size_t tlv1905NeighborDevice::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // mac_local_iface
+    class_size += sizeof(sMacAddr); // mac_local_iface
     return class_size;
 }
 
@@ -102,9 +102,9 @@ bool tlv1905NeighborDevice::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_mac_local_iface = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_mac_local_iface = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_local_iface->struct_init(); }
     m_mac_al_1905_device = (sMacAl1905Device*)m_buff_ptr__;
     if (m_length && m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -33,8 +33,8 @@ const uint16_t& tlvAlMacAddressType::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvAlMacAddressType::mac() {
-    return (sMacAddress&)(*m_mac);
+sMacAddr& tlvAlMacAddressType::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void tlvAlMacAddressType::class_swap()
@@ -48,7 +48,7 @@ size_t tlvAlMacAddressType::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -70,9 +70,9 @@ bool tlvAlMacAddressType::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_mac = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -159,7 +159,7 @@ uint8_t& cMacList::mac_list_length() {
     return (uint8_t&)(*m_mac_list_length);
 }
 
-std::tuple<bool, sMacAddress&> cMacList::mac_list(size_t idx) {
+std::tuple<bool, sMacAddr&> cMacList::mac_list(size_t idx) {
     bool ret_success = ( (m_mac_list_idx__ > 0) && (m_mac_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
@@ -173,7 +173,7 @@ bool cMacList::alloc_mac_list(size_t count) {
         TLVF_LOG(WARNING) << "can't allocate 0 bytes";
         return false;
     }
-    size_t len = sizeof(sMacAddress) * count;
+    size_t len = sizeof(sMacAddr) * count;
     if(getBuffRemainingBytes() < len )  {
         TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
         return false;
@@ -211,9 +211,9 @@ bool cMacList::init()
     m_mac_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_mac_list_length = 0;
     m_buff_ptr__ += sizeof(uint8_t) * 1;
-    m_mac_list = (sMacAddress*)m_buff_ptr__;
+    m_mac_list = (sMacAddr*)m_buff_ptr__;
     m_mac_list_idx__ = *m_mac_list_length;
-    m_buff_ptr__ += sizeof(sMacAddress)*(*m_mac_list_length);
+    m_buff_ptr__ += sizeof(sMacAddr)*(*m_mac_list_length);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -33,8 +33,8 @@ const uint16_t& tlvDeviceInformation::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvDeviceInformation::mac() {
-    return (sMacAddress&)(*m_mac);
+sMacAddr& tlvDeviceInformation::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 uint8_t& tlvDeviceInformation::info_length() {
@@ -85,7 +85,7 @@ size_t tlvDeviceInformation::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // mac
+    class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(uint8_t); // info_length
     return class_size;
 }
@@ -108,9 +108,9 @@ bool tlvDeviceInformation::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_mac = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
     m_info_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_info_length = 0;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -37,8 +37,8 @@ tlvLinkMetricQuery::eNeighborType& tlvLinkMetricQuery::neighbor_type() {
     return (eNeighborType&)(*m_neighbor_type);
 }
 
-sMacAddress& tlvLinkMetricQuery::mac_al_1905_device() {
-    return (sMacAddress&)(*m_mac_al_1905_device);
+sMacAddr& tlvLinkMetricQuery::mac_al_1905_device() {
+    return (sMacAddr&)(*m_mac_al_1905_device);
 }
 
 tlvLinkMetricQuery::eLinkMetricsType& tlvLinkMetricQuery::link_metrics() {
@@ -57,7 +57,7 @@ size_t tlvLinkMetricQuery::get_initial_size()
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
     class_size += sizeof(eNeighborType); // neighbor_type
-    class_size += sizeof(sMacAddress); // mac_al_1905_device
+    class_size += sizeof(sMacAddr); // mac_al_1905_device
     class_size += sizeof(eLinkMetricsType); // link_metrics
     return class_size;
 }
@@ -83,9 +83,9 @@ bool tlvLinkMetricQuery::init()
     m_neighbor_type = (eNeighborType*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(eNeighborType) * 1;
     if(m_length && !m_parse__){ (*m_length) += sizeof(eNeighborType); }
-    m_mac_al_1905_device = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_mac_al_1905_device = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_al_1905_device->struct_init(); }
     m_link_metrics = (eLinkMetricsType*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(eLinkMetricsType) * 1;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -33,11 +33,11 @@ const uint16_t& tlvNon1905neighborDeviceList::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvNon1905neighborDeviceList::mac_local_iface() {
-    return (sMacAddress&)(*m_mac_local_iface);
+sMacAddr& tlvNon1905neighborDeviceList::mac_local_iface() {
+    return (sMacAddr&)(*m_mac_local_iface);
 }
 
-std::tuple<bool, sMacAddress&> tlvNon1905neighborDeviceList::mac_non_1905_device(size_t idx) {
+std::tuple<bool, sMacAddr&> tlvNon1905neighborDeviceList::mac_non_1905_device(size_t idx) {
     bool ret_success = ( (m_mac_non_1905_device_idx__ > 0) && (m_mac_non_1905_device_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
@@ -51,7 +51,7 @@ bool tlvNon1905neighborDeviceList::alloc_mac_non_1905_device(size_t count) {
         TLVF_LOG(WARNING) << "can't allocate 0 bytes";
         return false;
     }
-    size_t len = sizeof(sMacAddress) * count;
+    size_t len = sizeof(sMacAddr) * count;
     if(getBuffRemainingBytes() < len )  {
         TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
         return false;
@@ -80,7 +80,7 @@ size_t tlvNon1905neighborDeviceList::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // mac_local_iface
+    class_size += sizeof(sMacAddr); // mac_local_iface
     return class_size;
 }
 
@@ -102,16 +102,16 @@ bool tlvNon1905neighborDeviceList::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_mac_local_iface = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_mac_local_iface = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_local_iface->struct_init(); }
-    m_mac_non_1905_device = (sMacAddress*)m_buff_ptr__;
+    m_mac_non_1905_device = (sMacAddr*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - kMinimumLength - m_buff__);
-        m_mac_non_1905_device_idx__ = len/sizeof(sMacAddress);
+        m_mac_non_1905_device_idx__ = len/sizeof(sMacAddr);
         m_buff_ptr__ += len;
     }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -33,20 +33,20 @@ const uint16_t& tlvPushButtonJoinNotification::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvPushButtonJoinNotification::al_mac_notification_src() {
-    return (sMacAddress&)(*m_al_mac_notification_src);
+sMacAddr& tlvPushButtonJoinNotification::al_mac_notification_src() {
+    return (sMacAddr&)(*m_al_mac_notification_src);
 }
 
 uint16_t& tlvPushButtonJoinNotification::mid_of_the_notification() {
     return (uint16_t&)(*m_mid_of_the_notification);
 }
 
-sMacAddress& tlvPushButtonJoinNotification::transmitter_iface_mac_of_new_device_joined() {
-    return (sMacAddress&)(*m_transmitter_iface_mac_of_new_device_joined);
+sMacAddr& tlvPushButtonJoinNotification::transmitter_iface_mac_of_new_device_joined() {
+    return (sMacAddr&)(*m_transmitter_iface_mac_of_new_device_joined);
 }
 
-sMacAddress& tlvPushButtonJoinNotification::iface_mac_of_new_device_joined() {
-    return (sMacAddress&)(*m_iface_mac_of_new_device_joined);
+sMacAddr& tlvPushButtonJoinNotification::iface_mac_of_new_device_joined() {
+    return (sMacAddr&)(*m_iface_mac_of_new_device_joined);
 }
 
 void tlvPushButtonJoinNotification::class_swap()
@@ -63,10 +63,10 @@ size_t tlvPushButtonJoinNotification::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // al_mac_notification_src
+    class_size += sizeof(sMacAddr); // al_mac_notification_src
     class_size += sizeof(uint16_t); // mid_of_the_notification
-    class_size += sizeof(sMacAddress); // transmitter_iface_mac_of_new_device_joined
-    class_size += sizeof(sMacAddress); // iface_mac_of_new_device_joined
+    class_size += sizeof(sMacAddr); // transmitter_iface_mac_of_new_device_joined
+    class_size += sizeof(sMacAddr); // iface_mac_of_new_device_joined
     return class_size;
 }
 
@@ -88,20 +88,20 @@ bool tlvPushButtonJoinNotification::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_al_mac_notification_src = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_al_mac_notification_src = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_notification_src->struct_init(); }
     m_mid_of_the_notification = (uint16_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
-    m_transmitter_iface_mac_of_new_device_joined = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_transmitter_iface_mac_of_new_device_joined = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_transmitter_iface_mac_of_new_device_joined->struct_init(); }
-    m_iface_mac_of_new_device_joined = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_iface_mac_of_new_device_joined = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_iface_mac_of_new_device_joined->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -33,12 +33,12 @@ const uint16_t& tlvReceiverLinkMetric::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvReceiverLinkMetric::al_mac_of_the_device_that_transmits() {
-    return (sMacAddress&)(*m_al_mac_of_the_device_that_transmits);
+sMacAddr& tlvReceiverLinkMetric::al_mac_of_the_device_that_transmits() {
+    return (sMacAddr&)(*m_al_mac_of_the_device_that_transmits);
 }
 
-sMacAddress& tlvReceiverLinkMetric::al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv() {
-    return (sMacAddress&)(*m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv);
+sMacAddr& tlvReceiverLinkMetric::al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv() {
+    return (sMacAddr&)(*m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv);
 }
 
 std::tuple<bool, tlvReceiverLinkMetric::sInterfacePairInfo&> tlvReceiverLinkMetric::interface_pair_info(size_t idx) {
@@ -85,8 +85,8 @@ size_t tlvReceiverLinkMetric::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // al_mac_of_the_device_that_transmits
-    class_size += sizeof(sMacAddress); // al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv
+    class_size += sizeof(sMacAddr); // al_mac_of_the_device_that_transmits
+    class_size += sizeof(sMacAddr); // al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv
     return class_size;
 }
 
@@ -108,13 +108,13 @@ bool tlvReceiverLinkMetric::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_al_mac_of_the_device_that_transmits = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_al_mac_of_the_device_that_transmits = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_device_that_transmits->struct_init(); }
-    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
     if (m_length && m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -33,12 +33,12 @@ const uint16_t& tlvTransmitterLinkMetric::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvTransmitterLinkMetric::al_mac_of_the_device_that_transmits() {
-    return (sMacAddress&)(*m_al_mac_of_the_device_that_transmits);
+sMacAddr& tlvTransmitterLinkMetric::al_mac_of_the_device_that_transmits() {
+    return (sMacAddr&)(*m_al_mac_of_the_device_that_transmits);
 }
 
-sMacAddress& tlvTransmitterLinkMetric::al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv() {
-    return (sMacAddress&)(*m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv);
+sMacAddr& tlvTransmitterLinkMetric::al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv() {
+    return (sMacAddr&)(*m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv);
 }
 
 std::tuple<bool, tlvTransmitterLinkMetric::sInterfacePairInfo&> tlvTransmitterLinkMetric::interface_pair_info(size_t idx) {
@@ -85,8 +85,8 @@ size_t tlvTransmitterLinkMetric::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // al_mac_of_the_device_that_transmits
-    class_size += sizeof(sMacAddress); // al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv
+    class_size += sizeof(sMacAddr); // al_mac_of_the_device_that_transmits
+    class_size += sizeof(sMacAddr); // al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv
     return class_size;
 }
 
@@ -108,13 +108,13 @@ bool tlvTransmitterLinkMetric::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_al_mac_of_the_device_that_transmits = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_al_mac_of_the_device_that_transmits = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_device_that_transmits->struct_init(); }
-    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
     if (m_length && m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -33,8 +33,8 @@ const uint16_t& tlvApRadioBasicCapabilities::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvApRadioBasicCapabilities::radio_uid() {
-    return (sMacAddress&)(*m_radio_uid);
+sMacAddr& tlvApRadioBasicCapabilities::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
 }
 
 uint8_t& tlvApRadioBasicCapabilities::maximum_number_of_bsss_supported() {
@@ -112,7 +112,7 @@ size_t tlvApRadioBasicCapabilities::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvTypeMap); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // radio_uid
+    class_size += sizeof(sMacAddr); // radio_uid
     class_size += sizeof(uint8_t); // maximum_number_of_bsss_supported
     class_size += sizeof(uint8_t); // operating_classes_info_list_length
     return class_size;
@@ -136,9 +136,9 @@ bool tlvApRadioBasicCapabilities::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_radio_uid = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_maximum_number_of_bsss_supported = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint8_t) * 1;

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -33,8 +33,8 @@ const uint16_t& tlvApRadioIdentifier::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvApRadioIdentifier::radio_uid() {
-    return (sMacAddress&)(*m_radio_uid);
+sMacAddr& tlvApRadioIdentifier::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
 }
 
 void tlvApRadioIdentifier::class_swap()
@@ -48,7 +48,7 @@ size_t tlvApRadioIdentifier::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvTypeMap); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // radio_uid
+    class_size += sizeof(sMacAddr); // radio_uid
     return class_size;
 }
 
@@ -70,9 +70,9 @@ bool tlvApRadioIdentifier::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_radio_uid = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -33,8 +33,8 @@ const uint16_t& tlvChannelPreference::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddress& tlvChannelPreference::radio_uid() {
-    return (sMacAddress&)(*m_radio_uid);
+sMacAddr& tlvChannelPreference::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
 }
 
 uint8_t& tlvChannelPreference::operating_classes_list_length() {
@@ -108,7 +108,7 @@ size_t tlvChannelPreference::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvTypeMap); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddress); // radio_uid
+    class_size += sizeof(sMacAddr); // radio_uid
     class_size += sizeof(uint8_t); // operating_classes_list_length
     return class_size;
 }
@@ -131,9 +131,9 @@ bool tlvChannelPreference::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_radio_uid = (sMacAddress*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddress) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddress); }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;

--- a/framework/tlvf/test/main.cpp
+++ b/framework/tlvf/test/main.cpp
@@ -58,50 +58,50 @@ int main(int argc, char *argv[])
         true); //false is returned in case that there isn't enough space on the buffer for the allocation
 
     auto first_mac = firstTlv->mac_non_1905_device(
-        0); //get the first mac address struct in this tlv. returns a <bool,sMacAddress&> collection.
+        0); //get the first mac address struct in this tlv. returns a <bool,sMacAddr&> collection.
     bool isExist = std::get<0>(
         first_mac); //checking the first parameter, boolean, if the address in this index exists
     if (isExist) {
         auto &address =
             std::get<1>(first_mac); //knowing that the address exists, get the address struct
-        address.mac[0] = 0x00;
-        address.mac[1] = 0x01;
-        address.mac[2] = 0x02;
-        address.mac[3] = 0x03;
-        address.mac[4] = 0x04;
-        address.mac[5] = 0x05;
-        MAPF_INFO("WRITE 1 : " << (int)address.mac[3]);
+        address.oct[0] = 0x00;
+        address.oct[1] = 0x01;
+        address.oct[2] = 0x02;
+        address.oct[3] = 0x03;
+        address.oct[4] = 0x04;
+        address.oct[5] = 0x05;
+        MAPF_INFO("WRITE 1 : " << (int)address.oct[3]);
     }
 
     auto second_mac = firstTlv->mac_non_1905_device(
-        1); //get the second mac address struct in this tlv. returns a bool-sMacAddress& collection.
+        1); //get the second mac address struct in this tlv. returns a bool-sMacAddr& collection.
     isExist = std::get<0>(
         second_mac); //checking the first parameter, boolean, if the address in this index exists
     if (isExist) {
         auto &address =
             std::get<1>(second_mac); //knowing that the address exists, get the address struct
-        address.mac[0] = 0x05;
-        address.mac[1] = 0x05;
-        address.mac[2] = 0x05;
-        address.mac[3] = 0x05;
-        address.mac[4] = 0x05;
-        address.mac[5] = 0x05;
-        MAPF_INFO("WRITE 2 : " << (int)address.mac[3]);
+        address.oct[0] = 0x05;
+        address.oct[1] = 0x05;
+        address.oct[2] = 0x05;
+        address.oct[3] = 0x05;
+        address.oct[4] = 0x05;
+        address.oct[5] = 0x05;
+        MAPF_INFO("WRITE 2 : " << (int)address.oct[3]);
     }
 
     auto third_mac = firstTlv->mac_non_1905_device(
-        2); //get the third mac address struct in this tlv. returns a bool-sMacAddress& collection.
+        2); //get the third mac address struct in this tlv. returns a bool-sMacAddr& collection.
     isExist = std::get<0>(
         third_mac); //checking the first parameter, boolean, if the address in this index exists
     if (isExist) {
         auto &address =
             std::get<1>(third_mac); //knowing that the address exists, get the address struct
-        address.mac[0] = 0xFF;
-        address.mac[1] = 0xFF;
-        address.mac[2] = 0xFF;
-        address.mac[3] = 0xFF;
-        address.mac[4] = 0xFF;
-        address.mac[5] = 0xFF;
+        address.oct[0] = 0xFF;
+        address.oct[1] = 0xFF;
+        address.oct[2] = 0xFF;
+        address.oct[3] = 0xFF;
+        address.oct[4] = 0xFF;
+        address.oct[5] = 0xFF;
 
         // Remove "unused variable" warning
         (void)address;
@@ -148,20 +148,20 @@ int main(int argc, char *argv[])
         //tlv1->alloc_mac_non_1905_device(3);
 
         auto mac2 = tlv1->mac_non_1905_device(
-            2); //get the second mac address struct in this tlv. returns a bool-sMacAddress& collection.
+            2); //get the second mac address struct in this tlv. returns a bool-sMacAddr& collection.
         isExist = std::get<0>(
             mac2); //checking the first parameter, boolean, if the address in this index exists
         if (isExist) {
             auto address =
                 std::get<1>(mac2); //knowing that the address exists, get the address struct
-                                   /*       address.mac[0] = 0x05;
-            address.mac[1] = 0x05;
-            address.mac[2] = 0x05;
-            address.mac[3] = 0x05;
-            address.mac[4] = 0x05;
-            address.mac[5] = 0x05;*/
+                                   /*       address.oct[0] = 0x05;
+            address.oct[1] = 0x05;
+            address.oct[2] = 0x05;
+            address.oct[3] = 0x05;
+            address.oct[4] = 0x05;
+            address.oct[5] = 0x05;*/
 
-            std::cout << "ADDRESS IS " << (int)address.mac[0] << std::endl;
+            std::cout << "ADDRESS IS " << (int)address.oct[0] << std::endl;
         } else {
             MAPF_ERR("TLV DOES NOT EXIST");
             errors++;

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -2,7 +2,7 @@
 ---
 _include: {
   tlvf/WSC/eWscLengths.h,
-  tlvf/common/sMacAddress.h,
+  tlvf/common/sMacAddr.h,
 }
 _namespace: WSC
 
@@ -62,7 +62,7 @@ sWscAttrMac:
   data_length:
     _type: uint16_t
     _value: WSC_MAC_LENGTH
-  data: sMacAddress
+  data: sMacAddr
 
 sWscAttrEnroleeNonce:
   _type: struct
@@ -373,7 +373,7 @@ sWscAttrBssid:
     _type: uint16_t
     _value: WSC_MAC_LENGTH
   data:
-    _type: sMacAddress
+    _type: sMacAddr
 
 sWscAttrEncryptedSettings:
   _type: struct

--- a/framework/tlvf/yaml/tlvf/common/sMacAddr.yaml
+++ b/framework/tlvf/yaml/tlvf/common/sMacAddr.yaml
@@ -1,9 +1,9 @@
 #
 ---
 
-sMacAddress:
+sMacAddr:
   _type: struct
-  mac:
+  oct:
     _type: uint8_t
     _length: [ 6 ]
     _value: 0

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/s802_11SpecificInformation.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/s802_11SpecificInformation.yaml
@@ -13,7 +13,7 @@ eRole:
 
 s802_11SpecificInformation:
   _type: struct
-  network_membership: sMacAddress
+  network_membership: sMacAddr
   role: eRole
   ap_channel_band:
     _type: uint8_t

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlv1905NeighborDevice.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlv1905NeighborDevice.yaml
@@ -10,7 +10,7 @@ tlv1905NeighborDevice:
     _value_const: TLV_1905_NEIGHBOR_DEVICE
   length:
     _type: uint16_t
-  mac_local_iface: sMacAddress
+  mac_local_iface: sMacAddr
   mac_al_1905_device:
     _type: sMacAl1905Device
     _length: []
@@ -23,6 +23,6 @@ eBridgesExist:
 
 sMacAl1905Device:
   _type: struct
-  mac: sMacAddress
+  mac: sMacAddr
   bridges_exist: eBridgesExist
 

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvAlMacAddressType.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvAlMacAddressType.yaml
@@ -9,4 +9,4 @@ tlvAlMacAddressType:
     _type: eTlvType
     _value_const: TLV_AL_MAC_ADDRESS_TYPE
   length: uint16_t
-  mac: sMacAddress
+  mac: sMacAddr

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.yaml
@@ -22,7 +22,7 @@ cMacList:
     _type: uint8_t
     _length_var: True
   mac_list:
-    _type: sMacAddress
+    _type: sMacAddr
     _length: [ mac_list_length ]
 
   

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvDeviceInformation.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvDeviceInformation.yaml
@@ -9,7 +9,7 @@ tlvDeviceInformation:
     _type: eTlvType
     _value_const: TLV_DEVICE_INFORMATION
   length: uint16_t
-  mac: sMacAddress
+  mac: sMacAddr
   info_length:
     _type: uint8_t
     _length_var: True
@@ -19,7 +19,7 @@ tlvDeviceInformation:
 
 sInfo:
   _type: struct
-  mac: sMacAddress
+  mac: sMacAddr
   media_type: eMediaType
   media_info_length: uint8_t
   media_info: eMediaType

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvLinkMetricQuery.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvLinkMetricQuery.yaml
@@ -11,7 +11,7 @@ tlvLinkMetricQuery:
   length: uint16_t
   neighbor_type: eNeighborType
   mac_al_1905_device:
-    _type: sMacAddress
+    _type: sMacAddr
     _optional: true
   link_metrics: eLinkMetricsType
 

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.yaml
@@ -9,8 +9,8 @@ tlvNon1905neighborDeviceList:
     _type: eTlvType
     _value_const: TLV_NON_1905_NEIGHBOR_DEVICE_LIST
   length: uint16_t
-  mac_local_iface: sMacAddress
+  mac_local_iface: sMacAddr
   mac_non_1905_device:
-    _type: sMacAddress
+    _type: sMacAddr
     _length: []
   

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.yaml
@@ -9,15 +9,15 @@ tlvPushButtonJoinNotification:
     _type: eTlvType
     _value_const: TLV_PUSH_BUTTON_JOIN_NOTIFICATION
   length: uint16_t
-  al_mac_notification_src: sMacAddress
+  al_mac_notification_src: sMacAddr
   mid_of_the_notification: uint16_t
   transmitter_iface_mac_of_new_device_joined:
-    _type: sMacAddress  
+    _type: sMacAddr  
     _comment: |
       Interface-specific MAC address of the interface of the transmitting device
       belonging to the medium on which a new device joined.
   iface_mac_of_new_device_joined:
-    _type: sMacAddress
+    _type: sMacAddr
     _comment: |
       Interface-specific MAC address of the interface of the new device that was
       joined to the network as a result of the push button configuration sequence.

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvReceiverLinkMetric.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvReceiverLinkMetric.yaml
@@ -9,8 +9,8 @@ tlvReceiverLinkMetric:
     _type: eTlvType
     _value_const: TLV_RECEIVER_LINK_METRIC
   length: uint16_t
-  al_mac_of_the_device_that_transmits: sMacAddress
-  al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv: sMacAddress
+  al_mac_of_the_device_that_transmits: sMacAddr
+  al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv: sMacAddr
   interface_pair_info:
     _comment: |
       The following fields shall be repeated for each connected interface pair between the
@@ -40,7 +40,7 @@ sLinkMetricInfo:
 
 sInterfacePairInfo:
   _type: struct
-  mac_of_an_interface_in_the_receiving_al: sMacAddress
-  mac_of_an_interface_in_the_neighbor_al: sMacAddress
+  mac_of_an_interface_in_the_receiving_al: sMacAddr
+  mac_of_an_interface_in_the_neighbor_al: sMacAddr
   link_metric_info: sLinkMetricInfo
 

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.yaml
@@ -9,8 +9,8 @@ tlvTransmitterLinkMetric:
     _type: eTlvType
     _value_const: TLV_TRANSMITTER_LINK_METRIC
   length: uint16_t
-  al_mac_of_the_device_that_transmits: sMacAddress
-  al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv: sMacAddress
+  al_mac_of_the_device_that_transmits: sMacAddr
+  al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv: sMacAddr
   interface_pair_info:
     _type: sInterfacePairInfo
     _length: []
@@ -51,6 +51,6 @@ sLinkMetricInfo:
 
 sInterfacePairInfo:
   _type: struct
-  mac_of_an_interface_in_the_receiving_al: sMacAddress
-  mac_of_an_interface_in_the_neighbor_al: sMacAddress
+  mac_of_an_interface_in_the_receiving_al: sMacAddr
+  mac_of_an_interface_in_the_neighbor_al: sMacAddr
   link_metric_info: sLinkMetricInfo

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApRadioBasicCapabilities.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApRadioBasicCapabilities.yaml
@@ -9,7 +9,7 @@ tlvApRadioBasicCapabilities:
     _type: eTlvTypeMap
     _value_const: TLV_AP_RADIO_BASIC_CAPABILITIES
   length: uint16_t
-  radio_uid: sMacAddress
+  radio_uid: sMacAddr
   maximum_number_of_bsss_supported: uint8_t
   operating_classes_info_list_length:
     _type: uint8_t

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApRadioIdentifier.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApRadioIdentifier.yaml
@@ -9,5 +9,5 @@ tlvApRadioIdentifier:
     _type: eTlvTypeMap
     _value_const: TLV_AP_RADIO_IDENTIFIER
   length: uint16_t
-  radio_uid: sMacAddress
+  radio_uid: sMacAddr
   

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvChannelPreference.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvChannelPreference.yaml
@@ -9,7 +9,7 @@ tlvChannelPreference:
     _type: eTlvTypeMap
     _value_const: TLV_CHANNEL_PREFERENCE
   length: uint16_t
-  radio_uid: sMacAddress
+  radio_uid: sMacAddr
   operating_classes_list_length:
     _type: uint8_t
     _length_var: True


### PR DESCRIPTION
There are 2 structs in the codebase describing a MAC address - one in
the BCL, beerocks::net::sMacAddr, and the other in the TLV factory,
sMacAddress. Refactor the code to use a single struct, the one defined
in the TLV factory.

Changed the struct name to match shorter name set in BCL, and change the
bytes array name to oct to prevent conflicts. After that simply remove
the namespace prefix and we're done.

No point in splitting this commit to auto-generated and yaml since each
commit must not break, and this will break it.

Main files which were changed:
- bcl net_struct.h - removed beerocks::net::sMacAddr and move compare
operators outside the namespace
- tlvf sMacAddress.yaml - renamed to sMacAddr.yaml, changed the
struct name to sMacAddr and changed the byte array from mac[] to oct[].
This is for reducing the conflicts in all of the code base to almost
zero after removing the namespace prefixes.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>