### PR TITLE
bugfix: prevent segmentation faults when receiving mismatched TLVs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,6 +76,21 @@
             ]
         },
         {
+            "name": "(gdb) Attach to prplMesh Monitor",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/../build/install/bin/beerocks_monitor",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "(gdb) Attach to prplMesh CLI",
             "type": "cppdbg",
             "request": "attach",

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -54,15 +54,11 @@ bool cACTION_APMANAGER_4ADDR_STA_JOINED::init()
         return false;
     }
     m_src_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_src_mac->struct_init(); }
     m_dst_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_dst_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -106,15 +102,11 @@ bool cACTION_APMANAGER_JOINED_NOTIFICATION::init()
         return false;
     }
     m_params = (sNodeHostap*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeHostap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -142,10 +134,6 @@ size_t cACTION_APMANAGER_INIT_DONE_NOTIFICATION::get_initial_size()
 bool cACTION_APMANAGER_INIT_DONE_NOTIFICATION::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -186,12 +174,8 @@ bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
         return false;
     }
     m_params = (sApSetRestrictedFailsafe*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApSetRestrictedFailsafe) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApSetRestrictedFailsafe))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -228,11 +212,7 @@ bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
         return false;
     }
     m_success = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -269,11 +249,7 @@ bool cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -316,14 +292,10 @@ bool cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     m_vap_info = (sVapInfo*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVapInfo) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVapInfo))) { return false; }
     if (!m_parse__) { m_vap_info->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -351,10 +323,6 @@ size_t cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::get_initial_size()
 bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -395,12 +363,8 @@ bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
         return false;
     }
     m_params = (sVapsList*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVapsList) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVapsList))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -438,12 +402,8 @@ bool cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -481,12 +441,8 @@ bool cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -524,12 +480,8 @@ bool cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -567,12 +519,8 @@ bool cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -623,17 +571,13 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_supported_channels_list = (sWifiChannel*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(sWifiChannel) * beerocks::message::SUPPORTED_CHANNELS_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(sWifiChannel)*(beerocks::message::SUPPORTED_CHANNELS_LENGTH))) { return false; }
     m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -672,12 +616,8 @@ bool cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsCacCompleted*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sDfsCacCompleted) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sDfsCacCompleted))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -715,12 +655,8 @@ bool cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsChannelAvailable*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sDfsChannelAvailable) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sDfsChannelAvailable))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -758,12 +694,8 @@ bool cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -801,12 +733,8 @@ bool cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -844,12 +772,8 @@ bool cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborSetParams11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNeighborSetParams11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNeighborSetParams11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -887,12 +811,8 @@ bool cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborRemoveParams11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNeighborRemoveParams11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNeighborRemoveParams11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -930,12 +850,8 @@ bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::init()
         return false;
     }
     m_params = (sClientAssociationParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientAssociationParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientAssociationParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -973,12 +889,8 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::init()
         return false;
     }
     m_params = (sClientDisconnectionParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientDisconnectionParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectionParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1033,18 +945,14 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     m_type = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_reason = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1082,12 +990,8 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     m_params = (sClientDisconnectResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientDisconnectResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1130,14 +1034,10 @@ bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_reject_sta = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1181,15 +1081,11 @@ bool cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_ipv4->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1227,12 +1123,8 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurementRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1270,12 +1162,8 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurement) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1313,12 +1201,8 @@ bool cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1356,12 +1240,8 @@ bool cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::init()
         return false;
     }
     m_params = (sNodeBssSteerRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeBssSteerRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1399,12 +1279,8 @@ bool cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::init()
         return false;
     }
     m_params = (sNodeBssSteerResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeBssSteerResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1442,12 +1318,8 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1485,12 +1357,8 @@ bool cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_params = (sSteeringClientSetRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientSetRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1528,12 +1396,8 @@ bool cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringClientSetResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientSetResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1571,12 +1435,8 @@ bool cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvProbeReq*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvProbeReq) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvProbeReq))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1614,12 +1474,8 @@ bool cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvAuthFail*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvAuthFail) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvAuthFail))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1647,10 +1503,6 @@ size_t cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::get_initial_size()
 bool cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -144,23 +144,19 @@ bool cACTION_BACKHAUL_REGISTER_REQUEST::init()
         return false;
     }
     m_sta_iface = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_sta_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_hostap_iface = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_hostap_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_local_master = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_local_gw = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_sta_iface_filter_low = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_onboarding = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -197,11 +193,7 @@ bool cACTION_BACKHAUL_REGISTER_RESPONSE::init()
         return false;
     }
     m_is_backhaul_manager = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -229,10 +221,6 @@ size_t cACTION_BACKHAUL_BUSY_NOTIFICATION::get_initial_size()
 bool cACTION_BACKHAUL_BUSY_NOTIFICATION::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -551,43 +539,39 @@ bool cACTION_BACKHAUL_ENABLE::init()
         return false;
     }
     m_bridge_iface = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_bridge_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_iface_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_iface_mac->struct_init(); }
     m_iface_is_5ghz = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_wire_iface = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_wire_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_sta_iface = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_sta_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_ap_iface = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_ap_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_ssid = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::WIFI_SSID_MAX_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_SSID_MAX_LENGTH))) { return false; }
     m_ssid_idx__  = beerocks::message::WIFI_SSID_MAX_LENGTH;
     m_pass = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::WIFI_PASS_MAX_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_PASS_MAX_LENGTH))) { return false; }
     m_pass_idx__  = beerocks::message::WIFI_PASS_MAX_LENGTH;
     m_security_type = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_preferred_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_preferred_bssid->struct_init(); }
     m_wire_iface_type = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_wireless_iface_type = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_wired_backhaul = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -625,12 +609,8 @@ bool cACTION_BACKHAUL_CONNECTED_NOTIFICATION::init()
         return false;
     }
     m_params = (sBackhaulParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBackhaulParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -667,11 +647,7 @@ bool cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::init()
         return false;
     }
     m_stopped = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -709,12 +685,8 @@ bool cACTION_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     m_params = (sBackhaulRoam*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBackhaulRoam) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRoam))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -751,11 +723,7 @@ bool cACTION_BACKHAUL_ROAM_RESPONSE::init()
         return false;
     }
     m_connected = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -783,10 +751,6 @@ size_t cACTION_BACKHAUL_RESET::get_initial_size()
 bool cACTION_BACKHAUL_RESET::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -827,12 +791,8 @@ bool cACTION_BACKHAUL_4ADDR_CONNECTED::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -870,12 +830,8 @@ bool cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
         return false;
     }
     m_params = (sBackhaulRssi*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBackhaulRssi) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRssi))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -913,11 +869,7 @@ bool cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
         return false;
     }
     m_attempts = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -955,12 +907,8 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurementRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -998,12 +946,8 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurement) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1041,12 +985,8 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -41,10 +41,6 @@ bool cACTION_BML_PING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -75,10 +71,6 @@ bool cACTION_BML_PING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -106,10 +98,6 @@ size_t cACTION_BML_NW_MAP_REQUEST::get_initial_size()
 bool cACTION_BML_NW_MAP_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -192,7 +180,7 @@ bool cACTION_BML_NW_MAP_RESPONSE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -217,19 +205,15 @@ bool cACTION_BML_NW_MAP_RESPONSE::init()
         return false;
     }
     m_node_num = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    m_buff_ptr__ += sizeof(char)*(buffer_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -309,7 +293,7 @@ bool cACTION_BML_NW_MAP_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -334,19 +318,15 @@ bool cACTION_BML_NW_MAP_UPDATE::init()
         return false;
     }
     m_node_num = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    m_buff_ptr__ += sizeof(char)*(buffer_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -426,7 +406,7 @@ bool cACTION_BML_STATS_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -451,19 +431,15 @@ bool cACTION_BML_STATS_UPDATE::init()
         return false;
     }
     m_num_of_stats_bulks = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    m_buff_ptr__ += sizeof(char)*(buffer_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -539,7 +515,7 @@ bool cACTION_BML_EVENTS_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -563,16 +539,12 @@ bool cACTION_BML_EVENTS_UPDATE::init()
     }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    m_buff_ptr__ += sizeof(char)*(buffer_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -600,10 +572,6 @@ size_t cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::get_initial_size()
 bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -637,10 +605,6 @@ bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -668,10 +632,6 @@ size_t cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::get_initial_size()
 bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -705,10 +665,6 @@ bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -736,10 +692,6 @@ size_t cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::get_initial_size()
 bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -773,10 +725,6 @@ bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -804,10 +752,6 @@ size_t cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::get_initial_size()
 bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -841,10 +785,6 @@ bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -872,10 +812,6 @@ size_t cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::get_initial_size()
 bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -909,10 +845,6 @@ bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -940,10 +872,6 @@ size_t cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::get_initial_size()
 bool cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -977,10 +905,6 @@ bool cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1011,10 +935,6 @@ bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1042,10 +962,6 @@ size_t cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::get_initial_size()
 bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1085,11 +1001,7 @@ bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1126,11 +1038,7 @@ bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1167,11 +1075,7 @@ bool cACTION_BML_SET_CLIENT_ROAMING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1202,10 +1106,6 @@ bool cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1233,10 +1133,6 @@ size_t cACTION_BML_GET_CLIENT_ROAMING_REQUEST::get_initial_size()
 bool cACTION_BML_GET_CLIENT_ROAMING_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1276,11 +1172,7 @@ bool cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1317,11 +1209,7 @@ bool cACTION_BML_SET_DFS_REENTRY_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1352,10 +1240,6 @@ bool cACTION_BML_SET_DFS_REENTRY_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1383,10 +1267,6 @@ size_t cACTION_BML_GET_DFS_REENTRY_REQUEST::get_initial_size()
 bool cACTION_BML_GET_DFS_REENTRY_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1426,11 +1306,7 @@ bool cACTION_BML_GET_DFS_REENTRY_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1467,11 +1343,7 @@ bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1502,10 +1374,6 @@ bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1533,10 +1401,6 @@ size_t cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::get_initia
 bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1576,11 +1440,7 @@ bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1617,11 +1477,7 @@ bool cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1652,10 +1508,6 @@ bool cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1683,10 +1535,6 @@ size_t cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::get_initial_size()
 bool cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1726,11 +1574,7 @@ bool cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1767,11 +1611,7 @@ bool cACTION_BML_SET_IRE_ROAMING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1802,10 +1642,6 @@ bool cACTION_BML_SET_IRE_ROAMING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1833,10 +1669,6 @@ size_t cACTION_BML_GET_IRE_ROAMING_REQUEST::get_initial_size()
 bool cACTION_BML_GET_IRE_ROAMING_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1876,11 +1708,7 @@ bool cACTION_BML_GET_IRE_ROAMING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1917,11 +1745,7 @@ bool cACTION_BML_SET_LOAD_BALANCER_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1952,10 +1776,6 @@ bool cACTION_BML_SET_LOAD_BALANCER_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1983,10 +1803,6 @@ size_t cACTION_BML_GET_LOAD_BALANCER_REQUEST::get_initial_size()
 bool cACTION_BML_GET_LOAD_BALANCER_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2026,11 +1842,7 @@ bool cACTION_BML_GET_LOAD_BALANCER_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2067,11 +1879,7 @@ bool cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2102,10 +1910,6 @@ bool cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2133,10 +1937,6 @@ size_t cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::get_initial_size()
 bool cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2176,11 +1976,7 @@ bool cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2218,12 +2014,8 @@ bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sLoggingLevelChange) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2251,10 +2043,6 @@ size_t cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::get_initial_size()
 bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2295,12 +2083,8 @@ bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::init()
         return false;
     }
     m_params = (sWifiCredentials*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWifiCredentials) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2338,11 +2122,7 @@ bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2380,12 +2160,8 @@ bool cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::init()
         return false;
     }
     m_params = (sRestrictedChannels*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sRestrictedChannels) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2423,11 +2199,7 @@ bool cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2465,12 +2237,8 @@ bool cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::init()
         return false;
     }
     m_params = (sRestrictedChannels*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sRestrictedChannels) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2508,12 +2276,8 @@ bool cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::init()
         return false;
     }
     m_params = (sRestrictedChannels*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sRestrictedChannels) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2550,11 +2314,7 @@ bool cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2585,10 +2345,6 @@ bool cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2616,10 +2372,6 @@ size_t cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::get_initial_size()
 bool cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2659,11 +2411,7 @@ bool cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2718,7 +2466,7 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::alloc_vap_list(size_t count) 
     }
     m_vap_list_idx__ += count;
     *m_vap_list_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if (!m_parse__) { 
         for (size_t i = m_vap_list_idx__ - count; i < m_vap_list_idx__; i++) { m_vap_list[i].struct_init(); }
     }
