### PR TITLE
tlvf: fix swap length in init when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,4 @@ script:
   - git update-index -q --refresh
   - git diff-index --exit-code HEAD
   # Start controller & agent node detached and check status
-  - sudo ./run.sh start-controller-agent -d -n controller-agent
-  - sudo ./run.sh start-agent -d -n agent
-  - sleep 5
-  - sudo ./test.sh -v -n controller-agent
-  # Remote agent doesn't get to operational YET, so don't fail the build on that
-  - sudo ./test.sh -v -n agent || true
+  - sudo ./tests/test_gw_repeater.sh --rm || true

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -220,7 +220,7 @@ bool cACTION_BML_NW_MAP_RESPONSE::init()
     m_buff_ptr__ += sizeof(uint32_t) * 1;
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size));
+    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     m_buff_ptr__ += sizeof(char)*(buffer_size);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
@@ -334,7 +334,7 @@ bool cACTION_BML_NW_MAP_UPDATE::init()
     m_buff_ptr__ += sizeof(uint32_t) * 1;
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size));
+    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     m_buff_ptr__ += sizeof(char)*(buffer_size);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
@@ -448,7 +448,7 @@ bool cACTION_BML_STATS_UPDATE::init()
     m_buff_ptr__ += sizeof(uint32_t) * 1;
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size));
+    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     m_buff_ptr__ += sizeof(char)*(buffer_size);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
@@ -554,7 +554,7 @@ bool cACTION_BML_EVENTS_UPDATE::init()
     m_buff_ptr__ += sizeof(uint32_t) * 1;
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size));
+    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     m_buff_ptr__ += sizeof(char)*(buffer_size);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
@@ -3406,7 +3406,7 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::init()
     m_buff_ptr__ += sizeof(uint32_t) * 1;
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size));
+    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     m_buff_ptr__ += sizeof(char)*(buffer_size);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -323,7 +323,7 @@ bool cACTION_CLI_RESPONSE_STR::init()
     m_buff_ptr__ += sizeof(uint32_t) * 1;
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size));
+    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     m_buff_ptr__ += sizeof(char)*(buffer_size);
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -645,7 +645,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
     m_buff_ptr__ += sizeof(char)*(manufacturer_length);
     m_model_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
@@ -658,7 +658,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
     m_buff_ptr__ += sizeof(char)*(model_name_length);
     m_model_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
@@ -671,7 +671,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
     m_buff_ptr__ += sizeof(char)*(model_number_length);
     m_serial_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
@@ -684,7 +684,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
     m_buff_ptr__ += sizeof(char)*(serial_number_length);
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType*)m_buff_ptr__;
@@ -701,7 +701,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_device_name = (char*)m_buff_ptr__;
     uint16_t device_name_length = *m_device_name_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
     m_device_name_idx__ = device_name_length;
     m_buff_ptr__ += sizeof(char)*(device_name_length);
     m_rf_bands_attr = (WSC::sWscAttrRfBands*)m_buff_ptr__;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -556,7 +556,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
     m_buff_ptr__ += sizeof(char)*(manufacturer_length);
     m_model_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
@@ -569,7 +569,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
     m_buff_ptr__ += sizeof(char)*(model_name_length);
     m_model_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
@@ -582,7 +582,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
     m_buff_ptr__ += sizeof(char)*(model_number_length);
     m_serial_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
@@ -595,7 +595,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
     m_buff_ptr__ += sizeof(char)*(serial_number_length);
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType*)m_buff_ptr__;

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -238,14 +238,14 @@ bool tlvTestVarList::init()
     m_buff_ptr__ += sizeof(uint16_t) * 1;
     m_simple_list = (uint16_t*)m_buff_ptr__;
     uint16_t simple_list_length = *m_simple_list_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&simple_list_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&simple_list_length)); }
     m_simple_list_idx__ = simple_list_length;
     m_buff_ptr__ += sizeof(uint16_t)*(simple_list_length);
     m_complex_list_length = (uint16_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
     m_complex_list = (cInner*)m_buff_ptr__;
     uint16_t complex_list_length = *m_complex_list_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&complex_list_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&complex_list_length)); }
     m_complex_list_idx__ = complex_list_length;
     for (size_t i = 0; i < complex_list_length; i++) {
         if (!add_complex_list(create_complex_list())) { 
@@ -350,7 +350,7 @@ bool cInner::init()
     m_buff_ptr__ += sizeof(uint16_t) * 1;
     m_list = (uint8_t*)m_buff_ptr__;
     uint16_t list_length = *m_list_length;
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(&list_length));
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&list_length)); }
     m_list_idx__ = list_length;
     m_buff_ptr__ += sizeof(uint8_t)*(list_length);
     m_var1 = (uint32_t*)m_buff_ptr__;

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -736,7 +736,7 @@ class TlvF:
                 length_type = obj_meta.children_types[param_length]
                 lines_cpp.append("%s %s = *m_%s;" %(length_type.type_str, param_length, param_length))
                 if length_type.swap_needed:
-                    lines_cpp.append("%s&%s%s;" %(length_type.swap_prefix, param_length, length_type.swap_suffix))
+                    lines_cpp.append("if (m_%s__ && m_%s__) {  %s&%s%s; }" %(self.MEMBER_PARSE, self.MEMBER_SWAP, length_type.swap_prefix, param_length, length_type.swap_suffix))
                 lines_cpp.append("m_%s_idx__ = %s;" % (param_name, param_length))
                 if TypeInfo(param_type).type == TypeInfo.CLASS: #TODO:only if it's the last list member of the class
                     lines_cpp.append("for (size_t i = 0; i < %s; i++) {" % (param_length))


### PR DESCRIPTION
Commit c5f4548 added a swap for variable length list length member.
This was needed since on Init, when parsing a TLV, the byte order of the
length field is the network byte order and the swap function is only
called at the end of the init function.
However, we need the real value in order to set the correct pointers
which come after the list.

However 2, which is the reason for this commit, is that on some
occasions, swap is not needed since the message is already swapped - for
example messages which are sent over UDS, therefore m_swap__ is set to
false.
This commit adds a condition to only swap the value if m_swap__ and
m_parse__ are True, same condition which later is used before init
function completes.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>