### PR TITLE
documentation: README.md add 'bridge-utils' to install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To build prplMesh, you need (on Ubuntu) the following packages:
 ```bash
 sudo apt install curl gcc cmake binutils git autoconf autogen libtool pkg-config \
     libreadline-dev libncurses-dev libssl-dev libjson-c-dev libnl-genl-3-dev libzmq3-dev \
-     python python-yaml python-paramiko repo
+     python python-yaml python-paramiko repo bridge-utils
 ```
 
 If you haven't done so already, set up your git configuration:


### PR DESCRIPTION
The 'bridge-utils' was missing from the apt install command in the requirements,
causing 'prplmesh_utils.sh start' fail when searching for brctl.

Signed-off-by: Lior Amram <lior.amram@intel.com>