### PR TITLE
tlvf: fix duplicate length set for classes

### DIFF
--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -63,7 +63,6 @@ bool tlvEndOfMessage::init()
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!m_parse__) *m_length = 0x0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -647,8 +647,8 @@ class TlvF:
                 # add default value to init func
                 lines_cpp.append("m_%s = (%s*)m_%s__;" % ( param_name, param_type, self.MEMBER_BUFF_PTR))
                 if self.is_tlv_class and param_name == MetaData.TLV_TYPE_LENGTH:
-                        lines_cpp.append("if (!m_%s__) *m_%s = 0;" % (self.MEMBER_PARSE, param_name) )
-                if param_val_const != None:
+                    lines_cpp.append("if (!m_%s__) *m_%s = 0;" % (self.MEMBER_PARSE, param_name) )
+                elif param_val_const != None:
                     if (param_type_info.type == TypeInfo.ENUM or param_type_info.type == TypeInfo.ENUM_CLASS):
                         param_val_const = param_type + "::" + param_val_const
                     lines_cpp.append("if (!m_%s__) *m_%s = %s;" % ( self.MEMBER_PARSE, param_name, param_val_const) )


### PR DESCRIPTION
Fix multiple set of TLV length field for TLV classes.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>