### PR TITLE
agent: autoconfig: use al_mac instead of radio_mac

### DIFF
--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -53,7 +53,7 @@ private:
                                 ieee1905_1::CmduMessageRx &cmdu_rx);
     void handle_cmdu_control_ieee1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_intel_slave_join(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx,
-                                 ieee1905_1::CmduMessageTx &cmdu_tx, const std::string &radio_mac);
+                                 ieee1905_1::CmduMessageTx &cmdu_tx);
 
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);


### PR DESCRIPTION
According to section 7.1 in the Multi-AP specification, the WSC M1 MAC
address should be set to the Agent's AL_MAC:

To initiate (re)configuration of a radio, a Multi-AP Agent shall send an
AP-Autoconfiguration WSC message per section 17.1.3. A Multi-AP Agent
shall send a separate AP-Autoconfiguration WSC message per section
17.1.3 for each of its radio(s). The Multi-AP Agent shall indicate the
radio of the 802.11 configuration with a Radio Unique Identifier in the
AP Radio Basic Capabilities TLV (see section 17.2.7). The Multi-AP Agent
shall set the MAC Address attribute in M1 in the AP-Autoconfiguration
WSC message to the 1905 AL MAC address of the Multi-AP device. The
Multi-AP Agent shall set the Authentication Type Flags attribute in M1
in the AP-Autoconfiguration WSC message to indicate support for
WPA2-Personal and Open System Authentication types.

The current code in the agent sets the M1 MAC to the hostap MAC, AKA the
radio MAC of the radio agent, which is wrong. Change that to set the
AL_MAC instead, which is the br-lan MAC address in prplMesh agent
implementation.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>