### PR TITLE
autoconfig WSC add M1/M2 parameters in agent and controller

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -87,11 +87,12 @@ private:
         std::string radio_mac;
         std::string hostap_iface;
         std::string sta_iface;
-        beerocks::eFreqType freq_type  = beerocks::eFreqType::FREQ_UNKNOWN;
-        bool sta_iface_filter_low      = false;
-        bool slave_is_backhaul_manager = false;
-        bool controller_discovered     = false;
-        beerocks::eIfaceType slave_iface_type;
+        eFreqType freq_type              = eFreqType::FREQ_UNKNOWN;
+        bool sta_iface_filter_low        = false;
+        bool slave_is_backhaul_manager   = false;
+        bool controller_discovered       = false;
+        bool operational_on_registration = false;
+        eIfaceType slave_iface_type;
 
         std::shared_ptr<bwl::sta_wlan_hal> sta_wlan_hal;
         Socket *sta_hal_ext_events = nullptr;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -259,6 +259,7 @@ private:
 
     bool parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool autoconfig_wsc_add_m1();
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -95,7 +95,11 @@ base_wlan_hal_dummy::~base_wlan_hal_dummy() { detach(); }
 
 bool base_wlan_hal_dummy::fsm_setup() { return true; }
 
-HALState base_wlan_hal_dummy::attach(bool block) { return (m_hal_state = HALState::Operational); }
+HALState base_wlan_hal_dummy::attach(bool block)
+{
+    refresh_radio_info();
+    return (m_hal_state = HALState::Operational);
+}
 
 bool base_wlan_hal_dummy::detach() { return true; }
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_wsc.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_wsc.h
@@ -1,0 +1,60 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Tomer Eliyahu (Intel Corporation)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WSC_WSC_ATTRIBUTES_HELPERS_H_
+#define _TLVF_WSC_WSC_ATTRIBUTES_HELPERS_H_
+
+#include <beerocks/bcl/beerocks_utils.h>
+#include <tlvf/WSC/WSC_Attributes.h>
+
+namespace WSC {
+    enum eBssType : uint8_t {
+        BACKHAUL_STA  = 0x80,
+        BACKHAUL_BSS  = 0x40,
+        FRONTHAUL_BSS = 0x20,
+        TEARDOWN      = 0x10
+    };
+
+    static int vendor_extentions_bss_type(sWscAttrVendorExtension &attr)
+    {
+        // verify Multi-AP vendor Id
+        if (attr.data[0] != WSC_VENDOR_ID_WFA_1 ||
+            attr.data[1] != WSC_VENDOR_ID_WFA_2 ||
+            attr.data[2] != WSC_VENDOR_ID_WFA_3)
+            return -1;
+        
+        // verify subelement ID and length match Multi-AP Extension subelement
+        if (attr.data[3] != 0x6 || attr.data[4] != 1)
+            return -1;
+        
+        // set the Bss type
+        return attr.data[5];
+    }
+
+    static void set_vendor_extentions_bss_type(sWscAttrVendorExtension &attr, uint8_t type)
+    {
+        attr.data[0] = WSC_VENDOR_ID_WFA_1;
+        attr.data[1] = WSC_VENDOR_ID_WFA_2;
+        attr.data[2] = WSC_VENDOR_ID_WFA_3;
+        attr.data[3] = 0x6;
+        attr.data[4] = 1;
+        attr.data[5] = type;
+    }
+
+    static void set_primary_device_type(sWscAttrPrimaryDeviceType &attr, uint16_t type)
+    {
+        attr.category_id = WSC_DEV_NETWORK_INFRA;
+        attr.sub_category_id = type; //eWscDev device type
+        attr.oui = 0x0050F204; // WSC WiFi Alliance OUI
+    }
+}
+
+#endif //_TLVF_WSC_WSC_ATTRIBUTES_HELPERS_H_

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_wsc.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_wsc.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Tomer Eliyahu (Intel Corporation)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WSC_WSC_ATTRIBUTES_HELPERS_H_
+#define _TLVF_WSC_WSC_ATTRIBUTES_HELPERS_H_
+
+#include <beerocks/bcl/beerocks_utils.h>
+#include <tlvf/WSC/WSC_Attributes.h>
+
+namespace WSC {
+    enum eBssType : uint8_t {
+        BACKHAUL_STA  = 0x80,
+        BACKHAUL_BSS  = 0x40,
+        FRONTHAUL_BSS = 0x20,
+        TEARDOWN      = 0x10
+    };
+
+    static int vendor_extentions_bss_type(sWscAttrVendorExtension &attr)
+    {
+        // verify Multi-AP vendor Id
+        if (attr.data[0] != WSC_VENDOR_ID_WFA_1 ||
+            attr.data[1] != WSC_VENDOR_ID_WFA_2 ||
+            attr.data[2] != WSC_VENDOR_ID_WFA_3)
+            return -1;
+        
+        // verify subelement ID and length match Multi-AP Extension subelement
+        if (attr.data[3] != 0x6 || attr.data[4] != 1)
+            return -1;
+        
+        // set the Bss type
+        return attr.data[5];
+    }
+
+    static void set_vendor_extentions_bss_type(sWscAttrVendorExtension &attr, uint8_t type)
+    {
+        attr.data[0] = WSC_VENDOR_ID_WFA_1;
+        attr.data[1] = WSC_VENDOR_ID_WFA_2;
+        attr.data[2] = WSC_VENDOR_ID_WFA_3;
+        attr.data[3] = 0x6;
+        attr.data[4] = 1;
+        attr.data[5] = type;
+    }
+
+    static void set_primary_device_type(sWscAttrPrimaryDeviceType &attr, uint16_t type)
+    {
+        attr.category_id = WSC_DEV_NETWORK_INFRA;
+        attr.sub_category_id = type; //eWscDev device type
+        attr.oui = 0x0050F204; // WSC WiFi Alliance OUI
+    }
+}
+
+#endif //_TLVF_WSC_WSC_ATTRIBUTES_HELPERS_H_

