### PR TITLE
autoconfig: change WSC M1 CMDU TLVs order

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3697,6 +3697,13 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             return false;
         }
 
+        // All attributes which are not explicitely set below are set to
+        // default by the TLV factory, see WSC_Attributes.yml
+        if (!autoconfig_wsc_add_m1()) {
+            LOG(ERROR) << "Failed adding WSC M1 TLV";
+            return false;
+        }
+
         auto radio_basic_caps = cmdu_tx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
         if (!radio_basic_caps) {
             LOG(ERROR) << "Error creating TLV_AP_RADIO_BASIC_CAPABILITIES";
@@ -3732,13 +3739,6 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 LOG(ERROR) << "add_operating_classes_info_list failed";
                 return false;
             }
-        }
-
-        // All attributes which are not explicitely set below are set to
-        // default by the TLV factory, see WSC_Attributes.yml
-        if (!autoconfig_wsc_add_m1()) {
-            LOG(ERROR) << "Failed adding WSC M1 TLV";
-            return false;
         }
 
         auto vs = cmdu_tx.add_vs_tlv(ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL);
@@ -4424,8 +4424,8 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
     // way to distinguish them: the M1 message has the AP_Radio_Basic_Capabilities TLV,
     // while the M2 has the AP_Radio_Identifier TLV.
     // If this is a looped back M1 CMDU, we can treat is as handled successfully.
