### PR TITLE
Feature/add client capability flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - git diff-index --exit-code HEAD
   # Tests
   - ./run.sh --entrypoint "$PWD/../../../build/install/bin/tests/tlvf_test"
-  - ./tests/test_flows.sh topology initial_ap_config channel_selection
+  - ./tests/test_flows.sh topology initial_ap_config channel_selection client_capability_query

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -126,8 +126,8 @@ bool main_thread::init()
             ieee1905_1::eMessageType::AP_AUTOCONFIGURATION_WSC_MESSAGE,
             ieee1905_1::eMessageType::CHANNEL_PREFERENCE_QUERY_MESSAGE,
             ieee1905_1::eMessageType::CHANNEL_SELECTION_REQUEST_MESSAGE,
-            ieee1905_1::eMessageType::ACK_MESSAGE,
-            ieee1905_1::eMessageType::TOPOLOGY_QUERY_MESSAGE})) {
+            ieee1905_1::eMessageType::ACK_MESSAGE, ieee1905_1::eMessageType::TOPOLOGY_QUERY_MESSAGE,
+            ieee1905_1::eMessageType::CLIENT_CAPABILITY_QUERY_MESSAGE})) {
         LOG(ERROR) << "Failed to init mapf_bus";
         return false;
     }

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -70,7 +70,6 @@ private:
                                                 const std::string &src_mac);
     bool handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx);
     //bool sta_handle_event(const std::string &iface,const std::string& event_name, void* event_obj);
-
     bool hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr, std::string iface);
 
     bool is_eth_link_up();

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -70,6 +70,7 @@ private:
                                                 const std::string &src_mac);
     bool handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx);
     //bool sta_handle_event(const std::string &iface,const std::string& event_name, void* event_obj);
+
     bool hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr, std::string iface);
 
     bool is_eth_link_up();

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -476,6 +476,9 @@ bool slave_thread::handle_cmdu_control_ieee1905_1_message(Socket *sd,
         return handle_channel_preference_query(sd, cmdu_rx);
     case ieee1905_1::eMessageType::CHANNEL_SELECTION_REQUEST_MESSAGE:
         return handle_channel_selection_request(sd, cmdu_rx);
+    case ieee1905_1::eMessageType::CLIENT_CAPABILITY_QUERY_MESSAGE: {
+        return handle_client_capability_query(sd, cmdu_rx);
+    }
     default:
         LOG(ERROR) << "Unknown CMDU message type: " << std::hex << int(cmdu_message_type);
         return false;
@@ -4693,6 +4696,13 @@ bool slave_thread::parse_non_intel_join_response(Socket *sd)
 
     slave_state = STATE_UPDATE_MONITOR_SON_CONFIG;
 
+    return true;
+}
+
+bool slave_thread::handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    const auto mid = cmdu_rx.getMessageId();
+    LOG(DEBUG) << "Received CLIENT_CAPABILITY_QUERY_MESSAGE, mid=" << std::dec << int(mid);
     return true;
 }
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4702,7 +4702,7 @@ bool slave_thread::parse_non_intel_join_response(Socket *sd)
 bool slave_thread::handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     const auto mid = cmdu_rx.getMessageId();
-    LOG(DEBUG) << "Received CLIENT_CAPABILITY_QUERY_MESSAGE, mid=" << std::dec << int(mid);
+    LOG(DEBUG) << "Received CLIENT_CAPABILITY_QUERY_MESSAGE , mid=" << std::dec << int(mid);
     return true;
 }
 

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -283,6 +283,7 @@ private:
     bool autoconfig_wsc_add_m1();
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 
 } // namespace son

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -100,7 +100,7 @@ test_ap_capability_info_reporting() {
 test_client_capability_query() { 
     status "test client capability"  
 
-eval send_bml_command '"bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$AL_MAC,MessageTypeValue,0x8009,tlv_type,0x90,tlv_length,\
+    eval send_bml_command '"bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$AL_MAC,MessageTypeValue,0x8009,tlv_type,0x90,tlv_length,\
 0x000C,tlv_value,{$RADIO_WLAN0_MAC 0x000000110022}\""'    
     sleep 1
     dbg "Confirming client capability query has been received on agent"
@@ -153,7 +153,7 @@ test_init() {
         exit 1
     }
     AL_MAC=$(docker exec -it gateway ${installdir}/bin/beerocks_cli -c bml_conn_map | grep IRE_BRIDGE | awk '{print $5}' | cut -d ',' -f 1)
-    RADIO_WLAN0_MAC=$(docker exec -it gateway /home/cor/work/dev1/build/install/bin/beerocks_cli -c bml_conn_map | grep "RADIO: wlan0" | head -1 | awk '{print $4}' | cut -d ',' -f 1 | tr --delete :)    
+    RADIO_WLAN0_MAC=$(docker exec -it gateway ${installdir}/bin/beerocks_cli -c bml_conn_map | grep "RADIO: wlan0" | head -1 | awk '{print $4}' | cut -d ',' -f 1 | tr --delete :)    
     RADIO_WLAN0_MAC="0x${RADIO_WLAN0_MAC}"     
 
     RADIO_WLAN2_MAC=$(docker exec -it gateway ${installdir}/bin/beerocks_cli -c bml_conn_map | grep "RADIO: wlan2" | head -1 | awk '{print $4}' | cut -d ',' -f 1 | tr --delete :)    


### PR DESCRIPTION
The following pull request adds support for passing Controller Certification
Client Capability Query test.
According to section 5.6.2 in the EasyMesh Test Plan v1.0 [1],
the MCUT (MultiAP Controller Under Test) sends a client capability query
in order to get information about the CTT STA.

The following changes were made :
1.     The Agent subscribes to a message of type :	CLIENT_CAPABILITY_QUERY_MESSAGE.

2.     Add handle method which responsible for handle the CMDU when receive at the agent.

3.     A shell test flow have been added to `test_flows.sh` for the Client Capability Query,
       according to section 5.6.2 in the EasyMesh Test Plan v1.0 [1].
        
