### PR TITLE
tools:docker: fix netcat package name

### DIFF
--- a/tools/docker/runner/Dockerfile
+++ b/tools/docker/runner/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 	iproute2 \
 	psmisc \
 	clang-format \
-	nc \
+	netcat \
     && rm -rf /var/lib/apt/lists/*
 
 ARG bridgeip


### PR DESCRIPTION
The current bug is that when we are trying to install netcat utils 'nc'
name is used. That is name of application not a package itself and caused error on Ubuntu 18.04.

For that reason, the package name was changed to 'netcat'

Signed-off-by: Maksym Bielan <maksym.bielan@globallogic.com>