### PR TITLE
autoconfig: wsc encryption/decryption support

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -11,10 +11,15 @@
 
 #include "ap_manager_thread.h"
 
+#include <beerocks/bcl/beerocks_backport.h>
 #include <beerocks/bcl/beerocks_logging.h>
 #include <beerocks/bcl/beerocks_socket_thread.h>
 
 #include <beerocks/tlvf/beerocks_message_header.h>
+
+#include <mapf/common/encryption.h>
+#include <tlvf/ieee_1905_1/tlvWscM1.h>
+#include <tlvf/ieee_1905_1/tlvWscM2.h>
 
 namespace son {
 class slave_thread : public beerocks::socket_thread {
@@ -256,6 +261,17 @@ private:
     beerocks::eRadioStatus iface_status_bh_wired_prev = beerocks::eRadioStatus::INVALID;
     bool iface_status_operational_state               = false;
     bool iface_status_operational_state_prev          = false;
+
+    // Encryption support - move to common library
+    bool autoconfig_wsc_calculate_keys(std::shared_ptr<ieee1905_1::tlvWscM2> m2,
+                                       uint8_t authkey[32], uint8_t keywrapkey[16]);
+    bool autoconfig_wsc_parse_m2_encrypted_settings(std::shared_ptr<ieee1905_1::tlvWscM2> m2,
+                                                    uint8_t authkey[32], uint8_t keywrapkey[16],
+                                                    std::string &ssid, sMacAddr &bssid,
+                                                    WSC::eWscAuth &auth_type,
+                                                    WSC::eWscEncr &encr_type);
+
+    std::unique_ptr<mapf::encryption::diffie_hellman> dh = nullptr;
 
     bool parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -373,6 +373,97 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_search(Socket *sd,
     return son_actions::send_cmdu_to_agent(sd, cmdu_tx);
 }
 
+/**
+ * @brief Encrypt the config data using AES and add to the WSC M2 TLV
+ *        The encrypted data length is the config data length padded to 16 bytes boundary.
+ *
+ * @param[in] m2 WSC M2 TLV
+ * @param[in] config_data config data in network byte order (swapped)
+ * @param[in] authkey 32 bytes calculated authentication key
+ * @param[in] keywrapkey 16 bytes calculated key wrap key
+ * @return true on success
+ * @return false on failure
+ */
+bool master_thread::autoconfig_wsc_add_m2_encrypted_settings(
+    std::shared_ptr<ieee1905_1::tlvWscM2> m2, WSC::cConfigData &config_data, uint8_t authkey[32],
+    uint8_t keywrapkey[16])
+{
+    size_t len = (config_data.getLen() + 15) & ~0xFU; // Align to 16 bytes boundary
+
+    auto encrypted_settings = m2->create_encrypted_settings();
+    if (!encrypted_settings)
+        return false;
+    if (!encrypted_settings->alloc_encrypted_settings(len))
+        return false;
+    if (!m2->add_encrypted_settings(encrypted_settings))
+        return false;
+
+    std::copy_n(config_data.getStartBuffPtr(), config_data.getLen(),
+                encrypted_settings->encrypted_settings());
+    uint8_t *iv = reinterpret_cast<uint8_t *>(m2->encrypted_settings()->iv());
+
+    if (!mapf::encryption::create_iv(iv, WSC::WSC_ENCRYPTED_SETTINGS_IV_LENGTH))
+        return false;
+
+    if (!mapf::encryption::aes_encrypt(
+            keywrapkey, iv, reinterpret_cast<uint8_t *>(encrypted_settings->encrypted_settings()),
+            encrypted_settings->encrypted_settings_length())) {
+        LOG(DEBUG) << "aes encrypt";
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Calculate keys and update M2 attributes.
+ *
+ * @param[in] m1 WSC M1 TLV received from the radio agent
+ * @param[in] m2 WSC M2 TLV to be sent to the radio agent
+ * @param[in] dh diffie helman key exchange class containing the keypair
+ * @param[out] authkey 32 bytes calculated authentication key
+ * @param[out] keywrapkey 16 bytes calculated key wrap key
+ * @return true on success
+ * @return false on failure
+ */
+bool master_thread::autoconfig_wsc_calculate_keys(std::shared_ptr<ieee1905_1::tlvWscM1> m1,
+                                                  std::shared_ptr<ieee1905_1::tlvWscM2> m2,
+                                                  const mapf::encryption::diffie_hellman &dh,
+                                                  uint8_t authkey[32], uint8_t keywrapkey[16])
+{
+    m2->authentication_type_flags_attr().data = WSC::WSC_AUTH_OPEN | WSC::WSC_AUTH_WPA2PSK;
+    m2->encryption_type_flags_attr().data     = WSC::WSC_ENCR_NONE | WSC::WSC_ENCR_AES;
+    std::copy_n(m1->enrolee_nonce_attr().data, m1->enrolee_nonce_attr().data_length,
+                m2->enrolee_nonce_attr().data);
+    std::copy_n(dh.nonce(), dh.nonce_length(), m2->registrar_nonce_attr().data);
+    if (!mapf::encryption::wps_calculate_keys(
+            dh, m1->public_key_attr().data, m1->public_key_attr().data_length,
+            m1->enrolee_nonce_attr().data, m1->mac_attr().data.oct, m2->registrar_nonce_attr().data,
+            authkey, keywrapkey)) {
+        LOG(ERROR) << "Failed to calculate WPS keys";
+        return false;
+    }
+    std::copy(dh.pubkey(), dh.pubkey() + dh.pubkey_length(), m2->public_key_attr().data);
+
+    return true;
+}
+
+/**
+ * @brief add WSC M2 TLV to the current CMDU
+ *
+ *        the config_data contains the secret ssid, authentication and encryption types,
+ *        the network key, bssid and the key_wrap_auth attribute.
+ *        It does encryption using the keywrapkey and HMAC with the authkey generated
+ *        in the WSC keys calculation from the M1 and M2 nonce values, the radio agent's
+ *        mac, and a random initialization vector.
+ *        The encrypted config_data blob is copied to the encrypted_data attribute
+ *        in the M2 TLV, which marks the WSC M2 TLV ready to be sent to the agent.
+ *
+ * @param tlvWscM1 WSC M1 TLV received from the radio agent as part of the WSC autoconfiguration
+ *        CMDU
+ * @return true on success
+ * @return false on failure
+ */
 bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> tlvWscM1)
 {
     if (!tlvWscM1) {
@@ -397,9 +488,6 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
     if (!tlvWscM2->set_serial_number("prpl12345"))
         return false;
     std::memset(tlvWscM2->uuid_r_attr().data, 0xee, tlvWscM2->uuid_r_attr().data_length);
-    tlvWscM2->authentication_type_flags_attr().data =
-        tlvWscM1->authentication_type_flags_attr().data;
-    tlvWscM2->encryption_type_flags_attr().data = tlvWscM1->encryption_type_flags_attr().data;
     tlvWscM2->rf_bands_attr().data = (tlvWscM1->rf_bands_attr().data & WSC::WSC_RF_BAND_5GHZ)
                                          ? WSC::WSC_RF_BAND_5GHZ
                                          : WSC::WSC_RF_BAND_2GHZ;
@@ -408,30 +496,45 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
             ? WSC::FRONTHAUL_BSS
             : (bss_type & WSC::BACKHAUL_BSS ? WSC::BACKHAUL_BSS : WSC::TEARDOWN);
     tlvWscM2->primary_device_type_attr().sub_category_id = WSC::WSC_DEV_NETWORK_INFRA_GATEWAY;
-    // Encrypted settings
-    auto encrypted_settings = tlvWscM2->create_encrypted_settings();
-    if (!encrypted_settings) {
-        LOG(ERROR) << "Failed to create encrypted settings";
-        return false;
-    }
-    // TODO - actually encrypt the data
-    encrypted_settings->set_ssid("prplMesh_ssid");
-    encrypted_settings->authentication_type_attr().data = WSC::WSC_AUTH_WPA2; //DUMMY
-    encrypted_settings->encryption_type_attr().data     = WSC::WSC_ENCR_AES;
-    std::fill(encrypted_settings->network_key_attr().data,
-              encrypted_settings->network_key_attr().data +
-                  encrypted_settings->network_key_attr().data_length,
-              0xaa); //DUMMY
-    encrypted_settings->bssid_attr().data = tlvWscM1->mac_attr().data;
-    std::fill(encrypted_settings->key_wrap_auth_attr().data,
-              encrypted_settings->key_wrap_auth_attr().data +
-                  encrypted_settings->key_wrap_auth_attr().data_length,
-              0xff); //DUMMY
 
-    if (!tlvWscM2->add_encrypted_settings(encrypted_settings)) {
-        LOG(ERROR) << "Failed to add encrypted settings";
+    ///////////////////////////////
+    // @brief encryption support //
+    ///////////////////////////////
+    mapf::encryption::diffie_hellman dh;
+    uint8_t authkey[32];
+    uint8_t keywrapkey[16];
+    if (!autoconfig_wsc_calculate_keys(tlvWscM1, tlvWscM2, dh, authkey, keywrapkey))
         return false;
-    }
+
+    // Encrypted settings
+    // Encrypted settings are the ConfigData + IV. First create the ConfigData,
+    // Then copy it to the encrypted data, add an IV and encrypt.
+    // Finally, add HMAC
+
+    // Create ConfigData
+    uint8_t buf[1024];
+    WSC::cConfigData config_data(buf, sizeof(buf), false, true);
+    config_data.set_ssid("prplMesh-ssid");
+    config_data.authentication_type_attr().data = WSC::WSC_AUTH_WPA2;
+    config_data.encryption_type_attr().data     = WSC::WSC_ENCR_AES;
+    std::fill(config_data.network_key_attr().data,
+              config_data.network_key_attr().data + config_data.network_key_attr().data_length,
+              0xaa); //DUMMY
+
+    LOG(DEBUG) << "WSC config_data:" << std::endl
+               << "     ssid: " << config_data.ssid() << std::endl
+               << "     authentication_type: " << config_data.authentication_type_attr().data
+               << std::endl
+               << "     encryption_type: " << config_data.encryption_type_attr().data << std::endl;
+
+    config_data.class_swap();
+
+    if (!autoconfig_wsc_add_m2_encrypted_settings(tlvWscM2, config_data, authkey, keywrapkey))
+        return false;
+
+    // TODO - add HMAC and authenticator
+    std::fill(tlvWscM2->authenticator().data,
+              tlvWscM2->authenticator().data + tlvWscM2->authenticator().data_length, 0xbb);
 
     return true;
 }
@@ -488,7 +591,10 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         return false;
     }
 
+    auto al_mac          = network_utils::mac_to_string(tlvwscM1->mac_attr().data.oct);
+    auto ruid            = network_utils::mac_to_string(tlvRuid->radio_uid());
     tlvRuid->radio_uid() = radio_basic_caps->radio_uid();
+    LOG(INFO) << "radio agent join (al_mac=" << al_mac << " ruid=" << ruid << " enrolee_nonce: ";
 
     for (int i = 0; i < radio_basic_caps->maximum_number_of_bsss_supported(); i++) {
         if (!autoconfig_wsc_add_m2(tlvwscM1)) {
@@ -505,9 +611,6 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         return false;
     }
 
-    auto al_mac = network_utils::mac_to_string(tlvwscM1->mac_attr().data.oct);
-    auto ruid   = network_utils::mac_to_string(tlvRuid->radio_uid());
-    LOG(INFO) << "Intel radio agent join (al_mac=" << al_mac << " ruid=" << ruid;
     if (!handle_intel_slave_join(sd, cmdu_rx, cmdu_tx)) {
         LOG(ERROR) << "Intel radio agent join failed (al_mac=" << al_mac << " ruid=" << ruid;
         return false;

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -19,13 +19,13 @@
 #include <beerocks/bcl/beerocks_socket_thread.h>
 #include <beerocks/bcl/network/network_utils.h>
 
+#include <mapf/common/encryption.h>
+#include <tlvf/ieee_1905_1/tlvWscM1.h>
+#include <tlvf/ieee_1905_1/tlvWscM2.h>
+
 #include <cstddef>
 #include <ctime>
 #include <stdint.h>
-
-namespace ieee1905_1 {
-class tlvWscM1;
-}
 
 namespace son {
 class master_thread : public beerocks::socket_thread {
@@ -58,11 +58,20 @@ private:
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_autoconfiguration_WSC(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> m1);
     bool handle_cmdu_1905_channel_preference_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_selection_response(Socket *sd,
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_operating_channel_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+
+    // Autoconfig encryption support
+    bool autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> m1);
+    bool autoconfig_wsc_add_m2_encrypted_settings(std::shared_ptr<ieee1905_1::tlvWscM2> m2,
+                                                  WSC::cConfigData &config_data,
+                                                  uint8_t authkey[32], uint8_t keywrapkey[16]);
+    bool autoconfig_wsc_calculate_keys(std::shared_ptr<ieee1905_1::tlvWscM1> m1,
+                                       std::shared_ptr<ieee1905_1::tlvWscM2> m2,
+                                       const mapf::encryption::diffie_hellman &dh,
+                                       uint8_t authkey[32], uint8_t keywrapkey[16]);
 
     db &database;
     task_pool tasks;

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -39,6 +39,7 @@
 
 namespace WSC {
 
+class cWscAttrEncryptedSettings;
 typedef struct sWscAttrVersion {
     eWscAttributes attribute_type;
     uint16_t data_length;
@@ -456,15 +457,13 @@ typedef struct sWscAttrAuthenticator {
 } __attribute__((packed)) sWscAttrAuthenticator;
 
 
-class cWscAttrEncryptedSettings : public BaseClass
+class cConfigData : public BaseClass
 {
     public:
-        cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
-        ~cWscAttrEncryptedSettings();
+        cConfigData(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        cConfigData(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~cConfigData();
 
-        const eWscAttributes& type();
-        const uint16_t& length();
         eWscAttributes& ssid_type();
         uint16_t& ssid_length();
         char* ssid(size_t length = 0);
@@ -475,14 +474,11 @@ class cWscAttrEncryptedSettings : public BaseClass
         sWscAttrEncryptionType& encryption_type_attr();
         sWscAttrNetworkKey& network_key_attr();
         sWscAttrBssid& bssid_attr();
-        sWscAttrKeyWrapAuthenticator& key_wrap_auth_attr();
         void class_swap();
         static size_t get_initial_size();
 
     private:
         bool init();
-        eWscAttributes* m_type = nullptr;
-        uint16_t* m_length = nullptr;
         eWscAttributes* m_ssid_type = nullptr;
         uint16_t* m_ssid_length = nullptr;
         char* m_ssid = nullptr;
@@ -492,7 +488,37 @@ class cWscAttrEncryptedSettings : public BaseClass
         sWscAttrEncryptionType* m_encryption_type_attr = nullptr;
         sWscAttrNetworkKey* m_network_key_attr = nullptr;
         sWscAttrBssid* m_bssid_attr = nullptr;
-        sWscAttrKeyWrapAuthenticator* m_key_wrap_auth_attr = nullptr;
+};
+
+class cWscAttrEncryptedSettings : public BaseClass
+{
+    public:
+        cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~cWscAttrEncryptedSettings();
+
+        const eWscAttributes& type();
+        const uint16_t& length();
+        char* iv(size_t length = 0);
+        bool set_iv(const std::string& str);
+        bool set_iv(const char buffer[], size_t size);
+        size_t encrypted_settings_length() { return m_encrypted_settings_idx__ * sizeof(char); }
+        char* encrypted_settings(size_t length = 0);
+        bool set_encrypted_settings(const std::string& str);
+        bool set_encrypted_settings(const char buffer[], size_t size);
+        bool alloc_encrypted_settings(size_t count = 1);
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        char* m_iv = nullptr;
+        size_t m_iv_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+        char* m_encrypted_settings = nullptr;
+        size_t m_encrypted_settings_idx__ = 0;
 };
 
 }; // close namespace: WSC

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -15,33 +15,25 @@
 
 using namespace WSC;
 
-cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+cConfigData::cConfigData(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
     BaseClass(buff, buff_len, parse, swap_needed) {
     m_init_succeeded = init();
 }
-cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+cConfigData::cConfigData(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
 BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
     m_init_succeeded = init();
 }
-cWscAttrEncryptedSettings::~cWscAttrEncryptedSettings() {
+cConfigData::~cConfigData() {
 }
-const eWscAttributes& cWscAttrEncryptedSettings::type() {
-    return (const eWscAttributes&)(*m_type);
-}
-
-const uint16_t& cWscAttrEncryptedSettings::length() {
-    return (const uint16_t&)(*m_length);
-}
-
-eWscAttributes& cWscAttrEncryptedSettings::ssid_type() {
+eWscAttributes& cConfigData::ssid_type() {
     return (eWscAttributes&)(*m_ssid_type);
 }
 
-uint16_t& cWscAttrEncryptedSettings::ssid_length() {
+uint16_t& cConfigData::ssid_length() {
     return (uint16_t&)(*m_ssid_length);
 }
 
-char* cWscAttrEncryptedSettings::ssid(size_t length) {
+char* cConfigData::ssid(size_t length) {
     if( (m_ssid_idx__ <= 0) || (m_ssid_idx__ < length) ) {
         TLVF_LOG(ERROR) << "ssid length is smaller than requested length";
         return nullptr;
@@ -49,7 +41,7 @@ char* cWscAttrEncryptedSettings::ssid(size_t length) {
     return ((char*)m_ssid);
 }
 
-bool cWscAttrEncryptedSettings::set_ssid(const std::string& str) {
+bool cConfigData::set_ssid(const std::string& str) {
     size_t str_size = str.size();
     if (str_size == 0) {
         TLVF_LOG(WARNING) << "set_ssid received an empty string.";
@@ -59,7 +51,7 @@ bool cWscAttrEncryptedSettings::set_ssid(const std::string& str) {
     tlvf_copy_string(m_ssid, str.c_str(), str_size + 1);
     return true;
 }
-bool cWscAttrEncryptedSettings::set_ssid(const char str[], size_t size) {
+bool cConfigData::set_ssid(const char str[], size_t size) {
     if (str == nullptr || size == 0) { 
         TLVF_LOG(WARNING) << "set_ssid received an empty string.";
         return false;
@@ -69,7 +61,7 @@ bool cWscAttrEncryptedSettings::set_ssid(const char str[], size_t size) {
     m_ssid[size] = '\0';
     return true;
 }
-bool cWscAttrEncryptedSettings::alloc_ssid(size_t count) {
+bool cConfigData::alloc_ssid(size_t count) {
     if (m_lock_order_counter__ > 0) {;
         TLVF_LOG(ERROR) << "Out of order allocation for variable length list ssid, abort!";
         return false;
@@ -94,45 +86,198 @@ bool cWscAttrEncryptedSettings::alloc_ssid(size_t count) {
     m_encryption_type_attr = (sWscAttrEncryptionType *)((uint8_t *)(m_encryption_type_attr) + len);
     m_network_key_attr = (sWscAttrNetworkKey *)((uint8_t *)(m_network_key_attr) + len);
     m_bssid_attr = (sWscAttrBssid *)((uint8_t *)(m_bssid_attr) + len);
-    m_key_wrap_auth_attr = (sWscAttrKeyWrapAuthenticator *)((uint8_t *)(m_key_wrap_auth_attr) + len);
     m_ssid_idx__ += count;
     *m_ssid_length += count;
     m_buff_ptr__ += len;
-    if(m_length){ (*m_length) += len; }
     return true;
 }
 
-sWscAttrAuthenticationType& cWscAttrEncryptedSettings::authentication_type_attr() {
+sWscAttrAuthenticationType& cConfigData::authentication_type_attr() {
     return (sWscAttrAuthenticationType&)(*m_authentication_type_attr);
 }
 
-sWscAttrEncryptionType& cWscAttrEncryptedSettings::encryption_type_attr() {
+sWscAttrEncryptionType& cConfigData::encryption_type_attr() {
     return (sWscAttrEncryptionType&)(*m_encryption_type_attr);
 }
 
-sWscAttrNetworkKey& cWscAttrEncryptedSettings::network_key_attr() {
+sWscAttrNetworkKey& cConfigData::network_key_attr() {
     return (sWscAttrNetworkKey&)(*m_network_key_attr);
 }
 
-sWscAttrBssid& cWscAttrEncryptedSettings::bssid_attr() {
+sWscAttrBssid& cConfigData::bssid_attr() {
     return (sWscAttrBssid&)(*m_bssid_attr);
 }
 
-sWscAttrKeyWrapAuthenticator& cWscAttrEncryptedSettings::key_wrap_auth_attr() {
-    return (sWscAttrKeyWrapAuthenticator&)(*m_key_wrap_auth_attr);
-}
-
-void cWscAttrEncryptedSettings::class_swap()
+void cConfigData::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ssid_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ssid_length));
     m_authentication_type_attr->struct_swap();
     m_encryption_type_attr->struct_swap();
     m_network_key_attr->struct_swap();
     m_bssid_attr->struct_swap();
-    m_key_wrap_auth_attr->struct_swap();
+}
+
+size_t cConfigData::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // ssid_type
+    class_size += sizeof(uint16_t); // ssid_length
+    class_size += sizeof(sWscAttrAuthenticationType); // authentication_type_attr
+    class_size += sizeof(sWscAttrEncryptionType); // encryption_type_attr
+    class_size += sizeof(sWscAttrNetworkKey); // network_key_attr
+    class_size += sizeof(sWscAttrBssid); // bssid_attr
+    return class_size;
+}
+
+bool cConfigData::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_ssid_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_ssid_type = ATTR_SSID;
+    m_buff_ptr__ += sizeof(eWscAttributes) * 1;
+    m_ssid_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_ssid_length = 0;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    m_ssid = (char*)m_buff_ptr__;
+    uint16_t ssid_length = *m_ssid_length;
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&ssid_length)); }
+    m_ssid_idx__ = ssid_length;
+    m_buff_ptr__ += sizeof(char)*(ssid_length);
+    m_authentication_type_attr = (sWscAttrAuthenticationType*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sWscAttrAuthenticationType) * 1;
+    if (!m_parse__) { m_authentication_type_attr->struct_init(); }
+    m_encryption_type_attr = (sWscAttrEncryptionType*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sWscAttrEncryptionType) * 1;
+    if (!m_parse__) { m_encryption_type_attr->struct_init(); }
+    m_network_key_attr = (sWscAttrNetworkKey*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sWscAttrNetworkKey) * 1;
+    if (!m_parse__) { m_network_key_attr->struct_init(); }
+    m_bssid_attr = (sWscAttrBssid*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sWscAttrBssid) * 1;
+    if (!m_parse__) { m_bssid_attr->struct_init(); }
+    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    return true;
+}
+
+cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+cWscAttrEncryptedSettings::~cWscAttrEncryptedSettings() {
+}
+const eWscAttributes& cWscAttrEncryptedSettings::type() {
+    return (const eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrEncryptedSettings::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+char* cWscAttrEncryptedSettings::iv(size_t length) {
+    if( (m_iv_idx__ <= 0) || (m_iv_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "iv length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_iv);
+}
+
+bool cWscAttrEncryptedSettings::set_iv(const std::string& str) {
+    size_t str_size = str.size();
+    if (str_size == 0) {
+        TLVF_LOG(WARNING) << "set_iv received an empty string.";
+        return false;
+    }
+    if (str_size + 1 > WSC_ENCRYPTED_SETTINGS_IV_LENGTH) { // +1 for null terminator
+        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
+        return false;
+    }
+    tlvf_copy_string(m_iv, str.c_str(), str_size + 1);
+    return true;
+}
+bool cWscAttrEncryptedSettings::set_iv(const char str[], size_t size) {
+    if (str == nullptr || size == 0) { 
+        TLVF_LOG(WARNING) << "set_iv received an empty string.";
+        return false;
+    }
+    if (size + 1 > WSC_ENCRYPTED_SETTINGS_IV_LENGTH) { // +1 for null terminator
+        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
+        return false;
+    }
+    tlvf_copy_string(m_iv, str, size + 1);
+    m_iv[size] = '\0';
+    return true;
+}
+char* cWscAttrEncryptedSettings::encrypted_settings(size_t length) {
+    if( (m_encrypted_settings_idx__ <= 0) || (m_encrypted_settings_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "encrypted_settings length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_encrypted_settings);
+}
+
+bool cWscAttrEncryptedSettings::set_encrypted_settings(const std::string& str) {
+    size_t str_size = str.size();
+    if (str_size == 0) {
+        TLVF_LOG(WARNING) << "set_encrypted_settings received an empty string.";
+        return false;
+    }
+    if (!alloc_encrypted_settings(str_size + 1)) { return false; } // +1 for null terminator
+    tlvf_copy_string(m_encrypted_settings, str.c_str(), str_size + 1);
+    return true;
+}
+bool cWscAttrEncryptedSettings::set_encrypted_settings(const char str[], size_t size) {
+    if (str == nullptr || size == 0) { 
+        TLVF_LOG(WARNING) << "set_encrypted_settings received an empty string.";
+        return false;
+    }
+    if (!alloc_encrypted_settings(size + 1)) { return false; } // +1 for null terminator
+    tlvf_copy_string(m_encrypted_settings, str, size + 1);
+    m_encrypted_settings[size] = '\0';
+    return true;
+}
+bool cWscAttrEncryptedSettings::alloc_encrypted_settings(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list encrypted_settings, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_encrypted_settings;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_encrypted_settings_idx__ += count;
+    m_buff_ptr__ += len;
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscAttrEncryptedSettings::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
 }
 
 size_t cWscAttrEncryptedSettings::get_initial_size()
@@ -140,13 +285,7 @@ size_t cWscAttrEncryptedSettings::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eWscAttributes); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(eWscAttributes); // ssid_type
-    class_size += sizeof(uint16_t); // ssid_length
-    class_size += sizeof(sWscAttrAuthenticationType); // authentication_type_attr
-    class_size += sizeof(sWscAttrEncryptionType); // encryption_type_attr
-    class_size += sizeof(sWscAttrNetworkKey); // network_key_attr
-    class_size += sizeof(sWscAttrBssid); // bssid_attr
-    class_size += sizeof(sWscAttrKeyWrapAuthenticator); // key_wrap_auth_attr
+    class_size += WSC_ENCRYPTED_SETTINGS_IV_LENGTH * sizeof(char); // iv
     return class_size;
 }
 
@@ -162,39 +301,20 @@ bool cWscAttrEncryptedSettings::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_ssid_type = (eWscAttributes*)m_buff_ptr__;
-    if (!m_parse__) *m_ssid_type = ATTR_SSID;
-    m_buff_ptr__ += sizeof(eWscAttributes) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscAttributes); }
-    m_ssid_length = (uint16_t*)m_buff_ptr__;
-    if (!m_parse__) *m_ssid_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
-    m_ssid = (char*)m_buff_ptr__;
-    uint16_t ssid_length = *m_ssid_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&ssid_length)); }
-    m_ssid_idx__ = ssid_length;
-    m_buff_ptr__ += sizeof(char)*(ssid_length);
-    m_authentication_type_attr = (sWscAttrAuthenticationType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrAuthenticationType) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sWscAttrAuthenticationType); }
-    if (!m_parse__) { m_authentication_type_attr->struct_init(); }
-    m_encryption_type_attr = (sWscAttrEncryptionType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrEncryptionType) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sWscAttrEncryptionType); }
-    if (!m_parse__) { m_encryption_type_attr->struct_init(); }
-    m_network_key_attr = (sWscAttrNetworkKey*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrNetworkKey) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sWscAttrNetworkKey); }
-    if (!m_parse__) { m_network_key_attr->struct_init(); }
-    m_bssid_attr = (sWscAttrBssid*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrBssid) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sWscAttrBssid); }
-    if (!m_parse__) { m_bssid_attr->struct_init(); }
-    m_key_wrap_auth_attr = (sWscAttrKeyWrapAuthenticator*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrKeyWrapAuthenticator) * 1;
-    if(m_length && !m_parse__){ (*m_length) += sizeof(sWscAttrKeyWrapAuthenticator); }
-    if (!m_parse__) { m_key_wrap_auth_attr->struct_init(); }
+    m_iv = (char*)m_buff_ptr__;
+    m_buff_ptr__ += (sizeof(char) * WSC_ENCRYPTED_SETTINGS_IV_LENGTH);
+    m_iv_idx__  = WSC_ENCRYPTED_SETTINGS_IV_LENGTH;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(char) * WSC_ENCRYPTED_SETTINGS_IV_LENGTH); }
+    }
+    m_encrypted_settings = (char*)m_buff_ptr__;
+    if (m_length && m_parse__) {
+        size_t len = *m_length;
+        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
+        m_encrypted_settings_idx__ = len/sizeof(char);
+        m_buff_ptr__ += len;
+    }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -347,15 +347,8 @@ sWscAttrAuthenticator:
     _type: char
     _length: [ WSC_AUTHENTICATOR_LENGTH ]
 
-cWscAttrEncryptedSettings:
+cConfigData:
   _type: class
-  _is_tlv_class : True
-  type:
-    _type: eWscAttributes
-    _value_const: ATTR_ENCR_SETTINGS
-  length:
-    _type: uint16_t
-    _length_var: True
   ssid_type:
     _type: eWscAttributes
     _value: ATTR_SSID
@@ -369,4 +362,19 @@ cWscAttrEncryptedSettings:
   encryption_type_attr: sWscAttrEncryptionType
   network_key_attr: sWscAttrNetworkKey
   bssid_attr: sWscAttrBssid
-  key_wrap_auth_attr: sWscAttrKeyWrapAuthenticator
+
+cWscAttrEncryptedSettings:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value_const: ATTR_ENCR_SETTINGS
+  length:
+    _type: uint16_t
+    _length_var: True
+  iv:
+    _type: char
+    _length: [WSC_ENCRYPTED_SETTINGS_IV_LENGTH]
+  encrypted_settings:
+    _type: char
+    _length: []


### PR DESCRIPTION
Issue #126 

Encrypt/decrypt and authenticate the WSC M2 frame.

Steps:
- [x] Add Diffie-Hellman key exchange
- [x] Add function for generating nonce
- [x] Add function for sha256
- [x] Add function for AES encryption
- [x] Add function for sha256/AES HMAC
- [x] Compute authentication and key wrap keys according to WSC spec
- [ ] Perform HMAC on encrypted settings to generate authenticator and key_wrap_auth
- [x] Perform AES on encrypted settings
- [x] Apply the above to M2 frame