@@ -2748,18 +2496,14 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_vap_list_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vap_list_size = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_vap_list = (sConfigVapInfo*)m_buff_ptr__;
     uint8_t vap_list_size = *m_vap_list_size;
     m_vap_list_idx__ = vap_list_size;
-    m_buff_ptr__ += sizeof(sConfigVapInfo)*(vap_list_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sConfigVapInfo)*(vap_list_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2797,11 +2541,7 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2856,7 +2596,7 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::alloc_vap_list(size_t count)
     }
     m_vap_list_idx__ += count;
     *m_vap_list_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if (!m_parse__) { 
         for (size_t i = m_vap_list_idx__ - count; i < m_vap_list_idx__; i++) { m_vap_list[i].struct_init(); }
     }
@@ -2886,18 +2626,14 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_vap_list_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vap_list_size = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_vap_list = (sConfigVapInfo*)m_buff_ptr__;
     uint8_t vap_list_size = *m_vap_list_size;
     m_vap_list_idx__ = vap_list_size;
-    m_buff_ptr__ += sizeof(sConfigVapInfo)*(vap_list_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sConfigVapInfo)*(vap_list_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2935,11 +2671,7 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2994,19 +2726,15 @@ bool cACTION_BML_STEERING_SET_GROUP_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_cfg_2 = (sSteeringApConfig*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringApConfig) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringApConfig))) { return false; }
     if (!m_parse__) { m_cfg_2->struct_init(); }
     m_cfg_5 = (sSteeringApConfig*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringApConfig) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringApConfig))) { return false; }
     if (!m_parse__) { m_cfg_5->struct_init(); }
     m_remove = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3044,11 +2772,7 @@ bool cACTION_BML_STEERING_SET_GROUP_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3109,22 +2833,18 @@ bool cACTION_BML_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_config = (sSteeringClientConfig*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientConfig) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientConfig))) { return false; }
     if (!m_parse__) { m_config->struct_init(); }
     m_remove = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3162,11 +2882,7 @@ bool cACTION_BML_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3203,11 +2919,7 @@ bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::init()
         return false;
     }
     m_unregister = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3245,11 +2957,7 @@ bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3310,21 +3018,17 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_type = (eDisconnectType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eDisconnectType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eDisconnectType))) { return false; }
     m_reason = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3362,11 +3066,7 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3416,17 +3116,13 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3464,11 +3160,7 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3544,7 +3236,7 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -3568,16 +3260,12 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::init()
     }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    m_buff_ptr__ += sizeof(char)*(buffer_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3615,12 +3303,8 @@ bool cACTION_BML_TRIGGER_TOPOLOGY_QUERY::init()
         return false;
     }
     m_al_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_al_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3664,15 +3348,11 @@ bool cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::init()
         return false;
     }
     m_al_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_al_mac->struct_init(); }
     m_ruid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ruid->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3748,7 +3428,7 @@ bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::alloc_command(size_t count) {
     }
     m_command_idx__ += count;
     *m_command_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -3772,16 +3452,12 @@ bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::init()
     }
     m_command_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_command_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_command = (char*)m_buff_ptr__;
     uint16_t command_length = *m_command_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&command_length)); }
     m_command_idx__ = command_length;
-    m_buff_ptr__ += sizeof(char)*(command_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(command_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3857,7 +3533,7 @@ bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::alloc_reply(size_t count) {
     }
     m_reply_idx__ += count;
     *m_reply_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -3881,16 +3557,12 @@ bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::init()
     }
     m_reply_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_reply_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_reply = (char*)m_buff_ptr__;
     uint16_t reply_length = *m_reply_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&reply_length)); }
     m_reply_idx__ = reply_length;
