### PR TITLE
controller:beerocks:cli:fix bml_conn_map command

### DIFF
--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -659,7 +659,10 @@ void cli_bml::connection_map_cb(const struct BML_NODE_ITER *node_iter, bool to_c
             bml_utils_dump_conn_map(pThis->conn_map_nodes, network_utils::ZERO_MAC_STRING, ind, ss);
             pThis->conn_map_nodes.clear();
         }
+        // Printing the connection map
         std::cout << std::endl << ss.str();
+        //No need to wait anymore - this is the last fragment
+        pThis->pending_response = false;
     }
 }
 
@@ -682,7 +685,6 @@ void cli_bml::connection_map_to_console_cb(const struct BML_NODE_ITER *node_iter
         std::cout << "ERROR: Internal error - invalid context!" << std::endl;
         return;
     }
-    pThis->pending_response = false;
 }
 
 void cli_bml::map_query_to_socket_cb(const struct BML_NODE_ITER *node_iter)

--- a/controller/src/beerocks/cli/beerocks_cli_main.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_main.cpp
@@ -34,7 +34,6 @@ BEEROCKS_INIT_BEEROCKS_VERSION
 
 static bool g_running       = true;
 static bool g_loop_cmd_exec = false;
-static long g_wait_time     = 0;
 
 #ifdef HAVE_READLINE
 static std::vector<std::string> g_cli_cmds;
@@ -237,8 +236,6 @@ static int cli_non_interactive(std::string path, std::string tmp_path, std::stri
     if (-1 == cli_ptr->multiple_commands(command_string)) {
         status_code = 1;
     }
-
-    UTILS_SLEEP_MSEC(1000 * g_wait_time);
 
     // Max timeout according to CAPI specifications is 120 seconds
     auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(120);
@@ -471,7 +468,7 @@ int main(int argc, char *argv[])
     std::string command_string;
     uint16_t port = 0;
 
-    while ((opt = getopt(argc, argv, "pi:c:w:a:u:")) != -1) {
+    while ((opt = getopt(argc, argv, "pi:c:a:u:")) != -1) {
         switch (opt) {
         case 'p': {
             cli_role = CLI_PROXY;
@@ -484,10 +481,6 @@ int main(int argc, char *argv[])
         case 'c': {
             command_string = std::string(optarg);
             cli_role       = CLI_NON_INTERACTIVE;
-            break;
-        }
-        case 'w': {
-            g_wait_time = std::atoi(optarg);
             break;
         }
         case 'a': {


### PR DESCRIPTION
This pull request fixes the` bml_conn_map` command in the
beerocks CLI.

The following changes were made :

- Move the action of set to false pThis->pending_response to the right place

- Remove the "-w" option from in the beerocks CLI.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>