### PR TITLE
autoconfig: add authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - git diff-index --exit-code HEAD
   # Tests
   - ./run.sh --entrypoint "$PWD/../../../build/install/bin/tests/tlvf_test"
-  - ./tests/test_flows.sh -v topology
+  - ./tests/test_flows.sh topology initial_ap_config

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -270,8 +270,12 @@ private:
                                                     std::string &ssid, sMacAddr &bssid,
                                                     WSC::eWscAuth &auth_type,
                                                     WSC::eWscEncr &encr_type);
+    bool autoconfig_wsc_authenticate(std::shared_ptr<ieee1905_1::tlvWscM2> m2, uint8_t authkey[32]);
 
     std::unique_ptr<mapf::encryption::diffie_hellman> dh = nullptr;
+    //copy of M1 message used for authentication
+    uint8_t *m1_auth_buf   = nullptr;
+    size_t m1_auth_buf_len = 0;
 
     bool parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool parse_non_intel_join_response(Socket *sd);

--- a/common/beerocks/bcl/include/beerocks/bcl/beerocks_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/beerocks_utils.h
@@ -76,6 +76,7 @@ public:
     static void hex_dump(const std::string &description, uint8_t *addr, int len,
                          const char *calling_file = __builtin_FILE(),
                          int calling_line         = __builtin_LINE());
+    static std::string dump_buffer(uint8_t *buffer, size_t len);
 };
 
 } //namespace beerocks

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -247,9 +247,8 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
                       << print_cmdu_types(uds_header);
 
     std::ptrdiff_t available_bytes = uds_header->length + sizeof(message::sUdsHeader);
-    utils::hex_dump(
-        std::string("hex_dump (" + std::to_string(available_bytes) + " bytes):").c_str(),
-        (uint8_t *)uds_header, available_bytes);
+    LOG(DEBUG) << "hex_dump (" + std::to_string(available_bytes) + " bytes):" << std::endl
+               << utils::dump_buffer((uint8_t *)uds_header, available_bytes);
     return ret;
 }
 

--- a/common/beerocks/bcl/source/beerocks_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_utils.cpp
@@ -8,8 +8,8 @@
 
 #include "../include/beerocks/bcl/beerocks_utils.h"
 #include "../include/beerocks/bcl/beerocks_string_utils.h"
-
 #include <easylogging++.h>
+#include <iomanip>
 
 using namespace beerocks;
 
@@ -298,6 +298,17 @@ void utils::merge_list(std::vector<uint8_t> &ret, std::vector<uint8_t> &list)
             ret.push_back(*it);
         }
     }