--- a/common/beerocks/tlvf/tlvf_conf.yaml
+++ b/common/beerocks/tlvf/tlvf_conf.yaml
@@ -9,13 +9,7 @@ include_yaml_path: {
 include_source_path: {
   "src/beerocks_message.cpp",
   "include/beerocks/tlvf/beerocks_message.h",
-  # "include/beerocks/tlvf/beerocks_message.h",
-  # "include/tlvf/BaseClass.h",
-  # "src/BaseClass.cpp",
-  # "include/tlvf/CmduMessage.h",
-  # "src/CmduMessage.cpp",
-  # "include/tlvf/beerocks/beerocks_message.h",
-  # "src/beerocks/beerocks_message.cpp",
+  "include/beerocks/tlvf/beerocks_wsc.h",
 }
 
 # Relative to tlvf.py src_path variable

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -23,6 +23,10 @@
 #include <ctime>
 #include <stdint.h>
 
+namespace ieee1905_1 {
+class tlvWscM1;
+}
+
 namespace son {
 class master_thread : public beerocks::socket_thread {
 
@@ -54,6 +58,7 @@ private:
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_autoconfiguration_WSC(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> m1);
 
     db &database;
     task_pool tasks;

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -27,6 +27,7 @@
 #include "tlvf/WSC/eWscAuth.h"
 #include "tlvf/WSC/eWscEncr.h"
 #include "tlvf/WSC/eWscLengths.h"
+#include "tlvf/WSC/eWscVendorId.h"
 #include "tlvf/common/sMacAddr.h"
 
 namespace WSC {
@@ -389,7 +390,7 @@ typedef struct sWscAttrOsVersion {
     }
 } __attribute__((packed)) sWscAttrOsVersion;
 
-typedef struct sWscAttrVersionExtension {
+typedef struct sWscAttrVendorExtension {
     eWscAttributes attribute_type;
     uint16_t data_length;
     uint8_t data[WSC_VENDOR_EXTENSIONS_LENGTH];
@@ -401,7 +402,7 @@ typedef struct sWscAttrVersionExtension {
         attribute_type = ATTR_VENDOR_EXTENSION;
         data_length = WSC_VENDOR_EXTENSIONS_LENGTH;
     }
-} __attribute__((packed)) sWscAttrVersionExtension;
+} __attribute__((packed)) sWscAttrVendorExtension;
 
 typedef struct sWscAttrKeyWrapAuthenticator {
     eWscAttributes attribute_type;

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -28,6 +28,7 @@
 #include "tlvf/WSC/eWscEncr.h"
 #include "tlvf/WSC/eWscLengths.h"
 #include "tlvf/WSC/eWscVendorId.h"
+#include "tlvf/WSC/eWscDev.h"
 #include "tlvf/common/sMacAddr.h"
 
 namespace WSC {

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM1.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM1.h
@@ -43,7 +43,7 @@ typedef struct sM1 {
     sWscAttrDevicePasswordID device_password_id_attr;
     sWscAttrConfigurationError configuration_error_attr;
     sWscAttrOsVersion os_version_attr;
-    sWscAttrVersionExtension vendor_extensions_attr;
+    sWscAttrVendorExtension vendor_extensions_attr;
     void struct_swap(){
         version_attr.struct_swap();
         message_type_attr.struct_swap();

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM2.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/sM2.h
@@ -41,7 +41,7 @@ typedef struct sM2 {
     WSC::sWscAttrConfigurationError configuration_error_attr;
     WSC::sWscAttrDevicePasswordID device_password_id_attr;
     WSC::sWscAttrOsVersion os_version_attr;
-    WSC::sWscAttrVersionExtension vendor_extensions_attr;
+    WSC::sWscAttrVendorExtension vendor_extensions_attr;
     sWscAttrEncryptedSettings encrypted_settings_attr;
     void struct_swap(){
         version_attr.struct_swap();

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -3,6 +3,7 @@
 _include: {
   tlvf/WSC/eWscLengths.h,
   tlvf/WSC/eWscVendorId.h,
+  tlvf/WSC/eWscDev.h,
   tlvf/common/sMacAddr.h,
 }
 _namespace: WSC

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -2,6 +2,7 @@
 ---
 _include: {
   tlvf/WSC/eWscLengths.h,
+  tlvf/WSC/eWscVendorId.h,
   tlvf/common/sMacAddr.h,
 }
 _namespace: WSC
@@ -292,7 +293,7 @@ sWscAttrOsVersion:
     _type: uint32_t
     _value: 0x80000001
 
-sWscAttrVersionExtension:
+sWscAttrVendorExtension:
   _type: struct
   attribute_type:
     _type: eWscAttributes

--- a/framework/tlvf/yaml/tlvf/WSC/sM1.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/sM1.yaml
@@ -27,5 +27,5 @@ sM1:
   device_password_id_attr: sWscAttrDevicePasswordID
   configuration_error_attr: sWscAttrConfigurationError
   os_version_attr: sWscAttrOsVersion
-  vendor_extensions_attr: sWscAttrVersionExtension
+  vendor_extensions_attr: sWscAttrVendorExtension
   

--- a/framework/tlvf/yaml/tlvf/WSC/sM2.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/sM2.yaml
@@ -25,7 +25,7 @@ sM2:
   configuration_error_attr: WSC::sWscAttrConfigurationError
   device_password_id_attr: WSC::sWscAttrDevicePasswordID
   os_version_attr: WSC::sWscAttrOsVersion
-  vendor_extensions_attr: WSC::sWscAttrVersionExtension
+  vendor_extensions_attr: WSC::sWscAttrVendorExtension
 
   #encrypted data
   encrypted_settings_attr: sWscAttrEncryptedSettings


### PR DESCRIPTION
## Overview
Add M1 M2 parameters set for the WSC messages sent from the controller and agent (and vice versa) as part of the AP autoconfiguration flow.
Currently all agent M1 parameters are dummy, and all the controller's M2 are either based on the agent or dummy as well.
With this, we can see the full M1 and M2(s) sent and received correctly using wireshark.

Related Task - #71 

## Changes summary
- Fix vendor extention yaml typo
- Fix a bug where the 5GHz slave is set to 2.4Ghz in dummy mode
- Port a fix to a bug in the backhaul manager which causes M1 to be sent twice by the backhaul manager slave
- Add helper functions to support setting and reading WSC attributes which are not covered by TLVF
- Set all M1 parameters in the agent autoconfig WSC message sent to the controller during autoconfig.
- Set all M2 parameters in the controller autoconfig WSC message based on the M1 parameters received from the agent


Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>