### PR TITLE
Controller : save metrics data to DB

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -140,6 +140,7 @@ bool main_thread::init()
             ieee1905_1::eMessageType::MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE,
             ieee1905_1::eMessageType::AP_METRICS_QUERY_MESSAGE,
             ieee1905_1::eMessageType::LINK_METRIC_QUERY_MESSAGE,
+            ieee1905_1::eMessageType::COMBINED_INFRASTRUCTURE_METRICS_MESSAGE,
             ieee1905_1::eMessageType::ACK_MESSAGE,
         })) {
         LOG(ERROR) << "Failed to init mapf_bus";
@@ -1625,7 +1626,6 @@ bool main_thread::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
     case ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE: {
         return handle_1905_higher_layer_data_message(cmdu_rx, src_mac);
     }
-
     default: {
         // TODO add a warning once all vendor specific flows are replaced with EasyMesh
         // flows, since we won't expect a 1905 message not handled in this function

--- a/controller/src/beerocks/master/beerocks_master_mrouter.cpp
+++ b/controller/src/beerocks/master/beerocks_master_mrouter.cpp
@@ -62,6 +62,7 @@ bool master_mrouter::init()
         ieee1905_1::eMessageType::STEERING_COMPLETED_MESSAGE,
         ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE,
         ieee1905_1::eMessageType::LINK_METRIC_RESPONSE_MESSAGE,
+        ieee1905_1::eMessageType::AP_METRICS_RESPONSE_MESSAGE,
         ieee1905_1::eMessageType::ACK_MESSAGE,
 
     }));

--- a/controller/src/beerocks/master/beerocks_master_mrouter.cpp
+++ b/controller/src/beerocks/master/beerocks_master_mrouter.cpp
@@ -61,7 +61,9 @@ bool master_mrouter::init()
         ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE,
         ieee1905_1::eMessageType::STEERING_COMPLETED_MESSAGE,
         ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE,
+        ieee1905_1::eMessageType::LINK_METRIC_RESPONSE_MESSAGE,
         ieee1905_1::eMessageType::ACK_MESSAGE,
+
     }));
 }
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -640,6 +640,12 @@ int db::get_node_last_ping_avg_ms(std::string mac)
     return n->last_ping_avg_ms;
 }
 
+std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, son::node::link_metrics_data>> &
+db::get_link_metric_data_map()
+{
+    return m_link_metric_data;
+}
+
 bool db::set_hostap_active(std::string mac, bool active)
 {
     auto n = get_node(mac);

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -646,6 +646,11 @@ db::get_link_metric_data_map()
     return m_link_metric_data;
 }
 
+std::unordered_map<sMacAddr, son::node::ap_metrics_data> &db::get_ap_metric_data_map()
+{
+    return m_ap_metric_data;
+}
+
 bool db::set_hostap_active(std::string mac, bool active)
 {
     auto n = get_node(mac);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -238,6 +238,13 @@ public:
     void disconnected_slave_mac_queue_push(std::string node_mac);
     std::string node_to_string(std::string mac);
 
+    /**
+     * @brief Get the link metric database
+     * @return reference to the map that holds link metric data of all agents.
+     */
+    std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, son::node::link_metrics_data>> &
+    get_link_metric_data_map();
+
     //
     // DB node functions (get only)
     //
@@ -725,6 +732,15 @@ private:
     friend class network_map;
 
     std::shared_ptr<vaps_list_t> m_vap_list;
+
+    /*
+    * This map holds link metric "data struct" per reporting Agent sMacAddr .
+    * "data struct" holds map of the actual link_metrics_data vector (tx/rx) per reported Agent sMacAddr.
+    * Map is Used in TYPE_GW/TYPE_IRE nodes.
+    * Map created empty in all other nodes.
+    */
+    std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, son::node::link_metrics_data>>
+        m_link_metric_data;
 
     // certification
     std::shared_ptr<uint8_t> certification_tx_buffer;

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -245,6 +245,12 @@ public:
     std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, son::node::link_metrics_data>> &
     get_link_metric_data_map();
 
+    /**
+     * @brief Get the ap metric database
+     * @return reference to the map that holds ap metric data of all agents.
+     */
+    std::unordered_map<sMacAddr, son::node::ap_metrics_data> &get_ap_metric_data_map();
+
     //
     // DB node functions (get only)
     //
@@ -741,6 +747,13 @@ private:
     */
     std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, son::node::link_metrics_data>>
         m_link_metric_data;
+
+    /*
+    * This map holds ap metric data per reporting Agent sMacAddr .
+    * Map is Used in TYPE_GW/TYPE_IRE nodes.
+    * Map created empty in all other nodes.
+    */
+    std::unordered_map<sMacAddr, son::node::ap_metrics_data> m_ap_metric_data;
 
     // certification
     std::shared_ptr<uint8_t> certification_tx_buffer;

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -343,3 +343,30 @@ bool node::link_metrics_data::add_receiver_link_metric(
     }
     return true;
 }