-    m_buff_ptr__ += sizeof(char)*(reply_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(reply_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -47,11 +47,7 @@ bool cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::init()
         return false;
     }
     m_isEnable = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -88,11 +84,7 @@ bool cACTION_CLI_ENABLE_LOAD_BALANCER::init()
         return false;
     }
     m_isEnable = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -129,11 +121,7 @@ bool cACTION_CLI_ENABLE_DEBUG::init()
         return false;
     }
     m_isEnable = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -171,11 +159,7 @@ bool cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::init()
         return false;
     }
     m_attempts = (int32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -217,13 +201,9 @@ bool cACTION_CLI_RESPONSE_INT::init()
         return false;
     }
     m_isOK = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_currentValue = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -299,7 +279,7 @@ bool cACTION_CLI_RESPONSE_STR::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -323,16 +303,12 @@ bool cACTION_CLI_RESPONSE_STR::init()
     }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    m_buff_ptr__ += sizeof(char)*(buffer_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -382,18 +358,14 @@ bool cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_center_frequency = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_center_frequency = 0x0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -431,12 +403,8 @@ bool cACTION_CLI_OPTIMAL_PATH_TASK::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -474,12 +442,8 @@ bool cACTION_CLI_LOAD_BALANCER_TASK::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -507,10 +471,6 @@ size_t cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::get_initial_size()
 bool cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -551,12 +511,8 @@ bool cACTION_CLI_DUMP_NODE_INFO::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -606,16 +562,12 @@ bool cACTION_CLI_PING_SLAVE_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_num_of_req = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_size = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -659,13 +611,9 @@ bool cACTION_CLI_PING_ALL_SLAVES_REQUEST::init()
         return false;
     }
     m_num_of_req = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_size = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -703,12 +651,8 @@ bool cACTION_CLI_BACKHAUL_SCAN_RESULTS::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -752,15 +696,11 @@ bool cACTION_CLI_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     m_slave_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_slave_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -804,15 +744,11 @@ bool cACTION_CLI_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -856,15 +792,11 @@ bool cACTION_CLI_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -914,16 +846,12 @@ bool cACTION_CLI_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_type = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_reason = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -973,17 +901,13 @@ bool cACTION_CLI_CLIENT_BSS_STEER_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_disassoc_timer = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1027,15 +951,11 @@ bool cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1084,17 +1004,13 @@ bool cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1186,32 +1102,28 @@ bool cACTION_CLI_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_ssid = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(uint8_t) * beerocks::message::WIFI_SSID_MAX_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(beerocks::message::WIFI_SSID_MAX_LENGTH))) { return false; }
     m_ssid_idx__  = beerocks::message::WIFI_SSID_MAX_LENGTH;
     m_use_optional_ssid = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_channel = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_measurement_mode = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_duration = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_rand_ival = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_repeats = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_op_class = (int16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int16_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int16_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1266,20 +1178,16 @@ bool cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_peer_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_peer_mac->struct_init(); }
     m_group_identity = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1323,15 +1231,11 @@ bool cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1369,12 +1273,8 @@ bool cACTION_CLI_HOSTAP_TX_ON_REQUEST::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1412,12 +1312,8 @@ bool cACTION_CLI_HOSTAP_TX_OFF_REQUEST::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1471,19 +1367,15 @@ bool cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ap_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1532,17 +1424,13 @@ bool cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ap_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1580,12 +1468,8 @@ bool cACTION_CLI_HOSTAP_STATS_MEASUREMENT::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -139,38 +139,34 @@ bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::init()
         return false;
     }
     m_slave_version = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::VERSION_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::VERSION_LENGTH))) { return false; }
     m_slave_version_idx__  = beerocks::message::VERSION_LENGTH;
     m_platform_settings = (sPlatformSettings*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sPlatformSettings) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) { return false; }
     if (!m_parse__) { m_platform_settings->struct_init(); }
     m_wlan_settings = (sWlanSettings*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWlanSettings) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) { return false; }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
     m_backhaul_params = (sBackhaulParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBackhaulParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulParams))) { return false; }
     if (!m_parse__) { m_backhaul_params->struct_init(); }
     m_hostap = (sNodeHostap*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeHostap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) { return false; }
     if (!m_parse__) { m_hostap->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_platform = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_low_pass_filter_on = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_enable_repeater_mode = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_radio_identifier = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_radio_identifier->struct_init(); }
     m_is_slave_reconf = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -254,17 +250,13 @@ bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::init()
         return false;
     }
     m_master_version = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::VERSION_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::VERSION_LENGTH))) { return false; }
     m_master_version_idx__  = beerocks::message::VERSION_LENGTH;
     m_err_code = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_config = (sSonConfig*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSonConfig) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) { return false; }
     if (!m_parse__) { m_config->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -326,24 +318,20 @@ bool cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::init()
         return false;
     }
     m_backhaul_iface_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_backhaul_iface_mac->struct_init(); }
     m_backhaul_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_backhaul_ipv4->struct_init(); }
     m_bridge_iface_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bridge_iface_mac->struct_init(); }
     m_bridge_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_bridge_ipv4->struct_init(); }
     m_hostap = (sNodeHostap*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeHostap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) { return false; }
     if (!m_parse__) { m_hostap->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -381,12 +369,8 @@ bool cACTION_CONTROL_SON_CONFIG_UPDATE::init()
         return false;
     }
     m_config = (sSonConfig*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSonConfig) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) { return false; }
     if (!m_parse__) { m_config->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -443,7 +427,7 @@ bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -470,16 +454,12 @@ bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_seq = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_size = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -536,7 +516,7 @@ bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -563,16 +543,12 @@ bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_seq = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_size = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -629,7 +605,7 @@ bool cACTION_CONTROL_AGENT_PING_REQUEST::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -656,16 +632,12 @@ bool cACTION_CONTROL_AGENT_PING_REQUEST::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_seq = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_size = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -722,7 +694,7 @@ bool cACTION_CONTROL_AGENT_PING_RESPONSE::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -749,16 +721,12 @@ bool cACTION_CONTROL_AGENT_PING_RESPONSE::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_seq = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_size = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -796,12 +764,8 @@ bool cACTION_CONTROL_ARP_QUERY_REQUEST::init()
         return false;
     }
     m_params = (sArpQuery*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sArpQuery) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sArpQuery))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -839,12 +803,8 @@ bool cACTION_CONTROL_ARP_QUERY_RESPONSE::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sArpMonitorData) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -882,12 +842,8 @@ bool cACTION_CONTROL_VERSION_MISMATCH_NOTIFICATION::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVersions) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
     if (!m_parse__) { m_versions->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -930,14 +886,10 @@ bool cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         return false;
     }
     m_bridge_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_bridge_mac->struct_init(); }
     m_operational = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -975,12 +927,8 @@ bool cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
         return false;
     }
     m_params = (sBackhaulRssi*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBackhaulRssi) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRssi))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1008,10 +956,6 @@ size_t cACTION_CONTROL_BACKHAUL_RESET::get_initial_size()
 bool cACTION_CONTROL_BACKHAUL_RESET::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1052,12 +996,8 @@ bool cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     m_params = (sBackhaulRoam*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBackhaulRoam) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRoam))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1095,12 +1035,8 @@ bool cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sLoggingLevelChange) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1138,12 +1074,8 @@ bool cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_PREPARE_REQUEST::init()
         return false;
     }
     m_params = (sWifiCredentials*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWifiCredentials) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1181,11 +1113,7 @@ bool cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_PREPARE_RESPONSE::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1213,10 +1141,6 @@ size_t cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_PRE_COMMIT_REQUEST::get_initial_s
 bool cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_PRE_COMMIT_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1257,11 +1181,7 @@ bool cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_PRE_COMMIT_RESPONSE::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1289,10 +1209,6 @@ size_t cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_COMMIT_REQUEST::get_initial_size(
 bool cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_COMMIT_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1326,10 +1242,6 @@ bool cACTION_CONTROL_WIFI_CREDENTIALS_UPDATE_ABORT_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1357,10 +1269,6 @@ size_t cACTION_CONTROL_HOSTAP_TX_ON_REQUEST::get_initial_size()
 bool cACTION_CONTROL_HOSTAP_TX_ON_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1394,10 +1302,6 @@ bool cACTION_CONTROL_HOSTAP_TX_OFF_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1425,10 +1329,6 @@ size_t cACTION_CONTROL_HOSTAP_TX_ON_RESPONSE::get_initial_size()
 bool cACTION_CONTROL_HOSTAP_TX_ON_RESPONSE::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1469,12 +1369,8 @@ bool cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1512,12 +1408,8 @@ bool cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1555,12 +1447,8 @@ bool cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1611,17 +1499,13 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_supported_channels = (sWifiChannel*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(sWifiChannel) * beerocks::message::SUPPORTED_CHANNELS_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(sWifiChannel)*(beerocks::message::SUPPORTED_CHANNELS_LENGTH))) { return false; }
     m_supported_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1660,12 +1544,8 @@ bool cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsCacCompleted*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sDfsCacCompleted) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sDfsCacCompleted))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1703,12 +1583,8 @@ bool cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsChannelAvailable*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sDfsChannelAvailable) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sDfsChannelAvailable))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1746,12 +1622,8 @@ bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
         return false;
     }
     m_params = (sApSetRestrictedFailsafe*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApSetRestrictedFailsafe) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApSetRestrictedFailsafe))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1788,11 +1660,7 @@ bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
         return false;
     }
     m_success = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1830,12 +1698,8 @@ bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1873,11 +1737,7 @@ bool cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
         return false;
     }
     m_attempts = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1905,10 +1765,6 @@ size_t cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::get_initial_size()
 bool cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1949,12 +1805,8 @@ bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApChannelSwitch) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1991,11 +1843,7 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_sync = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2050,7 +1898,7 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
     }
     m_sta_stats_idx__ += count;
     *m_sta_stats_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if (!m_parse__) { 
         for (size_t i = m_sta_stats_idx__ - count; i < m_sta_stats_idx__; i++) { m_sta_stats[i].struct_init(); }
     }
@@ -2080,19 +1928,15 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_ap_stats = (sApStatsParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApStatsParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) { return false; }
     if (!m_parse__) { m_ap_stats->struct_init(); }
     m_sta_stats_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_sta_stats_size = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_sta_stats = (sStaStatsParams*)m_buff_ptr__;
     uint8_t sta_stats_size = *m_sta_stats_size;
     m_sta_stats_idx__ = sta_stats_size;
-    m_buff_ptr__ += sizeof(sStaStatsParams)*(sta_stats_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sStaStatsParams)*(sta_stats_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2130,12 +1974,8 @@ bool cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sApLoadNotificationParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApLoadNotificationParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApLoadNotificationParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2173,12 +2013,8 @@ bool cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborSetParams11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNeighborSetParams11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNeighborSetParams11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2216,12 +2052,8 @@ bool cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborRemoveParams11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNeighborRemoveParams11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNeighborRemoveParams11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2259,12 +2091,8 @@ bool cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sApActivityNotificationParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApActivityNotificationParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApActivityNotificationParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2302,12 +2130,8 @@ bool cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
         return false;
     }
     m_params = (sVapsList*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVapsList) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVapsList))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2344,11 +2168,7 @@ bool cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2391,14 +2211,10 @@ bool cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     m_vap_info = (sVapInfo*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVapInfo) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVapInfo))) { return false; }
     if (!m_parse__) { m_vap_info->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2436,12 +2252,8 @@ bool cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::init()
         return false;
     }
     m_params = (sClientMonitoringParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientMonitoringParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientMonitoringParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2479,12 +2291,8 @@ bool cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2522,12 +2330,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurementRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2565,12 +2369,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurement) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2608,12 +2408,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2651,12 +2447,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2694,12 +2486,8 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurement) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2737,12 +2525,8 @@ bool cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2780,12 +2564,8 @@ bool cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2823,12 +2603,8 @@ bool cACTION_CONTROL_CLIENT_ASSOCIATED_NOTIFICATION::init()
         return false;
     }
     m_params = (sClientAssociationParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientAssociationParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientAssociationParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2866,12 +2642,8 @@ bool cACTION_CONTROL_CLIENT_DISCONNECTED_NOTIFICATION::init()
         return false;
     }
     m_params = (sClientDisconnectionParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientDisconnectionParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectionParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2914,14 +2686,10 @@ bool cACTION_CONTROL_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_reject_sta = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2965,15 +2733,11 @@ bool cACTION_CONTROL_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_ipv4->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3028,18 +2792,14 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     m_type = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_reason = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3077,12 +2837,8 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     m_params = (sClientDisconnectResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientDisconnectResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3120,12 +2876,8 @@ bool cACTION_CONTROL_CLIENT_BSS_STEER_REQUEST::init()
         return false;
     }
     m_params = (sNodeBssSteerRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeBssSteerRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3163,12 +2915,8 @@ bool cACTION_CONTROL_CLIENT_BSS_STEER_RESPONSE::init()
         return false;
     }
     m_params = (sNodeBssSteerResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeBssSteerResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3253,18 +3001,14 @@ bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_ipv4->struct_init(); }
     m_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::NODE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::NODE_NAME_LENGTH))) { return false; }
     m_name_idx__  = beerocks::message::NODE_NAME_LENGTH;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3302,12 +3046,8 @@ bool cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sArpMonitorData) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3345,12 +3085,8 @@ bool cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     m_params = (sBeaconRequest11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBeaconRequest11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBeaconRequest11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3388,12 +3124,8 @@ bool cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::init()
         return false;
     }
     m_params = (sBeaconResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBeaconResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBeaconResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3431,12 +3163,8 @@ bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     m_params = (sStaChannelLoadRequest11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStaChannelLoadRequest11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadRequest11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3474,12 +3202,8 @@ bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStaChannelLoadResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStaChannelLoadResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3517,12 +3241,8 @@ bool cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     m_params = (sStatisticsRequest11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStatisticsRequest11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsRequest11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3560,12 +3280,8 @@ bool cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStatisticsResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStatisticsResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3603,12 +3319,8 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3646,12 +3358,8 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sLinkMeasurementsResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sLinkMeasurementsResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sLinkMeasurementsResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3689,12 +3397,8 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::init()
         return false;
     }
     m_params = (sSteeringSetGroupRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringSetGroupRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3732,12 +3436,8 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringSetGroupResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringSetGroupResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3775,12 +3475,8 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_params = (sSteeringClientSetRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientSetRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3818,12 +3514,8 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringClientSetResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientSetResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3861,12 +3553,8 @@ bool cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvActivity*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvActivity) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvActivity))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3904,12 +3592,8 @@ bool cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvSnrXing*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvSnrXing) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvSnrXing))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3947,12 +3631,8 @@ bool cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvProbeReq*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvProbeReq) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvProbeReq))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3990,12 +3670,8 @@ bool cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvAuthFail*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvAuthFail) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvAuthFail))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
