### PR TITLE
tools:docker: fix condition check

### DIFF
--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -105,8 +105,7 @@ main() {
     else
         DOCKEROPTS="$DOCKEROPTS -d"
     fi
-
-    if [ -n "$(docker ps -q -l -f name="${NAME}")" ]; then
+    if [ -n "$(docker ps -f name="${NAME}" | grep -w "${NAME}")" ]; then
         info "Container ${NAME} is already running"
         if [ "$FORCE" = "true" ]; then
             run docker container rm -f "$NAME"


### PR DESCRIPTION
The current bug is that when we check if a specific container is already
running, in some cases it returns the wrong answer.

For example, if "repeater1" is already running, the condition returns
true for "repeater".

For that reason, the condition check was changed so now it returns the
right answer.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>