### PR TITLE
tlvf: fix int length lists parsing

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -161,6 +161,7 @@ class cACTION_CONTROL_CONTROLLER_PING_REQUEST : public BaseClass
         uint16_t& total();
         uint16_t& seq();
         uint16_t& size();
+        size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
         std::tuple<bool, uint8_t&> data(size_t idx);
         bool alloc_data(size_t count = 1);
         void class_swap();
@@ -190,6 +191,7 @@ class cACTION_CONTROL_CONTROLLER_PING_RESPONSE : public BaseClass
         uint16_t& total();
         uint16_t& seq();
         uint16_t& size();
+        size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
         std::tuple<bool, uint8_t&> data(size_t idx);
         bool alloc_data(size_t count = 1);
         void class_swap();
@@ -219,6 +221,7 @@ class cACTION_CONTROL_AGENT_PING_REQUEST : public BaseClass
         uint16_t& total();
         uint16_t& seq();
         uint16_t& size();
+        size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
         std::tuple<bool, uint8_t&> data(size_t idx);
         bool alloc_data(size_t count = 1);
         void class_swap();
@@ -248,6 +251,7 @@ class cACTION_CONTROL_AGENT_PING_RESPONSE : public BaseClass
         uint16_t& total();
         uint16_t& seq();
         uint16_t& size();
+        size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
         std::tuple<bool, uint8_t&> data(size_t idx);
         bool alloc_data(size_t count = 1);
         void class_swap();

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -628,9 +628,9 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
     m_supported_channels_list = (sWifiChannel*)m_buff_ptr__;
     m_buff_ptr__ += (sizeof(sWifiChannel) * beerocks::message::SUPPORTED_CHANNELS_LENGTH);
     m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
-        if (!m_parse__) { 
-            for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
-        }
+    if (!m_parse__) {
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+    }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -1590,9 +1590,9 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
     m_supported_channels = (sWifiChannel*)m_buff_ptr__;
     m_buff_ptr__ += (sizeof(sWifiChannel) * beerocks::message::SUPPORTED_CHANNELS_LENGTH);
     m_supported_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
-        if (!m_parse__) { 
-            for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
-        }
+    if (!m_parse__) {
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
+    }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
@@ -52,6 +52,7 @@ class tlv1905NeighborDevice : public BaseClass
         const eTlvType& type();
         const uint16_t& length();
         sMacAddr& mac_local_iface();
+        size_t mac_al_1905_device_length() { return m_mac_al_1905_device_idx__ * sizeof(tlv1905NeighborDevice::sMacAl1905Device); }
         std::tuple<bool, sMacAl1905Device&> mac_al_1905_device(size_t idx);
         bool alloc_mac_al_1905_device(size_t count = 1);
         void class_swap();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h
@@ -36,6 +36,7 @@ class tlvNon1905neighborDeviceList : public BaseClass
         const eTlvType& type();
         const uint16_t& length();
         sMacAddr& mac_local_iface();
+        size_t mac_non_1905_device_length() { return m_mac_non_1905_device_idx__ * sizeof(sMacAddr); }
         std::tuple<bool, sMacAddr&> mac_non_1905_device(size_t idx);
         bool alloc_mac_non_1905_device(size_t count = 1);
         void class_swap();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
@@ -78,6 +78,7 @@ class tlvReceiverLinkMetric : public BaseClass
         sMacAddr& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
         //The following fields shall be repeated for each connected interface pair between the
         //receiving 1905.1 AL and the neighbor 1905.1 AL.
+        size_t interface_pair_info_length() { return m_interface_pair_info_idx__ * sizeof(tlvReceiverLinkMetric::sInterfacePairInfo); }
         std::tuple<bool, sInterfacePairInfo&> interface_pair_info(size_t idx);
         bool alloc_interface_pair_info(size_t count = 1);
         void class_swap();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
@@ -89,6 +89,7 @@ class tlvTransmitterLinkMetric : public BaseClass
         sMacAddr& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
         //The fields shall be repeated for each connected interface pair between the receiving
         //905.1 AL and the neighbor 1905.1 AL.
+        size_t interface_pair_info_length() { return m_interface_pair_info_idx__ * sizeof(tlvTransmitterLinkMetric::sInterfacePairInfo); }
         std::tuple<bool, sInterfacePairInfo&> interface_pair_info(size_t idx);
         bool alloc_interface_pair_info(size_t count = 1);
         void class_swap();

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -43,6 +43,7 @@ class tlvTestVarList : public BaseClass
         std::shared_ptr<cInner> create_var1();
         bool add_var1(std::shared_ptr<cInner> ptr);
         std::shared_ptr<cInner> var1() { return m_var1_ptr; }
