### PR TITLE
controller:wfa_ca: fix bug with consecutive sends

### DIFF
--- a/controller/src/beerocks/master/wfa_ca.cpp
+++ b/controller/src/beerocks/master/wfa_ca.cpp
@@ -277,7 +277,7 @@ void wfa_ca::handle_wfa_ca_message(
 
         // NOTE: Note sure this parameters are actually needed. There is a controversial
         // between TestPlan and CAPI specification regarding if these params are required.
-        static std::unordered_map<std::string, std::string> params{
+        std::unordered_map<std::string, std::string> params{
             // {"name", std::string()},
             // {"program", std::string()},
             // {"devrole", std::string()},
@@ -389,8 +389,8 @@ void wfa_ca::handle_wfa_ca_message(
         * CA: status,COMPLETE,MID,0xb3c9
         */
 
-        static std::unordered_map<std::string, std::string> params{
-            {"destalid", std::string()}, {"messagetypevalue", std::string()}};
+        std::unordered_map<std::string, std::string> params{{"destalid", std::string()},
+                                                            {"messagetypevalue", std::string()}};
 
         const auto mandatory_params_num = params.size();
 
@@ -520,7 +520,7 @@ void wfa_ca::handle_wfa_ca_message(
 
         // NOTE: Note sure this parameters are actually needed. There is a controversial
         // between TestPlan and CAPI specification regarding if these params are required.
-        static std::unordered_map<std::string, std::string> params{
+        std::unordered_map<std::string, std::string> params{
             // {"name", std::string()},
             // {"program", std::string()},
         };


### PR DESCRIPTION
The MCUT (MultiAP Controller Under Test) gets a string command from
WTS UCC (Wifi Test Suite Unified CAPI Console).

The wfa_cp.cpp file is responsible of parsing the string to a command
and handle its execution.

The current bug is that the WTS successfuly sends the command on the
first time,but on the second time it fails.

The reason for that is that the unordered_map params was defined as a
static variable, preventing its value from resetting, causimg it to
increase in size.

This caused the size check on line 434 to be false in every iteration
after the first.Thus causing it not to create a CMDU.

The solution is to make the unordered_map an instance variable on
relevant locations.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>