-    if (cmdu_rx.getNextTlvType() == int(wfa_map::eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES)) {
-        LOG(DEBUG) << "looped back M1 CMDU";
+    if (cmdu_rx.hasTlv(uint8_t(wfa_map::eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES))) {
+        LOG(DEBUG) << "agent M1 CMDU, ignore";
         return true;
     }
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -601,8 +601,10 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
     // way to distinguish them: the M1 message has the AP_Radio_Basic_Capabilities TLV,
     // while the M2 has the AP_Radio_Identifier TLV.
     // If this is a looped back M2 CMDU, we can treat is as handled successfully.
-    if (cmdu_rx.getNextTlvType() == int(wfa_map::eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER))
+    if (cmdu_rx.hasTlv(uint8_t(wfa_map::eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER))) {
+        LOG(DEBUG) << "CMDU contains radio identifier TLV, ignore (looped back WSC M2 CMDU)";
         return true;
+    }
 
     LOG(DEBUG) << "Received AP_AUTOCONFIGURATION_WSC_MESSAGE";
     /**

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -69,6 +69,7 @@ public:
     uint8_t *getMessageBuff() const;
     bool getNextTlvType(eTlvType &tlvType) const;
     int getNextTlvType() const;
+    bool hasTlv(uint8_t tlvType) const;
     uint16_t getNextTlvLength() const;
     void swap();
     bool is_finalized() const { return m_finalized; };
@@ -78,6 +79,21 @@ public:
 
 protected:
     void reset();
+    // packed TLV struct to help in the parsing of the packet
+#pragma pack(push, 1)
+    struct Tlv {
+    protected:
+        uint8_t tlvType;
+        uint16_t tlvLength;
+
+    public:
+        uint8_t &type() { return tlvType; }
+
+        Tlv *next() { return (Tlv *)((uint8_t *)this + size()); }
+
+        size_t size() { return sizeof(Tlv) + ntohs(tlvLength); }
+    };
+#pragma pack(pop)
 
     size_t m_buff_len            = 0;
     bool m_finalized             = false;

--- a/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
@@ -28,6 +28,36 @@ std::shared_ptr<BaseClass> CmduMessage::getClass(size_t idx) const
     }
 }
 
+bool CmduMessage::hasTlv(uint8_t tlvType) const
+{
+    uint8_t type = 0;
+    Tlv *tlvhdr;
+
+    // for already parsed TLVs, check the class vector (no need for endianess conversion)
+    for (size_t idx = 0; idx < m_class_vector.size(); idx++) {
+        type = *m_class_vector.at(idx).get()->getBuffPtr();
+        if (type == tlvType)
+            return true;
+    }
+
+    // for TLVs not yet parsed, go through the rest till EOM or the type which is searched
+    if (m_class_vector.size() == 0) {
+        tlvhdr = reinterpret_cast<Tlv *>(m_cmdu_header->getBuffPtr());
+    } else {
+        tlvhdr = reinterpret_cast<Tlv *>(m_class_vector.back()->getBuffPtr());
+    }
+
+    size_t len = getMessageLength();
+    do {
+        if (tlvhdr->type() == tlvType)
+            return true;
+        len += tlvhdr->size();
+        tlvhdr = tlvhdr->next();
+    } while (len < getMessageBuffLength() && tlvhdr->type() != 0);
+
+    return false;
+}
+
 int CmduMessage::getNextTlvType() const
 {
     uint8_t tlvValue = 0;

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -66,6 +66,7 @@ public:
     uint8_t *getMessageBuff() const;
     bool getNextTlvType(eTlvType &tlvType) const;
     int getNextTlvType() const;
+    bool hasTlv(uint8_t tlvType) const;
     uint16_t getNextTlvLength() const;
     void swap();
     bool is_finalized() const { return m_finalized; };
@@ -75,6 +76,21 @@ public:
 
 protected:
     void reset();
+    // packed TLV struct to help in the parsing of the packet
+#pragma pack(push, 1)
+    struct Tlv {
+    protected:
+        uint8_t tlvType;
+        uint16_t tlvLength;
+
+    public:
+        uint8_t &type() { return tlvType; }
+
+        Tlv *next() { return (Tlv *)((uint8_t *)this + size()); }
+
+        size_t size() { return sizeof(Tlv) + ntohs(tlvLength); }
+    };
+#pragma pack(pop)
 
     size_t m_buff_len            = 0;
     bool m_finalized             = false;

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -25,6 +25,36 @@ std::shared_ptr<BaseClass> CmduMessage::getClass(size_t idx) const
     }
 }
 
+bool CmduMessage::hasTlv(uint8_t tlvType) const
+{
+    uint8_t type = 0;
+    Tlv *tlvhdr;
+
+    // for already parsed TLVs, check the class vector (no need for endianess conversion)
+    for (size_t idx = 0; idx < m_class_vector.size(); idx++) {
+        type = *m_class_vector.at(idx).get()->getBuffPtr();
+        if (type == tlvType)
+            return true;
+    }
+
+    // for TLVs not yet parsed, go through the rest till EOM or the type which is searched
+    if (m_class_vector.size() == 0) {
+        tlvhdr = reinterpret_cast<Tlv *>(m_cmdu_header->getBuffPtr());
+    } else {
+        tlvhdr = reinterpret_cast<Tlv *>(m_class_vector.back()->getBuffPtr());
+    }
+
+    size_t len = getMessageLength();
+    do {
+        if (tlvhdr->type() == tlvType)
+            return true;
+        len += tlvhdr->size();
+        tlvhdr = tlvhdr->next();
+    } while (len < getMessageBuffLength() && tlvhdr->type() != 0);
+
+    return false;
+}
+
 int CmduMessage::getNextTlvType() const
 {
     uint8_t tlvValue = 0;


### PR DESCRIPTION
While testing with reference CTT agent in the testbed, it was seen that
the agent sends the WSC autoconfig CMDU in a different order than what
the prplMesh controller expects - radio identifier TLV followed by WSC
M1 TLV, which caused the prplMesh controller to fail on parsing.

This commit changes the order of the created M1 to align to the golden
unit.

In addition, this commit changes the detection of looped back WSC
messages in the controller and agent WSC handlers as follows:

Autoconfig WSC message sent by an agent contains one AP Radio Basic
Capabilities TLV and one WSC TLV containing M1.
Autoconfig WSC message sent by a controller contains one AP Radio
Identifier TLV and one or more WSC TLVs containing M2.

Based on this, the controller can detect that a message is looped back
if it contains an AP Radio Identifier TLV. This is done using
the hasTlv() API from CmduMessage class.

The radio agent can detect that a message is either looped back or sent
by another agent (only for WSC CMDUs) if the message contains an AP
Radio Basic Capabilities. This is done as well using the hasTlv() API.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>