### PR TITLE
build: unify CMAKE find_package() calls

### DIFF
--- a/agent/cmake/multiap-helpers.cmake
+++ b/agent/cmake/multiap-helpers.cmake
@@ -9,3 +9,9 @@ execute_process(COMMAND "date" "+%F %T" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_
 message(STATUS "MultiAP ${PROJECT} Version: ${${PROJECT}_VERSION_STRING}")
 message(STATUS "MultiAP ${PROJECT} Build Date: ${${PROJECT}_BUILD_DATE}")
 message(STATUS "MultiAP ${PROJECT} Revision: ${${PROJECT}_REVISION}")
+
+find_package(MapfCommon REQUIRED)
+find_package(bcl REQUIRED)
+find_package(Tlvf REQUIRED)
+find_package(btlvf REQUIRED)
+find_package(elpp REQUIRED)

--- a/agent/src/beerocks/monitor/CMakeLists.txt
+++ b/agent/src/beerocks/monitor/CMakeLists.txt
@@ -5,12 +5,7 @@ project (${PROJECT_NAME})
 message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
 # Dependecies
-find_package(bcl REQUIRED)
 find_package(bwl REQUIRED)
-
-find_package(Tlvf REQUIRED)
-find_package(btlvf REQUIRED)
-find_package(elpp REQUIRED)
 
 # Set the base path for the current module
 set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})

--- a/agent/src/beerocks/slave/CMakeLists.txt
+++ b/agent/src/beerocks/slave/CMakeLists.txt
@@ -5,21 +5,7 @@ project (${PROJECT_NAME})
 message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
 # Use BPL package from mAP Framework
-find_package(bcl REQUIRED)
-find_package(bwl REQUIRED)
 find_package(btl REQUIRED)
-
-##############################################
-# There is an unresolved depenency of BPL in MapfCommon
-# The dependency was not resolved due to BPL is to be replaced by Platform Service
-# Both those find_package should be deleted as one.
-find_package(MapfCommon REQUIRED)
-find_package(bpl REQUIRED)
-#############################################
-
-find_package(Tlvf REQUIRED)
-find_package(btlvf REQUIRED)
-find_package(elpp REQUIRED)
 
 # Set the base path for the current module
 set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})

--- a/common/beerocks/btl/CMakeLists.txt
+++ b/common/beerocks/btl/CMakeLists.txt
@@ -4,10 +4,6 @@ set(PROJECT_NAME btl)
 project(${PROJECT_NAME})
 message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${BEEROCKS_TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
-# Dependecies
-find_package(bcl REQUIRED)
-
-find_package(MapfCommon REQUIRED)
 find_package(MapfTransport QUIET)
 
 if(MapfTransport_FOUND)
@@ -28,15 +24,12 @@ find_package(elpp REQUIRED)
 # Set the base path for the current module
 set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
-
 # Build the library
 add_library(${PROJECT_NAME} SHARED ${btl_sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT}_VERSION_STRING} SOVERSION ${${PROJECT}_VERSION_MAJOR})
+target_link_libraries(${PROJECT_NAME} PUBLIC beerocks::bcl tlvf elpp beerocks::btlvf mapf::common)
 if (MapfTransport_FOUND)
-     target_link_libraries(${PROJECT_NAME} PUBLIC beerocks::bcl tlvf beerocks::btlvf
-         PRIVATE mapf::common mapf::ieee1905_transport_messages elpp)
-else() # UDS Bus
-    target_link_libraries(${PROJECT_NAME} PUBLIC beerocks::bcl tlvf elpp beerocks::btlvf)
+     target_link_libraries(${PROJECT_NAME} PRIVATE mapf::ieee1905_transport_messages)
 endif()
 
 # Include paths

--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -3,9 +3,6 @@ cmake_minimum_required(VERSION 2.8)
 set(PROJECT_NAME bwl)
 project(${PROJECT_NAME})
 
-# Find required packages
-find_package(bcl REQUIRED)
-
 # Set the base path for the current module
 set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 

--- a/common/beerocks/tlvf/CMakeLists.txt
+++ b/common/beerocks/tlvf/CMakeLists.txt
@@ -4,8 +4,6 @@ set(PROJECT_NAME btlvf)
 project(${PROJECT_NAME})
 
 find_package(PythonInterp REQUIRED)
-find_package(bcl REQUIRED)
-find_package(Tlvf REQUIRED)
 find_program(PythonTlvf NAMES tlvf.py)
 
 if (NOT PythonTlvf)

--- a/common/cmake/multiap-helpers.cmake
+++ b/common/cmake/multiap-helpers.cmake
@@ -9,3 +9,8 @@ execute_process(COMMAND "date" "+%F %T" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_
 message(STATUS "MultiAP ${PROJECT} Version: ${PROJECT}_VERSION_STRING")
 message(STATUS "MultiAP ${PROJECT} Build Date: ${${PROJECT}_BUILD_DATE}")
 message(STATUS "MultiAP ${PROJECT} Revision: ${${PROJECT}_REVISION}")
+
+find_package(MapfCommon REQUIRED)
+find_package(bcl REQUIRED)
+find_package(Tlvf REQUIRED)
+find_package(elpp REQUIRED)

--- a/controller/cmake/multiap-helpers.cmake
+++ b/controller/cmake/multiap-helpers.cmake
@@ -9,3 +9,9 @@ execute_process(COMMAND "date" "+%F %T" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_
 message(STATUS "MultiAP ${PROJECT} Version: ${${PROJECT}_VERSION_STRING}")
 message(STATUS "MultiAP ${PROJECT} Build Date: ${${PROJECT}_BUILD_DATE}")
 message(STATUS "MultiAP ${PROJECT} Revision: ${${PROJECT}_REVISION}")
+
+find_package(MapfCommon REQUIRED)
+find_package(bcl REQUIRED)
+find_package(Tlvf REQUIRED)
+find_package(btlvf REQUIRED)
+find_package(elpp REQUIRED)

--- a/controller/src/beerocks/bml/CMakeLists.txt
+++ b/controller/src/beerocks/bml/CMakeLists.txt
@@ -4,12 +4,6 @@ set(PROJECT_NAME bml)
 project(${PROJECT_NAME})
 message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
-# Dependecies
-find_package(bcl REQUIRED)
-find_package(Tlvf REQUIRED)
-find_package(btlvf REQUIRED)
-find_package(elpp REQUIRED)
-
 # Set the base path for the current module
 set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 

--- a/controller/src/beerocks/cli/CMakeLists.txt
+++ b/controller/src/beerocks/cli/CMakeLists.txt
@@ -5,10 +5,6 @@ project (${PROJECT_NAME})
 message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
 # Dependecies
-find_package(bcl REQUIRED)
-find_package(btlvf REQUIRED)
-find_package(Tlvf REQUIRED)
-find_package(elpp REQUIRED)
 find_package(readline)
 
 # Set the base path for the current module

--- a/controller/src/beerocks/master/CMakeLists.txt
+++ b/controller/src/beerocks/master/CMakeLists.txt
@@ -5,12 +5,7 @@ project (${PROJECT_NAME})
 message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
 # Dependecies
-find_package(bcl REQUIRED)
 find_package(btl REQUIRED)
-
-find_package(Tlvf REQUIRED)
-find_package(btlvf REQUIRED)
-find_package(elpp REQUIRED)
 
 # Set the base path for the current module
 set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
Move all common find_package() calls for the controller, agent and
common which finds the installed framework and common packages to
multiap-helpers.cmake in each module (controller, agent and common).

This is done now since both the controller and agent now needs to link
to mapf::common since they will need the encryption support which will
be added there.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>