+        size_t unknown_length_list_length();
         std::tuple<bool, cInner&> unknown_length_list(size_t idx);
         std::shared_ptr<cInner> create_unknown_length_list();
         bool add_unknown_length_list(std::shared_ptr<cInner> ptr);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -71,11 +71,12 @@ bool tlvMacAddress::init()
     m_mac = (uint8_t*)m_buff_ptr__;
     m_buff_ptr__ += (sizeof(uint8_t) * 6);
     m_mac_idx__  = 6;
-    if(m_length){ (*m_length) += (sizeof(uint8_t) * 6); }
-    for (size_t i = 0; i < 6; i++){
-        m_mac[i] = 0x0;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * 6); }
+        for (size_t i = 0; i < 6; i++){
+            m_mac[i] = 0x0;
+        }
     }
-    
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -504,7 +504,7 @@ void tlvWscM2::class_swap()
     m_device_password_id_attr->struct_swap();
     m_os_version_attr->struct_swap();
     m_vendor_extensions_attr->struct_swap();
-    if (m_encrypted_settings) { m_encrypted_settings_ptr->class_swap(); }
+    if (m_encrypted_settings_ptr) { m_encrypted_settings_ptr->class_swap(); }
     m_authenticator->struct_swap();
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -205,6 +205,15 @@ bool tlvTestVarList::add_var1(std::shared_ptr<cInner> ptr) {
     return true;
 }
 
