### PR TITLE
Feature/add client steering flow

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -133,6 +133,7 @@ bool main_thread::init()
             ieee1905_1::eMessageType::CLIENT_CAPABILITY_QUERY_MESSAGE,
             ieee1905_1::eMessageType::CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE,
             ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE,
+            ieee1905_1::eMessageType::CLIENT_STEERING_REQUEST_MESSAGE,
             ieee1905_1::eMessageType::AP_CAPABILITY_QUERY_MESSAGE,
             ieee1905_1::eMessageType::MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE,
             ieee1905_1::eMessageType::ACK_MESSAGE,

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -489,6 +489,8 @@ bool slave_thread::handle_cmdu_control_ieee1905_1_message(Socket *sd,
         return handle_channel_selection_request(sd, cmdu_rx);
     case ieee1905_1::eMessageType::CLIENT_STEERING_REQUEST_MESSAGE:
         return handle_client_steering_request(sd, cmdu_rx);
+    case ieee1905_1::eMessageType::ACK_MESSAGE:
+        return handle_ack_message(sd, cmdu_rx);
     case ieee1905_1::eMessageType::CLIENT_CAPABILITY_QUERY_MESSAGE:
         return handle_client_capability_query(sd, cmdu_rx);
     case ieee1905_1::eMessageType::MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE:
@@ -4817,6 +4819,15 @@ bool slave_thread::handle_client_association_request(Socket *sd, ieee1905_1::Cmd
     }
     LOG(DEBUG) << "sending ACK message back to controller";
     return send_cmdu_to_controller(cmdu_tx);
+}
+
+bool slave_thread::handle_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    //TODO - this is a stub handler for the purpose of controller certification testing,
+    //       will be implemented later on agent certification
+    const auto mid = cmdu_rx.getMessageId();
+    LOG(DEBUG) << "Received ACK_MESSAGE, mid=" << std::dec << int(mid);
+    return true;
 }
 
 bool slave_thread::handle_client_steering_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -436,8 +436,6 @@ bool slave_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         }
         }
     } else { // IEEE 1905.1 message
-        LOG(DEBUG) << "handle_cmdu_control_ieee1905_1_message " << std::hex
-                   << int(cmdu_rx.getMessageType());
         return handle_cmdu_control_ieee1905_1_message(sd, cmdu_rx);
     }
     return true;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -290,6 +290,7 @@ private:
     bool handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_ap_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_association_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_client_steering_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 
 } // namespace son

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -291,6 +291,7 @@ private:
     bool handle_ap_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_association_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_steering_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/beerocks_master_mrouter.cpp
+++ b/controller/src/beerocks/master/beerocks_master_mrouter.cpp
@@ -59,6 +59,7 @@ bool master_mrouter::init()
         ieee1905_1::eMessageType::OPERATING_CHANNEL_REPORT_MESSAGE,
         ieee1905_1::eMessageType::TOPOLOGY_DISCOVERY_MESSAGE,
         ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE,
+        ieee1905_1::eMessageType::STEERING_COMPLETED_MESSAGE,
         ieee1905_1::eMessageType::ACK_MESSAGE,
     }));
 }

--- a/controller/src/beerocks/master/beerocks_master_mrouter.cpp
+++ b/controller/src/beerocks/master/beerocks_master_mrouter.cpp
@@ -55,6 +55,7 @@ bool master_mrouter::init()
         ieee1905_1::eMessageType::AP_AUTOCONFIGURATION_WSC_MESSAGE,
         ieee1905_1::eMessageType::CHANNEL_PREFERENCE_REPORT_MESSAGE,
         ieee1905_1::eMessageType::CHANNEL_SELECTION_RESPONSE_MESSAGE,
