### PR TITLE
Feature/wfa-ca DEV_SET_CONFIG implementation

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4517,8 +4517,8 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
                    << "     Manufacturer: " << manufacturer << std::endl
                    << "     ssid: " << ssid << std::endl
                    << "     bssid: " << network_utils::mac_to_string(bssid) << std::endl
-                   << "     authentication_type: " << authtype << std::endl
-                   << "     encryption_type: " << enctype << std::endl;
+                   << "     authentication_type: " << std::hex << int(authtype) << std::endl
+                   << "     encryption_type: " << int(enctype) << std::dec << std::endl;
     }
 
     if (slave_state != STATE_WAIT_FOR_JOINED_RESPONSE) {
@@ -5012,8 +5012,9 @@ bool slave_thread::autoconfig_wsc_add_m1()
     dh = std::make_unique<mapf::encryption::diffie_hellman>();
     std::copy(dh->pubkey(), dh->pubkey() + dh->pubkey_length(), tlvWscM1->public_key_attr().data);
     std::copy(dh->nonce(), dh->nonce() + dh->nonce_length(), tlvWscM1->enrolee_nonce_attr().data);
-    tlvWscM1->authentication_type_flags_attr().data = WSC::WSC_AUTH_OPEN | WSC::WSC_AUTH_WPA2PSK;
-    tlvWscM1->encryption_type_flags_attr().data     = WSC::WSC_ENCR_AES;
+    tlvWscM1->authentication_type_flags_attr().data =
+        uint16_t(WSC::eWscAuth::WSC_AUTH_OPEN) | uint16_t(WSC::eWscAuth::WSC_AUTH_WPA2PSK);
+    tlvWscM1->encryption_type_flags_attr().data = uint16_t(WSC::eWscEncr::WSC_ENCR_AES);
 
     // Authentication support - store swapped M1 for later M1 || M2* authentication
     // This is the content of M1, without the type and length.

--- a/common/beerocks/bcl/include/beerocks/bcl/beerocks_string_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/beerocks_string_utils.h
@@ -71,7 +71,7 @@ public:
 #define __builtin_LINE() __LINE__
 #endif
 
-    static int64_t stoi(std::string str, const char *calling_file = __builtin_FILE(),
+    static int64_t stoi(const std::string &str, const char *calling_file = __builtin_FILE(),
                         int calling_line = __builtin_LINE());
 
     static std::string int_to_hex_string(const unsigned int integer,

--- a/common/beerocks/bcl/source/beerocks_string_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_string_utils.cpp
@@ -93,8 +93,16 @@ std::vector<std::string> string_utils::str_split(const std::string &s, char deli
     return elems;
 }
 
-int64_t string_utils::stoi(std::string str, const char *calling_file, int calling_line)
+int64_t string_utils::stoi(const std::string &str, const char *calling_file, int calling_line)
 {
+    if (str.find_first_not_of("0123456789") != std::string::npos) {
+        auto calling_file_str       = std::string(calling_file);
+        const auto caller_file_name = calling_file_str.substr(calling_file_str.rfind('/') + 1);
+        LOG(WARNING) << "string_utils::stoi(), string \"" << str
+                     << "\" has illegal characters, caller: " << caller_file_name << "["
+                     << calling_line << "]";
+        return 0;
+    }
     std::stringstream val_s(str);
     int64_t val;
     val_s >> val;

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -3082,6 +3082,19 @@ void db::setting_certification_mode(bool en)
     config.certification_mode = true;
 }
 
+void db::add_bss_info_configuration(const std::string &al_mac, const bss_info_conf_t &bss_info)
+{
+    bss_infos[al_mac].push_back(bss_info);
+}
+
+std::list<db::bss_info_conf_t> &db::get_bss_info_configuration(const std::string &al_mac)
+{
+    // If al_mac not exist, it will be added, and return empty list
+    return bss_infos[al_mac];
+}
+
+void db::clear_bss_info_configuration() { bss_infos.clear(); }
+
 //
 // PRIVATE FUNCTIONS
 //   must be used from a thread safe context

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -14,6 +14,10 @@
 #include <beerocks/bcl/beerocks_defines.h>
 #include <beerocks/bcl/beerocks_logging.h>
 
+#include <tlvf/WSC/eWscAuth.h>
+#include <tlvf/WSC/eWscEncr.h>
+#include <tlvf/WSC/eWscVendorExt.h>
+
 #include <mutex>
 #include <queue>
 
@@ -503,6 +507,18 @@ public:
                     certification_tx_buffer.get());
     };
 
+    struct bss_info_conf_t {
+        uint8_t operating_class;
+        std::string ssid;
+        WSC::eWscAuth authentication_type;
+        WSC::eWscEncr encryption_type;
+        std::string network_key;
+        WSC::eWscVendorExtSubelementBssType bss_type;
+    };
+    void add_bss_info_configuration(const std::string &al_mac, const bss_info_conf_t &bss_info);
+    std::list<db::bss_info_conf_t> &get_bss_info_configuration(const std::string &al_mac);
+    void clear_bss_info_configuration();
+
     //
     // tasks
     //
@@ -693,6 +709,7 @@ private:
 
     // certification
     std::shared_ptr<uint8_t> certification_tx_buffer;
+    std::unordered_map<std::string, std::list<bss_info_conf_t>> bss_infos; // key=al_mac
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -444,8 +444,10 @@ bool master_thread::autoconfig_wsc_calculate_keys(std::shared_ptr<ieee1905_1::tl
                                                   const mapf::encryption::diffie_hellman &dh,
                                                   uint8_t authkey[32], uint8_t keywrapkey[16])
 {
-    m2->authentication_type_flags_attr().data = WSC::WSC_AUTH_OPEN | WSC::WSC_AUTH_WPA2PSK;
-    m2->encryption_type_flags_attr().data     = WSC::WSC_ENCR_NONE | WSC::WSC_ENCR_AES;
+    m2->authentication_type_flags_attr().data =
+        uint16_t(WSC::eWscAuth::WSC_AUTH_OPEN) | uint16_t(WSC::eWscAuth::WSC_AUTH_WPA2PSK);
+    m2->encryption_type_flags_attr().data =
+        uint16_t(WSC::eWscEncr::WSC_ENCR_NONE) | uint16_t(WSC::eWscEncr::WSC_ENCR_AES);
     std::copy_n(m1->enrolee_nonce_attr().data, m1->enrolee_nonce_attr().data_length,
                 m2->enrolee_nonce_attr().data);
     std::copy_n(dh.nonce(), dh.nonce_length(), m2->registrar_nonce_attr().data);
@@ -571,17 +573,18 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
     uint8_t buf[1024];
     WSC::cConfigData config_data(buf, sizeof(buf), false, true);
     config_data.set_ssid("prplMesh-ssid");
-    config_data.authentication_type_attr().data = WSC::WSC_AUTH_WPA2;
-    config_data.encryption_type_attr().data     = WSC::WSC_ENCR_AES;
+    config_data.authentication_type_attr().data = WSC::eWscAuth::WSC_AUTH_WPA2;
+    config_data.encryption_type_attr().data     = WSC::eWscEncr::WSC_ENCR_AES;
     std::fill(config_data.network_key_attr().data,
               config_data.network_key_attr().data + config_data.network_key_attr().data_length,
               0xaa); //DUMMY
 
-    LOG(DEBUG) << "WSC config_data:" << std::endl
+    LOG(DEBUG) << "WSC config_data:" << std::hex << std::endl
                << "     ssid: " << config_data.ssid() << std::endl
-               << "     authentication_type: " << config_data.authentication_type_attr().data
+               << "     authentication_type: " << int(config_data.authentication_type_attr().data)
                << std::endl
-               << "     encryption_type: " << config_data.encryption_type_attr().data << std::endl;
+               << "     encryption_type: " << int(config_data.encryption_type_attr().data)
+               << std::dec << std::endl;
 
     config_data.class_swap();
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscAuth.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscAuth.h
@@ -19,13 +19,33 @@
 
 namespace WSC {
 
-enum eWscAuth: uint16_t {
+enum class eWscAuth : uint16_t {
     WSC_AUTH_OPEN = 0x1,
     WSC_AUTH_WPAPSK = 0x2,
     WSC_AUTH_SHARED = 0x4,
     WSC_AUTH_WPA = 0x8,
     WSC_AUTH_WPA2 = 0x10,
     WSC_AUTH_WPA2PSK = 0x20,
+};
+class eWscAuthValidate {
+public:
+    static bool check(uint16_t value) {
+        bool ret = false;
+        switch (value) {
+        case 0x1:
+        case 0x2:
+        case 0x4:
+        case 0x8:
+        case 0x10:
+        case 0x20:
+                ret = true;
+                break;
+            default:
+                ret = false;
+                break;
+        }
+        return ret;
+    }
 };
 
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscEncr.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscEncr.h
@@ -19,11 +19,29 @@
 
 namespace WSC {
 
-enum eWscEncr: uint16_t {
+enum class eWscEncr : uint16_t {
     WSC_ENCR_NONE = 0x1,
     WSC_ENCR_WEP = 0x2,
     WSC_ENCR_TKIP = 0x4,
     WSC_ENCR_AES = 0x8,
+};
+class eWscEncrValidate {
+public:
+    static bool check(uint16_t value) {
+        bool ret = false;
+        switch (value) {
+        case 0x1:
+        case 0x2:
+        case 0x4:
+        case 0x8:
+                ret = true;
+                break;
+            default:
+                ret = false;
+                break;
+        }
+        return ret;
+    }
 };
 
 

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -199,17 +199,18 @@ bool add_encrypted_settings(std::shared_ptr<tlvWscM2> m2, uint8_t *keywrapkey, u
     uint8_t buf[1024];
     WSC::cConfigData config_data(buf, sizeof(buf), false, true);
     config_data.set_ssid("test_ssid");
-    config_data.authentication_type_attr().data = WSC::WSC_AUTH_WPA2; //DUMMY
-    config_data.encryption_type_attr().data     = WSC::WSC_ENCR_AES;
+    config_data.authentication_type_attr().data = WSC::eWscAuth::WSC_AUTH_WPA2; //DUMMY
+    config_data.encryption_type_attr().data     = WSC::eWscEncr::WSC_ENCR_AES;
     std::fill(config_data.network_key_attr().data,
               config_data.network_key_attr().data + config_data.network_key_attr().data_length,
               0xaa); //DUMMY
 
     LOG(DEBUG) << "WSC config_data:" << std::endl
                << "     ssid: " << config_data.ssid() << std::endl
-               << "     authentication_type: " << config_data.authentication_type_attr().data
+               << "     authentication_type: " << int(config_data.authentication_type_attr().data)
                << std::endl
-               << "     encryption_type: " << config_data.encryption_type_attr().data << std::endl;
+               << "     encryption_type: " << int(config_data.encryption_type_attr().data)
+               << std::endl;
     config_data.class_swap();
 
     size_t len             = (config_data.getLen() + 16) & ~0xFU;
@@ -260,9 +261,10 @@ bool parse_encrypted_settings(std::shared_ptr<tlvWscM2> m2, uint8_t *keywrapkey,
 
     LOG(DEBUG) << "WSC config_data:" << std::endl
                << "     ssid: " << config_data.ssid() << std::endl
-               << "     authentication_type: " << config_data.authentication_type_attr().data
+               << "     authentication_type: " << int(config_data.authentication_type_attr().data)
                << std::endl
-               << "     encryption_type: " << config_data.encryption_type_attr().data << std::endl;
+               << "     encryption_type: " << int(config_data.encryption_type_attr().data)
+               << std::endl;
     LOG(DEBUG) << "authenticator type:" << m2->authenticator().attribute_type;
     LOG(DEBUG) << "authenticator length:" << m2->authenticator().data_length;
     LOG(DEBUG) << "authenticator buffer: " << std::endl

--- a/framework/tlvf/yaml/tlvf/WSC/eWscAuth.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/eWscAuth.yaml
@@ -3,7 +3,7 @@
 _namespace: WSC
 
 eWscAuth:
-  _type: enum
+  _type: enum_class
   _enum_storage: uint16_t
   WSC_AUTH_OPEN: 0x0001
   WSC_AUTH_WPAPSK: 0x0002

--- a/framework/tlvf/yaml/tlvf/WSC/eWscEncr.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/eWscEncr.yaml
@@ -3,7 +3,7 @@
 _namespace: WSC
 
 eWscEncr:
-  _type: enum
+  _type: enum_class
   _enum_storage: uint16_t
   WSC_ENCR_NONE: 0x0001
   WSC_ENCR_WEP: 0x0002


### PR DESCRIPTION
Until now, "DEV_SET_CONFIG" had a dummy handler.
Add correct handling and parsing of CAPI command "DEV_SET_CONFIG". 
After the bss info string is being parsed, it is saved on the controller
the database.
In addition, clear bss info configuration when receiving CAPI command "DEV_RESET_DEFAULT".
DR #229