### PR TITLE
controller: Refactor WFA-CA DEV_SEND_1905 handling

### DIFF
--- a/controller/src/beerocks/master/wfa_ca.h
+++ b/controller/src/beerocks/master/wfa_ca.h
@@ -47,7 +47,8 @@ private:
                              std::string &err_string);
 
     static bool create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
-                            ieee1905_1::eMessageType message_type);
+                            ieee1905_1::eMessageType message_type, db &database,
+                            std::string &err_string);
 
     struct tlv_hex_t {
         std::string *type   = nullptr;


### PR DESCRIPTION
When DEV_SEND_1905 command was received with no TLVs, we had to try to
create the CMDU from scratch because there was no way to know if it was
really CMDU with no TLVs or it just CMDU which we need to fill the TLVs
manually from a preprepared buffer.

Refactor the handler so it will try automatically to create the CMDU
from a preprepared buffer, and if there is no preprepared buffer from that
message type it will skip it, and add the TLV's from the command.
This saves confusion to if we need to create a handler for a specific
message type or not, and shorten the code since it is no more necessary
to create CMDU, for command with no TLVs.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>