+
+bool node::ap_metrics_data::add_ap_metric_data(std::shared_ptr<wfa_map::tlvApMetric> ApMetricData)
+{
+    bssid                               = ApMetricData->bssid();
+    channel_utilization                 = ApMetricData->channel_utilization();
+    number_of_stas_currently_associated = ApMetricData->number_of_stas_currently_associated();
+
+    for (int i = 0; i < 3; i++) {
+        if (ApMetricData->estimated_service_parameters().include_ac_be) {
+            estimated_service_info_field_ac_be[i] =
+                *ApMetricData->estimated_service_info_field_ac_be(i);
+        }
+        if (ApMetricData->estimated_service_parameters().include_ac_bk) {
+            estimated_service_info_field_ac_bk[i] =
+                *ApMetricData->estimated_service_info_field_ac_bk(i);
+        }
+        if (ApMetricData->estimated_service_parameters().include_ac_vo) {
+            estimated_service_info_field_ac_vo[i] =
+                *ApMetricData->estimated_service_info_field_ac_vo(i);
+        }
+        if (ApMetricData->estimated_service_parameters().include_ac_vi) {
+            estimated_service_info_field_ac_vi[i] =
+                *ApMetricData->estimated_service_info_field_ac_vi(i);
+        }
+    }
+    return true;
+}

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -297,3 +297,49 @@ bool node::set_type(beerocks::eType type_)
     }
     return false;
 }
