### PR TITLE
Use dockerhub in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ services:
 
 script:
   - cd tools/docker
-  - sudo ./image-build.sh
+  # Try to pull from dockerhub, build the container images if that fails
+  - sudo ./image-pull.sh || sudo ./image-build.sh
   # Run clang-format and check there are no modified files by checking git status
   - sudo ./clang-format.sh
   - git diff-index --exit-code HEAD

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -20,7 +20,8 @@ main() {
         run ${scriptdir}/image-build.sh
     }
 
-    run docker container run -v ${topdir}:${topdir} --interactive --tty --rm prplmesh-builder $@
+    run docker container run --workdir=$topdir --user=${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)} \
+        -v ${topdir}:${topdir} --interactive --tty --rm prplmesh-builder $@
 }
 
 main $@

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -32,10 +32,4 @@ RUN apt-get update && apt-get install -y \
 	vim \
     && rm -rf /var/lib/apt/lists/*
 
-ARG uid
-ARG gid
-ARG topdir
-
-USER $uid:$gid
-WORKDIR $topdir
 ENTRYPOINT ["./prplMesh/tools/maptools.py", "build"]

--- a/tools/docker/image-build.sh
+++ b/tools/docker/image-build.sh
@@ -39,7 +39,7 @@ usage() {
 }
 
 main() {
-    OPTS=`getopt -o 'hvb:t:' --long verbose,help,base-image,tag -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hnvb:t:' --long verbose,help,base-image,native,tag -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -54,7 +54,7 @@ main() {
                                         . /etc/os-release
                                         distro="$(echo $NAME | awk '{print tolower($0)}')"
                                         echo "$distro:$VERSION_ID"
-                                    ) ;;
+                                    ); shift ;;
             -t | --tag)             TAG=":$2"; shift ; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;

--- a/tools/docker/image-build.sh
+++ b/tools/docker/image-build.sh
@@ -69,9 +69,6 @@ main() {
     info "Generating builder docker image (prplmesh-builder$TAG)"
     run docker image build \
         --build-arg image=$IMAGE \
-        --build-arg topdir=$topdir \
-        --build-arg uid=${SUDO_UID:-0} \
-        --build-arg gid=${SUDO_GID:-0} \
         --tag prplmesh-builder$TAG \
         ${scriptdir}/builder
 

--- a/tools/docker/image-pull.sh
+++ b/tools/docker/image-pull.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2019 Tomer Eliyahu (Intel), Arnout Vandecappelle (Essensium/Mind)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+dbg() {
+    [ "$VERBOSE" = "true" ] && echo "$(basename $0): $*"
+}
+
+err() {
+	printf '\033[1;31m'"$(basename $0): $@"'\033[0m\n'
+}
+
+info() {
+	printf '\033[1;35m'"$(basename $0): $@"'\033[0m\n'
+}
+
+run() {
+    dbg "$*"
+    "$@" || exit $?
+}
+
+scriptdir="$(cd "${0%/*}"; pwd)"
+topdir="${scriptdir%/*/*/*}"
+
+usage() {
+    echo "usage: $(basename $0) [-hvbt]"
+    echo "  options:"
+    echo "      -h|--help - show this help menu"
+    echo "      -v|--verbose - verbosity on"
+    echo "      -b|--base-image - Base OS image to use (Dockerfile 'FROM')"
+    echo "      -n|--native - Use the same base OS image as the running system"
+    echo "      -t|--tag - tag to add to prplmesh-builder and prplmesh-runner images"
+}
+
+pull_and_tag() {
+    name="$1"
+    upstream_tag="$2"
+    local_tag="$3"
+
+    repo="prplfoundationinc/$name:$upstream_tag"
+
+    info "Pulling $name$local_tag from $repo"
+    run docker pull "$repo"
+    run docker tag "$repo" "$name$local_tag"
+}
+
+main() {
+    OPTS=`getopt -o 'hvnb:t:' --long verbose,help,base-image,tag -n 'parse-options' -- "$@"`
+
+    if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
+
+    eval set -- "$OPTS"
+
+    while true; do
+        case "$1" in
+            -v | --verbose)         VERBOSE=true; shift ;;
+            -h | --help)            usage; exit 0; shift ;;
+            -b | --base-image)      IMAGE="$2"; shift ; shift ;;
+            -n | --native)          IMAGE=$(
+                                        . /etc/os-release
+                                        distro="$(echo $NAME | awk '{print tolower($0)}')"
+                                        echo "$distro:$VERSION_ID"
+                                    ); shift ;;
+            -t | --tag)             TAG=":$2"; shift ; shift ;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1 ;;
+        esac
+    done
+
+    dbg "TAG=$TAG"
+    dbg "topdir=$topdir"
+
+    # The tag used in dockerhub is the base image with : converted to -
+    upstream_tag="$(echo "$IMAGE" | tr : -)"
+    info "Base docker image $IMAGE -> tag $tag"
+
+    pull_and_tag prplmesh-builder "$upstream_tag" "$TAG"
+    pull_and_tag prplmesh-runner "$upstream_tag" "$TAG"
+}
+
+VERBOSE=false
+NATIVE=false
+IMAGE="ubuntu:18.04"
+
+main $@


### PR DESCRIPTION
We have a dockerhub organisation for prplfoundation, with repositories for prplmesh-builder and prplmesh-runner.

@tomereli and @arnout have push access to these repositories.

Add a script to pull from there instead of building the images.

Also fix an issue introduced by @arnout when he added the -n/--native option.

The USER and WORKDIR were encoded in the builder image. Because of that, it was not universally usable.
Move those options to the docker run call, so the values are appropriate for the context in which the image is used.

Ubuntu 18.04 images have already been pushed to dockerhub, so Travis should work right away.

@tomereli may want to push Ubuntu 19.04 images as well.