### PR TITLE
docker: fix the MAC address inside the containers

### DIFF
--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -30,6 +30,7 @@ usage() {
     echo "      -v|--verbose - verbosity on"
     echo "      -d|--detach - run in background"
     echo "      -i|--ipaddr - ipaddr for container br-lan (should be in network subnet)"
+    echo "      -m|--mac - base MAC address for interfaces in the container"
     echo "      -n|--name - container name (for later easy attach)"
     echo "      -I|--image - docker network to which to attach the container"
     echo "      -N|--network - docker network to which to attach the container"
@@ -51,7 +52,7 @@ generate_container_random_ip() {
 }
 
 main() {
-    OPTS=`getopt -o 'hvdi:n:N:o:t:' --long verbose,help,detach,ipaddr:,name:,network:,entrypoint:,tag:,options: -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvdi:m:n:N:o:t:' --long verbose,help,detach,ipaddr:,mac:,name:,network:,entrypoint:,tag:,options: -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -63,6 +64,7 @@ main() {
             -h | --help)        usage; exit 0; shift ;;
             -d | --detach)      DETACH=true; shift ;;
             -i | --ipaddr)      IPADDR="$2"; shift; shift ;;
+            -m | --mac)         BASE_MAC="$2"; shift; shift ;;
             -n | --name)        NAME="$2"; shift; shift ;;
             -t | --tag)         TAG=":$2"; shift; shift ;;
             -N | --network)     NETWORK="$2"; shift; shift ;;
@@ -92,6 +94,7 @@ main() {
     dbg "NETWORK=${NETWORK}"
     dbg "IMAGE=prplmesh-runner$TAG"
     dbg "IPADDR=${IPADDR}"
+    dbg "BASE_MAC=${BASE_MAC}"
     dbg "NAME=${NAME}"
 
     DOCKEROPTS="-e USER=${SUDO_USER}
@@ -109,7 +112,7 @@ main() {
         DOCKEROPTS="$DOCKEROPTS -d"
     fi
     
-    run docker container run ${DOCKEROPTS} prplmesh-runner$TAG $IPADDR "$@"
+    run docker container run ${DOCKEROPTS} prplmesh-runner$TAG $IPADDR "$BASE_MAC" "$@"
 }
 
 VERBOSE=false
@@ -118,5 +121,6 @@ NETWORK=prplMesh-net
 IPADDR=
 NAME=prplMesh
 ENTRYPOINT=
+BASE_MAC=44:55:66:77
 
 main $@

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -13,20 +13,20 @@ run() {
 
 bridge_ip="$1"; shift
 
-run ip link add br-lan type bridge
-run ip link add wlan0 type dummy
-run ip link add wlan2 type dummy
-run ip link add sim-eth0 type dummy
-run ip link set sim-eth0 master br-lan
-run ip link set eth0 master br-lan
-run ip link set wlan0 master br-lan
-run ip link set wlan2 master br-lan
+run ip link add          br-lan   type bridge
+run ip link add          wlan0    type dummy
+run ip link add          wlan2    type dummy
+run ip link add          sim-eth0 type dummy
+run ip link set      dev sim-eth0 master br-lan
+run ip link set      dev eth0     master br-lan
+run ip link set      dev wlan0    master br-lan
+run ip link set      dev wlan2    master br-lan
 run ip address flush dev eth0
-run ip link set dev sim-eth0 up
-run ip link set dev wlan0 up
-run ip link set dev wlan2 up
-run ip address add dev br-lan "$bridge_ip"
-run ip link set dev br-lan up
+run ip link set      dev sim-eth0 up
+run ip link set      dev wlan0    up
+run ip link set      dev wlan2    up
+run ip address add   dev br-lan "$bridge_ip"
+run ip link set      dev br-lan   up
 
 cd ${INSTALL_DIR}
 exec /bin/bash "$@"

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -12,11 +12,12 @@ run() {
 }
 
 bridge_ip="$1"; shift
+base_mac="$1"; shift
 
-run ip link add          br-lan   type bridge
-run ip link add          wlan0    type dummy
-run ip link add          wlan2    type dummy
-run ip link add          sim-eth0 type dummy
+run ip link add          br-lan   address "${base_mac}:00:00" type bridge
+run ip link add          wlan0    address "${base_mac}:00:10" type dummy
+run ip link add          wlan2    address "${base_mac}:00:20" type dummy
+run ip link add          sim-eth0 address "${base_mac}:00:30" type dummy
 run ip link set      dev sim-eth0 master br-lan
 run ip link set      dev eth0     master br-lan
 run ip link set      dev wlan0    master br-lan

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -11,6 +11,8 @@ run() {
     "$@" || exit $?
 }
 
+bridge_ip="$1"; shift
+
 run ip link add br-lan type bridge
 run ip link add wlan0 type dummy
 run ip link add wlan2 type dummy
@@ -23,10 +25,8 @@ run ip address flush dev eth0
 run ip link set dev sim-eth0 up
 run ip link set dev wlan0 up
 run ip link set dev wlan2 up
-run ip address add dev br-lan ${1}
+run ip address add dev br-lan "$bridge_ip"
 run ip link set dev br-lan up
-
-shift
 
 cd ${INSTALL_DIR}
 exec /bin/bash "$@"

--- a/tools/docker/tests/test_gw_repeater.sh
+++ b/tools/docker/tests/test_gw_repeater.sh
@@ -76,11 +76,11 @@ main() {
     dbg DELAY=$DELAY
 
     status "Start GW (Controller + local Agent)"
-    ${scriptdir}/../run.sh start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33
+    ${scriptdir}/../run.sh ${OPT} start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33
     [ -z $GATEWAY_ONLY ] && {
         sleep ${DELAY}
         status "Start Repeater (Remote Agent)"
-        ${scriptdir}/../run.sh start-agent -d -n ${REPEATER_NAME} -m aa:bb:cc:dd
+        ${scriptdir}/../run.sh ${OPT} start-agent -d -n ${REPEATER_NAME} -m aa:bb:cc:dd
     }
     
     status "Delay ${DELAY} seconds..."

--- a/tools/docker/tests/test_gw_repeater.sh
+++ b/tools/docker/tests/test_gw_repeater.sh
@@ -76,11 +76,11 @@ main() {
     dbg DELAY=$DELAY
 
     status "Start GW (Controller + local Agent)"
-    ${scriptdir}/../run.sh start-controller-agent -d -n ${GW_NAME}
+    ${scriptdir}/../run.sh start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33
     [ -z $GATEWAY_ONLY ] && {
         sleep ${DELAY}
         status "Start Repeater (Remote Agent)"
-        ${scriptdir}/../run.sh start-agent -d -n ${REPEATER_NAME}
+        ${scriptdir}/../run.sh start-agent -d -n ${REPEATER_NAME} -m aa:bb:cc:dd
     }
     
     status "Delay ${DELAY} seconds..."


### PR DESCRIPTION
A predictable MAC address makes testing and debugging easier.

In addition, if the MAC address of the bridge is not set explicitly, it is taken from one of the interfaces. This may happen to be a wlan interface, and in that
case the controller doesn't accept it as a slave due to an address conflict with the bridge.