+
+bool node::link_metrics_data::add_transmitter_link_metric(
+    std::shared_ptr<ieee1905_1::tlvTransmitterLinkMetric> tx_link_metric_data)
+{
+    //  interface_pair_info_length() returns the length in bytes (number of elements * sizeof(sInterfacePairInfo).
+    size_t info_size = tx_link_metric_data->interface_pair_info_length() /
+                       sizeof(ieee1905_1::tlvTransmitterLinkMetric::sInterfacePairInfo);
+
+    for (size_t i = 0; i < info_size; i++) {
+        auto info_tuple = tx_link_metric_data->interface_pair_info(i);
+
+        if (!std::get<0>(info_tuple)) {
+            LOG(ERROR) << "add_transmitter_link_metric getting operating class entry has failed!";
+            return false;
+        }
+        auto &InterfacePairInfo = std::get<1>(info_tuple);
+        transmitterLinkMetrics.push_back(InterfacePairInfo);
+
+        LOG(DEBUG) << "adding tlvTransmitterLinkMetric data to list"
+                   << " phy_rate = " << int(InterfacePairInfo.link_metric_info.phy_rate);
+    }
+    return true;
+}
+
+bool node::link_metrics_data::add_receiver_link_metric(
+    std::shared_ptr<ieee1905_1::tlvReceiverLinkMetric> RxLinkMetricData)
+{
+    //  interface_pair_info_length() returns the length in bytes (number of elements * sizeof(sInterfacePairInfo).
+    size_t info_size = RxLinkMetricData->interface_pair_info_length() /
+                       sizeof(ieee1905_1::tlvReceiverLinkMetric::sInterfacePairInfo);
+
+    for (size_t i = 0; i < info_size; i++) {
+        auto info_tuple = RxLinkMetricData->interface_pair_info(i);
+
+        if (!std::get<0>(info_tuple)) {
+            LOG(ERROR) << "add_receiver_link_metric getting operating class entry has failed!";
+            return false;
+        }
+        auto &InterfacePairInfo = std::get<1>(info_tuple);
+        receiverLinkMetrics.push_back(InterfacePairInfo);
+
+        LOG(DEBUG) << "adding tlvReceiverLinkMetric data to list"
+                   << " rssi_db = " << int(InterfacePairInfo.link_metric_info.rssi_db);
+    }
+    return true;
+}

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -350,23 +350,28 @@ bool node::ap_metrics_data::add_ap_metric_data(std::shared_ptr<wfa_map::tlvApMet
     channel_utilization                 = ApMetricData->channel_utilization();
     number_of_stas_currently_associated = ApMetricData->number_of_stas_currently_associated();
 
-    for (int i = 0; i < 3; i++) {
-        if (ApMetricData->estimated_service_parameters().include_ac_be) {
-            estimated_service_info_field_ac_be[i] =
-                *ApMetricData->estimated_service_info_field_ac_be(i);
-        }
-        if (ApMetricData->estimated_service_parameters().include_ac_bk) {
-            estimated_service_info_field_ac_bk[i] =
-                *ApMetricData->estimated_service_info_field_ac_bk(i);
-        }
-        if (ApMetricData->estimated_service_parameters().include_ac_vo) {
-            estimated_service_info_field_ac_vo[i] =
-                *ApMetricData->estimated_service_info_field_ac_vo(i);
-        }
-        if (ApMetricData->estimated_service_parameters().include_ac_vi) {
-            estimated_service_info_field_ac_vi[i] =
-                *ApMetricData->estimated_service_info_field_ac_vi(i);
-        }
+    if (ApMetricData->estimated_service_parameters().include_ac_be) {
+        std::copy(ApMetricData->estimated_service_info_field_ac_be(),
+                  ApMetricData->estimated_service_info_field_ac_be() + 3,
+                  estimated_service_info_field_ac_be);
+    }
+
+    if (ApMetricData->estimated_service_parameters().include_ac_bk) {
+        std::copy(ApMetricData->estimated_service_info_field_ac_bk(),
+                  ApMetricData->estimated_service_info_field_ac_bk() + 3,
+                  estimated_service_info_field_ac_bk);
+    }
+
+    if (ApMetricData->estimated_service_parameters().include_ac_vo) {
+        std::copy(ApMetricData->estimated_service_info_field_ac_vo(),
+                  ApMetricData->estimated_service_info_field_ac_vo() + 3,
+                  estimated_service_info_field_ac_vo);
+    }
+
+    if (ApMetricData->estimated_service_parameters().include_ac_vi) {
+        std::copy(ApMetricData->estimated_service_info_field_ac_vi(),
+                  ApMetricData->estimated_service_info_field_ac_vi() + 3,
+                  estimated_service_info_field_ac_vi);
     }
     return true;
 }

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -13,6 +13,7 @@
 #include <tlvf/common/sMacAddr.h>
 #include <tlvf/ieee_1905_1/tlvReceiverLinkMetric.h>
 #include <tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h>
+#include <tlvf/wfa_map/tlvApMetric.h>
 
 #include <list>
 #include <map>
@@ -201,6 +202,22 @@ public:
             std::shared_ptr<ieee1905_1::tlvTransmitterLinkMetric> TxLinkMetricData);
         bool add_receiver_link_metric(
             std::shared_ptr<ieee1905_1::tlvReceiverLinkMetric> RxLinkMetricData);
+    };
+
+    class ap_metrics_data {
+    public:
+        ap_metrics_data(){};
+        ~ap_metrics_data(){};
+
+        sMacAddr bssid;
+        uint8_t channel_utilization;
+        uint16_t number_of_stas_currently_associated;
+        uint8_t estimated_service_info_field_ac_be[3];
+        uint8_t estimated_service_info_field_ac_bk[3];
+        uint8_t estimated_service_info_field_ac_vo[3];
+        uint8_t estimated_service_info_field_ac_vi[3];
+
+        bool add_ap_metric_data(std::shared_ptr<wfa_map::tlvApMetric> ApMetricData);
     };
 
     beerocks::eBandType band_type   = beerocks::eBandType::INVALID_BAND;

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -10,8 +10,12 @@
 #define _NODE_H_
 
 #include "../tasks/task.h"
+#include <tlvf/common/sMacAddr.h>
+#include <tlvf/ieee_1905_1/tlvReceiverLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h>
 
 #include <list>
