### PR TITLE
Set configdata in M2 from database

### DIFF
--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -432,6 +432,29 @@ bool son_actions::validate_beacon_measurement_report(beerocks_message::sBeaconRe
            (network_utils::mac_to_string(report.bssid) == bssid);
 }
 
+/**
+ * @brief Check if the operating classes of @a radio_basic_caps matches any of the operating classes
+ *        in @a bss_info_conf
+ *
+ * @param radio_basic_caps The AP Radio Basic Capabilities TLV of the radio
+ * @param bss_info_conf The BSS Info we try to configure
+ * @return true if one of the operating classes overlaps, false if they are disjoint
+ */
+bool son_actions::has_matching_operating_class(
+    wfa_map::tlvApRadioBasicCapabilities &radio_basic_caps,
+    const db::bss_info_conf_t &bss_info_conf)
+{
+    for (uint8_t i = 0; i < radio_basic_caps.operating_classes_info_list_length(); i++) {
+        auto operating_class_info = std::get<1>(radio_basic_caps.operating_classes_info_list(i));
+        for (auto operating_class : bss_info_conf.operating_class) {
+            if (operating_class == operating_class_info.operating_class()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 bool son_actions::send_cmdu_to_agent(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
                                      const std::string &radio_mac)
 {

--- a/controller/src/beerocks/master/son_actions.h
+++ b/controller/src/beerocks/master/son_actions.h
@@ -48,6 +48,8 @@ public:
                                  ieee1905_1::CmduMessageTx &cmdu_tx, task_pool &tasks);
     static bool validate_beacon_measurement_report(beerocks_message::sBeaconResponse11k report,
                                                    std::string sta_mac, std::string bssid);
+    static bool has_matching_operating_class(wfa_map::tlvApRadioBasicCapabilities &radio_basic_caps,
+                                             const db::bss_info_conf_t &bss_info_conf);
     static bool send_cmdu_to_agent(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
                                    const std::string &radio_mac = std::string());
 

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -73,7 +73,8 @@ private:
     bool autoconfig_wsc_parse_radio_caps(
         std::string radio_mac, std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps);
     // Autoconfig encryption support
-    bool autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> m1);
+    bool autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> m1,
+                               const db::bss_info_conf_t *bss_info_conf);
     bool autoconfig_wsc_add_m2_encrypted_settings(std::shared_ptr<ieee1905_1::tlvWscM2> m2,
                                                   WSC::cConfigData &config_data,
                                                   uint8_t authkey[32], uint8_t keywrapkey[16]);


### PR DESCRIPTION
Closes #227

There is no test yet. The easiest way to test this is by adding support for AUTOCONFIG_RENEW to the agent, so that we can re-trigger autoconfiguration in one of the test flows. But that's a bigger change so I'll do it in a separate PR.