### PR TITLE
Docker: use a working distro by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 script:
   - cd tools/docker
-  - sudo ./image-build.sh -b ubuntu:18.04
+  - sudo ./image-build.sh
   # Run clang-format and check there are no modified files by checking git status
   - sudo ./clang-format.sh
   - git diff-index --exit-code HEAD

--- a/tools/docker/image-build.sh
+++ b/tools/docker/image-build.sh
@@ -34,6 +34,7 @@ usage() {
     echo "      -h|--help - show this help menu"
     echo "      -v|--verbose - verbosity on"
     echo "      -b|--base-image - Base OS image to use (Dockerfile 'FROM')"
+    echo "      -n|--native - Use the same base OS image as the running system"
     echo "      -t|--tag - tag to add to prplmesh-builder and prplmesh-runner images"
 }
 
@@ -49,16 +50,16 @@ main() {
             -v | --verbose)         VERBOSE=true; shift ;;
             -h | --help)            usage; exit 0; shift ;;
             -b | --base-image)      IMAGE="$2"; shift ; shift ;;
+            -n | --native)          IMAGE=$(
+                                        . /etc/os-release
+                                        distro="$(echo $NAME | awk '{print tolower($0)}')"
+                                        echo "$distro:$VERSION_ID"
+                                    ) ;;
             -t | --tag)             TAG=":$2"; shift ; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
     done
-
-    [ -z "$IMAGE" ] && IMAGE=$(
-        . /etc/os-release
-        echo "$(echo $NAME | awk '{print tolower($0)}'):$VERSION_ID"
-    )
 
     dbg IMAGE=$IMAGE
     dbg TAG=$TAG
@@ -83,6 +84,6 @@ main() {
 
 VERBOSE=false
 NATIVE=false
-IMAGE=
+IMAGE="ubuntu:18.04"
 
 main $@


### PR DESCRIPTION
Since I'm using Fedora, the default same-as-running-system distro that is used by image-build.sh simply doesn't work.

Also, in the README we never say that people should make sure they use an Ubuntu docker.

Therefore, it is better to default to ubuntu:18.04, while still giving an easy way to use the native distro for people who can use it.