### PR TITLE
tools: clang-format.sh: run as user

### DIFF
--- a/tools/docker/clang-format.sh
+++ b/tools/docker/clang-format.sh
@@ -48,6 +48,7 @@ main() {
     DOCKEROPTS="-e USER=${SUDO_USER:-${USER}}
                 -e SOURCES_DIR=${sourcesdir}
                 -v ${sourcesdir}:${sourcesdir}
+                --user=${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)}
                 --name prplMesh-clang-format"
 
     DOCKEROPTS="$DOCKEROPTS --interactive --tty --rm"


### PR DESCRIPTION
Since clang-format.sh uses the 'runner' container, it runs as root.
Therefore, if any file is modified, it is no longer writable by the
user.

Avoid this by explicitly running as the calling user.