### PR TITLE
Feature/autoconfig parse radio caps

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3720,8 +3720,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 LOG(ERROR) << "Failed creating operating classes info list";
                 return false;
             }
-            operationClassesInfo->operating_class()            = i;     // dummy value
-            operationClassesInfo->maximum_transmit_power_dbm() = i + 1; // dummy value
+            operationClassesInfo->operating_class()            = 81; // dummy value
+            operationClassesInfo->maximum_transmit_power_dbm() = 0;  // dummy value
 
             // TODO - the number of statically non operable channels can be 0 - meaning it is
             // an optional variable length list, this is not yet supported in tlvf according to issue #8
@@ -3731,7 +3731,10 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 return false;
             }
             // Set Dummy value for non operable channel list
-            std::get<1>(operationClassesInfo->statically_non_operable_channels_list(0)) = i;
+            auto non_operable_channel =
+                *son::wireless_utils::operating_class_to_channel_set(81).begin();
+            std::get<1>(operationClassesInfo->statically_non_operable_channels_list(0)) =
+                non_operable_channel;
 
             if (!radio_basic_caps->add_operating_classes_info_list(operationClassesInfo)) {
                 LOG(ERROR) << "add_operating_classes_info_list failed";

--- a/common/beerocks/bcl/include/beerocks/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/son/son_wireless_utils.h
@@ -13,6 +13,7 @@
 #include "../beerocks_message_structs.h"
 
 #include <iostream>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -108,6 +109,7 @@ public:
                                                                uint16_t prev_vht_center_frequency,
                                                                beerocks::eWiFiBandwidth bw,
                                                                uint16_t vht_center_frequency);