@@ -92,32 +92,28 @@ bool cACTION_HEADER::init()
     }
     m_magic = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_magic = beerocks::message::MESSAGE_MAGIC;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_version = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_version = beerocks::message::MESSAGE_VERSION;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_action = (eAction*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eAction) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eAction))) { return false; }
     m_action_op = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_direction = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_direction = 0x1;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_radio_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_radio_mac->struct_init(); }
     m_last = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_last = 0x0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_id = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0x0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -47,11 +47,7 @@ bool cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -79,10 +75,6 @@ size_t cACTION_MONITOR_JOINED_NOTIFICATION::get_initial_size()
 bool cACTION_MONITOR_JOINED_NOTIFICATION::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -123,12 +115,8 @@ bool cACTION_MONITOR_SON_CONFIG_UPDATE::init()
         return false;
     }
     m_config = (sSonConfig*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSonConfig) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) { return false; }
     if (!m_parse__) { m_config->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -166,12 +154,8 @@ bool cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sLoggingLevelChange) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -209,11 +193,7 @@ bool cACTION_MONITOR_ERROR_NOTIFICATION::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -244,10 +224,6 @@ bool cACTION_MONITOR_ERROR_NOTIFICATION_ACK::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -275,10 +251,6 @@ size_t cACTION_MONITOR_HEARTBEAT_NOTIFICATION::get_initial_size()
 bool cACTION_MONITOR_HEARTBEAT_NOTIFICATION::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -319,12 +291,8 @@ bool cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::init()
         return false;
     }
     m_params = (sClientMonitoringParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sClientMonitoringParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sClientMonitoringParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -362,12 +330,8 @@ bool cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -405,12 +369,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurementRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -459,17 +419,13 @@ bool cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_ipv4->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -507,12 +463,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurement) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -550,12 +502,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sNodeRssiMeasurement) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -593,12 +541,8 @@ bool cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -636,12 +580,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -679,12 +619,8 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -722,12 +658,8 @@ bool cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -765,12 +697,8 @@ bool cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sApActivityNotificationParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApActivityNotificationParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApActivityNotificationParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -807,11 +735,7 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_sync = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -853,13 +777,9 @@ bool cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::init()
         return false;
     }
     m_new_tx_state = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     m_new_hostap_enabled_state = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -914,7 +834,7 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
     }
     m_sta_stats_idx__ += count;
     *m_sta_stats_size += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if (!m_parse__) { 
         for (size_t i = m_sta_stats_idx__ - count; i < m_sta_stats_idx__; i++) { m_sta_stats[i].struct_init(); }
     }
@@ -944,19 +864,15 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_ap_stats = (sApStatsParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApStatsParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) { return false; }
     if (!m_parse__) { m_ap_stats->struct_init(); }
     m_sta_stats_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_sta_stats_size = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_sta_stats = (sStaStatsParams*)m_buff_ptr__;
     uint8_t sta_stats_size = *m_sta_stats_size;
     m_sta_stats_idx__ = sta_stats_size;
-    m_buff_ptr__ += sizeof(sStaStatsParams)*(sta_stats_size);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sStaStatsParams)*(sta_stats_size))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -994,12 +910,8 @@ bool cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sApLoadNotificationParams*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sApLoadNotificationParams) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sApLoadNotificationParams))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1037,12 +949,8 @@ bool cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     m_params = (sBeaconRequest11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBeaconRequest11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBeaconRequest11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1080,12 +988,8 @@ bool cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::init()
         return false;
     }
     m_params = (sBeaconResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sBeaconResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sBeaconResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1123,12 +1027,8 @@ bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     m_params = (sStaChannelLoadRequest11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStaChannelLoadRequest11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadRequest11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1166,12 +1066,8 @@ bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStaChannelLoadResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStaChannelLoadResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1209,12 +1105,8 @@ bool cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     m_params = (sStatisticsRequest11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStatisticsRequest11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsRequest11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1252,12 +1144,8 @@ bool cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStatisticsResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sStatisticsResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1295,12 +1183,8 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1338,12 +1222,8 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sLinkMeasurementsResponse11k*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sLinkMeasurementsResponse11k) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sLinkMeasurementsResponse11k))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1381,12 +1261,8 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::init()
         return false;
     }
     m_params = (sSteeringSetGroupRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringSetGroupRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1424,12 +1300,8 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringSetGroupResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringSetGroupResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1467,12 +1339,8 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_params = (sSteeringClientSetRequest*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientSetRequest) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1510,12 +1378,8 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringClientSetResponse*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringClientSetResponse) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1553,12 +1417,8 @@ bool cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvActivity*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvActivity) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvActivity))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1596,12 +1456,8 @@ bool cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvSnrXing*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sSteeringEvSnrXing) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvSnrXing))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -47,11 +47,7 @@ bool cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::init(
         return false;
     }
     m_is_backhaul_manager = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -124,12 +120,8 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -179,17 +171,13 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::init()
         return false;
     }
     m_platform_settings = (sPlatformSettings*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sPlatformSettings) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) { return false; }
     if (!m_parse__) { m_platform_settings->struct_init(); }
     m_wlan_settings = (sWlanSettings*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWlanSettings) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) { return false; }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
     m_valid = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -262,12 +250,8 @@ bool cACTION_PLATFORM_POST_INIT_CONFIG_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -304,11 +288,7 @@ bool cACTION_PLATFORM_POST_INIT_CONFIG_RESPONSE::init()
         return false;
     }
     m_result = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -346,12 +326,8 @@ bool cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sArpMonitorData) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -389,12 +365,8 @@ bool cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::init()
         return false;
     }
     m_wlan_settings = (sWlanSettings*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWlanSettings) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) { return false; }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -490,22 +462,18 @@ bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_dhcp_op = (eDHCPOp*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eDHCPOp) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eDHCPOp))) { return false; }
     m_op = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(beerocks::net::sIpv4Addr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
     if (!m_parse__) { m_ipv4->struct_init(); }
     m_hostname = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::NODE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::NODE_NAME_LENGTH))) { return false; }
     m_hostname_idx__  = beerocks::message::NODE_NAME_LENGTH;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -543,12 +511,8 @@ bool cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sLoggingLevelChange) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -586,12 +550,8 @@ bool cACTION_PLATFORM_ARP_QUERY_REQUEST::init()
         return false;
     }
     m_params = (sArpQuery*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sArpQuery) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sArpQuery))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -629,12 +589,8 @@ bool cACTION_PLATFORM_ARP_QUERY_RESPONSE::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sArpMonitorData) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -662,10 +618,6 @@ size_t cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::get_initial_size()
 bool cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -706,12 +658,8 @@ bool cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::init()
         return false;
     }
     m_params = (sOnboarding*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sOnboarding) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sOnboarding))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -749,12 +697,8 @@ bool cACTION_PLATFORM_ONBOARD_SET_REQUEST::init()
         return false;
     }
     m_params = (sOnboarding*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sOnboarding) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sOnboarding))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -827,12 +771,8 @@ bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -870,12 +810,8 @@ bool cACTION_PLATFORM_BEEROCKS_CREDENTIALS_UPDATE_REQUEST::init()
         return false;
     }
     m_params = (sWifiCredentials*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWifiCredentials) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -913,11 +849,7 @@ bool cACTION_PLATFORM_BEEROCKS_CREDENTIALS_UPDATE_RESPONSE::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1113,21 +1045,17 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_ssid = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::WIFI_SSID_MAX_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_SSID_MAX_LENGTH))) { return false; }
     m_ssid_idx__  = beerocks::message::WIFI_SSID_MAX_LENGTH;
     m_pass = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::WIFI_PASS_MAX_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_PASS_MAX_LENGTH))) { return false; }
     m_pass_idx__  = beerocks::message::WIFI_PASS_MAX_LENGTH;
     m_security_type = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH))) { return false; }
     m_security_type_idx__  = beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1205,14 +1133,10 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_RESPONSE::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_success = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1250,11 +1174,7 @@ bool cACTION_PLATFORM_ADVERTISE_SSID_FLAG_UPDATE_REQUEST::init()
         return false;
     }
     m_flag = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1292,11 +1212,7 @@ bool cACTION_PLATFORM_ADVERTISE_SSID_FLAG_UPDATE_RESPONSE::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1324,10 +1240,6 @@ size_t cACTION_PLATFORM_GET_WLAN_READY_STATUS_REQUEST::get_initial_size()
 bool cACTION_PLATFORM_GET_WLAN_READY_STATUS_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1367,11 +1279,7 @@ bool cACTION_PLATFORM_GET_WLAN_READY_STATUS_RESPONSE::init()
         return false;
     }
     m_result = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1408,11 +1316,7 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::init()
         return false;
     }
     m_vap_id = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1462,17 +1366,13 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::init()
         return false;
     }
     m_front_params = (sWifiCredentials*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWifiCredentials) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
     if (!m_parse__) { m_front_params->struct_init(); }
     m_back_params = (sWifiCredentials*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWifiCredentials) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
     if (!m_parse__) { m_back_params->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1500,10 +1400,6 @@ size_t cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::get_initial_size()
 bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1550,14 +1446,10 @@ bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::init()
         return false;
     }
     m_params = (sAdminCredentials*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sAdminCredentials) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sAdminCredentials))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1585,10 +1477,6 @@ size_t cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::get_initial_size()
 bool cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1635,14 +1523,10 @@ bool cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::init()
         return false;
     }
     m_params = (sDeviceInfo*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sDeviceInfo) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sDeviceInfo))) { return false; }
     if (!m_parse__) { m_params->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1670,10 +1554,6 @@ size_t cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::get_initial_size()
 bool cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1713,11 +1593,7 @@ bool cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::init()
         return false;
     }
     m_local_master = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1795,14 +1671,10 @@ bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_iface_operation = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1885,16 +1757,12 @@ bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_RESPONSE::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_iface_operation = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     m_success = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1972,14 +1840,10 @@ bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_enable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2062,16 +1926,12 @@ bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_RESPONSE::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_enable = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_success = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2109,12 +1969,8 @@ bool cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVersions) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
     if (!m_parse__) { m_versions->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2152,12 +2008,8 @@ bool cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVersions) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
     if (!m_parse__) { m_versions->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2185,10 +2037,6 @@ size_t cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::get_initial_size()
 bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2235,14 +2083,10 @@ bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVersions) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
     if (!m_parse__) { m_versions->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2321,14 +2165,10 @@ bool cACTION_PLATFORM_ERROR_NOTIFICATION::init()
         return false;
     }
     m_code = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     m_data = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * 256);
