### PR TITLE
tools: docker: move scripts boilerplate

### DIFF
--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -6,13 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-run() {
-    echo "$*"
-    "$@" || exit $?
-}
-
 scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 main() {
     docker image inspect prplmesh-builder >/dev/null 2>&1 || {

--- a/tools/docker/clang-format.sh
+++ b/tools/docker/clang-format.sh
@@ -6,21 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$*"
-}
-
-err() {
-	printf '\033[1;31m'"$@\n"'\033[0m'
-}
-
-run() {
-    dbg "$*"
-    "$@" || exit $?
-}
-
 scriptdir="$(cd "${0%/*}"; pwd)"
-sourcesdir="${scriptdir%/*/*}"
+topdir="${scriptdir%/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 usage() {
     echo "usage: $(basename $0) [-hvd] [-i ip] [-n name] [-N network]"

--- a/tools/docker/functions.sh
+++ b/tools/docker/functions.sh
@@ -1,0 +1,44 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2019 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+installdir="${topdir}/build/install"
+sourcesdir="${topdir}/prplMesh"
+
+dbg() {
+    [ "$VERBOSE" = "true" ] && echo "$(basename $0): $*"
+}
+
+status() {
+	printf '\033[1;35m'"$@\n"'\033[0m'
+}
+
+err() {
+    printf '\033[1;31m'"$@\n"'\033[0m'
+}
+
+info() {
+	printf '\033[1;35m'"$(basename $0): $@"'\033[0m\n'
+}
+
+success() {
+    printf '\033[1;36m'"$@\n"'\033[0m'
+}
+
+run() {
+    echo "$*"
+    "$@" || exit $?
+}
+
+report() {
+    msg="$1"; shift
+    if "$@"; then
+        success "OK $msg"
+    else
+        err "FAIL $msg"
+        error=1
+    fi
+}

--- a/tools/docker/image-build.sh
+++ b/tools/docker/image-build.sh
@@ -6,25 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$(basename $0): $*"
-}
-
-err() {
-	echo '\033[1;31m'"$(basename $0): $@"'\033[0m'
-}
-
-info() {
-	echo '\033[1;35m'"$(basename $0): $@"'\033[0m'
-}
-
-run() {
-    dbg "$*"
-    "$@" || exit $?
-}
-
 scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 usage() {
     echo "usage: $(basename $0) [-hvbt]"

--- a/tools/docker/image-pull.sh
+++ b/tools/docker/image-pull.sh
@@ -6,25 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$(basename $0): $*"
-}
-
-err() {
-	printf '\033[1;31m'"$(basename $0): $@"'\033[0m\n'
-}
-
-info() {
-	printf '\033[1;35m'"$(basename $0): $@"'\033[0m\n'
-}
-
-run() {
-    dbg "$*"
-    "$@" || exit $?
-}
-
 scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 usage() {
     echo "usage: $(basename $0) [-hvbt]"

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -6,22 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$*"
-}
-
-err() {
-	printf '\033[1;31m'"$@\n"'\033[0m'
-}
-
-run() {
-    dbg "$*"
-    "$@" || exit $?
-}
-
 scriptdir="$(cd "${0%/*}"; pwd)"
-installdir="${scriptdir%/*/*/*}/build/install"
-sourcesdir="${scriptdir%/*/*}"
+topdir="${scriptdir%/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 usage() {
     echo "usage: $(basename $0) [-hvd] [-i ip] [-n name] [-N network]"

--- a/tools/docker/test.sh
+++ b/tools/docker/test.sh
@@ -6,21 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$*"
-}
-
-err() {
-	printf '\033[1;31m'"$@\n"'\033[0m'
-}
-
-run() {
-    echo "$*"
-    "$@" || exit $?
-}
-
 scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 usage() {
     echo "usage: $(basename $0) [-hv] [-n name]"

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -1,6 +1,6 @@
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
-# Copyright (c) 2019 Gal Wiener (Intel)
+# Copyright (c) 2019 Gal Wiener (Intel), Tomer Eliyahu (Intel)
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 ###############################################################
@@ -11,39 +11,11 @@ ALL_TESTS="topology initial_ap_config ap_config_renew ap_config_bss_tear_down ch
            layer_data_payload_trigger layer_data_payload"
 
 scriptdir="$(cd "${0%/*}"; pwd)"
-installdir="${scriptdir%/*/*/*/*}/build/install"
+topdir="${scriptdir%/*/*/*/*}"
+
+. ${topdir}/prplMesh/tools/docker/functions.sh
+
 redirect="> /dev/null 2>&1"
-
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$@"
-}
-
-status() {
-	printf '\033[1;35m'"$@\n"'\033[0m'
-}
-
-err() {
-    printf '\033[1;31m'"$@\n"'\033[0m'
-}
-
-success() {
-    printf '\033[1;32m'"$@\n"'\033[0m'
-}
-
-run() {
-    dbg "$*"
-    "$@" || exit $?
-}
-
-report() {
-    msg="$1"; shift
-    if "$@"; then
-        success "OK $msg"
-    else
-        err "FAIL $msg"
-        error=1
-    fi
-}
 
 start_gw_repeater() {
     dbg "delete running containers before starting test"

--- a/tools/docker/tests/test_gw_repeater.sh
+++ b/tools/docker/tests/test_gw_repeater.sh
@@ -7,32 +7,9 @@
 ###############################################################
 
 scriptdir="$(cd "${0%/*}"; pwd)"
+topdir="${scriptdir%/*/*/*/*}"
 
-dbg() {
-    [ "$VERBOSE" = "true" ] && echo "$*"
-}
-
-status() {
-	printf '\033[1;35m'"$@\n"'\033[0m'
-}
-
-err() {
-    printf '\033[1;31m'"$@\n"'\033[0m'
-}
-
-success() {
-    printf '\033[1;36m'"$@\n"'\033[0m'
-}
-
-report() {
-    msg="$1"; shift
-    if "$@"; then
-        success "OK $msg"
-    else
-        err "FAIL $msg"
-        error=1
-    fi
-}
+. ${topdir}/prplMesh/tools/docker/functions.sh
 
 usage() {
     echo "usage: $(basename $0) [-hv] [-d delay]"


### PR DESCRIPTION
We have now a bunch of scripts all using similar infrastructure such as
functions for printing debug, error, info, etc.
Move this to a new script - functions.sh which is sourced by all other
scripts.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>