### PR TITLE
ieee1905: transport: pad short cmdus to 64 bytes

### DIFF
--- a/framework/transport/ieee1905_transport/include/mapf/transport/ieee1905_transport.h
+++ b/framework/transport/ieee1905_transport/include/mapf/transport/ieee1905_transport.h
@@ -136,6 +136,13 @@ private:
         struct iovec payload      = {.iov_base = NULL, .iov_len = 0};
 
         virtual std::ostream &print(std::ostream &os) const;
+
+        // add padding to minimum ethernet packet legnth
+        void pad(size_t count)
+        {
+            auto padding = count - ETH_HLEN - payload.iov_len;
+            payload.iov_len += padding;
+        }
     };
     friend std::ostream &operator<<(std::ostream &os, const Packet &m);
 


### PR DESCRIPTION
Add padding to 64 bytes for short CMDUs, since CMDUs are ethernet frames
and must conform to the minimum size requirement of 64 bytes.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>