+    static std::set<uint8_t> operating_class_to_channel_set(uint8_t operating_class);
 
 private:
     enum eAntennaFactor {

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -455,3 +455,56 @@ std::vector<uint8_t> wireless_utils::calc_5g_20MHz_subband_channels(
 
     return channels;
 }
+
+/**
+ * @brief convert operating class to channel set based on Table 4-E in the ieee 802.11 specification
+ *
+ * @param operating_class operating class
+ * @return std::set<uint8_t> set of supported channels by the operating class or empty if failure
+ */
+std::set<uint8_t> wireless_utils::operating_class_to_channel_set(uint8_t operating_class)
+{
+    static const std::map<uint8_t, std::set<uint8_t>> operating_class_to_channel_set = {
+        {81, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+        {82, {14}},
+        {83, {1, 2, 3, 4, 5, 6, 7, 8, 9}},
+        // TODO channels for operating classes 85,96,87 should be taken from the regulatory domain
+        {94, {133, 137}},
+        {95, {132, 134, 136, 138}},
+        {96, {131, 132, 133, 134, 135, 136, 137, 138}},
+        {101, {21, 25}},
+        {102, {11, 13, 15, 17, 19}},
+        {103, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+        {104, {184, 192}},
+        {105, {188, 196}},
+        {106, {191, 195}},
+        {107, {189, 191, 193, 195, 197}},
+        {108, {188, 189, 190, 191, 192, 193, 194, 195, 196, 197}},
+        {109, {184, 188, 192, 196}},
+        {110, {183, 184, 185, 186, 187, 189}},
+        {111, {182, 183, 184, 185, 186, 187, 189}},
+        {112, {8, 12, 16}},
+        {113, {7, 8, 9, 10, 11}},
+        {114, {6, 7, 8, 9, 10, 11}},
+        {115, {36, 40, 44, 48}},
+        {116, {36, 44}},
+        {117, {40, 48}},
+        {118, {52, 56, 60, 64}},
+        {119, {52, 60}},
+        {120, {56, 64}},
+        {121, {100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144}},
+        {122, {100, 108, 116, 124, 132, 140}},
+        {123, {104, 112, 120, 128, 136, 144}},
+        {124, {149, 153, 157, 161}},
+        {125, {149, 153, 157, 161, 165, 169}},
+        {126, {149, 157}},
+        {127, {153, 161}},
+        {180, {1, 2, 3, 4, 5, 6}}};
+
+    auto it = operating_class_to_channel_set.find(operating_class);
+    if (it == operating_class_to_channel_set.end()) {
+        LOG(ERROR) << "reserved operating class " << int(operating_class);
+        return std::set<uint8_t>();
+    }
+    return it->second;
+}

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -165,6 +165,7 @@ bool ap_wlan_hal_dummy::read_acs_report()
 {
     uint8_t idx = 0;
     if (m_radio_info.is_5ghz == false) {
+        m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
             m_radio_info.supported_channels[idx].channel     = ch;
@@ -175,6 +176,7 @@ bool ap_wlan_hal_dummy::read_acs_report()
         }
     } else {
         // 5G simulated report
+        m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
                 m_radio_info.supported_channels[idx].channel     = ch;

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1232,6 +1232,21 @@ const std::vector<beerocks_message::sWifiChannel> db::get_hostap_supported_chann
     return n->hostap->supported_channels;
 }
 
+std::string db::get_hostap_supported_channels_string(const std::string &radio_mac)
+{
+    std::ostringstream os;
+    auto supported_channels = get_hostap_supported_channels(radio_mac);
+    for (const auto &val : supported_channels) {
+        if (val.channel > 0) {
+            os << " ch = " << int(val.channel) << " | dfs = " << int(val.is_dfs_channel)
+               << " | tx_pow = " << int(val.tx_pow) << " | noise = " << int(val.noise)
+               << " [dbm] | bss_overlap = " << int(val.bss_overlap) << std::endl;
+        }
+    }
+
+    return os.str();
+}
+
 bool db::set_hostap_band_capability(std::string mac, beerocks::eRadioBandCapability capability)
 {
     auto n = get_node(mac);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -17,6 +17,7 @@
 #include <tlvf/WSC/eWscAuth.h>
 #include <tlvf/WSC/eWscEncr.h>
 #include <tlvf/WSC/eWscVendorExt.h>
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
 
 #include <mutex>
 #include <queue>
@@ -280,6 +281,10 @@ public:
     const std::vector<beerocks_message::sWifiChannel>
     get_hostap_supported_channels(std::string mac);
     std::string get_hostap_supported_channels_string(const std::string &radio_mac);
+
+    bool add_hostap_supported_operating_class(const std::string &radio_mac, uint8_t operating_class,
+                                              uint8_t tx_power,
+                                              const std::vector<uint8_t> &non_operable_channels);
 
     bool set_hostap_band_capability(std::string mac, beerocks::eRadioBandCapability capability);
     beerocks::eRadioBandCapability get_hostap_band_capability(std::string mac);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -279,6 +279,7 @@ public:
                                        int length);
     const std::vector<beerocks_message::sWifiChannel>
     get_hostap_supported_channels(std::string mac);
+    std::string get_hostap_supported_channels_string(const std::string &radio_mac);
 
     bool set_hostap_band_capability(std::string mac, beerocks::eRadioBandCapability capability);
     beerocks::eRadioBandCapability get_hostap_band_capability(std::string mac);

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -22,6 +22,7 @@
 #include <mapf/common/encryption.h>
 #include <tlvf/ieee_1905_1/tlvWscM1.h>
 #include <tlvf/ieee_1905_1/tlvWscM2.h>
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
 
 #include <cstddef>
 #include <ctime>
@@ -52,11 +53,14 @@ private:
                                 std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
                                 ieee1905_1::CmduMessageRx &cmdu_rx);
     void handle_cmdu_control_ieee1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool handle_intel_slave_join(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx,
+    bool handle_intel_slave_join(Socket *sd,
+                                 std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps,
+                                 ieee1905_1::CmduMessageRx &cmdu_rx,
                                  ieee1905_1::CmduMessageTx &cmdu_tx);
-    bool handle_non_intel_slave_join(Socket *sd, std::shared_ptr<ieee1905_1::tlvWscM1> tlvwscM1,
-                                     std::string bridge_mac, std::string radio_mac,
-                                     ieee1905_1::CmduMessageTx &cmdu_tx);
+    bool handle_non_intel_slave_join(
+        Socket *sd, std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps,
+        std::shared_ptr<ieee1905_1::tlvWscM1> tlvwscM1, std::string bridge_mac,
+        std::string radio_mac, ieee1905_1::CmduMessageTx &cmdu_tx);
 
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
@@ -66,6 +70,8 @@ private:
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_operating_channel_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 
+    bool autoconfig_wsc_parse_radio_caps(
+        std::string radio_mac, std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps);
     // Autoconfig encryption support
     bool autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> m1);
     bool autoconfig_wsc_add_m2_encrypted_settings(std::shared_ptr<ieee1905_1::tlvWscM2> m2,


### PR DESCRIPTION
Add a new API to the database to set the supported operating class as received from the Radio Basic Capabilities TLV as part of the autoconfig WSC message from the agent.
Currently, prplMesh stores channels and not operating classes. Since EasyMesh specification is using the operating classes and not directly channels, it makes sense to change our database
and channel selection code to use operating classes.
However, this will be a big change and should be done as part of the full channel selection flow.
In order to put things in the right direction, this commit adds a new API for storing the supported operating class in the DB, which performs the conversion to sWifiChannel which is used across the code. This will be used in a followup commit to storing the operating classes in
the DB which will be then updating the radio capabilities, which eventually allow bml_conn_map to show the correct band based on the operating class.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>