### PR TITLE
tools: add libssl to docker

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
 	libssl-dev \
 	libjson-c-dev \
 	libnl-genl-3-dev \
+	libssl-dev \
 	libzmq3-dev \
 	python \
 	python-yaml \


### PR DESCRIPTION
Add libssl to docker, as it will be used later for encryption.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>