### PR TITLE
framework: tlvf: fix wrong memory move on multiple allocations

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -181,8 +181,8 @@ bool cACTION_BML_NW_MAP_RESPONSE::alloc_buffer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_buffer;
-    uint8_t *dst = (uint8_t *)m_buffer + len;
+    uint8_t *src = (uint8_t *)&m_buffer[*m_buffer_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -295,8 +295,8 @@ bool cACTION_BML_NW_MAP_UPDATE::alloc_buffer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_buffer;
-    uint8_t *dst = (uint8_t *)m_buffer + len;
+    uint8_t *src = (uint8_t *)&m_buffer[*m_buffer_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -409,8 +409,8 @@ bool cACTION_BML_STATS_UPDATE::alloc_buffer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_buffer;
-    uint8_t *dst = (uint8_t *)m_buffer + len;
+    uint8_t *src = (uint8_t *)&m_buffer[*m_buffer_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -519,8 +519,8 @@ bool cACTION_BML_EVENTS_UPDATE::alloc_buffer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_buffer;
-    uint8_t *dst = (uint8_t *)m_buffer + len;
+    uint8_t *src = (uint8_t *)&m_buffer[*m_buffer_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -2548,8 +2548,8 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::alloc_vap_list(size_t count) 
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_vap_list;
-    uint8_t *dst = (uint8_t *)m_vap_list + len;
+    uint8_t *src = (uint8_t *)&m_vap_list[*m_vap_list_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -2686,8 +2686,8 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::alloc_vap_list(size_t count)
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_vap_list;
-    uint8_t *dst = (uint8_t *)m_vap_list + len;
+    uint8_t *src = (uint8_t *)&m_vap_list[*m_vap_list_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -3371,8 +3371,8 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::alloc_buffer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_buffer;
-    uint8_t *dst = (uint8_t *)m_buffer + len;
+    uint8_t *src = (uint8_t *)&m_buffer[*m_buffer_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -3529,8 +3529,8 @@ bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::alloc_command(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_command;
-    uint8_t *dst = (uint8_t *)m_command + len;
+    uint8_t *src = (uint8_t *)&m_command[*m_command_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -3635,8 +3635,8 @@ bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::alloc_reply(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_reply;
-    uint8_t *dst = (uint8_t *)m_reply + len;
+    uint8_t *src = (uint8_t *)&m_reply[*m_reply_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -288,8 +288,8 @@ bool cACTION_CLI_RESPONSE_STR::alloc_buffer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_buffer;
-    uint8_t *dst = (uint8_t *)m_buffer + len;
+    uint8_t *src = (uint8_t *)&m_buffer[*m_buffer_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -2016,8 +2016,8 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_sta_stats;
-    uint8_t *dst = (uint8_t *)m_sta_stats + len;
+    uint8_t *src = (uint8_t *)&m_sta_stats[*m_sta_stats_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -906,8 +906,8 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_sta_stats;
-    uint8_t *dst = (uint8_t *)m_sta_stats + len;
+    uint8_t *src = (uint8_t *)&m_sta_stats[*m_sta_stats_size];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -87,8 +87,8 @@ bool cWscAttrEncryptedSettings::alloc_ssid(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_ssid;
-    uint8_t *dst = (uint8_t *)m_ssid + len;
+    uint8_t *src = (uint8_t *)&m_ssid[*m_ssid_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -59,8 +59,11 @@ std::shared_ptr<cMacList> tlvDeviceBridgingCapability::create_bridging_tuples_li
     m_lock_order_counter__ = 0;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_bridging_tuples_list;
-    uint8_t *dst = (uint8_t *)m_bridging_tuples_list + len;
     if (!m_parse__) {
+        if (m_bridging_tuples_list_idx__ > 0) {
+            src = (uint8_t *)m_bridging_tuples_list_vector[m_bridging_tuples_list_idx__ - 1]->getBuffPtr();
+        }
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -76,7 +79,13 @@ bool tlvDeviceBridgingCapability::add_bridging_tuples_list(std::shared_ptr<cMacL
         TLVF_LOG(ERROR) << "No call to create_bridging_tuples_list was called before add_bridging_tuples_list";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_bridging_tuples_list) {
+    uint8_t *src = (uint8_t *)m_bridging_tuples_list;
+    if (!m_parse__) {
+        if (m_bridging_tuples_list_idx__ > 0) {
+            src = (uint8_t *)m_bridging_tuples_list_vector[m_bridging_tuples_list_idx__ - 1]->getBuffPtr();
+        }
+    }
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -190,8 +199,8 @@ bool cMacList::alloc_mac_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_mac_list;
-    uint8_t *dst = (uint8_t *)m_mac_list + len;
+    uint8_t *src = (uint8_t *)&m_mac_list[*m_mac_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -142,10 +142,17 @@ bool tlvDeviceBridgingCapability::init()
     uint8_t bridging_tuples_list_length = *m_bridging_tuples_list_length;
     m_bridging_tuples_list_idx__ = bridging_tuples_list_length;
     for (size_t i = 0; i < bridging_tuples_list_length; i++) {
-        if (!add_bridging_tuples_list(create_bridging_tuples_list())) { 
-            TLVF_LOG(ERROR) << "Failed adding bridging_tuples_list entry.";
+        auto bridging_tuples_list = create_bridging_tuples_list();
+        if (!bridging_tuples_list) {
+            TLVF_LOG(ERROR) << "create_bridging_tuples_list() failed";
             return false;
         }
+        if (!add_bridging_tuples_list(bridging_tuples_list)) {
+            TLVF_LOG(ERROR) << "add_bridging_tuples_list() failed";
+            return false;
+        }
+        // swap back since bridging_tuples_list will be swapped as part of the whole class swap
+        bridging_tuples_list->class_swap();
     }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -65,8 +65,8 @@ bool tlvDeviceInformation::alloc_info(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_info;
-    uint8_t *dst = (uint8_t *)m_info + len;
+    uint8_t *src = (uint8_t *)&m_info[*m_info_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -61,8 +61,8 @@ bool tlvPushButtonEventNotification::alloc_media_type_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_media_type_list;
-    uint8_t *dst = (uint8_t *)m_media_type_list + len;
+    uint8_t *src = (uint8_t *)&m_media_type_list[*m_media_type_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -131,8 +131,8 @@ bool tlvWscM1::alloc_manufacturer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_manufacturer;
-    uint8_t *dst = (uint8_t *)m_manufacturer + len;
+    uint8_t *src = (uint8_t *)&m_manufacturer[*m_manufacturer_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -217,8 +217,8 @@ bool tlvWscM1::alloc_model_name(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 1;
-    uint8_t *src = (uint8_t *)m_model_name;
-    uint8_t *dst = (uint8_t *)m_model_name + len;
+    uint8_t *src = (uint8_t *)&m_model_name[*m_model_name_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -300,8 +300,8 @@ bool tlvWscM1::alloc_model_number(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 2;
-    uint8_t *src = (uint8_t *)m_model_number;
-    uint8_t *dst = (uint8_t *)m_model_number + len;
+    uint8_t *src = (uint8_t *)&m_model_number[*m_model_number_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -380,8 +380,8 @@ bool tlvWscM1::alloc_serial_number(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 3;
-    uint8_t *src = (uint8_t *)m_serial_number;
-    uint8_t *dst = (uint8_t *)m_serial_number + len;
+    uint8_t *src = (uint8_t *)&m_serial_number[*m_serial_number_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -461,8 +461,8 @@ bool tlvWscM1::alloc_device_name(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 4;
-    uint8_t *src = (uint8_t *)m_device_name;
-    uint8_t *dst = (uint8_t *)m_device_name + len;
+    uint8_t *src = (uint8_t *)&m_device_name[*m_device_name_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -127,8 +127,8 @@ bool tlvWscM2::alloc_manufacturer(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_manufacturer;
-    uint8_t *dst = (uint8_t *)m_manufacturer + len;
+    uint8_t *src = (uint8_t *)&m_manufacturer[*m_manufacturer_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -212,8 +212,8 @@ bool tlvWscM2::alloc_model_name(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 1;
-    uint8_t *src = (uint8_t *)m_model_name;
-    uint8_t *dst = (uint8_t *)m_model_name + len;
+    uint8_t *src = (uint8_t *)&m_model_name[*m_model_name_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -294,8 +294,8 @@ bool tlvWscM2::alloc_model_number(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 2;
-    uint8_t *src = (uint8_t *)m_model_number;
-    uint8_t *dst = (uint8_t *)m_model_number + len;
+    uint8_t *src = (uint8_t *)&m_model_number[*m_model_number_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -373,8 +373,8 @@ bool tlvWscM2::alloc_serial_number(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 3;
-    uint8_t *src = (uint8_t *)m_serial_number;
-    uint8_t *dst = (uint8_t *)m_serial_number + len;
+    uint8_t *src = (uint8_t *)&m_serial_number[*m_serial_number_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -436,8 +436,8 @@ std::shared_ptr<WSC::cWscAttrEncryptedSettings> tlvWscM2::create_encrypted_setti
     m_lock_order_counter__ = 4;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_encrypted_settings;
-    uint8_t *dst = (uint8_t *)m_encrypted_settings + len;
     if (!m_parse__) {
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -454,7 +454,8 @@ bool tlvWscM2::add_encrypted_settings(std::shared_ptr<WSC::cWscAttrEncryptedSett
         TLVF_LOG(ERROR) << "No call to create_encrypted_settings was called before add_encrypted_settings";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_encrypted_settings) {
+    uint8_t *src = (uint8_t *)m_encrypted_settings;
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -63,8 +63,8 @@ bool tlvTestVarList::alloc_simple_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_simple_list;
-    uint8_t *dst = (uint8_t *)m_simple_list + len;
+    uint8_t *src = (uint8_t *)&m_simple_list[*m_simple_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
@@ -106,8 +106,11 @@ std::shared_ptr<cInner> tlvTestVarList::create_complex_list() {
     m_lock_order_counter__ = 1;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_complex_list;
-    uint8_t *dst = (uint8_t *)m_complex_list + len;
     if (!m_parse__) {
+        if (m_complex_list_idx__ > 0) {
+            src = (uint8_t *)m_complex_list_vector[m_complex_list_idx__ - 1]->getBuffPtr();
+        }
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -125,7 +128,13 @@ bool tlvTestVarList::add_complex_list(std::shared_ptr<cInner> ptr) {
         TLVF_LOG(ERROR) << "No call to create_complex_list was called before add_complex_list";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_complex_list) {
+    uint8_t *src = (uint8_t *)m_complex_list;
+    if (!m_parse__) {
+        if (m_complex_list_idx__ > 0) {
+            src = (uint8_t *)m_complex_list_vector[m_complex_list_idx__ - 1]->getBuffPtr();
+        }
+    }
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -160,8 +169,8 @@ std::shared_ptr<cInner> tlvTestVarList::create_var1() {
     m_lock_order_counter__ = 2;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_var1;
-    uint8_t *dst = (uint8_t *)m_var1 + len;
     if (!m_parse__) {
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -178,7 +187,8 @@ bool tlvTestVarList::add_var1(std::shared_ptr<cInner> ptr) {
         TLVF_LOG(ERROR) << "No call to create_var1 was called before add_var1";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_var1) {
+    uint8_t *src = (uint8_t *)m_var1;
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -216,6 +226,15 @@ std::shared_ptr<cInner> tlvTestVarList::create_unknown_length_list() {
     }
     m_lock_order_counter__ = 3;
     m_lock_allocation__ = true;
+    uint8_t *src = (uint8_t *)m_unknown_length_list;
+    if (!m_parse__) {
+        if (m_unknown_length_list_idx__ > 0) {
+            src = (uint8_t *)m_unknown_length_list_vector[m_unknown_length_list_idx__ - 1]->getBuffPtr();
+        }
+        uint8_t *dst = src + len;
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
     return std::make_shared<cInner>(getBuffPtr(), getBuffRemainingBytes(), m_parse__, m_swap__);
 }
 
@@ -228,7 +247,13 @@ bool tlvTestVarList::add_unknown_length_list(std::shared_ptr<cInner> ptr) {
         TLVF_LOG(ERROR) << "No call to create_unknown_length_list was called before add_unknown_length_list";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_unknown_length_list) {
+    uint8_t *src = (uint8_t *)m_unknown_length_list;
+    if (!m_parse__) {
+        if (m_unknown_length_list_idx__ > 0) {
+            src = (uint8_t *)m_unknown_length_list_vector[m_unknown_length_list_idx__ - 1]->getBuffPtr();
+        }
+    }
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -400,8 +425,8 @@ bool cInner::alloc_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_list;
-    uint8_t *dst = (uint8_t *)m_list + len;
+    uint8_t *src = (uint8_t *)&m_list[*m_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -329,10 +329,17 @@ bool tlvTestVarList::init()
     uint8_t complex_list_length = *m_complex_list_length;
     m_complex_list_idx__ = complex_list_length;
     for (size_t i = 0; i < complex_list_length; i++) {
-        if (!add_complex_list(create_complex_list())) { 
-            TLVF_LOG(ERROR) << "Failed adding complex_list entry.";
+        auto complex_list = create_complex_list();
+        if (!complex_list) {
+            TLVF_LOG(ERROR) << "create_complex_list() failed";
             return false;
         }
+        if (!add_complex_list(complex_list)) {
+            TLVF_LOG(ERROR) << "add_complex_list() failed";
+            return false;
+        }
+        // swap back since complex_list will be swapped as part of the whole class swap
+        complex_list->class_swap();
     }
     m_var1 = (cInner*)m_buff_ptr__;
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -160,10 +160,17 @@ bool tlvApRadioBasicCapabilities::init()
     uint8_t operating_classes_info_list_length = *m_operating_classes_info_list_length;
     m_operating_classes_info_list_idx__ = operating_classes_info_list_length;
     for (size_t i = 0; i < operating_classes_info_list_length; i++) {
-        if (!add_operating_classes_info_list(create_operating_classes_info_list())) { 
-            TLVF_LOG(ERROR) << "Failed adding operating_classes_info_list entry.";
+        auto operating_classes_info_list = create_operating_classes_info_list();
+        if (!operating_classes_info_list) {
+            TLVF_LOG(ERROR) << "create_operating_classes_info_list() failed";
             return false;
         }
+        if (!add_operating_classes_info_list(operating_classes_info_list)) {
+            TLVF_LOG(ERROR) << "add_operating_classes_info_list() failed";
+            return false;
+        }
+        // swap back since operating_classes_info_list will be swapped as part of the whole class swap
+        operating_classes_info_list->class_swap();
     }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -67,8 +67,11 @@ std::shared_ptr<cOperatingClassesInfo> tlvApRadioBasicCapabilities::create_opera
     m_lock_order_counter__ = 0;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_operating_classes_info_list;
-    uint8_t *dst = (uint8_t *)m_operating_classes_info_list + len;
     if (!m_parse__) {
+        if (m_operating_classes_info_list_idx__ > 0) {
+            src = (uint8_t *)m_operating_classes_info_list_vector[m_operating_classes_info_list_idx__ - 1]->getBuffPtr();
+        }
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -84,7 +87,13 @@ bool tlvApRadioBasicCapabilities::add_operating_classes_info_list(std::shared_pt
         TLVF_LOG(ERROR) << "No call to create_operating_classes_info_list was called before add_operating_classes_info_list";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_operating_classes_info_list) {
+    uint8_t *src = (uint8_t *)m_operating_classes_info_list;
+    if (!m_parse__) {
+        if (m_operating_classes_info_list_idx__ > 0) {
+            src = (uint8_t *)m_operating_classes_info_list_vector[m_operating_classes_info_list_idx__ - 1]->getBuffPtr();
+        }
+    }
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -216,8 +225,8 @@ bool cOperatingClassesInfo::alloc_statically_non_operable_channels_list(size_t c
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_statically_non_operable_channels_list;
-    uint8_t *dst = (uint8_t *)m_statically_non_operable_channels_list + len;
+    uint8_t *src = (uint8_t *)&m_statically_non_operable_channels_list[*m_statically_non_operable_channels_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -63,8 +63,11 @@ std::shared_ptr<cPreferenceOperatingClasses> tlvChannelPreference::create_operat
     m_lock_order_counter__ = 0;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_operating_classes_list;
-    uint8_t *dst = (uint8_t *)m_operating_classes_list + len;
     if (!m_parse__) {
+        if (m_operating_classes_list_idx__ > 0) {
+            src = (uint8_t *)m_operating_classes_list_vector[m_operating_classes_list_idx__ - 1]->getBuffPtr();
+        }
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -80,7 +83,13 @@ bool tlvChannelPreference::add_operating_classes_list(std::shared_ptr<cPreferenc
         TLVF_LOG(ERROR) << "No call to create_operating_classes_list was called before add_operating_classes_list";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_operating_classes_list) {
+    uint8_t *src = (uint8_t *)m_operating_classes_list;
+    if (!m_parse__) {
+        if (m_operating_classes_list_idx__ > 0) {
+            src = (uint8_t *)m_operating_classes_list_vector[m_operating_classes_list_idx__ - 1]->getBuffPtr();
+        }
+    }
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -204,8 +213,8 @@ bool cPreferenceOperatingClasses::alloc_channel_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_channel_list;
-    uint8_t *dst = (uint8_t *)m_channel_list + len;
+    uint8_t *src = (uint8_t *)&m_channel_list[*m_channel_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -152,10 +152,17 @@ bool tlvChannelPreference::init()
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
     m_operating_classes_list_idx__ = operating_classes_list_length;
     for (size_t i = 0; i < operating_classes_list_length; i++) {
-        if (!add_operating_classes_list(create_operating_classes_list())) { 
-            TLVF_LOG(ERROR) << "Failed adding operating_classes_list entry.";
+        auto operating_classes_list = create_operating_classes_list();
+        if (!operating_classes_list) {
+            TLVF_LOG(ERROR) << "create_operating_classes_list() failed";
             return false;
         }
+        if (!add_operating_classes_list(operating_classes_list)) {
+            TLVF_LOG(ERROR) << "add_operating_classes_list() failed";
+            return false;
+        }
+        // swap back since operating_classes_list will be swapped as part of the whole class swap
+        operating_classes_list->class_swap();
     }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -65,8 +65,8 @@ bool tlvOperatingChannelReport::alloc_operating_classes_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_operating_classes_list;
-    uint8_t *dst = (uint8_t *)m_operating_classes_list + len;
+    uint8_t *src = (uint8_t *)&m_operating_classes_list[*m_operating_classes_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -63,8 +63,11 @@ std::shared_ptr<cRestrictedOperatingClasses> tlvRadioOperationRestriction::creat
     m_lock_order_counter__ = 0;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_operating_classes_list;
-    uint8_t *dst = (uint8_t *)m_operating_classes_list + len;
     if (!m_parse__) {
+        if (m_operating_classes_list_idx__ > 0) {
+            src = (uint8_t *)m_operating_classes_list_vector[m_operating_classes_list_idx__ - 1]->getBuffPtr();
+        }
+        uint8_t *dst = src + len;
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
@@ -80,7 +83,13 @@ bool tlvRadioOperationRestriction::add_operating_classes_list(std::shared_ptr<cR
         TLVF_LOG(ERROR) << "No call to create_operating_classes_list was called before add_operating_classes_list";
         return false;
     }
-    if (ptr->getStartBuffPtr() != (uint8_t *)m_operating_classes_list) {
+    uint8_t *src = (uint8_t *)m_operating_classes_list;
+    if (!m_parse__) {
+        if (m_operating_classes_list_idx__ > 0) {
+            src = (uint8_t *)m_operating_classes_list_vector[m_operating_classes_list_idx__ - 1]->getBuffPtr();
+        }
+    }
+    if (ptr->getStartBuffPtr() != src) {
         TLVF_LOG(ERROR) << "Received to entry pointer is different than expected (excepting the same pointer returned from add method)";
         return false;
     }
@@ -204,8 +213,8 @@ bool cRestrictedOperatingClasses::alloc_channel_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_channel_list;
-    uint8_t *dst = (uint8_t *)m_channel_list + len;
+    uint8_t *src = (uint8_t *)&m_channel_list[*m_channel_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -152,10 +152,17 @@ bool tlvRadioOperationRestriction::init()
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
     m_operating_classes_list_idx__ = operating_classes_list_length;
     for (size_t i = 0; i < operating_classes_list_length; i++) {
-        if (!add_operating_classes_list(create_operating_classes_list())) { 
-            TLVF_LOG(ERROR) << "Failed adding operating_classes_list entry.";
+        auto operating_classes_list = create_operating_classes_list();
+        if (!operating_classes_list) {
+            TLVF_LOG(ERROR) << "create_operating_classes_list() failed";
             return false;
         }
+        if (!add_operating_classes_list(operating_classes_list)) {
+            TLVF_LOG(ERROR) << "add_operating_classes_list() failed";
+            return false;
+        }
+        // swap back since operating_classes_list will be swapped as part of the whole class swap
+        operating_classes_list->class_swap();
     }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -61,8 +61,8 @@ bool tlvSearchedService::alloc_searched_service_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_searched_service_list;
-    uint8_t *dst = (uint8_t *)m_searched_service_list + len;
+    uint8_t *src = (uint8_t *)&m_searched_service_list[*m_searched_service_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -61,8 +61,8 @@ bool tlvSupportedService::alloc_supported_service_list(size_t count) {
         return false;
     }
     m_lock_order_counter__ = 0;
-    uint8_t *src = (uint8_t *)m_supported_service_list;
-    uint8_t *dst = (uint8_t *)m_supported_service_list + len;
+    uint8_t *src = (uint8_t *)&m_supported_service_list[*m_supported_service_list_length];
+    uint8_t *dst = src + len;
     if (!m_parse__) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);


### PR DESCRIPTION
Problem:
When allocating/creating a new object in a dynamic list, the TLVF moving
all the memory from the beginning of the list to the end of the buffer
minus a new allocated size.
This could work only if increasing list size one time only when the
list size is 0.
When trying to do it multiple times, it caused memory override.

Solution:
Move the memory from (list beginning + its current size) instead of
(beginning of the list).

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>