### PR TITLE
CODEOWNERS: remove Ram and Semyon

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @tomereli @rammarzin @arnout @simonbaren
+*   @tomereli @arnout


### PR DESCRIPTION
Ram and Semyon are no longer assigned to the project. Even though they
may still contribute, they certainly no longer can be considered code
owners who will do reviews.

Remove them from CODEOWNERS.