### PR TITLE
Add initial virtual certification testbed support

### DIFF
--- a/agent/external_toolchain.cmake
+++ b/agent/external_toolchain.cmake
@@ -27,7 +27,7 @@ if(NOT WIN32)
 endif()
 
 # Check if "external_toolchain.cfg" file exists
-if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
+if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg" AND IS_SYMLINK "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
     file(STRINGS "external_toolchain.cfg" ConfigContents)
     foreach(NameAndValue ${ConfigContents})
         # Strip leading spaces

--- a/common/external_toolchain.cmake
+++ b/common/external_toolchain.cmake
@@ -27,7 +27,7 @@ if(NOT WIN32)
 endif()
 
 # Check if "external_toolchain.cfg" file exists
-if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
+if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg" AND IS_SYMLINK "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
 
     file(STRINGS "external_toolchain.cfg" ConfigContents)
     foreach(NameAndValue ${ConfigContents})

--- a/controller/external_toolchain.cmake
+++ b/controller/external_toolchain.cmake
@@ -27,7 +27,7 @@ if(NOT WIN32)
 endif()
 
 # Check if "external_toolchain.cfg" file exists
-if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
+if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg" AND IS_SYMLINK "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
     file(STRINGS "external_toolchain.cfg" ConfigContents)
     foreach(NameAndValue ${ConfigContents})
         # Strip leading spaces

--- a/framework/external_toolchain.cmake
+++ b/framework/external_toolchain.cmake
@@ -27,7 +27,7 @@ if(NOT WIN32)
 endif()
 
 # Check if "external_toolchain.cfg" file exists
-if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
+if (EXISTS "${CMAKE_SOURCE_DIR}/external_toolchain.cfg" AND IS_SYMLINK "${CMAKE_SOURCE_DIR}/external_toolchain.cfg")
 
     file(STRINGS "external_toolchain.cfg" ConfigContents)
     foreach(NameAndValue ${ConfigContents})