+    if (!buffPtrIncrementSafe(sizeof(char)*(256))) { return false; }
     m_data_idx__  = 256;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2467,25 +2307,21 @@ bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::init()
         return false;
     }
     m_iface_name_ap = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_ap_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_iface_name_bh = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * beerocks::message::IFACE_NAME_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
     m_iface_name_bh_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_status_ap = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_status_bh = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_status_bh_wired = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_is_bh_manager = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_status_operational = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2522,11 +2358,7 @@ bool cACTION_PLATFORM_WIFI_CONFIGURATION_UPDATE_REQUEST::init()
         return false;
     }
     m_config_start = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2554,10 +2386,6 @@ size_t cACTION_PLATFORM_WIFI_CONFIGURATION_UPDATE_RESPONSE::get_initial_size()
 bool cACTION_PLATFORM_WIFI_CONFIGURATION_UPDATE_RESPONSE::init()
 {
     if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2597,11 +2425,7 @@ bool cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         return false;
     }
     m_operational = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
@@ -27,6 +27,7 @@ public:
     uint8_t *getBuffPtr();
     uint8_t *getStartBuffPtr();
     size_t getBuffRemainingBytes(void *start = nullptr);
+    bool buffPtrIncrementSafe(size_t length);
     size_t getLen();
     bool isInitialized();
     virtual void class_swap() = 0;

--- a/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
@@ -28,6 +28,7 @@ public:
     uint8_t *getStartBuffPtr();
     size_t getBuffRemainingBytes(void *start = nullptr);
     bool buffPtrIncrementSafe(size_t length);
+
     size_t getLen();
     bool isInitialized();
     virtual void class_swap() = 0;

--- a/framework/tlvf/AutoGenerated/src/BaseClass.cpp
+++ b/framework/tlvf/AutoGenerated/src/BaseClass.cpp
@@ -24,6 +24,23 @@ size_t BaseClass::getBuffRemainingBytes(void *start)
 {
     return (m_buff_len__ - (size_t)(((uint8_t *)(start ? start : m_buff_ptr__)) - ((uint8_t *)m_buff__)));
 }
+
 size_t BaseClass::getLen() { return (size_t)((uint8_t *)m_buff_ptr__ - (uint8_t *)m_buff__); }
 
 bool BaseClass::isInitialized() { return m_init_succeeded; }
+
+/**
+ * @brief Increments m_buff_ptr__ pointer while avoiding out-of-bounds accesses.
+
+ * @param length size to increment by.
+ * @return true if incrementation is possible.
+ * @return false if incrementation is not possible and the process should be halted to avoid a segfault.
+ */
+bool BaseClass::buffPtrIncrementSafe(size_t length)
+{
+    if (getBuffRemainingBytes() <= length) {
+        return false;
+    }
+    m_buff_ptr__ += length;
+    return true;
+}

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -103,7 +103,7 @@ bool cConfigData::alloc_ssid(size_t count) {
     m_multiap_attr = (sWscAttrVendorExtMultiAp *)((uint8_t *)(m_multiap_attr) + len);
     m_ssid_idx__ += count;
     *m_ssid_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -159,34 +159,30 @@ bool cConfigData::init()
     }
     m_ssid_type = (eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_ssid_type = ATTR_SSID;
-    m_buff_ptr__ += sizeof(eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
     m_ssid_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_ssid_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_ssid = (char*)m_buff_ptr__;
     uint16_t ssid_length = *m_ssid_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&ssid_length)); }
     m_ssid_idx__ = ssid_length;
-    m_buff_ptr__ += sizeof(char)*(ssid_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(ssid_length))) { return false; }
     m_authentication_type_attr = (sWscAttrAuthenticationType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrAuthenticationType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrAuthenticationType))) { return false; }
     if (!m_parse__) { m_authentication_type_attr->struct_init(); }
     m_encryption_type_attr = (sWscAttrEncryptionType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrEncryptionType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrEncryptionType))) { return false; }
     if (!m_parse__) { m_encryption_type_attr->struct_init(); }
     m_network_key_attr = (sWscAttrNetworkKey*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrNetworkKey) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrNetworkKey))) { return false; }
     if (!m_parse__) { m_network_key_attr->struct_init(); }
     m_bssid_attr = (sWscAttrBssid*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrBssid) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrBssid))) { return false; }
     if (!m_parse__) { m_bssid_attr->struct_init(); }
     m_multiap_attr = (sWscAttrVendorExtMultiAp*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sWscAttrVendorExtMultiAp) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrVendorExtMultiAp))) { return false; }
     if (!m_parse__) { m_multiap_attr->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -305,7 +301,7 @@ bool cWscAttrEncryptedSettings::alloc_encrypted_settings(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_encrypted_settings_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -333,12 +329,12 @@ bool cWscAttrEncryptedSettings::init()
     }
     m_type = (eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_type = eWscAttributes::ATTR_ENCR_SETTINGS;
-    m_buff_ptr__ += sizeof(eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_iv = (char*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(char) * WSC_ENCRYPTED_SETTINGS_IV_LENGTH);
+    if (!buffPtrIncrementSafe(sizeof(char)*(WSC_ENCRYPTED_SETTINGS_IV_LENGTH))) { return false; }
     m_iv_idx__  = WSC_ENCRYPTED_SETTINGS_IV_LENGTH;
     if (!m_parse__) {
         if (m_length) { (*m_length) += (sizeof(char) * WSC_ENCRYPTED_SETTINGS_IV_LENGTH); }
@@ -349,11 +345,7 @@ bool cWscAttrEncryptedSettings::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_encrypted_settings_idx__ = len/sizeof(char);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
@@ -76,25 +76,21 @@ bool cCmduHeader::init()
     }
     m_message_version = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_message_version = 0x0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_reserved = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_reserved = 0x0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_message_type = (eMessageType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eMessageType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eMessageType))) { return false; }
     m_message_id = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_message_id = 0x0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_fragment_id = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_fragment_id = 0x0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_flags = (sFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sFlags))) { return false; }
     if (!m_parse__) { m_flags->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -68,7 +68,7 @@ bool tlv1905NeighborDevice::alloc_mac_al_1905_device(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_mac_al_1905_device_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_mac_al_1905_device_idx__ - count; i < m_mac_al_1905_device_idx__; i++) { m_mac_al_1905_device[i].struct_init(); }
@@ -102,12 +102,12 @@ bool tlv1905NeighborDevice::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_1905_NEIGHBOR_DEVICE;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_mac_local_iface = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_local_iface->struct_init(); }
     m_mac_al_1905_device = (sMacAl1905Device*)m_buff_ptr__;
@@ -116,11 +116,7 @@ bool tlv1905NeighborDevice::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_mac_al_1905_device_idx__ = len/sizeof(sMacAl1905Device);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -60,18 +60,14 @@ bool tlvAlMacAddressType::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AL_MAC_ADDRESS_TYPE;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_AL_MAC_ADDRESS_TYPE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -59,17 +59,13 @@ bool tlvAutoconfigFreqBand::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AUTOCONFIG_FREQ_BAND;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_value = (eValue*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eValue) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_AUTOCONFIG_FREQ_BAND) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -95,7 +95,7 @@ bool tlvDeviceBridgingCapability::add_bridging_tuples_list(std::shared_ptr<cMacL
     if (!m_parse__) { (*m_bridging_tuples_list_length)++; }
     size_t len = ptr->getLen();
     m_bridging_tuples_list_vector.push_back(ptr);
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -126,13 +126,13 @@ bool tlvDeviceBridgingCapability::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_bridging_tuples_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_bridging_tuples_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_bridging_tuples_list = (cMacList*)m_buff_ptr__;
     uint8_t bridging_tuples_list_length = *m_bridging_tuples_list_length;
@@ -149,10 +149,6 @@ bool tlvDeviceBridgingCapability::init()
         }
         // swap back since bridging_tuples_list will be swapped as part of the whole class swap
         bridging_tuples_list->class_swap();
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
@@ -210,7 +206,7 @@ bool cMacList::alloc_mac_list(size_t count) {
     }
     m_mac_list_idx__ += count;
     *m_mac_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if (!m_parse__) { 
         for (size_t i = m_mac_list_idx__ - count; i < m_mac_list_idx__; i++) { m_mac_list[i].struct_init(); }
     }
@@ -239,15 +235,11 @@ bool cMacList::init()
     }
     m_mac_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_mac_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_mac_list = (sMacAddr*)m_buff_ptr__;
     uint8_t mac_list_length = *m_mac_list_length;
     m_mac_list_idx__ = mac_list_length;
-    m_buff_ptr__ += sizeof(sMacAddr)*(mac_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(mac_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -73,7 +73,7 @@ bool tlvDeviceInformation::alloc_info(size_t count) {
     }
     m_info_idx__ += count;
     *m_info_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_info_idx__ - count; i < m_info_idx__; i++) { m_info[i].struct_init(); }
@@ -108,26 +108,22 @@ bool tlvDeviceInformation::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_INFORMATION;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
     m_info_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_info_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_info = (sInfo*)m_buff_ptr__;
     uint8_t info_length = *m_info_length;
     m_info_idx__ = info_length;
-    m_buff_ptr__ += sizeof(sInfo)*(info_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sInfo)*(info_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_DEVICE_INFORMATION) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -54,14 +54,10 @@ bool tlvEndOfMessage::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_END_OF_MESSAGE;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_END_OF_MESSAGE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -70,24 +70,20 @@ bool tlvLinkMetricQuery::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_QUERY;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_neighbor_type = (eNeighborType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eNeighborType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eNeighborType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eNeighborType); }
     m_mac_al_1905_device = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_al_1905_device->struct_init(); }
     m_link_metrics = (eLinkMetricsType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eLinkMetricsType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eLinkMetricsType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eLinkMetricsType); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_LINK_METRIC_QUERY) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -59,17 +59,13 @@ bool tlvLinkMetricResultCode::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_RESULT_CODE;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_value = (eValue*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eValue) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_LINK_METRIC_RESULT_CODE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -60,18 +60,14 @@ bool tlvMacAddress::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_MAC_ADDRESS;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_MAC_ADDRESS) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -68,7 +68,7 @@ bool tlvNon1905neighborDeviceList::alloc_mac_non_1905_device(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_mac_non_1905_device_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_mac_non_1905_device_idx__ - count; i < m_mac_non_1905_device_idx__; i++) { m_mac_non_1905_device[i].struct_init(); }
@@ -102,12 +102,12 @@ bool tlvNon1905neighborDeviceList::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_mac_local_iface = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_local_iface->struct_init(); }
     m_mac_non_1905_device = (sMacAddr*)m_buff_ptr__;