+        ieee1905_1::eMessageType::CLIENT_STEERING_BTM_REPORT_MESSAGE,
         ieee1905_1::eMessageType::OPERATING_CHANNEL_REPORT_MESSAGE,
         ieee1905_1::eMessageType::TOPOLOGY_DISCOVERY_MESSAGE,
         ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE,

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -224,6 +224,8 @@ bool master_thread::handle_cmdu_1905_1_message(Socket *sd, ieee1905_1::CmduMessa
         return handle_cmdu_1905_channel_preference_report(sd, cmdu_rx);
     case ieee1905_1::eMessageType::CHANNEL_SELECTION_RESPONSE_MESSAGE:
         return handle_cmdu_1905_channel_selection_response(sd, cmdu_rx);
+    case ieee1905_1::eMessageType::STEERING_COMPLETED_MESSAGE:
+        return handle_cmdu_1905_steering_completed_message(sd, cmdu_rx);
     case ieee1905_1::eMessageType::ACK_MESSAGE:
         return handle_cmdu_1905_ack_message(sd, cmdu_rx);
     case ieee1905_1::eMessageType::CLIENT_STEERING_BTM_REPORT_MESSAGE:
@@ -1004,6 +1006,22 @@ bool master_thread::handle_cmdu_1905_ack_message(Socket *sd, ieee1905_1::CmduMes
     //TODO: the ACK should be sent to the correct task and will be done as part of agent certification
     LOG(DEBUG) << "Received ACK_MESSAGE, mid=" << std::hex << int(mid);
     return true;
+}
+
+bool master_thread::handle_cmdu_1905_steering_completed_message(Socket *sd,
+                                                                ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    auto mid = cmdu_rx.getMessageId();
+    LOG(INFO) << "Received STEERING_COMPLETED_MESSAGE, mid=" << std::hex << int(mid);
+    // build ACK message CMDU
+    auto cmdu_tx_header = cmdu_tx.create(mid, ieee1905_1::eMessageType::ACK_MESSAGE);
+
+    if (!cmdu_tx_header) {
+        LOG(ERROR) << "cmdu creation of type ACK_MESSAGE, has failed";
+        return false;
+    }
+    LOG(DEBUG) << "sending ACK message back to agent, mid=" << std::hex << int(mid);
+    return son_actions::send_cmdu_to_agent(sd, cmdu_tx);
 }
 
 bool master_thread::handle_cmdu_1905_client_steering_btm_report_message(

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -213,8 +213,6 @@ bool master_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 
 bool master_thread::handle_cmdu_1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
-    LOG(DEBUG) << "handle_cmdu_1905_1_message " << std::hex << int(cmdu_rx.getMessageType());
-
     switch (cmdu_rx.getMessageType()) {
     case ieee1905_1::eMessageType::AP_AUTOCONFIGURATION_SEARCH_MESSAGE:
         return handle_cmdu_1905_autoconfiguration_search(sd, cmdu_rx);

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -226,6 +226,8 @@ bool master_thread::handle_cmdu_1905_1_message(Socket *sd, ieee1905_1::CmduMessa
         return handle_cmdu_1905_channel_selection_response(sd, cmdu_rx);
     case ieee1905_1::eMessageType::ACK_MESSAGE:
         return handle_cmdu_1905_ack_message(sd, cmdu_rx);
+    case ieee1905_1::eMessageType::CLIENT_STEERING_BTM_REPORT_MESSAGE:
+        return handle_cmdu_1905_client_steering_btm_report_message(sd, cmdu_rx);
     case ieee1905_1::eMessageType::OPERATING_CHANNEL_REPORT_MESSAGE:
         return handle_cmdu_1905_operating_channel_report(sd, cmdu_rx);
     case ieee1905_1::eMessageType::TOPOLOGY_DISCOVERY_MESSAGE:
@@ -1002,6 +1004,23 @@ bool master_thread::handle_cmdu_1905_ack_message(Socket *sd, ieee1905_1::CmduMes
     //TODO: the ACK should be sent to the correct task and will be done as part of agent certification
     LOG(DEBUG) << "Received ACK_MESSAGE, mid=" << std::hex << int(mid);
     return true;
+}
+
+bool master_thread::handle_cmdu_1905_client_steering_btm_report_message(
+    Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    auto mid = cmdu_rx.getMessageId();
+    LOG(INFO) << "Received CLIENT_STEERING_BTM_REPORT_MESSAGE, mid=" << std::hex << int(mid);
+
+    // build ACK message CMDU
+    auto cmdu_tx_header = cmdu_tx.create(mid, ieee1905_1::eMessageType::ACK_MESSAGE);
+
+    if (!cmdu_tx_header) {
+        LOG(ERROR) << "cmdu creation of type ACK_MESSAGE, has failed";
+        return false;
+    }
+    LOG(DEBUG) << "sending ACK message back to agent";
+    return son_actions::send_cmdu_to_agent(sd, cmdu_tx);
 }
 
 bool master_thread::handle_cmdu_1905_channel_selection_response(Socket *sd,

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -72,6 +72,9 @@ private:
     bool handle_cmdu_1905_topology_discovery(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_higher_layer_data_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_client_steering_btm_report_message(Socket *sd,
+                                                             ieee1905_1::CmduMessageRx &cmdu_rx);
+
     bool autoconfig_wsc_parse_radio_caps(
         std::string radio_mac, std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps);
     // Autoconfig encryption support

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -72,6 +72,8 @@ private:
     bool handle_cmdu_1905_topology_discovery(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_higher_layer_data_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_steering_completed_message(Socket *sd,
+                                                     ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_client_steering_btm_report_message(Socket *sd,
                                                              ieee1905_1::CmduMessageRx &cmdu_rx);
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringBTMReport.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringBTMReport.h
@@ -1,0 +1,56 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVSTEERINGBTMREPORT_H_
+#define _TLVF_WFA_MAP_TLVSTEERINGBTMREPORT_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+
+namespace wfa_map {
+
+
+class tlvSteeringBTMReport : public BaseClass
+{
+    public:
+        tlvSteeringBTMReport(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        tlvSteeringBTMReport(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~tlvSteeringBTMReport();
+
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& bssid();
+        sMacAddr& sta_mac();
+        uint8_t& btm_status_code();
+        sMacAddr& target_bssid();
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_sta_mac = nullptr;
+        uint8_t* m_btm_status_code = nullptr;
+        sMacAddr* m_target_bssid = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVSTEERINGBTMREPORT_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringRequest.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringRequest.h
@@ -1,0 +1,112 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVSTEERINGREQUEST_H_
+#define _TLVF_WFA_MAP_TLVSTEERINGREQUEST_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+#include <tuple>
+#include <asm/byteorder.h>
+
+namespace wfa_map {
+
+
+class tlvSteeringRequest : public BaseClass
+{
+    public:
+        tlvSteeringRequest(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        tlvSteeringRequest(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~tlvSteeringRequest();
+
+        typedef struct sRequestFlags {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t reserved : 5;
+            uint8_t btm_abridged_bit : 1;
+            uint8_t btm_disassociation_imminent_bit : 1;
+            uint8_t request_mode : 1;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t request_mode : 1;
+            uint8_t btm_disassociation_imminent_bit : 1;
+            uint8_t btm_abridged_bit : 1;
+            uint8_t reserved : 5;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+                reserved = 0x0;
+            }
+        } __attribute__((packed)) sRequestFlags;
+        
+        enum eRequestMode {
+            REQUEST_IS_A_STEERING_OPPORTUNITY = 0x0,
+            REQUEST_IS_A_STEERING_MANDATE_TO_TRIGGER_STEERING = 0x1,
+        };
+        
+        typedef struct sTargetBssidInfo {
+            //Wildcard BSSID is represented by FF:FF:FF:FF:FF:FF.
+            sMacAddr target_bssid;
+            uint8_t target_bss_operating_class;
+            uint8_t target_bss_channel_number;
+            void struct_swap(){
+                target_bssid.struct_swap();
+            }
+            void struct_init(){
+            }
+        } __attribute__((packed)) sTargetBssidInfo;
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& bssid();
+        sRequestFlags& request_flags();
+        //Time period in seconds (from reception of the Steering Request message) for which the request is valid.
+        //If Request Mode bit is 1, then this field is ignored 
+        uint16_t& steering_opportunity_window_sec();
+        //Time period in TUs of the disassociation timer in the BTM Request.
+        uint16_t& btm_disassociation_timer();
+        uint8_t& sta_list_length();
+        std::tuple<bool, sMacAddr&> sta_list(size_t idx);
+        bool alloc_sta_list(size_t count = 1);
+        uint8_t& target_bssid_list_length();
+        std::tuple<bool, sTargetBssidInfo&> target_bssid_list(size_t idx);
+        bool alloc_target_bssid_list(size_t count = 1);
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        sRequestFlags* m_request_flags = nullptr;
+        uint16_t* m_steering_opportunity_window_sec = nullptr;
+        uint16_t* m_btm_disassociation_timer = nullptr;
+        uint8_t* m_sta_list_length = nullptr;
+        sMacAddr* m_sta_list = nullptr;
+        size_t m_sta_list_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+        uint8_t* m_target_bssid_list_length = nullptr;
+        sTargetBssidInfo* m_target_bssid_list = nullptr;
+        size_t m_target_bssid_list_idx__ = 0;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVSTEERINGREQUEST_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
@@ -1,0 +1,113 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvSteeringBTMReport.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvSteeringBTMReport::tlvSteeringBTMReport(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+tlvSteeringBTMReport::tlvSteeringBTMReport(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+tlvSteeringBTMReport::~tlvSteeringBTMReport() {
+}
+const eTlvTypeMap& tlvSteeringBTMReport::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvSteeringBTMReport::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvSteeringBTMReport::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
+sMacAddr& tlvSteeringBTMReport::sta_mac() {
+    return (sMacAddr&)(*m_sta_mac);
+}
+
+uint8_t& tlvSteeringBTMReport::btm_status_code() {
+    return (uint8_t&)(*m_btm_status_code);
+}
+
+sMacAddr& tlvSteeringBTMReport::target_bssid() {
+    return (sMacAddr&)(*m_target_bssid);
+}
+
+void tlvSteeringBTMReport::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_bssid->struct_swap();
+    m_sta_mac->struct_swap();
+    m_target_bssid->struct_swap();
+}
+
+size_t tlvSteeringBTMReport::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // sta_mac
+    class_size += sizeof(uint8_t); // btm_status_code
+    class_size += sizeof(sMacAddr); // target_bssid
+    return class_size;
+}
+
+bool tlvSteeringBTMReport::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_STEERING_BTM_REPORT;
+    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_bssid->struct_init(); }
+    m_sta_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_sta_mac->struct_init(); }
+    m_btm_status_code = (uint8_t*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_target_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_target_bssid->struct_init(); }
+    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_STEERING_BTM_REPORT) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_STEERING_BTM_REPORT) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
@@ -1,0 +1,226 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvSteeringRequest.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvSteeringRequest::tlvSteeringRequest(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+tlvSteeringRequest::tlvSteeringRequest(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+tlvSteeringRequest::~tlvSteeringRequest() {
+}
+const eTlvTypeMap& tlvSteeringRequest::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvSteeringRequest::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvSteeringRequest::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
+tlvSteeringRequest::sRequestFlags& tlvSteeringRequest::request_flags() {
+    return (sRequestFlags&)(*m_request_flags);
+}
+
+uint16_t& tlvSteeringRequest::steering_opportunity_window_sec() {
+    return (uint16_t&)(*m_steering_opportunity_window_sec);
+}
+
+uint16_t& tlvSteeringRequest::btm_disassociation_timer() {
+    return (uint16_t&)(*m_btm_disassociation_timer);
+}
+
+uint8_t& tlvSteeringRequest::sta_list_length() {
+    return (uint8_t&)(*m_sta_list_length);
+}
+
+std::tuple<bool, sMacAddr&> tlvSteeringRequest::sta_list(size_t idx) {
+    bool ret_success = ( (m_sta_list_idx__ > 0) && (m_sta_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, m_sta_list[ret_idx]);
+}
+
+bool tlvSteeringRequest::alloc_sta_list(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list sta_list, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(sMacAddr) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_sta_list[*m_sta_list_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_target_bssid_list_length = (uint8_t *)((uint8_t *)(m_target_bssid_list_length) + len);
+    m_target_bssid_list = (sTargetBssidInfo *)((uint8_t *)(m_target_bssid_list) + len);
+    m_sta_list_idx__ += count;
+    *m_sta_list_length += count;
+    m_buff_ptr__ += len;
+    if(m_length){ (*m_length) += len; }
+    if (!m_parse__) { 
+        for (size_t i = m_sta_list_idx__ - count; i < m_sta_list_idx__; i++) { m_sta_list[i].struct_init(); }
+    }
+    return true;
+}
+
+uint8_t& tlvSteeringRequest::target_bssid_list_length() {
+    return (uint8_t&)(*m_target_bssid_list_length);
+}
+
+std::tuple<bool, tlvSteeringRequest::sTargetBssidInfo&> tlvSteeringRequest::target_bssid_list(size_t idx) {
+    bool ret_success = ( (m_target_bssid_list_idx__ > 0) && (m_target_bssid_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, m_target_bssid_list[ret_idx]);
+}
+
+bool tlvSteeringRequest::alloc_target_bssid_list(size_t count) {
+    if (m_lock_order_counter__ > 1) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list target_bssid_list, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(sTargetBssidInfo) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 1;
+    uint8_t *src = (uint8_t *)&m_target_bssid_list[*m_target_bssid_list_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_target_bssid_list_idx__ += count;
+    *m_target_bssid_list_length += count;
+    m_buff_ptr__ += len;
+    if(m_length){ (*m_length) += len; }
+    if (!m_parse__) { 
+        for (size_t i = m_target_bssid_list_idx__ - count; i < m_target_bssid_list_idx__; i++) { m_target_bssid_list[i].struct_init(); }
+    }
+    return true;
+}
+
+void tlvSteeringRequest::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_bssid->struct_swap();
+    m_request_flags->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_steering_opportunity_window_sec));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_btm_disassociation_timer));
+    for (size_t i = 0; i < (size_t)*m_sta_list_length; i++){
+        m_sta_list[i].struct_swap();
+    }
+    for (size_t i = 0; i < (size_t)*m_target_bssid_list_length; i++){
+        m_target_bssid_list[i].struct_swap();
+    }
+}
+
+size_t tlvSteeringRequest::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(sRequestFlags); // request_flags
+    class_size += sizeof(uint16_t); // steering_opportunity_window_sec
+    class_size += sizeof(uint16_t); // btm_disassociation_timer
+    class_size += sizeof(uint8_t); // sta_list_length
+    class_size += sizeof(uint8_t); // target_bssid_list_length
+    return class_size;
+}
+
+bool tlvSteeringRequest::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_STEERING_REQUEST;
+    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_bssid->struct_init(); }
+    m_request_flags = (sRequestFlags*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sRequestFlags) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sRequestFlags); }
+    if (!m_parse__) { m_request_flags->struct_init(); }
+    m_steering_opportunity_window_sec = (uint16_t*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_btm_disassociation_timer = (uint16_t*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_sta_list_length = (uint8_t*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_sta_list = (sMacAddr*)m_buff_ptr__;
+    uint8_t sta_list_length = *m_sta_list_length;
+    m_sta_list_idx__ = sta_list_length;
+    m_buff_ptr__ += sizeof(sMacAddr)*(sta_list_length);
+    m_target_bssid_list_length = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_target_bssid_list_length = 0;
+    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_target_bssid_list = (sTargetBssidInfo*)m_buff_ptr__;
+    uint8_t target_bssid_list_length = *m_target_bssid_list_length;
+    m_target_bssid_list_idx__ = target_bssid_list_length;
+    m_buff_ptr__ += sizeof(sTargetBssidInfo)*(target_bssid_list_length);
+    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_STEERING_REQUEST) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_STEERING_REQUEST) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -21,6 +21,7 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvOperatingChannelReport.yaml",
   "tlvf/wfa_map/tlvHigherLayerData.yaml",
   "tlvf/wfa_map/tlvSteeringBTMReport.yaml",
+  "tlvf/wfa_map/tlvSteeringRequest.yaml",
 }
 
 # Relative to tlvf.py src_path variable

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -20,6 +20,7 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvTransmitPowerLimit.yaml",
   "tlvf/wfa_map/tlvOperatingChannelReport.yaml",
   "tlvf/wfa_map/tlvHigherLayerData.yaml",
+  "tlvf/wfa_map/tlvSteeringBTMReport.yaml",
 }
 
 # Relative to tlvf.py src_path variable

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -93,9 +93,9 @@ test_channel_selection() {
     dbg "Confirming 1905.1 Ack Message request was received on agent"
     # TODO: When creating handler for the ACK message on the agent, replace lookup of this string
     check docker exec -it repeater1 sh -c \
-        'grep -i -q "handle_cmdu_control_ieee1905_1_message 8000" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+        'grep -i -q "ACK_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
     check docker exec -it repeater1 sh -c \
-        'grep -i -q "handle_cmdu_control_ieee1905_1_message 8000" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
+        'grep -i -q "ACK_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
 
     return $check_error
 }


### PR DESCRIPTION
According to section 5.8.1 in the EasyMesh Test Plan v1.0 [1], 
add support for passing the Controller Certification
client steering for Steering Mandate and Steering Opportunity test.

According to Multi-AP Specification v1.0, the client steering control 
message enable efficient steering of STAs between BSSs in a Multi-AP 
network. There are two message types:

1.  steering mandate : 
Request Mode bit set to one indicating a Steering Mandate.
The controller uses the Steering Mandate mechanism to
mandate an agent to attempt steering of one or more associated STAs. 


2. steering opportunity :
Request Mode bit set to zero indicating a Steering Opportunity.
The controller uses the Steering Opportunity mechanism to provide a time
window for an agent to steer one or more associated STAs.
The agent may attempt to steer the STA(s) identified in the request to any
other BSS in the Multi-AP network that the Multi-AP Agent has identified as
suitable target BSS(s) 

#212 #214 