### PR TITLE
 tlvf: Fix type checking for none uint8_t types

### DIFF
--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -96,12 +96,6 @@ bool tlv1905NeighborDevice::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_1905_NEIGHBOR_DEVICE;
-    else {
-            if (*m_type != eTlvType::TLV_1905_NEIGHBOR_DEVICE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_1905_NEIGHBOR_DEVICE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -123,6 +117,12 @@ bool tlv1905NeighborDevice::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_1905_NEIGHBOR_DEVICE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_1905_NEIGHBOR_DEVICE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -60,12 +60,6 @@ bool tlvAlMacAddressType::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AL_MAC_ADDRESS_TYPE;
-    else {
-            if (*m_type != eTlvType::TLV_AL_MAC_ADDRESS_TYPE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AL_MAC_ADDRESS_TYPE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -79,6 +73,12 @@ bool tlvAlMacAddressType::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_AL_MAC_ADDRESS_TYPE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AL_MAC_ADDRESS_TYPE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -59,12 +59,6 @@ bool tlvAutoconfigFreqBand::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AUTOCONFIG_FREQ_BAND;
-    else {
-            if (*m_type != eTlvType::TLV_AUTOCONFIG_FREQ_BAND) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AUTOCONFIG_FREQ_BAND) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -77,6 +71,12 @@ bool tlvAutoconfigFreqBand::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_AUTOCONFIG_FREQ_BAND) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AUTOCONFIG_FREQ_BAND) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -126,12 +126,6 @@ bool tlvDeviceBridgingCapability::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY;
-    else {
-            if (*m_type != eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -154,6 +148,12 @@ bool tlvDeviceBridgingCapability::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -108,12 +108,6 @@ bool tlvDeviceInformation::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_INFORMATION;
-    else {
-            if (*m_type != eTlvType::TLV_DEVICE_INFORMATION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_INFORMATION) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -135,6 +129,12 @@ bool tlvDeviceInformation::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_DEVICE_INFORMATION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_INFORMATION) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -54,12 +54,6 @@ bool tlvEndOfMessage::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_END_OF_MESSAGE;
-    else {
-            if (*m_type != eTlvType::TLV_END_OF_MESSAGE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_END_OF_MESSAGE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -70,6 +64,12 @@ bool tlvEndOfMessage::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_END_OF_MESSAGE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_END_OF_MESSAGE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -70,12 +70,6 @@ bool tlvLinkMetricQuery::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_QUERY;
-    else {
-            if (*m_type != eTlvType::TLV_LINK_METRIC_QUERY) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_QUERY) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -95,6 +89,12 @@ bool tlvLinkMetricQuery::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_LINK_METRIC_QUERY) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_QUERY) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -59,12 +59,6 @@ bool tlvLinkMetricResultCode::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_RESULT_CODE;
-    else {
-            if (*m_type != eTlvType::TLV_LINK_METRIC_RESULT_CODE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_RESULT_CODE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -77,6 +71,12 @@ bool tlvLinkMetricResultCode::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_LINK_METRIC_RESULT_CODE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_RESULT_CODE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -64,12 +64,6 @@ bool tlvMacAddress::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_MAC_ADDRESS;
-    else {
-            if (*m_type != eTlvType::TLV_MAC_ADDRESS) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_MAC_ADDRESS) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -87,6 +81,12 @@ bool tlvMacAddress::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_MAC_ADDRESS) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_MAC_ADDRESS) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -96,12 +96,6 @@ bool tlvNon1905neighborDeviceList::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST;
-    else {
-            if (*m_type != eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -123,6 +117,12 @@ bool tlvNon1905neighborDeviceList::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -102,12 +102,6 @@ bool tlvPushButtonEventNotification::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION;
-    else {
-            if (*m_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -125,6 +119,12 @@ bool tlvPushButtonEventNotification::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -78,12 +78,6 @@ bool tlvPushButtonJoinNotification::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION;
-    else {
-            if (*m_type != eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -108,6 +102,12 @@ bool tlvPushButtonJoinNotification::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -102,12 +102,6 @@ bool tlvReceiverLinkMetric::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_RECEIVER_LINK_METRIC;
-    else {
-            if (*m_type != eTlvType::TLV_RECEIVER_LINK_METRIC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_RECEIVER_LINK_METRIC) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -133,6 +127,12 @@ bool tlvReceiverLinkMetric::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_RECEIVER_LINK_METRIC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_RECEIVER_LINK_METRIC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -59,12 +59,6 @@ bool tlvSearchedRole::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SEARCHED_ROLE;
-    else {
-            if (*m_type != eTlvType::TLV_SEARCHED_ROLE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SEARCHED_ROLE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -77,6 +71,12 @@ bool tlvSearchedRole::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_SEARCHED_ROLE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SEARCHED_ROLE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -59,12 +59,6 @@ bool tlvSupportedFreqBand::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_FREQ_BAND;
-    else {
-            if (*m_type != eTlvType::TLV_SUPPORTED_FREQ_BAND) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_FREQ_BAND) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -77,6 +71,12 @@ bool tlvSupportedFreqBand::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_SUPPORTED_FREQ_BAND) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_FREQ_BAND) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -59,12 +59,6 @@ bool tlvSupportedRole::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_ROLE;
-    else {
-            if (*m_type != eTlvType::TLV_SUPPORTED_ROLE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_ROLE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -77,6 +71,12 @@ bool tlvSupportedRole::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_SUPPORTED_ROLE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_ROLE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -102,12 +102,6 @@ bool tlvTransmitterLinkMetric::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_TRANSMITTER_LINK_METRIC;
-    else {
-            if (*m_type != eTlvType::TLV_TRANSMITTER_LINK_METRIC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_TRANSMITTER_LINK_METRIC) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -133,6 +127,12 @@ bool tlvTransmitterLinkMetric::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_TRANSMITTER_LINK_METRIC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_TRANSMITTER_LINK_METRIC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -581,12 +581,6 @@ bool tlvWscM1::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
-    else {
-            if (*m_type != eTlvType::TLV_WSC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -733,6 +727,12 @@ bool tlvWscM1::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_WSC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -496,12 +496,6 @@ bool tlvWscM2::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
-    else {
-            if (*m_type != eTlvType::TLV_WSC) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvType) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -635,6 +629,12 @@ bool tlvWscM2::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_WSC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -222,12 +222,6 @@ bool tlvTestVarList::init()
     }
     m_type = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_type = 0x1;
-    else {
-            if (*m_type != 0x1) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0x1) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(uint8_t) * 1;
     m_var0 = (uint16_t*)m_buff_ptr__;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
@@ -268,6 +262,12 @@ bool tlvTestVarList::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != 0x1) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0x1) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
@@ -60,12 +60,6 @@ bool tlvApCapability::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_CAPABILITY;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_AP_CAPABILITY) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_CAPABILITY) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -79,6 +73,12 @@ bool tlvApCapability::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_CAPABILITY) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_CAPABILITY) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -137,12 +137,6 @@ bool tlvApRadioBasicCapabilities::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -172,6 +166,12 @@ bool tlvApRadioBasicCapabilities::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -60,12 +60,6 @@ bool tlvApRadioIdentifier::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -79,6 +73,12 @@ bool tlvApRadioIdentifier::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -132,12 +132,6 @@ bool tlvChannelPreference::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_PREFERENCE;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_CHANNEL_PREFERENCE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_PREFERENCE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -164,6 +158,12 @@ bool tlvChannelPreference::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_CHANNEL_PREFERENCE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_PREFERENCE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
@@ -65,12 +65,6 @@ bool tlvChannelSelectionResponse::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -87,6 +81,12 @@ bool tlvChannelSelectionResponse::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -114,12 +114,6 @@ bool tlvOperatingChannelReport::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -144,6 +138,12 @@ bool tlvOperatingChannelReport::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -132,12 +132,6 @@ bool tlvRadioOperationRestriction::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -164,6 +158,12 @@ bool tlvRadioOperationRestriction::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -96,12 +96,6 @@ bool tlvSearchedService::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SEARCHED_SERVICE;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SEARCHED_SERVICE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -119,6 +113,12 @@ bool tlvSearchedService::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SEARCHED_SERVICE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -96,12 +96,6 @@ bool tlvSupportedService::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SUPPORTED_SERVICE;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SUPPORTED_SERVICE) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -119,6 +113,12 @@ bool tlvSupportedService::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SUPPORTED_SERVICE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
@@ -65,12 +65,6 @@ bool tlvTransmitPowerLimit::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT;
-    else {
-            if (*m_type != eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) << ", received value: " << int(*m_type);
-            return false;
-        }
-    }
     m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
@@ -87,6 +81,12 @@ bool tlvTransmitPowerLimit::init()
         return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
Although most types are 1 byte, some can be larger - for example, the encrypted settings in the
M2 TLV is 2 bytes long.
The current validity check in the TLVF generated init() function is done before endianity conversion is executed, which is fine if the type is 1 byte, but causes the init() function to fail if the type is larger.
Move the type checking to after the swap call to prevent that.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>
