### PR TITLE
tools: docker: start_gw_repeater.sh repeater only

### DIFF
--- a/tools/docker/tests/test_gw_repeater.sh
+++ b/tools/docker/tests/test_gw_repeater.sh
@@ -22,10 +22,12 @@ usage() {
     echo "      -g|--gateway - gateway container name"
     echo "      -r|--repeater - repeater container name"
     echo "      --rm - remove containers after test completes"
+    echo "      --gateway-only - start gateway only"
+    echo "      --repeater-only - start repeater only"
 }
 
 main() {
-    OPTS=`getopt -o 'hvd:fg:r:' --long help,verbose,rm,gateway-only,delay:,force,gateway:,repeater: -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvd:fg:r:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater: -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -40,24 +42,33 @@ main() {
             -g | --gateway)       GW_NAME="$2"; shift; shift ;;
             -r | --repeater)      REPEATER_NAME="$2"; shift; shift ;;
             --rm)                 REMOVE=true; shift ;;
-            --gateway-only)       GATEWAY_ONLY=true; shift ;;
+            --gateway-only)       START_REPEATER=false; shift ;;
+            --repeater-only)      START_GATEWAY=false; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
     done
 
-    [ -z $GATEWAY_ONLY ] && status "Starting GW+Repeater test" || status "Starting GW only test"
+    status "Starting GW+Repeater test"
 
     dbg REMOVE=$REMOVE
     dbg GW_NAME=$GW_NAME
-    dbg GATEWAY_ONLY=$GATEWAY_ONLY
-    [ -z $GATEWAY_ONLY ] && dbg REPEATER_NAME=$REPEATER_NAME
+    dbg REPEATER_NAME=$REPEATER_NAME
+    dbg START_GATEWAY=$START_GATEWAY
+    dbg START_REPEATER=$START_REPEATER
     dbg DELAY=$DELAY
 
-    status "Start GW (Controller + local Agent)"
-    ${scriptdir}/../run.sh ${VERBOSE_OPT} ${FORCE_OPT} start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 "$@"
-    [ -z $GATEWAY_ONLY ] && {
+    [ "$START_GATEWAY" = "true" ] && {
+        status "Start GW (Controller + local Agent)"
+        ${scriptdir}/../run.sh ${VERBOSE_OPT} ${FORCE_OPT} start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 "$@"
+    }
+
+    [ "$START_GATEWAY" = "true" -a "$START_REPEATER" = "true" ] && {
+        status "Delay ${DELAY} seconds..."
         sleep ${DELAY}
+    }
+
+    [ "$START_REPEATER" = "true" ] && {
         status "Start Repeater (Remote Agent)"
         ${scriptdir}/../run.sh ${VERBOSE_OPT} ${FORCE_OPT} start-agent -d -n ${REPEATER_NAME} -m aa:bb:cc:dd "$@"
     }
@@ -66,12 +77,12 @@ main() {
     sleep ${DELAY}
 
     error=0
-    report "GW operational" \
+    [ "$START_GATEWAY" = "true" ] && report "GW operational" \
         ${scriptdir}/../test.sh ${VERBOSE_OPT} -n ${GW_NAME}
-    [ -z $GATEWAY_ONLY ] && {
-        report "Repeater operational" \
-            ${scriptdir}/../test.sh ${VERBOSE_OPT} -n ${REPEATER_NAME}
-    }
+    
+    [ "$START_REPEATER" = "true" ] && report "Repeater operational" \
+        ${scriptdir}/../test.sh ${VERBOSE_OPT} -n ${REPEATER_NAME}
+
     [ "$REMOVE" = "true" ] && {
         status "Deleting containers ${GW_NAME}, ${REPEATER_NAME}"
         docker rm -f ${GW_NAME} ${REPEATER_NAME} >/dev/null 2>&1
@@ -84,6 +95,8 @@ VERBOSE=false
 REMOVE=false
 GW_NAME=gateway
 REPEATER_NAME=repeater
+START_GATEWAY=true
+START_REPEATER=true
 DELAY=5
 
 main $@


### PR DESCRIPTION
Add options for start_gw_repeater.sh to start repeater only.
This is sometimes useful when we want to debug the controller's
behaviour when the repeater starts, so starting with gateway-only option
first, then attaching the debugger to the controller process, then
running the agent provides the oportunity to debug the controller.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>