### PR TITLE
controller: Fix saving of operating class from DEV_SET_CONFIG

### DIFF
--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -508,7 +508,7 @@ public:
     };
 
     struct bss_info_conf_t {
-        uint8_t operating_class;
+        std::list<uint8_t> operating_class;
         std::string ssid;
         WSC::eWscAuth authentication_type;
         WSC::eWscEncr encryption_type;

--- a/controller/src/beerocks/master/wfa_ca.cpp
+++ b/controller/src/beerocks/master/wfa_ca.cpp
@@ -104,12 +104,17 @@ static std::string parse_bss_info(const std::string &bss_info_str,
     bss_info_conf = {};
 
     // Operating class
-    uint operating_class = string_utils::stoi(confs[1]);
-    if (operating_class > UINT8_MAX || operating_class == 0) {
-        err_string = "invalid operating class";
+    auto &operating_class_str = confs[1];
+    if (operating_class_str == "8x") {
+        bss_info_conf.operating_class = {81, 83, 84};
+    } else if (operating_class_str == "11x") {
+        bss_info_conf.operating_class = {115, 116};
+    } else if (operating_class_str == "12x") {
+        bss_info_conf.operating_class = {124, 125, 126};
+    } else {
+        err_string = "invalid operating class " + operating_class_str;
         return std::string();
     }
-    bss_info_conf.operating_class = operating_class;
 
     // SSID
     bss_info_conf.ssid = confs[2];


### PR DESCRIPTION
When receiving bss info configuration as part of CAPI command
"DEV-SET_COMMAND", one of the fields is operating class.
On the documentation example this field appeared to be in the form:
"8x","11x" or "112x".
At first implementation of DEV_SET_CONFIG handler, we assumed that
instead of the 'x' the UCC will be an actual number so we tried to
convert it to integer and save it in the database, but it was wrong
assumption.

Instead of converting to an integer, check which operating class group
we received and save it in the database as a list of relevant operating
classes of this group, according to the EasyMesh Test Plan document.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>