### PR TITLE
tools: Add bash debug capability

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // Install "Bash Debug" VSCODE extension by "rogalmic" for that to work
+            "type": "bashdb",
+            "request": "launch",
+            "name": "Bash-Debug (select script from list of sh files)",
+            "cwd": "${workspaceFolder}/../",
+            "program": "${command:SelectScriptName}",
+            "args": []
+        },
+        {
             "name": "(gdb) Attach to prplMesh Cotroller",
             "type": "cppdbg",
             "request": "attach",


### PR DESCRIPTION
Inorder it to work, need to install VSCODE  "Bash Debug"  extension
by "rogalmic".

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>