### PR TITLE
Add a test for filling M2 from the database

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3712,8 +3712,6 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             return false;
         }
 
-        // All attributes which are not explicitely set below are set to
-        // default by the TLV factory, see WSC_Attributes.yml
         if (!autoconfig_wsc_add_m1()) {
             LOG(ERROR) << "Failed adding WSC M1 TLV";
             return false;
@@ -5078,6 +5076,8 @@ bool slave_thread::autoconfig_wsc_add_m1()
         return false;
     }
 
+    // All attributes which are not explicitely set below are set to default by the TLV factory,
+    // see WSC_Attributes.yml
     tlvWscM1->mac_attr().data = network_utils::mac_from_string(backhaul_params.bridge_mac);
     // TODO: read manufactured, name, model and device name from BPL
     if (!tlvWscM1->set_manufacturer("Intel"))

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4415,6 +4415,20 @@ bool slave_thread::autoconfig_wsc_parse_m2_encrypted_settings(
 
     // Swap back to host byte order to read and use config_data
     config_data.class_swap();
+
+    // TODO tlvf should check this
+    if (config_data.ssid_length() > WSC::WSC_MAX_SSID_LENGTH) {
+        LOG(INFO) << "SSID too long: " << config_data.ssid_length();
+        return false;
+    }
+    // TODO tlvf should do conversion to std::string
+    if (config_data.ssid_length() == 0)
+        ssid = "";
+    else
+        ssid = std::string(config_data.ssid(), config_data.ssid_length());
+    bssid            = config_data.bssid_attr().data;
+    auth_type        = config_data.authentication_type_attr().data;
+    encr_type        = config_data.encryption_type_attr().data;
     uint8_t bss_type = config_data.multiap_attr().subelement_value;
     LOG(INFO) << "bss_type: " << std::hex << int(bss_type);
     fronthaul = bss_type & WSC::eWscVendorExtSubelementBssType::FRONTHAUL_BSS;
@@ -4424,10 +4438,6 @@ bool slave_thread::autoconfig_wsc_parse_m2_encrypted_settings(
     if (bss_type & WSC::eWscVendorExtSubelementBssType::BACKHAUL_STA) {
         LOG(WARNING) << "Unexpected backhaul STA bit";
     }
-    ssid      = std::string(config_data.ssid(), config_data.ssid_length());
-    bssid     = config_data.bssid_attr().data;
-    auth_type = config_data.authentication_type_attr().data;
-    encr_type = config_data.encryption_type_attr().data;
     LOG(DEBUG) << "KWA (Key Wrap Auth) success";
 
     return true;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -5047,19 +5047,6 @@ bool slave_thread::add_radio_basic_capabilities()
     operationClassesInfo->operating_class()            = operating_class;
     operationClassesInfo->maximum_transmit_power_dbm() = 0;
 
-    // TODO - the number of statically non operable channels can be 0 - meaning it is
-    // an optional variable length list, this is not yet supported in tlvf according to issue #8
-    // for now - lets define only one.
-    if (!operationClassesInfo->alloc_statically_non_operable_channels_list(1)) {
-        LOG(ERROR) << "Allocation statically non operable channels list failed";
-        return false;
-    }
-    // Set Dummy value for non operable channel list
-    auto non_operable_channel =
-        *son::wireless_utils::operating_class_to_channel_set(operating_class).begin();
-    std::get<1>(operationClassesInfo->statically_non_operable_channels_list(0)) =
-        non_operable_channel;
-
     if (!radio_basic_caps->add_operating_classes_info_list(operationClassesInfo)) {
         LOG(ERROR) << "add_operating_classes_info_list failed";
         return false;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -281,6 +281,7 @@ private:
     bool parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool parse_non_intel_join_response(Socket *sd);
     bool handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_autoconfiguration_renew(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool autoconfig_wsc_add_m1();
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -269,7 +269,8 @@ private:
                                                     uint8_t authkey[32], uint8_t keywrapkey[16],
                                                     std::string &ssid, sMacAddr &bssid,
                                                     WSC::eWscAuth &auth_type,
-                                                    WSC::eWscEncr &encr_type);
+                                                    WSC::eWscEncr &encr_type, bool &backhaul,
+                                                    bool &fronthaul, bool &teardown);
     bool autoconfig_wsc_authenticate(std::shared_ptr<ieee1905_1::tlvWscM2> m2, uint8_t authkey[32]);
 
     std::unique_ptr<mapf::encryption::diffie_hellman> dh = nullptr;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -283,6 +283,7 @@ private:
     bool handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_autoconfiguration_renew(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool autoconfig_wsc_add_m1();
+    bool add_radio_basic_capabilities();
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -39,6 +39,22 @@ test_initial_ap_config() {
     check docker exec -it repeater1 sh -c \
         'grep -i -q "Controller configuration (WSC M2 Encrypted Settings)" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
 
+    # Configure the controller and send renew
+    eval send_bml_command "bml_wfa_ca_controller \"DEV_RESET_DEFAULT\"" $redirect
+    eval send_bml_command "bml_wfa_ca_controller \\\"DEV_SET_CONFIG,bss_info1,$mac_agent1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1,bss_info2,$mac_agent1 8x Multi-AP-24G-2 0x0020 0x0008 maprocks2 1 0\\\"" $redirect
+    gw_mac_without_colons="$(printf $mac_gateway | tr -d :)"
+    eval send_bml_command "bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}\"" $redirect
+
+    # Wait a bit for the renew to complete
+    sleep 3
+
+    check docker exec -it repeater1 sh -c \
+        'grep -i -q "ssid: Multi-AP-24G-1, .* fronthaul" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+    check docker exec -it repeater1 sh -c \
+        'grep -i -q "ssid: Multi-AP-24G-2, .* backhaul" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+    check docker exec -it repeater1 sh -c \
+        'grep -i -q "ssid: .* teardown" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
+
     return $check_error
 }
 
@@ -145,6 +161,9 @@ test_init() {
     connmap=$(tempfile)
     trap "rm -f $connmap" EXIT
     docker exec -it gateway ${installdir}/bin/beerocks_cli -c bml_conn_map > "$connmap"
+
+    mac_gateway=$(grep "GW_BRIDGE" "$connmap" | head -1 | awk '{print $5}' | cut -d ',' -f 1)
+    dbg "mac_gateway = ${mac_gateway}"
 
     mac_agent1=$(grep "IRE_BRIDGE" "$connmap" | head -1 | awk '{print $5}' | cut -d ',' -f 1)
     dbg "mac_agent1 = ${mac_agent1}"


### PR DESCRIPTION
To be able to do this test, we need the autoconfig renew message to be handled in the agent, so add that as well.

On the way, some other small issues were found in the agent. These are fixed in separate commits.