### PR TITLE
github: issue templates: remove milestone and project from task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -4,8 +4,7 @@ about: Feature currently being developed / reviewed
 title: "[TASK]"
 labels: enhancement
 assignees: ''
-milestone: Certifiable controller on Ubuntu NUC
-project: prplMesh
+
 ---
 
 ## Description


### PR DESCRIPTION
When the issue templates were added, we decided to default the milestone
to our first milestone 'Certifiable controller on Ubuntu NUC', and to
add it to the prplMesh project backlog.

However, we decided later to use the milestone as a high-level
dashboard, and to add individual tasks as sub-issues to the high-level
steps on the dashboard. Therefore, the milestone should no longer be set
for a task.

Also, we don't use the scrum project, so adding things to it is just
overhead.

Therefore, remove milestone and project from the template.

The other two templates don't have these tags, so don't need to be
updated.