+size_t tlvTestVarList::unknown_length_list_length()
+{
+    size_t len = 0;
+    for (size_t i = 0; i < m_unknown_length_list_idx__; i++) {
+        len += m_unknown_length_list_vector[i]->getLen();
+    }
+    return len;
+}
+
 std::tuple<bool, cInner&> tlvTestVarList::unknown_length_list(size_t idx) {
     bool ret_success = ( (m_unknown_length_list_idx__ > 0) && (m_unknown_length_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -283,7 +283,7 @@ void tlvTestVarList::class_swap()
     for (size_t i = 0; i < (size_t)*m_complex_list_length; i++){
         std::get<1>(complex_list(i)).class_swap();
     }
-    if (m_var1) { m_var1_ptr->class_swap(); }
+    if (m_var1_ptr) { m_var1_ptr->class_swap(); }
     for (size_t i = 0; i < m_unknown_length_list_idx__; i++){
         std::get<1>(unknown_length_list(i)).class_swap();
     }

--- a/framework/tlvf/test/main.cpp
+++ b/framework/tlvf/test/main.cpp
@@ -24,6 +24,8 @@
 #include <mapf/common/logger.h>
 #include <tlvf/wfa_map/tlvApCapability.h>
 
+#include <algorithm>
+#include <iterator>
 #include <stdio.h>
 
 using namespace ieee1905_1;
@@ -33,11 +35,20 @@ MAPF_INITIALIZE_LOGGER
 
 using namespace mapf;
 
+std::string dump_buffer(uint8_t *buffer, size_t len)
+{
+    std::ostringstream hexdump;
+    for (size_t i = 0; i < len; i += 16) {
+        for (size_t j = i; j < len && j < i + 16; j++)
+            hexdump << std::hex << std::setw(2) << std::setfill('0') << (unsigned)buffer[j] << " ";
+        hexdump << std::endl;
+    }
+    return hexdump.str();
+}
 int test_complex_list()
 {
     int errors                     = 0;
     const int complex_list_entries = 3;
-    mapf::Logger::Instance().LoggerInit("TLVF example");
     uint8_t tx_buffer[4096];
 
     MAPF_INFO(__FUNCTION__ << " start");
@@ -96,14 +107,7 @@ int test_complex_list()
     //MANDATORY - swaps to little indian.
     msg.finalize(true);
 
-    LOG(INFO) << "TX:";
-    for (size_t i = 0; i < msg.getMessageLength(); i += 16) {
-        std::ostringstream hexdump;
-        for (size_t j = i; j < msg.getMessageLength() && j < i + 16; j++)
-            hexdump << std::hex << std::setw(2) << std::setfill('0') << (unsigned)tx_buffer[j]
-                    << " ";
-        LOG(INFO) << hexdump.str();
-    }
+    LOG(INFO) << "TX: " << std::endl << dump_buffer(tx_buffer, msg.getMessageLength());
 
     uint8_t recv_buffer[sizeof(tx_buffer)];
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
@@ -140,7 +144,6 @@ int test_complex_list()
 int test_all()
 {
     int errors = 0;
-    mapf::Logger::Instance().LoggerInit("TLVF example");
     uint8_t tx_buffer[4096];
 
     //START BUILDING THE MESSAGE HERE
@@ -305,14 +308,7 @@ int test_all()
     //MANDATORY - swaps to little indian.
     msg.finalize(true);
 
-    LOG(INFO) << "TX:";
-    for (size_t i = 0; i < msg.getMessageLength(); i += 16) {
-        std::ostringstream hexdump;
-        for (size_t j = i; j < msg.getMessageLength() && j < i + 16; j++)
-            hexdump << std::hex << std::setw(2) << std::setfill('0') << (unsigned)tx_buffer[j]
-                    << " ";
-        LOG(INFO) << hexdump.str();
-    }
+    LOG(INFO) << "TX: " << std::endl << dump_buffer(tx_buffer, msg.getMessageLength());
 
     uint8_t recv_buffer[sizeof(tx_buffer)];
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
@@ -523,6 +519,7 @@ int test_all()
 
 int main(int argc, char *argv[])
 {
+    mapf::Logger::Instance().LoggerInit("tlvf_test");
     int errors = 0;
 
     errors += test_complex_list();

--- a/framework/tlvf/test/main.cpp
+++ b/framework/tlvf/test/main.cpp
@@ -337,6 +337,11 @@ int test_all()
     }
 
     LOG(INFO) << "TLV 4 length " << fourthTlv->length();
+    auto unknown = fourthTlv->create_unknown_length_list();
+    fourthTlv->add_unknown_length_list(unknown);
+    LOG(INFO) << "Unknown list size: " << unknown->getLen();
+    LOG(INFO) << "Total unknown Length: " << fourthTlv->unknown_length_list_length();
+    LOG(INFO) << "TLV 4 length " << fourthTlv->length();
 
     LOG(INFO) << "Finalize";
     //MANDATORY - swaps to little indian.
@@ -455,6 +460,13 @@ int test_all()
             }
         }
 
+        LOG(DEBUG) << "Total unknown Length: " << tlv4->unknown_length_list_length();
+        if (tlv4->unknown_length_list_length() != fourthTlv->unknown_length_list_length()) {
+            MAPF_ERR("TLV 4 unknown length list length mismatch");
+            errors++;
+        }
+
+        LOG(INFO) << "TLV 4 length " << tlv4->length();
         // TODO the complex list doesn't work at the moment if it has more than one element
         // Cfr. #137
         //        if (tlv4->complex_list_length() != 2) {

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -888,6 +888,20 @@ class TlvF:
 
             # add comment
             lines_h.extend(param_comment_line)
+            if is_dynamic_len:
+                if param_type_info.type == TypeInfo.CLASS:
+                    lines_h.append("size_t %s_length();" %(param_name))
+                    lines_cpp.append("size_t %s::%s_length()" %(obj_meta.name, param_name))
+                    lines_cpp.append("{")
+                    lines_cpp.append("%ssize_t len = 0;" %(self.getIndentation(1)))
+                    lines_cpp.append("%sfor (size_t i = 0; i < m_%s_idx__; i++) {" %(self.getIndentation(1), param_name))
+                    lines_cpp.append("%slen += m_%s_vector[i]->getLen();" %(self.getIndentation(2), param_name))
+                    lines_cpp.append("%s}" %(self.getIndentation(1)))
+                    lines_cpp.append("%sreturn len;" %(self.getIndentation(1)))
+                    lines_cpp.append("}")
+                    lines_cpp.append("")
+                else:
+                    lines_h.append("size_t %s_length() { return m_%s_idx__ * sizeof(%s); }" % (param_name, param_name, param_type_full))
 
             #add function to get char pointer
             if param_type_info.type == TypeInfo.CHAR:

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -659,7 +659,7 @@ class TlvF:
                 obj_meta.list_index = obj_meta.list_index + 1
 
                 # Add param to swap list
-                swap_func_lines = ["if (m_%s) { m_%s_ptr->class_swap(); }" %(param_name, param_name)]
+                swap_func_lines = ["if (m_%s_ptr) { m_%s_ptr->class_swap(); }" %(param_name, param_name)]
 
                 # Add allocation methods
                 self.addClassVarLenMethods(obj_meta, param_type, param_name, param_meta, param_length, False, False)

--- a/tools/prplMesh.code-workspace
+++ b/tools/prplMesh.code-workspace
@@ -77,7 +77,10 @@
 			"utility": "cpp",
 			"atomic": "cpp",
 			"codecvt": "cpp",
-			"memory": "cpp"
+			"memory": "cpp",
+			"future": "cpp",
+			"optional": "cpp",
+			"string_view": "cpp"
 		}
 	}
 }


### PR DESCRIPTION

- Fix bug when int length list values are initialized on parse
- Add a test to verify int len lists
- Add length function for unknown length lists
- Add unknown length list to the inner class in tlvVarList.yaml
- and a test in tlvf test to verfiy length function works as expected

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>