### PR TITLE
tools:docker: add configurations for visual debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,52 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "(gdb) Attach to prplMesh Cotroller",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/../build/install/bin/beerocks_controller",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true //TODO: pretty printing doesn't seem to work
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Attach to prplMesh Agent",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/../build/install/bin/beerocks_agent",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Attach to prplMesh CLI",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/../build/install/bin/beerocks_cli",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        
+        {
             "name": "(gdb) Launch beerocks_controller",
             "type": "cppdbg",
             "request": "launch",
@@ -44,6 +90,14 @@
         },
         {
             "name": "Python: Current File (Integrated Terminal)",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": []
+        },
+        {
+            "name": "Python: prplMesh tlvf",
             "type": "python",
             "request": "launch",
             "program": "${file}",


### PR DESCRIPTION
Using the configurations added to this file, it's now possible to attach
to the docker container processes runnnig on the local machine, and to
debug them using VSCode integrated visual debugger. To use, simply run
the relevant container, go to the debug tab on VSCode, choose the
relevant debug configuration, run the debugger and choose the
corresponding process.

In addition, a generic python debugging configuration is added, and
the TLVf debug configuration is added.

Happy debugging!

Signed-off-by: Gal Wiener <gal.wiener@intel.com>