### PR TITLE
tools: docker: `test_flows.sh`: dump logs on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - git diff-index --exit-code HEAD
   # Tests
   - ./run.sh --entrypoint "$PWD/../../../build/install/bin/tests/tlvf_test"
-  - ./tests/test_flows.sh topology initial_ap_config channel_selection client_capability_query ap_capability_query
+  - ./tests/test_flows.sh -v topology initial_ap_config channel_selection client_capability_query ap_capability_query

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -202,6 +202,19 @@ main() {
 
     if [ $error -gt 0 ]; then
         err "$error / $count tests failed"
+        if [ "$VERBOSE" == "true" ]; then
+            for dockerimage in gateway repeater; do
+                info "*** Dumping logs from $dockerimage ***"
+                docker exec $dockerimage sh -c '
+                    for logfile in controller agent agent_wlan0 agent_wlan2; do
+                        logpath=/tmp/$USER/beerocks/logs/beerocks_$logfile.log
+                        [ -e $logpath ] && {
+                            printf "\n\n==> %s <==\n" $logfile
+                            cat $logpath
+                        }
+                    done'
+            done
+        fi
     else
         success "$count / $count tests passed"
     fi


### PR DESCRIPTION
When the test fails, we need to be able to debug why. Since the logs are
not visible any more after the container is destroyed, dump the log
files to standard output on failure.

This is only done in verbose mode. When running manually, the user can
still access the containers because `test_flows.sh` doesn't kill them.
Therefore, also turn on verbose mode in Travis CI.