--- a/framework/wfa/AllInitConfig_MAP.txt
+++ b/framework/wfa/AllInitConfig_MAP.txt
@@ -1,0 +1,128 @@
+
+#$! File Name: AllInitConfig_MAP.txt
+#
+# Copyright (c) 2017 Wi-Fi Alliance
+# 
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY 
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER 
+# RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+# USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+#
+#   Description  : Hold all set up data need to be updated for your MultiAP test 
+#                  bed 
+#   Program      : MAP
+#   Version      : 1.0.0  first release with MultiAP project
+#   Release date : Aug. 25, 2017
+#  
+############################################################################ZZZ
+
+define!$CNTLR1_control_agent!0!
+define!$AGT1_control_agent!0!
+define!$AGT2_control_agent!0!
+define!$CNTLR1_Model_Number!0!
+define!$CNTLR1_Firmware_Version!0!
+define!$AGT1_Model_Number!0!
+define!$AGT1_Firmware_Version!0!
+define!$AGT2_Model_Number!0!
+define!$AGT2_Firmware_Version!0!
+
+### ===============  General set up ===========================================
+### Test bed qualification mode ###
+define!$TestQualMode!1!
+
+### Onboarding supported (0 - manual, 1 - automated for WiFi or Ethernet backhaul) ###
+define!$OnboardingSupported!1!
+
+###########Sniffer capture Upload#####################
+#0- No sniffer capture upload
+#1- upload sniffer capture to UCC
+define!$SnferCapUpld!0!
+
+######### DUT (Device Under Test) Information #########################
+## DUT can be either MAUT or MCUT
+define!$DUT!MAUT!
+
+### DUT Control Agent
+wfa_control_agent_dut!ipaddr=127.0.0.1,port=5000!
+dut_wireless_ip!192.165.100.140!
+define!$DUT_Name!BroadcomCTTDUT!
+
+########### Testbed Controller ################################
+wfa_control_agent_broadcomcntlr_cntlr!ipaddr=127.0.0.1,port=7001!
+define!$broadcomcntlr_cntlr_wireless_ip!192.165.100.140!
+
+wfa_control_agent_marvellcntlr_cntlr!ipaddr=127.0.0.1,port=7002!
+define!$marvellcntlr_cntlr_wireless_ip!192.165.100.201!
+
+wfa_control_agent_mediatekcntlr_cntlr!ipaddr=127.0.0.1,port=7003!
+define!$mediatekcntlr_cntlr_wireless_ip!192.165.100.102!
+
+wfa_control_agent_qualcommcntlr_cntlr!ipaddr=127.0.0.1,port=7004!
+define!$qualcommcntlr_cntlr_wireless_ip!192.165.100.123!
+
+########### Testbed MBO AP ################################
+# AP1
+wfa_control_agent_qualcommap_ap!ipaddr=127.0.0.1,port=7005!
+define!AP1IPAddress!192.165.100.223!
+
+########### Testbed Agent ################################
+wfa_control_agent_broadcomagt_agt!ipaddr=127.0.0.1,port=7006!
+define!AGT1IPAddress!192.165.100.140!
+
+wfa_control_agent_marvellagt_agt!ipaddr=127.0.0.1,port=7007!
+define!AGT1IPAddress!192.165.100.201!
+
+wfa_control_agent_mediatekagt_agt!ipaddr=127.0.0.1,port=7008!
+define!AGT1IPAddress!192.165.100.102!
+
+wfa_control_agent_qualcommagt_agt!ipaddr=127.0.0.1,port=7009!
+define!AGT1IPAddress!192.165.100.123!
+
+########### Testbed STAs ################################
+#STA1 (MBO certified)
+wfa_control_agent_marvellsta_sta!ipaddr=127.0.0.1,port=7010!
+define!$STA1_wifi_ip!192.165.100.64!
+
+################# Sniffer agent for wireless capture ########################
+#wfa_control_agent_capture_sta!ipaddr=127.0.0.1,port=7011!
+
+#################### Sniffer agent for Ethernet capture ##################################
+#wfa_sniffer!ipaddr=127.0.0.1,port=7012!
+
+# To enable the sniffing during all the test execution,set this variable to 1.
+# NOTE - Sniffer logs occupy large disk space. So make sure to clean the logs on
+#        Snifffer machine if choose to enable this option
+
+define!$sniffer_enable!0
+
+############################################################################
+### Static test data
+wfa_test_commands_init!DefaultTestData.txt!
+
+############################################################################
+### Static setting, no change in general
+wfa_test_commands_init!Non-WTS-DUT-Input.txt!
+
+
+##################Display Names#########################
+#Loading Display Names
+wfa_test_commands_init!DisplayNames.txt!
+
+
+### =============== Traffic parameters setting ================================
+define!$MaxHtRate!25000!
+
+### =============== Multicast IP Address  =====================================
+define!$multicast_ip_addr!224.0.0.5!
+
+#Test Network Netmask
+define!$netmask!255.255.0.0!
+
+
+
+

--- a/framework/wfa/ucc-dummy.py
+++ b/framework/wfa/ucc-dummy.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2019 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+import socket
+import argparse
+import threading
+
+def handle(host, port, respDict):
+    id = threading.get_ident()
+    print("{}: Listening on {}:{}".format(id, host, port))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, port))
+        s.listen()
+        with s.accept() as (conn, addr):
+            print("{}: {}@{} Connected by {}".format(id, host, port, addr))
+            while True:
+                try:
+                    data = conn.recv(1024)
+                except Exception as e:
+                    print("Exception {}".format(e))
+                    break
+                print("{}@{} Received: {}".format(host, port, data))
+                resp = [b'Status,RUNNING', b'Status,COMPLETE'] # default response
+                for key in respDict:
+                    if key in str(data):
+                        resp = respDict[key] # specific resonse
+                for r in resp:
+                    print("{}@{} Sending: {}".format(host, port, r))
+                    conn.sendall(r)
+    print("{}: {}@{} Exiting!".format(id, host, port))
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--ports", nargs='+', type=int,
+                    default=[7000, 7001, 7002, 7003, 7004, 7005, 7006,
+                             7007, 7008, 7009, 7010, 7011, 7012, 8888])
+parser.add_argument("--host", default='127.0.0.1')
+parser.add_argument("--dst-alid", default="11:22:33:44:55:66")
+args = parser.parse_args()
+
+respDict = {
+    'dev_reset_default' : [b'Status,RUNNING', b'Status,COMPLETE'],
+    'ca_get_version' : [b'Status,RUNNING', b'Status,COMPLETE,vendor,dummy,model,dummy,version,1.0'],
+    'dev_get_parameter' : [b'Status,RUNNING', 'Status,COMPLETE,aLid,{}'.format(args.dst_alid).encode()],
+}
+
+print("Starting threads on host {}, ports {}".format(args.host, args.ports))
+threads = list()
+
+for port in args.ports:
+    print("Creating thread {}@{}".format(args.host, port))
+    t = threading.Thread(target=handle, args=(args.host, port, respDict,))
+    threads.append(t)
+    print("Starting thread {}@{}".format(args.host, port))
+    t.start()
+
+for t in threads:
+    print("Before joining thread {}@{}".format(args.host, port))
+    t.join()
+    print("After joining thread {}@{}".format(args.host, port))

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -41,6 +41,24 @@ The runner docker allows running multiple containers, for example one with a con
 The 2 containers are connected using a docker network (bridge), so can
 communicate + sniffed by running `wireshark` / `tcpdump` on the bridge from the host to see 1905 packets.
 
