### PR TITLE
tools:docker: rename tests and remove redundants

### DIFF
--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -6,13 +6,12 @@
 ###############################################################
 
 ALL_TESTS="topology initial_ap_config ap_config_renew ap_config_bss_tear_down channel_selection
-           ap_capability_info_reporting client_capability_info_reporting link_metric_collection
-           steering_mandate_opportunity client_steering client_association backhaul_optimization
-           layer_data_payload_trigger layer_data_payload"
+           ap_capability_query client_capability_query combined_infra_metrics
+           client_steering_mandate client_steering_policy client_association
+           higher_layer_data_payload_trigger higher_layer_data_payload"
 
 scriptdir="$(cd "${0%/*}"; pwd)"
 topdir="${scriptdir%/*/*/*/*}"
-
 . ${topdir}/prplMesh/tools/docker/functions.sh
 
 redirect="> /dev/null 2>&1"
@@ -101,18 +100,24 @@ test_client_capability_info_reporting() {
     #TODO: Implement
     return 1
 }
-
+test_client_capability_query() {
+     #TODO: Implement
+    return 1
+}
 test_link_metric_collection() {
     #TODO: Implement
     return 1
 }
-
-test_steering_mandate_opportunity() {
+test_combined_infra_metrics() {
+    #TODO: Implement
+    return 1
+}
+test_client_steering_mandate() {
     #TODO: Implement
     return 1
 }
 
-test_client_steering() {
+test_client_steering_policy() {
     #TODO: Implement
     return 1
 }
@@ -122,28 +127,20 @@ test_client_association() {
     return 1
 }
 
-test_backhaul_optimization() {
+test_higher_layer_data_payload_trigger() {
     #TODO: Implement
     return 1
 }
-
-test_layer_data_payload_trigger() {
+test_higher_layer_data_payload() {
     #TODO: Implement
     return 1
 }
-
-test_layer_data_payload() {
-    #TODO: Implement
-    return 1
-}
-
 test_topology() {
     status "test topology query"
     eval send_bml_command "bml_trigger_topology_discovery $AL_MAC" $redirect
     dbg "Confirming topology query was received"
     docker exec -it repeater sh -c 'grep -i -q "Topology Query" /tmp/$USER/beerocks/logs/beerocks_agent.log'
 }
-
 test_init() {
     status "test initialization"
     start_gw_repeater || {
@@ -152,7 +149,6 @@ test_init() {
     }
     AL_MAC=$(docker exec -it gateway ${installdir}/bin/beerocks_cli -c bml_conn_map | grep IRE_BRIDGE | awk '{print $5}' | cut -d ',' -f 1)
 }
-
 usage() {
     echo "usage: $(basename $0) [-hv]"
     echo "  options:"
@@ -167,15 +163,15 @@ usage() {
     echo "      channel_selection - Channel Selection test"
     echo "      ap_capability_info_reporting - AP Capability info reporting test"
     echo "      client_capability_info_reporting - Capability info reporting test"
-    echo "      link_metric_collection - Link metric collection test"
-    echo "      steering_mandate_opportunity - Client Steering for Steering Mandate and Steering Opportunity test"
-    echo "      client_steering - Setting Client Steering Policy test"
+    echo "      client_steering_mandate - Client Steering for Steering Mandate and Steering Opportunity test"
+    echo "      client_steering_policy - Setting Client Steering Policy test"
     echo "      client_association - Client Association Control Message test"
-    echo "      backhaul_optimization - Backhaul optimization test"
-    echo "      layer_data_payload_trigger - Higher layer data payload over 1905 trigger test"
-    echo "      layer_data_payload - Higher layer data payload over 1905 test"
+    echo "      ap_capability_query - AP Capability query test"
+    echo "      client_capability_query - Client Capability info reporting test"
+    echo "      combined_infra_metrics - Link metric collection test"
+    echo "      higher_layer_data_payload_trigger - Higher layer data payload over 1905 trigger test"
+    echo "      higher_layer_data_payload - Higher layer data payload over 1905 test"
 }
-
 main() {
     OPTS=`getopt -o 'hv' --long help,verbose -n 'parse-options' -- "$@"`
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi


### PR DESCRIPTION
There are some tests in `test_flows.sh` that are stub in the _EasyMesh
Test Plan v1.0_, thus including them in the flow tests is unnecessary -
e.g `backhaul_optimization`.
In addition, some test names were inaccurate, e.g the two `higher_level_data
payload` tests. Those were fixed as well.

Signed-off-by: Gal Wiener <gal.wiener@intel.com>