### PR TITLE
tools: docker: Add channel selection to test flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - git diff-index --exit-code HEAD
   # Tests
   - ./run.sh --entrypoint "$PWD/../../../build/install/bin/tests/tlvf_test"
-  - ./tests/test_flows.sh topology initial_ap_config
+  - ./tests/test_flows.sh topology initial_ap_config channel_selection


### PR DESCRIPTION
Add the channel selection test flow to the test_flows.sh script.
Sending channel preference query  and channel selection request commands
and grep on the agent log to these messages + 1905.1 ACK message.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>