### PR TITLE
Dev/bugfix/add swap to vendor oui

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks_message.cpp
@@ -54,11 +54,8 @@ message::sUdsHeader *message_com::get_uds_header(ieee1905_1::CmduMessage &cmdu)
 bool message_com::intel_oui(
     std::shared_ptr<ieee1905_1::tlvVendorSpecific> tlv_vendor_specific_header)
 {
-    // FIXME: https://github.com/prplfoundation/prplMesh/issues/33
-    // return ieee1905_1::tlvVendorSpecific::eVendorOUI(
-    //            uint32_t(std::get<1>(tlv_vendor_specific_header->vendor_oui(0))) & 0x00FFFFFF) ==
-    //        ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
-    return true;
+    return tlv_vendor_specific_header->vendor_oui() ==
+           ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
 }
 
 std::shared_ptr<beerocks_message::cACTION_HEADER>

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -51,11 +51,8 @@ message::sUdsHeader *message_com::get_uds_header(ieee1905_1::CmduMessage &cmdu)
 bool message_com::intel_oui(
     std::shared_ptr<ieee1905_1::tlvVendorSpecific> tlv_vendor_specific_header)
 {
-    // FIXME: https://github.com/prplfoundation/prplMesh/issues/33
-    // return ieee1905_1::tlvVendorSpecific::eVendorOUI(
-    //            uint32_t(std::get<1>(tlv_vendor_specific_header->vendor_oui(0))) & 0x00FFFFFF) ==
-    //        ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
-    return true;
+    return tlv_vendor_specific_header->vendor_oui() ==
+           ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
 }
 
 std::shared_ptr<beerocks_message::cACTION_HEADER>

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/sVendorOUI.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/sVendorOUI.h
@@ -1,0 +1,43 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _SVENDOR_OUI_H_
+#define _SVENDOR_OUI_H_
+
+#include <stdint.h>
+#include <algorithm>
+
+typedef struct sVendorOUI {
+    uint8_t upper;
+    uint8_t middle;
+    uint8_t lower;
+    sVendorOUI(uint32_t val)
+    {
+        lower = val & 0xFF;
+        middle = (val >> 8 ) & 0xFF;
+        upper = (val >> 16 ) & 0xFF;
+    }
+
+    operator uint32_t() const
+    {
+        return (upper << 16) + (middle << 8) + lower;
+    }
+
+    void struct_swap()
+    {
+        std::swap(upper, lower);
+    }
+
+    void struct_init() { }
+} __attribute__((packed)) sVendorOUI;
+
+
+#endif //_SVENDOR_OUI_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include <tuple>
+#include "tlvf/ieee_1905_1/sVendorOUI.h"
 
 namespace ieee1905_1 {
 
@@ -39,8 +39,7 @@ class tlvVendorSpecific : public BaseClass
         
         const eTlvType& type();
         uint16_t& length();
-        //Use eVendorOUI
-        std::tuple<bool, uint8_t&> vendor_oui(size_t idx);
+        sVendorOUI& vendor_oui();
         void class_swap();
         static size_t get_initial_size();
 
@@ -48,9 +47,7 @@ class tlvVendorSpecific : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        uint8_t* m_vendor_oui = nullptr;
-        size_t m_vendor_oui_idx__ = 0;
-        int m_lock_order_counter__ = 0;
+        sVendorOUI* m_vendor_oui = nullptr;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/src/CmduMessageTx.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessageTx.cpp
@@ -56,13 +56,7 @@ std::shared_ptr<tlvVendorSpecific> CmduMessageTx::add_vs_tlv(tlvVendorSpecific::
         return nullptr;
     }
     //set vendor specific oui
-    uint32_t voui_uint32 = (uint32_t)voui;
-    for (int i = 0; i < 3; i++) {
-        auto ref = tlv->vendor_oui(i);
-        if (std::get<0>(ref))
-            std::get<1>(ref) = uint8_t(voui_uint32);
-        voui_uint32 >>= 8;
-    }
+    tlv->vendor_oui() = (uint32_t)voui;
 
     return tlv;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -33,18 +33,14 @@ uint16_t& tlvVendorSpecific::length() {
     return (uint16_t&)(*m_length);
 }
 
-std::tuple<bool, uint8_t&> tlvVendorSpecific::vendor_oui(size_t idx) {
-    bool ret_success = ( (m_vendor_oui_idx__ > 0) && (m_vendor_oui_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
-        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
-    }
-    return std::forward_as_tuple(ret_success, m_vendor_oui[ret_idx]);
+sVendorOUI& tlvVendorSpecific::vendor_oui() {
+    return (sVendorOUI&)(*m_vendor_oui);
 }
 
 void tlvVendorSpecific::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_vendor_oui->struct_swap();
 }
 
 size_t tlvVendorSpecific::get_initial_size()
@@ -52,7 +48,7 @@ size_t tlvVendorSpecific::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += 3 * sizeof(uint8_t); // vendor_oui
+    class_size += sizeof(sVendorOUI); // vendor_oui
     return class_size;
 }
 
@@ -68,9 +64,9 @@ bool tlvVendorSpecific::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0x3;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_vendor_oui = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(uint8_t) * 3);
-    m_vendor_oui_idx__  = 3;
+    m_vendor_oui = (sVendorOUI*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sVendorOUI) * 1;
+    if (!m_parse__) { m_vendor_oui->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/framework/tlvf/src/include/tlvf/ieee_1905_1/sVendorOUI.h
+++ b/framework/tlvf/src/include/tlvf/ieee_1905_1/sVendorOUI.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _SVENDOR_OUI_H_
+#define _SVENDOR_OUI_H_
+
+#include <stdint.h>
+#include <algorithm>
+
+typedef struct sVendorOUI {
+    uint8_t upper;
+    uint8_t middle;
+    uint8_t lower;
+    sVendorOUI(uint32_t val)
+    {
+        lower = val & 0xFF;
+        middle = (val >> 8 ) & 0xFF;
+        upper = (val >> 16 ) & 0xFF;
+    }
+
+    operator uint32_t() const
+    {
+        return (upper << 16) + (middle << 8) + lower;
+    }
+
+    void struct_swap()
+    {
+        std::swap(upper, lower);
+    }
+
+    void struct_init() { }
+} __attribute__((packed)) sVendorOUI;
+
+
+#endif //_SVENDOR_OUI_H_

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -53,13 +53,7 @@ std::shared_ptr<tlvVendorSpecific> CmduMessageTx::add_vs_tlv(tlvVendorSpecific::
         return nullptr;
     }
     //set vendor specific oui
-    uint32_t voui_uint32 = (uint32_t)voui;
-    for (int i = 0; i < 3; i++) {
-        auto ref = tlv->vendor_oui(i);
-        if (std::get<0>(ref))
-            std::get<1>(ref) = uint8_t(voui_uint32);
-        voui_uint32 >>= 8;
-    }
+    tlv->vendor_oui() = (uint32_t)voui;
 
     return tlv;
 }

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -34,6 +34,7 @@ include_source_path: {
   "src/CmduMessageTx.cpp",
   "include/tlvf/CmduMessageRx.h",
   "src/CmduMessageRx.cpp",
+  "include/tlvf/ieee_1905_1/sVendorOUI.h",
 }
 
 # Relative to tlvf.py src_path variable

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvVendorSpecific.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvVendorSpecific.yaml
@@ -12,9 +12,7 @@ tlvVendorSpecific:
     _value: 3
     _length_var: True
   vendor_oui:
-    _type: uint8_t
-    _length: [ 3 ]
-    _comment: Use eVendorOUI
+    _type: sVendorOUI
 
 eVendorOUI:
   _type: enum


### PR DESCRIPTION
Add a new 'sVendorOUI' struct to represent the 3 byte field of OUI in Vendor-Specific tlv.
This PR contains the struct definition, the changes needed in tlvVendorSpecific and CmduMessageTx to work with this struct and the changes in common, in the parts that write or read the OUI field, as well as all the autogenerated files.

Tested:
Build, operational and tlv structure in Wireshark.

This provides the functionality needed to solve this issue:
https://github.com/prplfoundation/prplMesh/issues/33