@@ -116,11 +116,7 @@ bool tlvNon1905neighborDeviceList::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_mac_non_1905_device_idx__ = len/sizeof(sMacAddr);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -69,7 +69,7 @@ bool tlvPushButtonEventNotification::alloc_media_type_list(size_t count) {
     }
     m_media_type_list_idx__ += count;
     *m_media_type_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_media_type_list_idx__ - count; i < m_media_type_list_idx__; i++) { m_media_type_list[i].struct_init(); }
@@ -102,22 +102,18 @@ bool tlvPushButtonEventNotification::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_media_type_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_media_type_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_media_type_list = (sMediaType*)m_buff_ptr__;
     uint8_t media_type_list_length = *m_media_type_list_length;
     m_media_type_list_idx__ = media_type_list_length;
-    m_buff_ptr__ += sizeof(sMediaType)*(media_type_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sMediaType)*(media_type_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -78,29 +78,25 @@ bool tlvPushButtonJoinNotification::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_al_mac_notification_src = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_notification_src->struct_init(); }
     m_mid_of_the_notification = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_transmitter_iface_mac_of_new_device_joined = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_transmitter_iface_mac_of_new_device_joined->struct_init(); }
     m_iface_mac_of_new_device_joined = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_iface_mac_of_new_device_joined->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -72,7 +72,7 @@ bool tlvReceiverLinkMetric::alloc_interface_pair_info(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_interface_pair_info_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_interface_pair_info_idx__ - count; i < m_interface_pair_info_idx__; i++) { m_interface_pair_info[i].struct_init(); }
@@ -108,16 +108,16 @@ bool tlvReceiverLinkMetric::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_RECEIVER_LINK_METRIC;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_al_mac_of_the_device_that_transmits = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_device_that_transmits->struct_init(); }
     m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
@@ -126,11 +126,7 @@ bool tlvReceiverLinkMetric::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_interface_pair_info_idx__ = len/sizeof(sInterfacePairInfo);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -59,17 +59,13 @@ bool tlvSearchedRole::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SEARCHED_ROLE;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_value = (eValue*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eValue) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_SEARCHED_ROLE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -59,17 +59,13 @@ bool tlvSupportedFreqBand::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_FREQ_BAND;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_value = (eValue*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eValue) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_SUPPORTED_FREQ_BAND) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -59,17 +59,13 @@ bool tlvSupportedRole::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_ROLE;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_value = (eValue*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eValue) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_SUPPORTED_ROLE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -72,7 +72,7 @@ bool tlvTransmitterLinkMetric::alloc_interface_pair_info(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_interface_pair_info_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_interface_pair_info_idx__ - count; i < m_interface_pair_info_idx__; i++) { m_interface_pair_info[i].struct_init(); }
@@ -108,16 +108,16 @@ bool tlvTransmitterLinkMetric::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_TRANSMITTER_LINK_METRIC;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_al_mac_of_the_device_that_transmits = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_device_that_transmits->struct_init(); }
     m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
@@ -126,11 +126,7 @@ bool tlvTransmitterLinkMetric::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_interface_pair_info_idx__ = len/sizeof(sInterfacePairInfo);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -60,17 +60,13 @@ bool tlvVendorSpecific::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_VENDOR_SPECIFIC;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0x3;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_vendor_oui = (sVendorOUI*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sVendorOUI) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sVendorOUI))) { return false; }
     if (!m_parse__) { m_vendor_oui->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -161,7 +161,7 @@ bool tlvWscM1::alloc_manufacturer(size_t count) {
     m_version2_attr = (WSC::sWscAttrVersion2 *)((uint8_t *)(m_version2_attr) + len);
     m_manufacturer_idx__ += count;
     *m_manufacturer_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -247,7 +247,7 @@ bool tlvWscM1::alloc_model_name(size_t count) {
     m_version2_attr = (WSC::sWscAttrVersion2 *)((uint8_t *)(m_version2_attr) + len);
     m_model_name_idx__ += count;
     *m_model_name_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -330,7 +330,7 @@ bool tlvWscM1::alloc_model_number(size_t count) {
     m_version2_attr = (WSC::sWscAttrVersion2 *)((uint8_t *)(m_version2_attr) + len);
     m_model_number_idx__ += count;
     *m_model_number_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -410,7 +410,7 @@ bool tlvWscM1::alloc_serial_number(size_t count) {
     m_version2_attr = (WSC::sWscAttrVersion2 *)((uint8_t *)(m_version2_attr) + len);
     m_serial_number_idx__ += count;
     *m_serial_number_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -490,7 +490,7 @@ bool tlvWscM1::alloc_device_name(size_t count) {
     m_version2_attr = (WSC::sWscAttrVersion2 *)((uint8_t *)(m_version2_attr) + len);
     m_device_name_idx__ += count;
     *m_device_name_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -596,151 +596,147 @@ bool tlvWscM1::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_version_attr = (WSC::sWscAttrVersion*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrVersion) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion); }
     if (!m_parse__) { m_version_attr->struct_init(); }
     m_message_type_attr = (WSC::sWscAttrMessageType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrMessageType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMessageType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMessageType); }
     if (!m_parse__) { m_message_type_attr->struct_init(); }
     m_uuid_e_attr = (WSC::sWscAttrUuidE*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrUuidE) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrUuidE))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrUuidE); }
     if (!m_parse__) { m_uuid_e_attr->struct_init(); }
     m_mac_attr = (WSC::sWscAttrMac*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrMac) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMac))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMac); }
     if (!m_parse__) { m_mac_attr->struct_init(); }
     m_enrolee_nonce_attr = (WSC::sWscAttrEnroleeNonce*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrEnroleeNonce) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnroleeNonce); }
     if (!m_parse__) { m_enrolee_nonce_attr->struct_init(); }
     m_public_key_attr = (WSC::sWscAttrPublicKey*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrPublicKey) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPublicKey); }
     if (!m_parse__) { m_public_key_attr->struct_init(); }
     m_authentication_type_flags_attr = (WSC::sWscAttrAuthenticationTypeFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrAuthenticationTypeFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticationTypeFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticationTypeFlags); }
     if (!m_parse__) { m_authentication_type_flags_attr->struct_init(); }
     m_encryption_type_flags_attr = (WSC::sWscAttrEncryptionTypeFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrEncryptionTypeFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEncryptionTypeFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEncryptionTypeFlags); }
     if (!m_parse__) { m_encryption_type_flags_attr->struct_init(); }
     m_connection_type_flags_attr = (WSC::sWscAttrConnectionTypeFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrConnectionTypeFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConnectionTypeFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConnectionTypeFlags); }
     if (!m_parse__) { m_connection_type_flags_attr->struct_init(); }
     m_configuration_methods_attr = (WSC::sWscAttrConfigurationMethods*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrConfigurationMethods) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationMethods))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationMethods); }
     if (!m_parse__) { m_configuration_methods_attr->struct_init(); }
     m_wsc_state_attr = (WSC::sWscAttrWscState*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrWscState) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrWscState))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrWscState); }
     if (!m_parse__) { m_wsc_state_attr->struct_init(); }
     m_manufacturer_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_type = WSC::ATTR_MANUFACTURER;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_manufacturer_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
-    m_buff_ptr__ += sizeof(char)*(manufacturer_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(manufacturer_length))) { return false; }
     m_model_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_type = WSC::ATTR_MODEL_NAME;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
-    m_buff_ptr__ += sizeof(char)*(model_name_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(model_name_length))) { return false; }
     m_model_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_type = WSC::ATTR_MODEL_NUMBER;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
-    m_buff_ptr__ += sizeof(char)*(model_number_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(model_number_length))) { return false; }
     m_serial_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_type = WSC::ATTR_SERIAL_NUMBER;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_serial_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
-    m_buff_ptr__ += sizeof(char)*(serial_number_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(serial_number_length))) { return false; }
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrPrimaryDeviceType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPrimaryDeviceType); }
     if (!m_parse__) { m_primary_device_type_attr->struct_init(); }
     m_device_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_device_name_type = WSC::ATTR_DEV_NAME;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_device_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_device_name_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_device_name = (char*)m_buff_ptr__;
     uint16_t device_name_length = *m_device_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
     m_device_name_idx__ = device_name_length;
-    m_buff_ptr__ += sizeof(char)*(device_name_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(device_name_length))) { return false; }
     m_rf_bands_attr = (WSC::sWscAttrRfBands*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrRfBands) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRfBands); }
     if (!m_parse__) { m_rf_bands_attr->struct_init(); }
     m_association_state_attr = (WSC::sWscAttrAssociationState*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrAssociationState) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAssociationState))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAssociationState); }
     if (!m_parse__) { m_association_state_attr->struct_init(); }
     m_device_password_id_attr = (WSC::sWscAttrDevicePasswordID*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrDevicePasswordID) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrDevicePasswordID))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrDevicePasswordID); }
     if (!m_parse__) { m_device_password_id_attr->struct_init(); }
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrConfigurationError) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationError))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationError); }
     if (!m_parse__) { m_configuration_error_attr->struct_init(); }
     m_os_version_attr = (WSC::sWscAttrOsVersion*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrOsVersion) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrOsVersion))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrOsVersion); }
     if (!m_parse__) { m_os_version_attr->struct_init(); }
     m_version2_attr = (WSC::sWscAttrVersion2*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrVersion2) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion2))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion2); }
     if (!m_parse__) { m_version2_attr->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_WSC) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -156,7 +156,7 @@ bool tlvWscM2::alloc_manufacturer(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_manufacturer_idx__ += count;
     *m_manufacturer_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -241,7 +241,7 @@ bool tlvWscM2::alloc_model_name(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_model_name_idx__ += count;
     *m_model_name_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -323,7 +323,7 @@ bool tlvWscM2::alloc_model_number(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_model_number_idx__ += count;
     *m_model_number_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -402,7 +402,7 @@ bool tlvWscM2::alloc_serial_number(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_serial_number_idx__ += count;
     *m_serial_number_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -478,7 +478,7 @@ bool tlvWscM2::add_encrypted_settings(std::shared_ptr<WSC::cWscAttrEncryptedSett
     size_t len = ptr->getLen();
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len - ptr->get_initial_size());
     m_encrypted_settings_ptr = ptr;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -562,128 +562,128 @@ bool tlvWscM2::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
-    m_buff_ptr__ += sizeof(eTlvType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_version_attr = (WSC::sWscAttrVersion*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrVersion) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion); }
     if (!m_parse__) { m_version_attr->struct_init(); }
     m_message_type_attr = (WSC::sWscAttrMessageType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrMessageType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMessageType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMessageType); }
     if (!m_parse__) { m_message_type_attr->struct_init(); }
     m_enrolee_nonce_attr = (WSC::sWscAttrEnroleeNonce*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrEnroleeNonce) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnroleeNonce); }
     if (!m_parse__) { m_enrolee_nonce_attr->struct_init(); }
     m_registrar_nonce_attr = (WSC::sWscAttrRegistrarNonce*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrRegistrarNonce) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRegistrarNonce))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRegistrarNonce); }
     if (!m_parse__) { m_registrar_nonce_attr->struct_init(); }
     m_uuid_r_attr = (WSC::sWscAttrUuidR*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrUuidR) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrUuidR))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrUuidR); }
     if (!m_parse__) { m_uuid_r_attr->struct_init(); }
     m_public_key_attr = (WSC::sWscAttrPublicKey*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrPublicKey) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPublicKey); }
     if (!m_parse__) { m_public_key_attr->struct_init(); }
     m_authentication_type_flags_attr = (WSC::sWscAttrAuthenticationTypeFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrAuthenticationTypeFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticationTypeFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticationTypeFlags); }
     if (!m_parse__) { m_authentication_type_flags_attr->struct_init(); }
     m_encryption_type_flags_attr = (WSC::sWscAttrEncryptionTypeFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrEncryptionTypeFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEncryptionTypeFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEncryptionTypeFlags); }
     if (!m_parse__) { m_encryption_type_flags_attr->struct_init(); }
     m_connection_type_flags_attr = (WSC::sWscAttrConnectionTypeFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrConnectionTypeFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConnectionTypeFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConnectionTypeFlags); }
     if (!m_parse__) { m_connection_type_flags_attr->struct_init(); }
     m_configuration_methods_attr = (WSC::sWscAttrConfigurationMethods*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrConfigurationMethods) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationMethods))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationMethods); }
     if (!m_parse__) { m_configuration_methods_attr->struct_init(); }
     m_manufacturer_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_type = WSC::ATTR_MANUFACTURER;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_manufacturer_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
