### PR TITLE
topology discovery minimal support

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -57,6 +57,7 @@ private:
         bool fConnected, std::shared_ptr<SSlaveSockets> pSocket = nullptr); // cmdu_duplicate
 
     bool send_autoconfig_search_message(std::shared_ptr<SSlaveSockets> soc);
+    bool send_1905_topology_discovery_message();
 
     // cmdu handlers
     bool handle_master_message(ieee1905_1::CmduMessageRx &cmdu_rx,

--- a/controller/src/beerocks/master/beerocks_master_mrouter.cpp
+++ b/controller/src/beerocks/master/beerocks_master_mrouter.cpp
@@ -56,6 +56,7 @@ bool master_mrouter::init()
         ieee1905_1::eMessageType::CHANNEL_PREFERENCE_REPORT_MESSAGE,
         ieee1905_1::eMessageType::CHANNEL_SELECTION_RESPONSE_MESSAGE,
         ieee1905_1::eMessageType::OPERATING_CHANNEL_REPORT_MESSAGE,
+        ieee1905_1::eMessageType::TOPOLOGY_DISCOVERY_MESSAGE,
     }));
 }
 

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -69,7 +69,7 @@ private:
     bool handle_cmdu_1905_channel_selection_response(Socket *sd,
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_operating_channel_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
-
+    bool handle_cmdu_1905_topology_discovery(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool autoconfig_wsc_parse_radio_caps(
         std::string radio_mac, std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps);
     // Autoconfig encryption support

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvMacAddress.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvMacAddress.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
-#include <tuple>
+#include "tlvf/common/sMacAddr.h"
 
 namespace ieee1905_1 {
 
@@ -34,7 +34,7 @@ class tlvMacAddress : public BaseClass
 
         const eTlvType& type();
         const uint16_t& length();
-        std::tuple<bool, uint8_t&> mac(size_t idx);
+        sMacAddr& mac();
         void class_swap();
         static size_t get_initial_size();
 
@@ -42,9 +42,7 @@ class tlvMacAddress : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        uint8_t* m_mac = nullptr;
-        size_t m_mac_idx__ = 0;
-        int m_lock_order_counter__ = 0;
+        sMacAddr* m_mac = nullptr;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -33,18 +33,14 @@ const uint16_t& tlvMacAddress::length() {
     return (const uint16_t&)(*m_length);
 }
 
-std::tuple<bool, uint8_t&> tlvMacAddress::mac(size_t idx) {
-    bool ret_success = ( (m_mac_idx__ > 0) && (m_mac_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
-        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
-    }
-    return std::forward_as_tuple(ret_success, m_mac[ret_idx]);
+sMacAddr& tlvMacAddress::mac() {
+    return (sMacAddr&)(*m_mac);
 }
 
 void tlvMacAddress::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_mac->struct_swap();
 }
 
 size_t tlvMacAddress::get_initial_size()
@@ -52,7 +48,7 @@ size_t tlvMacAddress::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += 6 * sizeof(uint8_t); // mac
+    class_size += sizeof(sMacAddr); // mac
     return class_size;
 }
 
@@ -68,15 +64,10 @@ bool tlvMacAddress::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     m_buff_ptr__ += sizeof(uint16_t) * 1;
-    m_mac = (uint8_t*)m_buff_ptr__;
-    m_buff_ptr__ += (sizeof(uint8_t) * 6);
-    m_mac_idx__  = 6;
-    if (!m_parse__) {
-        if (m_length) { (*m_length) += (sizeof(uint8_t) * 6); }
-        for (size_t i = 0; i < 6; i++){
-            m_mac[i] = 0x0;
-        }
-    }
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(sMacAddr) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_mac->struct_init(); }
     if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -58,8 +58,7 @@ int test_int_len_list()
     memset(tx_buffer, 0, sizeof(tx_buffer));
     {
         auto tlv = tlvMacAddress(tx_buffer, sizeof(tx_buffer), false, true);
-        auto mac = &std::get<1>(tlv.mac(0));
-        std::copy_n(gTlvMacAddress, 6, mac);
+        std::copy_n(gTlvMacAddress, 6, tlv.mac().oct);
         tlv.class_swap(); //finalize
         LOG(DEBUG) << "TX: " << std::endl << dump_buffer(tx_buffer, tlv.getLen());
     }
@@ -68,8 +67,8 @@ int test_int_len_list()
     memcpy(rx_buffer, tx_buffer, sizeof(rx_buffer));
     {
         auto tlv = tlvMacAddress(tx_buffer, sizeof(tx_buffer), true, true);
-        auto mac = &std::get<1>(tlv.mac(0));
-        if (!std::equal(mac, mac + 6, gTlvMacAddress)) {
+        auto mac = tlv.mac();
+        if (!std::equal(mac.oct, mac.oct + 6, gTlvMacAddress)) {
             MAPF_ERR("MAC address in received TLV does not match expected result");
             errors++;
         }

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvMacAddress.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvMacAddress.yaml
@@ -9,8 +9,4 @@ tlvMacAddress:
     _type: eTlvType
     _value_const: TLV_MAC_ADDRESS
   length: uint16_t
-  mac:
-    _type: uint8_t
-    _length: [ 6 ]
-    _value: 0
-
+  mac: sMacAddr


### PR DESCRIPTION
Add minimal topology discovery support in both the agent and controller.
The agent (backhaul manager thread) sends topology discovery after connecting to the controller, and after that every 60 seconds as defined in the 1905.1 specification section 8.2.1.1:
> A 1905.1 management entity shall transmit a topology discovery message
every 60 seconds or if an implementation-specific event occurs (e.g.,
device initialized or an interface is connected).m

The controller is updated to subscribe to the topology discovery message, and a handler is added to it which adds a node to the database in case it does not exist yet. This is done in order to save the socket descriptor of that agent in case autoconfiguration was not yet completed so the controller is unaware of it.
The need for adding the socket to the database comes from the controller certification for testcase 5.3.1 - topology query, where the CTT agent may or may not do autoconfiguration as part of the test  - it was seen that some reference agents do autoconfig and some do not.

Once the node have been added to the database, the controller can send messages to it when instructed to by the UCC application via 1905_send_cmdu CAPI command.

Tested with Broadcomm CTT agent on the certification testbed acting as the Marvell CTT agent (setting the Broadcomm agent in AllInitConfig_MAP.txt and MasterTestInfo.xml causes the test to fail for reasons we don't yet understand, but setting Agent1 to the IP Address of broadcomm works just fine and the test passes.