+## Docker all
+
+The all docker allows building and running prplMesh inside containers. It includes all the tools used for building and running prplMesh, and is mainly used for running prplMesh on Windows at the moment.
+
+Build this image:
+
+```bash
+cd tools/docker/all
+docker image build --tag prplmesh-all .
+```
+
+The current use case for using the `all` image is to run prplMesh on a Windows host for connecting to the WiFi TestSuite wts application (UCC).
+This is done by running the container (mapping the sources or cloning them from within the container) in priviliged mode on port X which is set in the UCC as the DUT port:
+
+```bash
+docker container run -v //c/Users/prplMesh/dev1/:/work/dev1 --privileged -p 5000:5000 --expose 5000 --name gateway -d --user=0:0 --interactive --tty --entrypoint bash --rm prplmesh-windows
+```
+
 ## Docker tester
 
 A simple wrapper which calls `docker exec <container name> -it <path/to>/build/install/scripts/prplmesh_utils.sh status` which prints the prplMesh operational status of the main and radio agents.

--- a/tools/docker/all/Dockerfile
+++ b/tools/docker/all/Dockerfile
@@ -1,0 +1,42 @@
+ARG image=ubuntu:18.04
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2019 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+FROM $image
+
+# Update Software repository
+RUN apt-get update && apt-get install -y \
+	curl \
+	gcc \
+	cmake \
+	ninja-build \
+	git \
+	autoconf \
+	autogen \
+	libtool \
+	pkg-config \
+	gdb \
+	binutils \
+	libreadline-dev \
+	libncurses-dev \
+	libssl-dev \
+	libjson-c-dev \
+	libnl-genl-3-dev \
+	libzmq3-dev \
+	python \
+	python-yaml \
+	vim \
+	net-tools \
+	bridge-utils \
+	iputils-ping \
+	iproute2 \
+	psmisc \
+	clang-format \
+	tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This PR adds the capability to run the WiFi Alliance UCC application for EasyMesh certification virtually using a single Windows PC. See (Virtual certification testbed on Windows WiKi)[https://github.com/prplfoundation/prplMesh/wiki/Virtual-certification-testbed-on-Windows] for full instructions.

Once the WiFi-TestSuite is installed, the `AllInitConfig_MAP.txt` is updated so that all testbed devices are set to localhost on running port numbers.
A dummy UCC server python script is also included which listens on those ports and replies to the testbed UCC application instead of real devices, thus allowing the tests to proceed with only a single DUT which is prplMesh controller & agent.

We are running prplMesh from a container and publish port 5000 which is used to receive commands from the UCC application.

This PR includes the following commits:
- Fix symlink issue - on Windows, symlinks are converted to text files which breaks native build as our build system mistakingly thinks that we are cross-compiling
- Add  Docker image for for complete containers which allow building and running from the same container.
- Add UCC AllInitConfig_MAP.txt reference and ucc dummy server 

Issue #172 