+#include <map>
 
 namespace son {
 typedef struct {
@@ -183,6 +187,21 @@ public:
         std::unordered_map<int8_t, sVapElement> vaps_info;
     };
     std::shared_ptr<radio> hostap;
+
+    class link_metrics_data {
+    public:
+        link_metrics_data(){};
+        ~link_metrics_data(){};
+
+        std::vector<ieee1905_1::tlvTransmitterLinkMetric::sInterfacePairInfo>
+            transmitterLinkMetrics;
+        std::vector<ieee1905_1::tlvReceiverLinkMetric::sInterfacePairInfo> receiverLinkMetrics;
+
+        bool add_transmitter_link_metric(
+            std::shared_ptr<ieee1905_1::tlvTransmitterLinkMetric> TxLinkMetricData);
+        bool add_receiver_link_metric(
+            std::shared_ptr<ieee1905_1::tlvReceiverLinkMetric> RxLinkMetricData);
+    };
 
     beerocks::eBandType band_type   = beerocks::eBandType::INVALID_BAND;
     beerocks::eIfaceType iface_type = beerocks::IFACE_TYPE_ETHERNET;

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -63,6 +63,8 @@ private:
         std::shared_ptr<ieee1905_1::tlvWscM1> tlvwscM1, std::string bridge_mac,
         std::string radio_mac, ieee1905_1::CmduMessageTx &cmdu_tx);
 