-    m_buff_ptr__ += sizeof(char)*(manufacturer_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(manufacturer_length))) { return false; }
     m_model_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_type = WSC::ATTR_MODEL_NAME;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
-    m_buff_ptr__ += sizeof(char)*(model_name_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(model_name_length))) { return false; }
     m_model_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_type = WSC::ATTR_MODEL_NUMBER;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
-    m_buff_ptr__ += sizeof(char)*(model_number_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(model_number_length))) { return false; }
     m_serial_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_type = WSC::ATTR_SERIAL_NUMBER;
-    m_buff_ptr__ += sizeof(WSC::eWscAttributes) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_serial_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
-    m_buff_ptr__ += sizeof(char)*(serial_number_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(serial_number_length))) { return false; }
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrPrimaryDeviceType) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPrimaryDeviceType); }
     if (!m_parse__) { m_primary_device_type_attr->struct_init(); }
     m_rf_bands_attr = (WSC::sWscAttrRfBands*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrRfBands) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRfBands); }
     if (!m_parse__) { m_rf_bands_attr->struct_init(); }
     m_association_state_attr = (WSC::sWscAttrAssociationState*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrAssociationState) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAssociationState))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAssociationState); }
     if (!m_parse__) { m_association_state_attr->struct_init(); }
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrConfigurationError) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationError))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationError); }
     if (!m_parse__) { m_configuration_error_attr->struct_init(); }
     m_device_password_id_attr = (WSC::sWscAttrDevicePasswordID*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrDevicePasswordID) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrDevicePasswordID))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrDevicePasswordID); }
     if (!m_parse__) { m_device_password_id_attr->struct_init(); }
     m_os_version_attr = (WSC::sWscAttrOsVersion*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrOsVersion) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrOsVersion))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrOsVersion); }
     if (!m_parse__) { m_os_version_attr->struct_init(); }
     m_version2_attr = (WSC::sWscAttrVersion2*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrVersion2) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion2))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion2); }
     if (!m_parse__) { m_version2_attr->struct_init(); }
     m_encrypted_settings = (WSC::cWscAttrEncryptedSettings*)m_buff_ptr__;
@@ -701,13 +701,9 @@ bool tlvWscM2::init()
         encrypted_settings->class_swap();
     }
     m_authenticator = (WSC::sWscAttrAuthenticator*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(WSC::sWscAttrAuthenticator) * 1;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticator))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticator); }
     if (!m_parse__) { m_authenticator->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_WSC) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -77,7 +77,7 @@ bool tlvTestVarList::alloc_simple_list(size_t count) {
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
     m_simple_list_idx__ += count;
     *m_simple_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -156,7 +156,7 @@ bool tlvTestVarList::alloc_test_string(size_t count) {
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
     m_test_string_idx__ += count;
     *m_test_string_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -229,7 +229,7 @@ bool tlvTestVarList::add_complex_list(std::shared_ptr<cInner> ptr) {
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len - ptr->get_initial_size());
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len - ptr->get_initial_size());
     m_complex_list_vector.push_back(ptr);
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -280,7 +280,7 @@ bool tlvTestVarList::add_var1(std::shared_ptr<cInner> ptr) {
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len - ptr->get_initial_size());
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len - ptr->get_initial_size());
     m_var1_ptr = ptr;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -356,7 +356,7 @@ bool tlvTestVarList::add_unknown_length_list(std::shared_ptr<cInner> ptr) {
     m_unknown_length_list_idx__++;
     size_t len = ptr->getLen();
     m_unknown_length_list_vector.push_back(ptr);
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -401,29 +401,29 @@ bool tlvTestVarList::init()
     }
     m_type = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_type = 0x1;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_var0 = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_simple_list_length = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_simple_list = (uint16_t*)m_buff_ptr__;
     uint8_t simple_list_length = *m_simple_list_length;
     m_simple_list_idx__ = simple_list_length;
-    m_buff_ptr__ += sizeof(uint16_t)*(simple_list_length);
+    if (!buffPtrIncrementSafe(sizeof(uint16_t)*(simple_list_length))) { return false; }
     m_test_string_length = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_test_string = (char*)m_buff_ptr__;
     uint8_t test_string_length = *m_test_string_length;
     m_test_string_idx__ = test_string_length;
-    m_buff_ptr__ += sizeof(char)*(test_string_length);
+    if (!buffPtrIncrementSafe(sizeof(char)*(test_string_length))) { return false; }
     m_complex_list_length = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_complex_list = (cInner*)m_buff_ptr__;
     uint8_t complex_list_length = *m_complex_list_length;
@@ -456,7 +456,7 @@ bool tlvTestVarList::init()
         var1->class_swap();
     }
     m_var2 = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint32_t); }
     m_unknown_length_list = (cInner*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -481,10 +481,6 @@ bool tlvTestVarList::init()
             unknown_length_list->class_swap();
             len -= unknown_length_list->getLen();
         }
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
@@ -551,7 +547,7 @@ bool cInner::alloc_list(size_t count) {
     m_unknown_length_list_inner = (char *)((uint8_t *)(m_unknown_length_list_inner) + len);
     m_list_idx__ += count;
     *m_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -616,7 +612,7 @@ bool cInner::alloc_unknown_length_list_inner(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_unknown_length_list_inner_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -646,19 +642,19 @@ bool cInner::init()
     }
     m_type = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_type = 0x1;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_list_length = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_list = (uint8_t*)m_buff_ptr__;
     uint8_t list_length = *m_list_length;
     m_list_idx__ = list_length;
-    m_buff_ptr__ += sizeof(uint8_t)*(list_length);
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(list_length))) { return false; }
     m_var1 = (uint32_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint32_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint32_t); }
     m_unknown_length_list_inner = (char*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -666,11 +662,7 @@ bool cInner::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_unknown_length_list_inner_idx__ = len/sizeof(char);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
@@ -60,18 +60,14 @@ bool tlvApCapability::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_CAPABILITY;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_value = (sValue*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sValue) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sValue))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sValue); }
     if (!m_parse__) { m_value->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_CAPABILITY) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
@@ -69,7 +69,7 @@ bool tlvApMetricQuery::alloc_bssid_list(size_t count) {
     }
     m_bssid_list_idx__ += count;
     *m_bssid_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_bssid_list_idx__ - count; i < m_bssid_list_idx__; i++) { m_bssid_list[i].struct_init(); }
@@ -102,22 +102,18 @@ bool tlvApMetricQuery::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_METRIC_QUERY;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_bssid_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_bssid_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_bssid_list = (sMacAddr*)m_buff_ptr__;
     uint8_t bssid_list_length = *m_bssid_list_length;
     m_bssid_list_idx__ = bssid_list_length;
-    m_buff_ptr__ += sizeof(sMacAddr)*(bssid_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(bssid_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_METRIC_QUERY) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -103,7 +103,7 @@ bool tlvApRadioBasicCapabilities::add_operating_classes_info_list(std::shared_pt
     if (!m_parse__) { (*m_operating_classes_info_list_length)++; }
     size_t len = ptr->getLen();
     m_operating_classes_info_list_vector.push_back(ptr);
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -137,20 +137,20 @@ bool tlvApRadioBasicCapabilities::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_maximum_number_of_bsss_supported = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_info_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_info_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_info_list = (cOperatingClassesInfo*)m_buff_ptr__;
     uint8_t operating_classes_info_list_length = *m_operating_classes_info_list_length;
@@ -167,10 +167,6 @@ bool tlvApRadioBasicCapabilities::init()
         }
         // swap back since operating_classes_info_list will be swapped as part of the whole class swap
         operating_classes_info_list->class_swap();
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
@@ -235,7 +231,7 @@ bool cOperatingClassesInfo::alloc_statically_non_operable_channels_list(size_t c
     }
     m_statically_non_operable_channels_list_idx__ += count;
     *m_statically_non_operable_channels_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -259,20 +255,16 @@ bool cOperatingClassesInfo::init()
         return false;
     }
     m_operating_class = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_maximum_transmit_power_dbm = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_statically_non_operable_channels_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_statically_non_operable_channels_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_statically_non_operable_channels_list = (uint8_t*)m_buff_ptr__;
     uint8_t statically_non_operable_channels_list_length = *m_statically_non_operable_channels_list_length;
     m_statically_non_operable_channels_list_idx__ = statically_non_operable_channels_list_length;
