### PR TITLE
controller:wfa-ca: Remove curly brackets from forbidden chars

### DIFF
--- a/controller/src/beerocks/master/wfa_ca.cpp
+++ b/controller/src/beerocks/master/wfa_ca.cpp
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 
-#define FORBIDDEN_CHARS "$#&*()[]{};/\\<>?|`~=+"
+#define FORBIDDEN_CHARS "$#&*()[];/\\<>?|`~=+"
 
 using namespace beerocks;
 


### PR DESCRIPTION
Remove curly brackets from forbidden chars on WFA-CA module.
Although curly brackets are forbidden characters according to CAPI
specifications. It seems that it is used in the DEV_SEND_1905 command.
Also, a colon is forbidden character but is being used in MAC address
field on some CAPI commands and been removed as well on another commit.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>