+    bool construct_combined_infra_metric();
+
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_autoconfiguration_WSC(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -66,6 +66,7 @@ private:
     // 1905 messages handlers
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_autoconfiguration_WSC(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_link_metric_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_preference_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_selection_response(Socket *sd,
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -67,6 +67,7 @@ private:
     bool handle_cmdu_1905_autoconfiguration_search(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_autoconfiguration_WSC(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_link_metric_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_ap_metric_response(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_preference_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_selection_response(Socket *sd,
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
@@ -57,25 +57,25 @@ class tlvReceiverLinkMetric : public BaseClass
         } __attribute__((packed)) sLinkMetricInfo;
         
         typedef struct sInterfacePairInfo {
-            sMacAddr mac_of_an_interface_in_the_receiving_al;
-            sMacAddr mac_of_an_interface_in_the_neighbor_al;
+            sMacAddr rc_interface_mac;
+            sMacAddr neighbor_interface_mac;
             sLinkMetricInfo link_metric_info;
             void struct_swap(){
-                mac_of_an_interface_in_the_receiving_al.struct_swap();
-                mac_of_an_interface_in_the_neighbor_al.struct_swap();
+                rc_interface_mac.struct_swap();
+                neighbor_interface_mac.struct_swap();
                 link_metric_info.struct_swap();
             }
             void struct_init(){
-                mac_of_an_interface_in_the_receiving_al.struct_init();
-                mac_of_an_interface_in_the_neighbor_al.struct_init();
+                rc_interface_mac.struct_init();
+                neighbor_interface_mac.struct_init();
                 link_metric_info.struct_init();
             }
         } __attribute__((packed)) sInterfacePairInfo;
         
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddr& al_mac_of_the_device_that_transmits();
-        sMacAddr& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
+        sMacAddr& reporter_al_mac();
+        sMacAddr& neighbor_al_mac();
         //The following fields shall be repeated for each connected interface pair between the
         //receiving 1905.1 AL and the neighbor 1905.1 AL.
         size_t interface_pair_info_length() { return m_interface_pair_info_idx__ * sizeof(tlvReceiverLinkMetric::sInterfacePairInfo); }
@@ -88,8 +88,8 @@ class tlvReceiverLinkMetric : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddr* m_al_mac_of_the_device_that_transmits = nullptr;
-        sMacAddr* m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = nullptr;
+        sMacAddr* m_reporter_al_mac = nullptr;
+        sMacAddr* m_neighbor_al_mac = nullptr;
         sInterfacePairInfo* m_interface_pair_info = nullptr;
         size_t m_interface_pair_info_idx__ = 0;
         int m_lock_order_counter__ = 0;

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
@@ -68,25 +68,25 @@ class tlvTransmitterLinkMetric : public BaseClass
         } __attribute__((packed)) sLinkMetricInfo;
         
         typedef struct sInterfacePairInfo {
-            sMacAddr mac_of_an_interface_in_the_receiving_al;
-            sMacAddr mac_of_an_interface_in_the_neighbor_al;
+            sMacAddr rc_interface_mac;
+            sMacAddr neighbor_interface_mac;
             sLinkMetricInfo link_metric_info;
             void struct_swap(){
-                mac_of_an_interface_in_the_receiving_al.struct_swap();
-                mac_of_an_interface_in_the_neighbor_al.struct_swap();
+                rc_interface_mac.struct_swap();
+                neighbor_interface_mac.struct_swap();
                 link_metric_info.struct_swap();
             }
             void struct_init(){
-                mac_of_an_interface_in_the_receiving_al.struct_init();
-                mac_of_an_interface_in_the_neighbor_al.struct_init();
+                rc_interface_mac.struct_init();
+                neighbor_interface_mac.struct_init();
                 link_metric_info.struct_init();
             }
         } __attribute__((packed)) sInterfacePairInfo;
         
         const eTlvType& type();
         const uint16_t& length();
-        sMacAddr& al_mac_of_the_device_that_transmits();
-        sMacAddr& al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv();
+        sMacAddr& reporter_al_mac();
+        sMacAddr& neighbor_al_mac();
         //The fields shall be repeated for each connected interface pair between the receiving
         //905.1 AL and the neighbor 1905.1 AL.
         size_t interface_pair_info_length() { return m_interface_pair_info_idx__ * sizeof(tlvTransmitterLinkMetric::sInterfacePairInfo); }
@@ -99,8 +99,8 @@ class tlvTransmitterLinkMetric : public BaseClass
         bool init();
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
-        sMacAddr* m_al_mac_of_the_device_that_transmits = nullptr;
-        sMacAddr* m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = nullptr;
+        sMacAddr* m_reporter_al_mac = nullptr;
+        sMacAddr* m_neighbor_al_mac = nullptr;
         sInterfacePairInfo* m_interface_pair_info = nullptr;
         size_t m_interface_pair_info_idx__ = 0;
         int m_lock_order_counter__ = 0;

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetric.h
@@ -1,0 +1,94 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVAPMETRIC_H_
+#define _TLVF_WFA_MAP_TLVAPMETRIC_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+#include <tuple>
+#include <asm/byteorder.h>
+
+namespace wfa_map {
+
+
+class tlvApMetric : public BaseClass
+{
+    public:
+        tlvApMetric(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        tlvApMetric(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~tlvApMetric();
+
+        typedef struct sEstimatedService {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t reserved : 4;
+            uint8_t include_ac_vi : 1;
+            uint8_t include_ac_vo : 1;
+            uint8_t include_ac_bk : 1;
+            uint8_t include_ac_be : 1;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t include_ac_be : 1;
+            uint8_t include_ac_bk : 1;
+            uint8_t include_ac_vo : 1;
+            uint8_t include_ac_vi : 1;
+            uint8_t reserved : 4;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+                include_ac_be = 0x1;
+            }
+        } __attribute__((packed)) sEstimatedService;
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& bssid();
+        uint8_t& channel_utilization();
+        uint16_t& number_of_stas_currently_associated();
+        sEstimatedService& estimated_service_parameters();
+        uint8_t* estimated_service_info_field_ac_be(size_t idx = 0);
+        uint8_t* estimated_service_info_field_ac_bk(size_t idx = 0);
+        uint8_t* estimated_service_info_field_ac_vo(size_t idx = 0);
+        uint8_t* estimated_service_info_field_ac_vi(size_t idx = 0);
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        uint8_t* m_channel_utilization = nullptr;
+        uint16_t* m_number_of_stas_currently_associated = nullptr;
+        sEstimatedService* m_estimated_service_parameters = nullptr;
+        uint8_t* m_estimated_service_info_field_ac_be = nullptr;
+        size_t m_estimated_service_info_field_ac_be_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+        uint8_t* m_estimated_service_info_field_ac_bk = nullptr;
+        size_t m_estimated_service_info_field_ac_bk_idx__ = 0;
+        uint8_t* m_estimated_service_info_field_ac_vo = nullptr;
+        size_t m_estimated_service_info_field_ac_vo_idx__ = 0;
+        uint8_t* m_estimated_service_info_field_ac_vi = nullptr;
+        size_t m_estimated_service_info_field_ac_vi_idx__ = 0;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVAPMETRIC_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -33,12 +33,12 @@ const uint16_t& tlvReceiverLinkMetric::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddr& tlvReceiverLinkMetric::al_mac_of_the_device_that_transmits() {
-    return (sMacAddr&)(*m_al_mac_of_the_device_that_transmits);
+sMacAddr& tlvReceiverLinkMetric::reporter_al_mac() {
+    return (sMacAddr&)(*m_reporter_al_mac);
 }
 
-sMacAddr& tlvReceiverLinkMetric::al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv() {
-    return (sMacAddr&)(*m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv);
+sMacAddr& tlvReceiverLinkMetric::neighbor_al_mac() {
+    return (sMacAddr&)(*m_neighbor_al_mac);
 }
 
 std::tuple<bool, tlvReceiverLinkMetric::sInterfacePairInfo&> tlvReceiverLinkMetric::interface_pair_info(size_t idx) {
@@ -83,8 +83,8 @@ bool tlvReceiverLinkMetric::alloc_interface_pair_info(size_t count) {
 void tlvReceiverLinkMetric::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    m_al_mac_of_the_device_that_transmits->struct_swap();
-    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_swap();
+    m_reporter_al_mac->struct_swap();
+    m_neighbor_al_mac->struct_swap();
     for (size_t i = 0; i < m_interface_pair_info_idx__; i++){
         m_interface_pair_info[i].struct_swap();
     }
@@ -95,8 +95,8 @@ size_t tlvReceiverLinkMetric::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddr); // al_mac_of_the_device_that_transmits
-    class_size += sizeof(sMacAddr); // al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv
+    class_size += sizeof(sMacAddr); // reporter_al_mac
+    class_size += sizeof(sMacAddr); // neighbor_al_mac
     return class_size;
 }
 
@@ -112,14 +112,14 @@ bool tlvReceiverLinkMetric::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
-    m_al_mac_of_the_device_that_transmits = (sMacAddr*)m_buff_ptr__;
+    m_reporter_al_mac = (sMacAddr*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
-    if (!m_parse__) { m_al_mac_of_the_device_that_transmits->struct_init(); }
-    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddr*)m_buff_ptr__;
+    if (!m_parse__) { m_reporter_al_mac->struct_init(); }
+    m_neighbor_al_mac = (sMacAddr*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
-    if (!m_parse__) { m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_init(); }
+    if (!m_parse__) { m_neighbor_al_mac->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -33,12 +33,12 @@ const uint16_t& tlvTransmitterLinkMetric::length() {
     return (const uint16_t&)(*m_length);
 }
 
-sMacAddr& tlvTransmitterLinkMetric::al_mac_of_the_device_that_transmits() {
-    return (sMacAddr&)(*m_al_mac_of_the_device_that_transmits);
+sMacAddr& tlvTransmitterLinkMetric::reporter_al_mac() {
+    return (sMacAddr&)(*m_reporter_al_mac);
 }
 
-sMacAddr& tlvTransmitterLinkMetric::al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv() {
-    return (sMacAddr&)(*m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv);
+sMacAddr& tlvTransmitterLinkMetric::neighbor_al_mac() {
+    return (sMacAddr&)(*m_neighbor_al_mac);
 }
 
 std::tuple<bool, tlvTransmitterLinkMetric::sInterfacePairInfo&> tlvTransmitterLinkMetric::interface_pair_info(size_t idx) {
@@ -83,8 +83,8 @@ bool tlvTransmitterLinkMetric::alloc_interface_pair_info(size_t count) {
 void tlvTransmitterLinkMetric::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    m_al_mac_of_the_device_that_transmits->struct_swap();
-    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_swap();
+    m_reporter_al_mac->struct_swap();
+    m_neighbor_al_mac->struct_swap();
     for (size_t i = 0; i < m_interface_pair_info_idx__; i++){
         m_interface_pair_info[i].struct_swap();
     }
@@ -95,8 +95,8 @@ size_t tlvTransmitterLinkMetric::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(eTlvType); // type
     class_size += sizeof(uint16_t); // length
-    class_size += sizeof(sMacAddr); // al_mac_of_the_device_that_transmits
-    class_size += sizeof(sMacAddr); // al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv
+    class_size += sizeof(sMacAddr); // reporter_al_mac
+    class_size += sizeof(sMacAddr); // neighbor_al_mac
     return class_size;
 }
 
@@ -112,14 +112,14 @@ bool tlvTransmitterLinkMetric::init()
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
-    m_al_mac_of_the_device_that_transmits = (sMacAddr*)m_buff_ptr__;
+    m_reporter_al_mac = (sMacAddr*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
-    if (!m_parse__) { m_al_mac_of_the_device_that_transmits->struct_init(); }
-    m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv = (sMacAddr*)m_buff_ptr__;
+    if (!m_parse__) { m_reporter_al_mac->struct_init(); }
+    m_neighbor_al_mac = (sMacAddr*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
-    if (!m_parse__) { m_al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv->struct_init(); }
+    if (!m_parse__) { m_neighbor_al_mac->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
@@ -1,0 +1,168 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvApMetric.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvApMetric::tlvApMetric(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+tlvApMetric::tlvApMetric(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+tlvApMetric::~tlvApMetric() {
+}
+const eTlvTypeMap& tlvApMetric::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvApMetric::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvApMetric::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
+uint8_t& tlvApMetric::channel_utilization() {
+    return (uint8_t&)(*m_channel_utilization);
+}
+
+uint16_t& tlvApMetric::number_of_stas_currently_associated() {
+    return (uint16_t&)(*m_number_of_stas_currently_associated);
+}
+
+tlvApMetric::sEstimatedService& tlvApMetric::estimated_service_parameters() {
+    return (sEstimatedService&)(*m_estimated_service_parameters);
+}
+
+uint8_t* tlvApMetric::estimated_service_info_field_ac_be(size_t idx) {
+    if ( (m_estimated_service_info_field_ac_be_idx__ <= 0) || (m_estimated_service_info_field_ac_be_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_estimated_service_info_field_ac_be[idx]);
+}
+
+uint8_t* tlvApMetric::estimated_service_info_field_ac_bk(size_t idx) {
+    if ( (m_estimated_service_info_field_ac_bk_idx__ <= 0) || (m_estimated_service_info_field_ac_bk_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_estimated_service_info_field_ac_bk[idx]);
+}
+
+uint8_t* tlvApMetric::estimated_service_info_field_ac_vo(size_t idx) {
+    if ( (m_estimated_service_info_field_ac_vo_idx__ <= 0) || (m_estimated_service_info_field_ac_vo_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_estimated_service_info_field_ac_vo[idx]);
+}
+
+uint8_t* tlvApMetric::estimated_service_info_field_ac_vi(size_t idx) {
+    if ( (m_estimated_service_info_field_ac_vi_idx__ <= 0) || (m_estimated_service_info_field_ac_vi_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_estimated_service_info_field_ac_vi[idx]);
+}
+
+void tlvApMetric::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_bssid->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_number_of_stas_currently_associated));
+    m_estimated_service_parameters->struct_swap();
+}
+
+size_t tlvApMetric::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(uint8_t); // channel_utilization
+    class_size += sizeof(uint16_t); // number_of_stas_currently_associated
+    class_size += sizeof(sEstimatedService); // estimated_service_parameters
+    class_size += 3 * sizeof(uint8_t); // estimated_service_info_field_ac_be
+    class_size += 3 * sizeof(uint8_t); // estimated_service_info_field_ac_bk
+    class_size += 3 * sizeof(uint8_t); // estimated_service_info_field_ac_vo
+    class_size += 3 * sizeof(uint8_t); // estimated_service_info_field_ac_vi
+    return class_size;
+}
+
+bool tlvApMetric::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_METRIC;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_bssid->struct_init(); }
+    m_channel_utilization = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_number_of_stas_currently_associated = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_estimated_service_parameters = (sEstimatedService*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sEstimatedService))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sEstimatedService); }
+    if (!m_parse__) { m_estimated_service_parameters->struct_init(); }
+    m_estimated_service_info_field_ac_be = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(3))) { return false; }
+    m_estimated_service_info_field_ac_be_idx__  = 3;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * 3); }
+    }
+    m_estimated_service_info_field_ac_bk = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(3))) { return false; }
+    m_estimated_service_info_field_ac_bk_idx__  = 3;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * 3); }
+    }
+    m_estimated_service_info_field_ac_vo = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(3))) { return false; }
+    m_estimated_service_info_field_ac_vo_idx__  = 3;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * 3); }
+    }
+    m_estimated_service_info_field_ac_vi = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(3))) { return false; }
+    m_estimated_service_info_field_ac_vi_idx__  = 3;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * 3); }
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_METRIC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_METRIC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -22,6 +22,7 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvHigherLayerData.yaml",
   "tlvf/wfa_map/tlvSteeringBTMReport.yaml",
   "tlvf/wfa_map/tlvSteeringRequest.yaml",
