### PR TITLE
Feature/add higher layer data payload flow

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -70,6 +70,8 @@ private:
     bool handle_1905_autoconfiguration_response(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                 const std::string &src_mac);
     bool handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                               const std::string &src_mac);
 
     //bool sta_handle_event(const std::string &iface,const std::string& event_name, void* event_obj);
     bool hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr, std::string iface);

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -963,7 +963,8 @@ bool master_thread::handle_cmdu_1905_channel_preference_report(Socket *sd,
 bool master_thread::handle_cmdu_1905_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto mid = cmdu_rx.getMessageId();
-    LOG(INFO) << "Received ACK_MESSAGE, mid=" << std::hex << int(mid);
+    //TODO: the ACK should be sent to the correct task and will be done as part of agent certification
+    LOG(DEBUG) << "Received ACK_MESSAGE, mid=" << std::hex << int(mid);
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvHigherLayerData.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvHigherLayerData.h
@@ -1,0 +1,60 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVHIGHERLAYERDATA_H_
+#define _TLVF_WFA_MAP_TLVHIGHERLAYERDATA_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include <tuple>
+
+namespace wfa_map {
+
+
+class tlvHigherLayerData : public BaseClass
+{
+    public:
+        tlvHigherLayerData(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        tlvHigherLayerData(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~tlvHigherLayerData();
+
+        enum eProtocol: uint8_t {
+            TR_181 = 0x1,
+        };
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        eProtocol& protocol();
+        size_t payload_length() { return m_payload_idx__ * sizeof(uint8_t); }
+        std::tuple<bool, uint8_t&> payload(size_t idx);
+        bool alloc_payload(size_t count = 1);
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eProtocol* m_protocol = nullptr;
+        uint8_t* m_payload = nullptr;
+        size_t m_payload_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVHIGHERLAYERDATA_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -1,0 +1,127 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvHigherLayerData.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvHigherLayerData::tlvHigherLayerData(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+tlvHigherLayerData::tlvHigherLayerData(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+tlvHigherLayerData::~tlvHigherLayerData() {
+}
+const eTlvTypeMap& tlvHigherLayerData::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvHigherLayerData::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+tlvHigherLayerData::eProtocol& tlvHigherLayerData::protocol() {
+    return (eProtocol&)(*m_protocol);
+}
+
+std::tuple<bool, uint8_t&> tlvHigherLayerData::payload(size_t idx) {
+    bool ret_success = ( (m_payload_idx__ > 0) && (m_payload_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, m_payload[ret_idx]);
+}
+
+bool tlvHigherLayerData::alloc_payload(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list payload, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_payload;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_payload_idx__ += count;
+    m_buff_ptr__ += len;
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void tlvHigherLayerData::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+size_t tlvHigherLayerData::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eProtocol); // protocol
+    return class_size;
+}
+
+bool tlvHigherLayerData::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_HIGHER_LAYER_DATA;
+    m_buff_ptr__ += sizeof(eTlvTypeMap) * 1;
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    m_protocol = (eProtocol*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(eProtocol) * 1;
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eProtocol); }
+    m_payload = (uint8_t*)m_buff_ptr__;
+    if (m_length && m_parse__) {
+        size_t len = *m_length;
+        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
+        m_payload_idx__ = len/sizeof(uint8_t);
+        m_buff_ptr__ += len;
+    }
+    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_HIGHER_LAYER_DATA) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_HIGHER_LAYER_DATA) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -19,6 +19,7 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvChannelSelectionResponse.yaml",
   "tlvf/wfa_map/tlvTransmitPowerLimit.yaml",
   "tlvf/wfa_map/tlvOperatingChannelReport.yaml",
+  "tlvf/wfa_map/tlvHigherLayerData.yaml",
 }
 
 # Relative to tlvf.py src_path variable

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -153,8 +153,29 @@ test_client_association() {
 }
 
 test_higher_layer_data_payload_trigger() {
-    #TODO: Implement
-    return 1
+    status "test higher layer data payload"
+    
+    mac_gateway_hex=`echo $mac_gateway | tr --delete :`
+    mac_gateway_hex="0x${mac_gateway_hex}"
+    copies=200
+    
+    for i in `seq 1 $copies`
+    do
+        payload="$payload $mac_gateway_hex"
+    done
+
+    dbg "Send Higher Layer Data message"
+    # MCUT sends Higher Layer Data message to CTT Agent1 by providing:
+    # Higher layer protocol = "0x00"
+    # Higher layer payload = 200 concatenated copies of the ALID of the MCUT (1200 octets)
+    eval send_bml_command '"bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8018,tlv_type,0xA0,tlv_length,\
+0x04b1,tlv_value,{0x00 $payload}\""' $redirect
+
+    dbg "Confirming higher layer data message was received in the agent" 
+    docker exec -it repeater1 sh -c 'grep -i -q "HIGHER_LAYER_DATA_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent.log'
+
+    dbg "Confirming ACK message was received in the controller"
+    docker exec -it gateway sh -c 'grep -i -q "ACK_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_controller.log'
 }
 test_higher_layer_data_payload() {
     #TODO: Implement


### PR DESCRIPTION
According to section 5.10.1 in the EasyMesh Test Plan v1.0 [1],
add support for passing the Controller Certification
Higher layer data payload over 1905 trigger test flow.

Therefore, add a test in test_flows.sh to trigger the controller to
send a Higher Layer Data message to the agent and make sure 
that the message has been received in the respective agent.

#166 