### PR TITLE
Fix/wfa ca topology query trigger

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1579,7 +1579,8 @@ bool main_thread::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
  */
 bool main_thread::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx)
 {
-    LOG(DEBUG) << "Received Topology Query message";
+    const auto mid = cmdu_rx.getMessageId();
+    LOG(DEBUG) << "Received TOPOLOGY_QUERY_MESSAGE , mid=" << std::dec << int(mid);
     //TODO - this should be part of the discovery agent, will be done as part of
     //       agent certification
     return true;

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -138,7 +138,7 @@ test_higher_layer_data_payload() {
 }
 test_topology() {
     status "test topology query"
-    eval send_bml_command "bml_trigger_topology_discovery $AL_MAC" $redirect
+    eval send_bml_command "bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$AL_MAC,MessageTypeValue,0x0002\"" $redirect    
     dbg "Confirming topology query was received"
     docker exec -it repeater sh -c 'grep -i -q "Topology Query" /tmp/$USER/beerocks/logs/beerocks_agent.log'
 }

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -140,7 +140,7 @@ test_topology() {
     status "test topology query"
     eval send_bml_command "bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$AL_MAC,MessageTypeValue,0x0002\"" $redirect    
     dbg "Confirming topology query was received"
-    docker exec -it repeater sh -c 'grep -i -q "Topology Query" /tmp/$USER/beerocks/logs/beerocks_agent.log'
+    docker exec -it repeater sh -c 'grep -i -q "TOPOLOGY_QUERY_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent.log'
 }
 test_init() {
     status "test initialization"


### PR DESCRIPTION
Change the MCUT to use the wfa_ca interface in the topology query.