+  "tlvf/wfa_map/tlvApMetric.yaml",
   "tlvf/wfa_map/tlvApMetricQuery.yaml",
   "tlvf/wfa_map/tlvClientAssociationEvent.yaml",
   "tlvf/wfa_map/tlvClientAssociationControlRequest.yaml",

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvReceiverLinkMetric.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvReceiverLinkMetric.yaml
@@ -9,8 +9,8 @@ tlvReceiverLinkMetric:
     _type: eTlvType
     _value_const: TLV_RECEIVER_LINK_METRIC
   length: uint16_t
-  al_mac_of_the_device_that_transmits: sMacAddr
-  al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv: sMacAddr
+  reporter_al_mac: sMacAddr
+  neighbor_al_mac: sMacAddr
   interface_pair_info:
     _comment: |
       The following fields shall be repeated for each connected interface pair between the
@@ -40,7 +40,7 @@ sLinkMetricInfo:
 
 sInterfacePairInfo:
   _type: struct
-  mac_of_an_interface_in_the_receiving_al: sMacAddr
-  mac_of_an_interface_in_the_neighbor_al: sMacAddr
+  rc_interface_mac: sMacAddr
+  neighbor_interface_mac: sMacAddr
   link_metric_info: sLinkMetricInfo
 

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.yaml
@@ -9,8 +9,8 @@ tlvTransmitterLinkMetric:
     _type: eTlvType
     _value_const: TLV_TRANSMITTER_LINK_METRIC
   length: uint16_t
