### PR TITLE
tlvf: fix dynamic list of classes

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -40,9 +40,12 @@ class tlvTestVarList : public BaseClass
         std::tuple<bool, cInner&> complex_list(size_t idx);
         std::shared_ptr<cInner> create_complex_list();
         bool add_complex_list(std::shared_ptr<cInner> ptr);
-        uint16_t& var1();
-        std::tuple<bool, uint16_t&> unknown_length_list(size_t idx);
-        bool alloc_unknown_length_list(size_t count = 1);
+        std::shared_ptr<cInner> create_var1();
+        bool add_var1(std::shared_ptr<cInner> ptr);
+        std::shared_ptr<cInner> var1() { return m_var1_ptr; }
+        std::tuple<bool, cInner&> unknown_length_list(size_t idx);
+        std::shared_ptr<cInner> create_unknown_length_list();
+        bool add_unknown_length_list(std::shared_ptr<cInner> ptr);
         void class_swap();
         static size_t get_initial_size();
 
@@ -60,9 +63,11 @@ class tlvTestVarList : public BaseClass
         size_t m_complex_list_idx__ = 0;
         std::vector<std::shared_ptr<cInner>> m_complex_list_vector;
         bool m_lock_allocation__ = false;
-        uint16_t* m_var1 = nullptr;
-        uint16_t* m_unknown_length_list = nullptr;
+        cInner *m_var1 = nullptr;
+        std::shared_ptr<cInner> m_var1_ptr = nullptr;
+        cInner* m_unknown_length_list = nullptr;
         size_t m_unknown_length_list_idx__ = 0;
+        std::vector<std::shared_ptr<cInner>> m_unknown_length_list_vector;
 };
 
 class cInner : public BaseClass

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -43,12 +43,7 @@ std::tuple<bool, cMacList&> tlvDeviceBridgingCapability::bridging_tuples_list(si
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    if (*m_bridging_tuples_list_length > 0) {
-        return std::forward_as_tuple(ret_success, *(m_bridging_tuples_list_vector[ret_idx]));
-    }
-    else {
-        return std::forward_as_tuple(ret_success, *(m_bridging_tuples_list));
-    }
+    return std::forward_as_tuple(ret_success, *(m_bridging_tuples_list_vector[ret_idx]));
 }
 
 std::shared_ptr<cMacList> tlvDeviceBridgingCapability::create_bridging_tuples_list() {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -51,12 +51,7 @@ std::tuple<bool, cOperatingClassesInfo&> tlvApRadioBasicCapabilities::operating_
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    if (*m_operating_classes_info_list_length > 0) {
-        return std::forward_as_tuple(ret_success, *(m_operating_classes_info_list_vector[ret_idx]));
-    }
-    else {
-        return std::forward_as_tuple(ret_success, *(m_operating_classes_info_list));
-    }
+    return std::forward_as_tuple(ret_success, *(m_operating_classes_info_list_vector[ret_idx]));
 }
 
 std::shared_ptr<cOperatingClassesInfo> tlvApRadioBasicCapabilities::create_operating_classes_info_list() {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -47,12 +47,7 @@ std::tuple<bool, cPreferenceOperatingClasses&> tlvChannelPreference::operating_c
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    if (*m_operating_classes_list_length > 0) {
-        return std::forward_as_tuple(ret_success, *(m_operating_classes_list_vector[ret_idx]));
-    }
-    else {
-        return std::forward_as_tuple(ret_success, *(m_operating_classes_list));
-    }
+    return std::forward_as_tuple(ret_success, *(m_operating_classes_list_vector[ret_idx]));
 }
 
 std::shared_ptr<cPreferenceOperatingClasses> tlvChannelPreference::create_operating_classes_list() {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -47,12 +47,7 @@ std::tuple<bool, cRestrictedOperatingClasses&> tlvRadioOperationRestriction::ope
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    if (*m_operating_classes_list_length > 0) {
-        return std::forward_as_tuple(ret_success, *(m_operating_classes_list_vector[ret_idx]));
-    }
-    else {
-        return std::forward_as_tuple(ret_success, *(m_operating_classes_list));
-    }
+    return std::forward_as_tuple(ret_success, *(m_operating_classes_list_vector[ret_idx]));
 }
 
 std::shared_ptr<cRestrictedOperatingClasses> tlvRadioOperationRestriction::create_operating_classes_list() {

--- a/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
+++ b/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
@@ -20,10 +20,10 @@ tlvTestVarList:
     _type: cInner
     _length: [ complex_list_length ]
 
-  var1: uint16_t
+  var1: cInner
 
   unknown_length_list:
-    _type: uint16_t
+    _type: cInner
     _length: []
 
 cInner:


### PR DESCRIPTION
Commit 24eb1d5 added dynamic list of classes support since it was believed
that the encrypted settings in the WSC M2 TLV are the last member in the TLV.
However, the last member is the authenticator attribute, therefore
commit 0f0e023 added support for class members, and now the WSC M2 is following the
spec.
However, the dynamic list of classes support got broken in the way,
so this commit fixes that:

- Fix bug in tlvf where list allocation lock declared multiple times
- Fix bug in getting reference for dynamic list members
- Fix bugs in add, create and alloc of dynamic lists
- Add dynamic list of classes and class member to tlvVarList.yaml which
demonstrates all type of class member supported
- Update autogenerated files

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>