### PR TITLE
WSC Flow phase 1 - support for none Intel agent

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4388,13 +4388,6 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
                    << "     bssid: " << bssid << std::endl
                    << "     authentication_type: " << authentication_type << std::endl
                    << "     encryption_type: " << encryption_type << std::endl;
-
-        if (!manufacturer.compare("Intel")) {
-            // TODO add support for none Intel agents
-            // https://github.com/prplfoundation/prplMesh/issues/134
-            LOG(ERROR) << "None Intel controller " << manufacturer << " , dropping message";
-            return false;
-        }
     }
 
     if (slave_state != STATE_WAIT_FOR_JOINED_RESPONSE) {

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -274,6 +274,7 @@ private:
     std::unique_ptr<mapf::encryption::diffie_hellman> dh = nullptr;
 
     bool parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool parse_non_intel_join_response(Socket *sd);
     bool handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool autoconfig_wsc_add_m1();
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -200,6 +200,25 @@ std::string db::get_node_ipv4(std::string mac)
     return n->ipv4;
 }
 
+bool db::set_node_manufacturer(std::string mac, std::string manufacturer)
+{
+    auto n = get_node(mac);
+    if (!n) {
+        return false;
+    }
+    n->manufacturer = manufacturer;
+    return true;
+}
+
+std::string db::get_node_manufacturer(std::string mac)
+{
+    auto n = get_node(mac);
+    if (!n) {
+        return std::string();
+    }
+    return n->manufacturer;
+}
+
 int db::get_node_channel(std::string mac)
 {
     auto n = get_node(mac);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -146,6 +146,9 @@ public:
     bool set_node_ipv4(std::string mac, std::string ipv4);
     std::string get_node_ipv4(std::string mac);
 
+    bool set_node_manufacturer(std::string mac, std::string manufacturer);
+    std::string get_node_manufacturer(std::string mac);
+
     int get_node_channel(std::string mac);
 
     bool set_node_vap_id(std::string mac, int8_t vap_id);

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -42,6 +42,7 @@ std::ostream &operator<<(std::ostream &os, const node &n)
            << " Name: " << n.name << std::endl
            << " Mac: " << n.mac << std::endl
            << " Ipv4: " << n.ipv4 << std::endl
+           << " Manufacturer: " << n.manufacturer << std::endl
            << " ParentMac: " << n.parent_mac << std::endl
            << " PreviousParentMac: " << n.previous_parent_mac << std::endl
            << " Channel: " << int(n.channel) << std::endl
@@ -127,6 +128,7 @@ std::ostream &operator<<(std::ostream &os, const node &n)
            << " State: " << n.state << std::endl
            << " Active: " << bool(n.hostap->active) << std::endl
            << " Is backhual manager: " << n.hostap->is_backhaul_manager << std::endl
+           << " Manufacturer: " << n.manufacturer << std::endl
            << " Channel: " << int(n.channel) << std::endl
            << " ChannelBandwidth: " << int(n.bandwidth) << std::endl
            << " ChannelExtAboveSecondary: " << bool(n.channel_ext_above_secondary) << std::endl

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -50,6 +50,7 @@ public:
     std::string radio_identifier;
 
     std::string ipv4;
+    std::string manufacturer;
     int channel = 0;
     std::string name;
     int hierarchy = -1; //redundant but more efficient

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1098,6 +1098,8 @@ bool master_thread::handle_intel_slave_join(Socket *sd, ieee1905_1::CmduMessageR
 
         database.set_node_ipv4(backhaul_mac, bridge_ipv4);
         database.set_node_ipv4(bridge_mac, bridge_ipv4);
+        database.set_node_manufacturer(backhaul_mac, "Intel");
+        database.set_node_manufacturer(bridge_mac, "Intel");
 
         database.set_node_type(backhaul_mac, beerocks::TYPE_IRE_BACKHAUL);
 
@@ -1113,6 +1115,7 @@ bool master_thread::handle_intel_slave_join(Socket *sd, ieee1905_1::CmduMessageR
         database.set_node_state(eth_switch_mac, beerocks::STATE_CONNECTED);
         database.set_node_name(eth_switch_mac, slave_name + "_ETH");
         database.set_node_ipv4(eth_switch_mac, bridge_ipv4);
+        database.set_node_manufacturer(eth_switch_mac, "Intel");
 
         //run locating task on ire
         if (!database.is_node_wireless(backhaul_mac)) {
@@ -1298,6 +1301,7 @@ bool master_thread::handle_intel_slave_join(Socket *sd, ieee1905_1::CmduMessageR
 
     database.set_node_name(radio_mac, slave_name + "_AP");
     database.set_node_ipv4(radio_mac, bridge_ipv4);
+    database.set_node_manufacturer(radio_mac, "Intel");
 
     // sd is assigned to src bridge mac
     sd->setPeerMac(bridge_mac);
@@ -1454,6 +1458,7 @@ bool master_thread::handle_non_intel_slave_join(Socket *sd,
                << ire_type;
     database.add_node(bridge_mac, backhaul_mac, ire_type);
     database.set_node_state(bridge_mac, beerocks::STATE_CONNECTED);
+    database.set_node_manufacturer(bridge_mac, tlvwscM1->manufacturer());
 
     // Controller expects backhaul which contains bridge which contains radio, but we only get radio...
 
@@ -1484,6 +1489,7 @@ bool master_thread::handle_non_intel_slave_join(Socket *sd,
     // TODO number of antennas comes from HT/VHT capabilities (implicit from NxM)
     // TODO ant_gain and conducted_power will not be set
     database.set_node_name(radio_mac, tlvwscM1->model_name());
+    database.set_node_manufacturer(radio_mac, tlvwscM1->manufacturer());
     // TODO ipv4 will not be set
 
     // sd is assigned to src bridge mac

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -602,14 +602,6 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         }
     }
 
-    std::string manufacturer =
-        std::string(tlvwscM1->manufacturer(), tlvwscM1->manufacturer_length());
-    if (!manufacturer.compare("Intel")) {
-        //TODO add support for none Intel agents
-        LOG(ERROR) << "None Intel radio agent " << manufacturer << " , dropping WSC M1 message";
-        return false;
-    }
-
     if (database.setting_certification_mode() ||
         cmdu_rx.getNextTlvType() == int(ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC)) {
         LOG(INFO) << "Intel radio agent join (al_mac=" << al_mac << " ruid=" << ruid;

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -572,6 +572,12 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         return false;
     }
 
+    auto al_mac = network_utils::mac_to_string(tlvwscM1->mac_attr().data.oct);
+    auto ruid   = network_utils::mac_to_string(radio_basic_caps->radio_uid());
+    LOG(INFO) << "AP_AUTOCONFIGURATION_WSC M1 al_mac=" << al_mac << " ruid=" << ruid;
+    LOG(DEBUG) << "   device " << tlvwscM1->manufacturer() << " " << tlvwscM1->model_name() << " "
+               << tlvwscM1->device_name() << " " << tlvwscM1->serial_number();
+
     //TODO autoconfig process the rest of the class
     //TODO autoconfig Keep intel agent support only as intel enhancements
     /**
@@ -590,10 +596,7 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         return false;
     }
 
-    auto al_mac          = network_utils::mac_to_string(tlvwscM1->mac_attr().data.oct);
-    auto ruid            = network_utils::mac_to_string(tlvRuid->radio_uid());
-    tlvRuid->radio_uid() = radio_basic_caps->radio_uid();
-    LOG(INFO) << "radio agent join (al_mac=" << al_mac << " ruid=" << ruid << " enrolee_nonce: ";
+    tlvRuid->radio_uid() = network_utils::mac_from_string(ruid);
 
     for (int i = 0; i < radio_basic_caps->maximum_number_of_bsss_supported(); i++) {
         if (!autoconfig_wsc_add_m2(tlvwscM1)) {

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -54,6 +54,9 @@ private:
     void handle_cmdu_control_ieee1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_intel_slave_join(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx,
                                  ieee1905_1::CmduMessageTx &cmdu_tx);
+    bool handle_non_intel_slave_join(Socket *sd, std::shared_ptr<ieee1905_1::tlvWscM1> tlvwscM1,
+                                     std::string bridge_mac, std::string radio_mac,
+                                     ieee1905_1::CmduMessageTx &cmdu_tx);
 
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);


### PR DESCRIPTION
The M2 still needs to be filled in with the relevant information, but that's a bigger change because it requires the database to be updated with SSID information (currently SSID updates are only performed from an explicit command).

This PR goes on top of #154.