-  al_mac_of_the_device_that_transmits: sMacAddr
-  al_mac_of_the_neighbor_whose_link_metric_is_reported_in_this_tlv: sMacAddr
+  reporter_al_mac: sMacAddr
+  neighbor_al_mac: sMacAddr
   interface_pair_info:
     _type: sInterfacePairInfo
     _length: []
@@ -51,6 +51,6 @@ sLinkMetricInfo:
 
 sInterfacePairInfo:
   _type: struct
-  mac_of_an_interface_in_the_receiving_al: sMacAddr
-  mac_of_an_interface_in_the_neighbor_al: sMacAddr
+  rc_interface_mac: sMacAddr
+  neighbor_interface_mac: sMacAddr
   link_metric_info: sLinkMetricInfo

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApMetric.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApMetric.yaml
@@ -9,22 +9,22 @@ tlvApMetric:
     _type: eTlvTypeMap
     _value_const: TLV_AP_METRIC 
   length: uint16_t
-  bssid: sAddress
+  bssid: sMacAddr
   channel_utilization: uint8_t
   number_of_stas_currently_associated: uint16_t
   estimated_service_parameters: sEstimatedService
   estimated_service_info_field_ac_be:
     _type: uint8_t
-    _length: [ ]
+    _length: [3]
   estimated_service_info_field_ac_bk:
     _type: uint8_t
-    _length: [ ]
+    _length: [3]
   estimated_service_info_field_ac_vo:
     _type: uint8_t
-    _length: [ ]
+    _length: [3]
   estimated_service_info_field_ac_vi:
     _type: uint8_t
-    _length: [ ]
+    _length: [3]
 
 sEstimatedService:
   _type: struct


### PR DESCRIPTION
add support for combined infrastructure metrics flow in order to pass controller certification test 5.7.1
Task #209

1. Controller:  add handler for LINK_METRIC_RESPONCE_MESSAGE
2. database: parse and store Transmitter/Receiver link metric TLVs to database from all Agents  for later usage building COMBINED_INFRASTRUCTURE_METRICS_MESSAGE 
3. Controller: add handler for AP_METRICS_RESPONSE_MESSAGE
4. database: parse and store AP Metric Query TLV to database from all Agents  for later usage building COMBINED_INFRASTRUCTURE_METRICS_MESSAGE 