+}
+
+std::string utils::dump_buffer(uint8_t *buffer, size_t len)
+{
+    std::ostringstream hexdump;
+    for (size_t i = 0; i < len; i += 16) {
+        for (size_t j = i; j < len && j < i + 16; j++)
+            hexdump << std::hex << std::setw(2) << std::setfill('0') << (unsigned)buffer[j] << " ";
+        hexdump << std::endl;
+    }
+    return hexdump.str();
 }
 
 void utils::hex_dump(const std::string &description, uint8_t *addr, int len,

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks_message.cpp
@@ -144,10 +144,10 @@ bool message_com::send_cmdu(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
 
     if (!cmdu_tx.finalize(swap)) {
         LOG(ERROR) << "finalize failed -> " << print_cmdu_types(uds_header);
-        utils::hex_dump(
-            std::string("hex_dump(" + std::to_string(cmdu_tx.getMessageLength()) + "):").c_str(),
-            (uint8_t *)(cmdu_tx.getMessageBuff() - sizeof(message::sUdsHeader)),
-            cmdu_tx.getMessageLength() + sizeof(message::sUdsHeader));
+        LOG(DEBUG) << "hex_dump(" + std::to_string(cmdu_tx.getMessageLength()) + "):" << std::endl
+                   << utils::dump_buffer((uint8_t *)(cmdu_tx.getMessageBuff()
+                                         - sizeof(message::sUdsHeader)),
+                                         cmdu_tx.getMessageLength() + sizeof(message::sUdsHeader));
         return false;
     }
 

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -141,10 +141,10 @@ bool message_com::send_cmdu(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
 
     if (!cmdu_tx.finalize(swap)) {
         LOG(ERROR) << "finalize failed -> " << print_cmdu_types(uds_header);
-        utils::hex_dump(
-            std::string("hex_dump(" + std::to_string(cmdu_tx.getMessageLength()) + "):").c_str(),
-            (uint8_t *)(cmdu_tx.getMessageBuff() - sizeof(message::sUdsHeader)),
-            cmdu_tx.getMessageLength() + sizeof(message::sUdsHeader));
+        LOG(DEBUG) << "hex_dump(" + std::to_string(cmdu_tx.getMessageLength()) + "):" << std::endl
+                   << utils::dump_buffer((uint8_t *)(cmdu_tx.getMessageBuff()
+                                         - sizeof(message::sUdsHeader)),
+                                         cmdu_tx.getMessageLength() + sizeof(message::sUdsHeader));
         return false;
     }
 

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -71,6 +71,9 @@ private:
     bool autoconfig_wsc_add_m2_encrypted_settings(std::shared_ptr<ieee1905_1::tlvWscM2> m2,
                                                   WSC::cConfigData &config_data,
                                                   uint8_t authkey[32], uint8_t keywrapkey[16]);
+    bool autoconfig_wsc_authentication(std::shared_ptr<ieee1905_1::tlvWscM1> m1,
+                                       std::shared_ptr<ieee1905_1::tlvWscM2> m2,
+                                       uint8_t authkey[32]);
     bool autoconfig_wsc_calculate_keys(std::shared_ptr<ieee1905_1::tlvWscM1> m1,
                                        std::shared_ptr<ieee1905_1::tlvWscM2> m2,
                                        const mapf::encryption::diffie_hellman &dh,

--- a/tools/docker/functions.sh
+++ b/tools/docker/functions.sh
@@ -33,12 +33,21 @@ run() {
     "$@" || exit $?
 }
 
+check() {
+    if "$@"; then
+        dbg "OK $@"
+    else
+        err "FAIL $@"
+        check_error=$((check_error+1))
+    fi
+}
+
 report() {
     msg="$1"; shift
     if "$@"; then
         success "OK $msg"
     else
         err "FAIL $msg"
-        error=1
+        error=$((error+1))
     fi
 }

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -31,8 +31,23 @@ send_bml_command() {
 }
 
 test_initial_ap_config() {
-    #TODO: Implement
-    return 1
+    status "test initial autoconfig"
+
+    check_error=0
+    check docker exec -it repeater sh -c \
+        'grep -i -q "WSC Global authentication success" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+    check docker exec -it repeater sh -c \
+        'grep -i -q "WSC Global authentication success" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
+    check docker exec -it repeater sh -c \
+        'grep -i -q "KWA (Key Wrap Auth) success" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+    check docker exec -it repeater sh -c \
+        'grep -i -q "KWA (Key Wrap Auth) success" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
+    check docker exec -it repeater sh -c \
+        'grep -i -q "Controller configuration (WSC M2 Encrypted Settings)" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+    check docker exec -it repeater sh -c \
+        'grep -i -q "Controller configuration (WSC M2 Encrypted Settings)" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
+
+    return $check_error
 }
 
 test_ap_config_renew() {

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -16,6 +16,7 @@ topdir="${scriptdir%/*/*/*/*}"
 . ${topdir}/prplMesh/tools/docker/functions.sh
 
 redirect="> /dev/null 2>&1"
+error=0
 
 start_gw_repeater() {
     dbg "delete running containers before starting test"
@@ -152,7 +153,14 @@ main() {
     test_init
     for test in $@; do
        report "test_${test}" test_${test}
+       count=$((count+1))
     done
+
+    if [ $error -gt 0 ]; then
+        err "$error / $count tests failed"
+    else
+        success "$count / $count tests passed"
+    fi
 
     exit $error
 }


### PR DESCRIPTION
Add WSC KWA (Key wrap auth) and global M1 and M2 authentication.

The KWA is the key wrap authenticator which comes after the
config_data in the encrypted settgins attribute.
It is calculated as the 1st 64 bits of HMAC of the config_data using the
authkey computed in wps_calculate_keys().

The global authenticator is carried in the M2 message in
the authenticator attribute, and is calculated with the same algorithm
but on the whole M1 || M2* messages (where M2* is the M2 message without
the authenticator attribute).

The radio agent handles each M2 TLV in the autoconfiguration WSC MultiAP
message by calculating the secret authkey and keywrapkey using
wps_calculate_keys() API, decrypts the encrypted settings buffer using keywrapkey,
then calculates the KWA using the authkey and authenticates the config_data by comparing
it to it to the KWA which comes after the config data.

For global authentication, it saves the M1 buffer each time, then on M2
reception the radio agent compares the authenticator attribute to its
computed one.

Note that in order to authenticate the config_data, and since parsing a
TLVF class automatically converts the whole class to host byte order,
We are required to convert back to network byte order before the authentication process.
Then we convert back to host byte order to use the decrypted config_data
settings. The first conversion to host byte order is required for getting the
config_data block length.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>