### PR TITLE
framework: tlvf: fix association state length

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -274,10 +274,11 @@ typedef struct sWscAttrAssociationState {
     void struct_swap(){
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&attribute_type));
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&data_length));
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&data));
     }
     void struct_init(){
         attribute_type = ATTR_ASSOC_STATE;
-        data_length = 0x1;
+        data_length = 0x2;
         data = WSC_ASSOC_NOT_ASSOC;
     }
 } __attribute__((packed)) sWscAttrAssociationState;

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscAssoc.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscAssoc.h
@@ -19,7 +19,7 @@
 
 namespace WSC {
 
-enum eWscAssoc: uint8_t {
+enum eWscAssoc: uint16_t {
     WSC_ASSOC_NOT_ASSOC = 0x0,
     WSC_ASSOC_CONN_SUCCESS = 0x1,
 };

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -196,7 +196,7 @@ sWscAttrAssociationState:
     _value: ATTR_ASSOC_STATE
   data_length:
     _type: uint16_t
-    _value: 1
+    _value: 2
   data:
     _type: eWscAssoc
     _value: WSC_ASSOC_NOT_ASSOC

--- a/framework/tlvf/yaml/tlvf/WSC/eWscAssoc.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/eWscAssoc.yaml
@@ -4,7 +4,7 @@ _namespace: WSC
 
 eWscAssoc:
   _type: enum
-  _enum_storage: uint8_t
+  _enum_storage: uint16_t
   WSC_ASSOC_NOT_ASSOC: 0
   WSC_ASSOC_CONN_SUCCESS: 1
   


### PR DESCRIPTION
Association state length should be 2 bytes, and was defined as 1 byte in
the yaml, which caused M1 received from a reference (none Intel) agent
to be parsed wrong, and the next TLV to fail on paring since the type
was wrong, so fix that.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>