-    m_buff_ptr__ += sizeof(uint8_t)*(statically_non_operable_channels_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(statically_non_operable_channels_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -60,18 +60,14 @@ bool tlvApRadioIdentifier::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -99,7 +99,7 @@ bool tlvChannelPreference::add_operating_classes_list(std::shared_ptr<cPreferenc
     if (!m_parse__) { (*m_operating_classes_list_length)++; }
     size_t len = ptr->getLen();
     m_operating_classes_list_vector.push_back(ptr);
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -132,17 +132,17 @@ bool tlvChannelPreference::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_PREFERENCE;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_list = (cPreferenceOperatingClasses*)m_buff_ptr__;
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
@@ -159,10 +159,6 @@ bool tlvChannelPreference::init()
         }
         // swap back since operating_classes_list will be swapped as part of the whole class swap
         operating_classes_list->class_swap();
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
@@ -224,7 +220,7 @@ bool cPreferenceOperatingClasses::alloc_channel_list(size_t count) {
     m_flags = (sFlags *)((uint8_t *)(m_flags) + len);
     m_channel_list_idx__ += count;
     *m_channel_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     return true;
 }
 
@@ -253,21 +249,17 @@ bool cPreferenceOperatingClasses::init()
         return false;
     }
     m_operating_class = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_channel_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_channel_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_channel_list = (uint8_t*)m_buff_ptr__;
     uint8_t channel_list_length = *m_channel_list_length;
     m_channel_list_idx__ = channel_list_length;
-    m_buff_ptr__ += sizeof(uint8_t)*(channel_list_length);
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(channel_list_length))) { return false; }
     m_flags = (sFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sFlags))) { return false; }
     if (!m_parse__) { m_flags->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
@@ -65,21 +65,17 @@ bool tlvChannelSelectionResponse::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_response_code = (eResponseCode*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eResponseCode) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eResponseCode))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eResponseCode); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -67,7 +67,7 @@ bool tlvHigherLayerData::alloc_payload(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_payload_idx__ += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -94,12 +94,12 @@ bool tlvHigherLayerData::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_HIGHER_LAYER_DATA;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_protocol = (eProtocol*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(eProtocol) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eProtocol))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eProtocol); }
     m_payload = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -107,11 +107,7 @@ bool tlvHigherLayerData::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_payload_idx__ = len/sizeof(uint8_t);
-        m_buff_ptr__ += len;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
+        if (!buffPtrIncrementSafe(len)) { return false; }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -74,7 +74,7 @@ bool tlvOperatingChannelReport::alloc_operating_classes_list(size_t count) {
     m_current_transmit_power = (int8_t *)((uint8_t *)(m_current_transmit_power) + len);
     m_operating_classes_list_idx__ += count;
     *m_operating_classes_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_operating_classes_list_idx__ - count; i < m_operating_classes_list_idx__; i++) { m_operating_classes_list[i].struct_init(); }
@@ -114,29 +114,25 @@ bool tlvOperatingChannelReport::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_list = (sOperatingClasses*)m_buff_ptr__;
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
     m_operating_classes_list_idx__ = operating_classes_list_length;
-    m_buff_ptr__ += sizeof(sOperatingClasses)*(operating_classes_list_length);
+    if (!buffPtrIncrementSafe(sizeof(sOperatingClasses)*(operating_classes_list_length))) { return false; }
     m_current_transmit_power = (int8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(int8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(int8_t); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -99,7 +99,7 @@ bool tlvRadioOperationRestriction::add_operating_classes_list(std::shared_ptr<cR
     if (!m_parse__) { (*m_operating_classes_list_length)++; }
     size_t len = ptr->getLen();
     m_operating_classes_list_vector.push_back(ptr);
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -132,17 +132,17 @@ bool tlvRadioOperationRestriction::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_list = (cRestrictedOperatingClasses*)m_buff_ptr__;
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
@@ -159,10 +159,6 @@ bool tlvRadioOperationRestriction::init()
         }
         // swap back since operating_classes_list will be swapped as part of the whole class swap
         operating_classes_list->class_swap();
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
@@ -224,7 +220,7 @@ bool cRestrictedOperatingClasses::alloc_channel_list(size_t count) {
     }
     m_channel_list_idx__ += count;
     *m_channel_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if (!m_parse__) { 
         for (size_t i = m_channel_list_idx__ - count; i < m_channel_list_idx__; i++) { m_channel_list[i].struct_init(); }
     }
@@ -253,18 +249,14 @@ bool cRestrictedOperatingClasses::init()
         return false;
     }
     m_operating_class = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_channel_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_channel_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_channel_list = (sChannelInfo*)m_buff_ptr__;
     uint8_t channel_list_length = *m_channel_list_length;
     m_channel_list_idx__ = channel_list_length;
-    m_buff_ptr__ += sizeof(sChannelInfo)*(channel_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sChannelInfo)*(channel_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -69,7 +69,7 @@ bool tlvSearchedService::alloc_searched_service_list(size_t count) {
     }
     m_searched_service_list_idx__ += count;
     *m_searched_service_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -96,22 +96,18 @@ bool tlvSearchedService::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SEARCHED_SERVICE;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_searched_service_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_searched_service_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_searched_service_list = (eSearchedService*)m_buff_ptr__;
     uint8_t searched_service_list_length = *m_searched_service_list_length;
     m_searched_service_list_idx__ = searched_service_list_length;
-    m_buff_ptr__ += sizeof(eSearchedService)*(searched_service_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(eSearchedService)*(searched_service_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
@@ -77,29 +77,25 @@ bool tlvSteeringBTMReport::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_STEERING_BTM_REPORT;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_sta_mac = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_sta_mac->struct_init(); }
     m_btm_status_code = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_target_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_target_bssid->struct_init(); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_STEERING_BTM_REPORT) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
@@ -87,7 +87,7 @@ bool tlvSteeringRequest::alloc_sta_list(size_t count) {
     m_target_bssid_list = (sTargetBssidInfo *)((uint8_t *)(m_target_bssid_list) + len);
     m_sta_list_idx__ += count;
     *m_sta_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_sta_list_idx__ - count; i < m_sta_list_idx__; i++) { m_sta_list[i].struct_init(); }
@@ -131,7 +131,7 @@ bool tlvSteeringRequest::alloc_target_bssid_list(size_t count) {
     }
     m_target_bssid_list_idx__ += count;
     *m_target_bssid_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_target_bssid_list_idx__ - count; i < m_target_bssid_list_idx__; i++) { m_target_bssid_list[i].struct_init(); }
@@ -176,43 +176,39 @@ bool tlvSteeringRequest::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_STEERING_REQUEST;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_request_flags = (sRequestFlags*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sRequestFlags) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sRequestFlags))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sRequestFlags); }
     if (!m_parse__) { m_request_flags->struct_init(); }
     m_steering_opportunity_window_sec = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_btm_disassociation_timer = (uint16_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_sta_list_length = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_sta_list = (sMacAddr*)m_buff_ptr__;
     uint8_t sta_list_length = *m_sta_list_length;
     m_sta_list_idx__ = sta_list_length;
-    m_buff_ptr__ += sizeof(sMacAddr)*(sta_list_length);
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(sta_list_length))) { return false; }
     m_target_bssid_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_target_bssid_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_target_bssid_list = (sTargetBssidInfo*)m_buff_ptr__;
     uint8_t target_bssid_list_length = *m_target_bssid_list_length;
     m_target_bssid_list_idx__ = target_bssid_list_length;
-    m_buff_ptr__ += sizeof(sTargetBssidInfo)*(target_bssid_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(sTargetBssidInfo)*(target_bssid_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_STEERING_REQUEST) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -69,7 +69,7 @@ bool tlvSupportedService::alloc_supported_service_list(size_t count) {
     }
     m_supported_service_list_idx__ += count;
     *m_supported_service_list_length += count;
-    m_buff_ptr__ += len;
+    if (!buffPtrIncrementSafe(len)) { return false; }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -96,22 +96,18 @@ bool tlvSupportedService::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SUPPORTED_SERVICE;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_supported_service_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_supported_service_list_length = 0;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_supported_service_list = (eSupportedService*)m_buff_ptr__;
     uint8_t supported_service_list_length = *m_supported_service_list_length;
     m_supported_service_list_idx__ = supported_service_list_length;
-    m_buff_ptr__ += sizeof(eSupportedService)*(supported_service_list_length);
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
+    if (!buffPtrIncrementSafe(sizeof(eSupportedService)*(supported_service_list_length))) { return false; }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
@@ -65,21 +65,17 @@ bool tlvTransmitPowerLimit::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT;
-    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_transmit_power_limit_dbm = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) {

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -24,6 +24,8 @@ public:
     uint8_t *getBuffPtr();
     uint8_t *getStartBuffPtr();
     size_t getBuffRemainingBytes(void *start = nullptr);
+    bool buffPtrIncrementSafe(size_t length);
+
     size_t getLen();
     bool isInitialized();
     virtual void class_swap() = 0;

--- a/framework/tlvf/src/src/BaseClass.cpp
+++ b/framework/tlvf/src/src/BaseClass.cpp
@@ -21,6 +21,23 @@ size_t BaseClass::getBuffRemainingBytes(void *start)
 {
     return (m_buff_len__ - (size_t)(((uint8_t *)(start ? start : m_buff_ptr__)) - ((uint8_t *)m_buff__)));
 }
+
 size_t BaseClass::getLen() { return (size_t)((uint8_t *)m_buff_ptr__ - (uint8_t *)m_buff__); }
 
 bool BaseClass::isInitialized() { return m_init_succeeded; }
+
+/**
+ * @brief Increments m_buff_ptr__ pointer while avoiding out-of-bounds accesses.
+
+ * @param length size to increment by.
+ * @return true if incrementation is possible.
+ * @return false if incrementation is not possible and the process should be halted to avoid a segfault.
+ */
+bool BaseClass::buffPtrIncrementSafe(size_t length)
+{
+    if (getBuffRemainingBytes() <= length) {
+        return false;
+    }
+    m_buff_ptr__ += length;
+    return true;
+}


### PR DESCRIPTION
Currently, a known bug causes the radio agent threads to segfault and
die as a result of receiving an M1 message when expecting an M2 message,
the agents attempt to parse an M2 TLV but if they end up receiving an M1
message.
Upon inspection, this is caused when `m_buff_ptr__` is incremented by
incorrect amounts as a result of the mismatch, causing a segmentation
fault.
**Of course, this issue could come up with other message types so it has to be handled on a larger scale.**
This pull requests implements changes that verify the message parsing process does not cause segmentation faults.
The method of action is the creation of the new `buffPtrIncrementSafe()` method and it's implementation in the relevant files generated by TLVF .

Closes #234 
