### PR TITLE
Controller:master:db use sMacaddr instead of std::string

### DIFF
--- a/common/beerocks/bcl/include/beerocks/bcl/network/network_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/network/network_utils.h
@@ -36,6 +36,7 @@ class network_utils {
 public:
     static const std::string ZERO_IP_STRING;
     static const std::string ZERO_MAC_STRING;
+    static const sMacAddr ZERO_MAC;
     static const std::string WILD_MAC_STRING;
 
     typedef struct {

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -70,6 +70,7 @@ static int read_iface_flags(const std::string &strIface, struct ifreq &if_req)
 
 const std::string network_utils::ZERO_IP_STRING("0.0.0.0");
 const std::string network_utils::ZERO_MAC_STRING("00:00:00:00:00:00");
+const sMacAddr network_utils::ZERO_MAC{.oct = {0}};
 const std::string network_utils::WILD_MAC_STRING("ff:ff:ff:ff:ff:ff");
 
 //////////////////////////////////////////////////////////////////////////////

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -152,9 +152,9 @@ public:
     void set_log_level_state(const beerocks::eLogLevel &log_level, const bool &new_state);
 
     // General set/get
-    bool has_node(std::string mac);
+    bool has_node(sMacAddr mac);
 
-    bool add_virtual_node(std::string mac, std::string real_node_mac);
+    bool add_virtual_node(sMacAddr mac, sMacAddr real_node_mac);
     bool add_node(std::string mac, std::string parent_mac = std::string(),
                   beerocks::eType type         = beerocks::TYPE_CLIENT,
                   std::string radio_identifier = std::string());
@@ -663,6 +663,8 @@ public:
 private:
     std::string local_slave_mac;
     std::shared_ptr<node> get_node(std::string key); //key can be <mac> or <al_mac>_<ruid>
+    std::shared_ptr<node> get_node(sMacAddr mac);
+    std::shared_ptr<node> get_node(sMacAddr al_mac, sMacAddr ruid);
     int get_node_hierarchy(std::shared_ptr<node> n);
     std::set<std::shared_ptr<node>> get_node_subtree(std::shared_ptr<node> n);
     void adjust_subtree_hierarchy(std::shared_ptr<node> n);


### PR DESCRIPTION
The master database son::dbuses std::string types to represent MAC addresses. This leads to a lot of conversions to sMacAddr structures, and carries a risk that a string sneaks in somewhere that is not a valid MAC address.

So all MAC addresses currently are represented by sMacAddr structure

Signed-off-by: Maksym Bielan <maksym.bielan@globallogic.com>