### PR TITLE
tlvf: missing skip tlv function

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvUnknown.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvUnknown.h
@@ -1,0 +1,53 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_IEEE_1905_1_TLVUNKNOWN_H_
+#define _TLVF_IEEE_1905_1_TLVUNKNOWN_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tuple>
+
+namespace ieee1905_1 {
+
+
+class tlvUnknown : public BaseClass
+{
+    public:
+        tlvUnknown(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        tlvUnknown(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~tlvUnknown();
+
+        uint8_t& type();
+        const uint16_t& length();
+        size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
+        uint8_t* data(size_t idx = 0);
+        bool alloc_data(size_t count = 1);
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        uint8_t* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_data = nullptr;
+        size_t m_data_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_TLVF/IEEE_1905_1_TLVUNKNOWN_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
@@ -1,0 +1,111 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/ieee_1905_1/tlvUnknown.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace ieee1905_1;
+
+tlvUnknown::tlvUnknown(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+tlvUnknown::tlvUnknown(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+tlvUnknown::~tlvUnknown() {
+}
+uint8_t& tlvUnknown::type() {
+    return (uint8_t&)(*m_type);
+}
+
+const uint16_t& tlvUnknown::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t* tlvUnknown::data(size_t idx) {
+    if ( (m_data_idx__ <= 0) || (m_data_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_data[idx]);
+}
+
+bool tlvUnknown::alloc_data(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list data, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_data;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_data_idx__ += count;
+    m_buff_ptr__ += len;
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void tlvUnknown::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+size_t tlvUnknown::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(uint8_t); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool tlvUnknown::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (uint8_t*)m_buff_ptr__;
+    m_buff_ptr__ += sizeof(uint8_t) * 1;
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    m_buff_ptr__ += sizeof(uint16_t) * 1;
+    m_data = (uint8_t*)m_buff_ptr__;
+    if (m_length && m_parse__) {
+        size_t len = *m_length;
+        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
+        m_data_idx__ = len/sizeof(uint8_t);
+        m_buff_ptr__ += len;
+    }
+    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    return true;
+}
+
+

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -16,6 +16,7 @@
 #include "tlvf/ieee_1905_1/tlvLinkMetricQuery.h"
 #include "tlvf/ieee_1905_1/tlvMacAddress.h"
 #include "tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h"
+#include "tlvf/ieee_1905_1/tlvUnknown.h"
 #include "tlvf/ieee_1905_1/tlvVendorSpecific.h"
 #include "tlvf/ieee_1905_1/tlvWscM2.h"
 #include "tlvf/wfa_map/tlvApCapability.h"
@@ -402,6 +403,12 @@ int test_all()
     LOG(DEBUG) << "Done (WSC M2)";
     MAPF_DBG("TLV LENGTH WSC M2: " << thirdTlv->length());
 
+    auto mactlv                     = msg.addClass<tlvMacAddress>();
+    const uint8_t gTlvMacAddress[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    std::copy_n(gTlvMacAddress, 6, mactlv->mac().oct);
+
+    MAPF_DBG("TLV LENGHT MAC: " << mactlv->length());
+
     auto fourthTlv     = msg.addClass<tlvTestVarList>();
     fourthTlv->var0()  = 0xa0;
     allocation_succeed = fourthTlv->alloc_simple_list(2);
@@ -542,6 +549,18 @@ int test_all()
         errors++;
     }
 
+    auto tlvunknown = received_message.addClass<tlvUnknown>();
+    if (tlvunknown != nullptr) {
+        LOG(DEBUG) << "TLVUnknown Type: " << int(tlvunknown->type());
+
+        LOG(DEBUG) << "TLVUnknown data:";
+        for (uint8_t data_idx = 0; data_idx < tlvunknown->data_length(); data_idx++) {
+            LOG(DEBUG) << " " << int(tlvunknown->data()[data_idx]);
+        }
+    } else {
+        MAPF_ERR("TLVUnknown is NULL");
+        errors++;
+    }
     auto tlv4 = received_message.addClass<tlvTestVarList>();
     if (tlv4 == nullptr) {
         MAPF_ERR("TLV4 is NULL");

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -725,7 +725,7 @@ class TlvF:
                     
                     # Add type checking
                     lines_cpp = []
-                    if obj_meta.is_tlv_class and param_name == MetaData.TLV_TYPE_TYPE:
+                    if obj_meta.is_tlv_class and param_name == MetaData.TLV_TYPE_TYPE and param_val_const:
                         lines_cpp.append("if (m_%s__) {" % (self.MEMBER_PARSE))
                         lines_cpp.append( "%sif (*m_type != %s) {" % ( self.getIndentation(1), param_val_const ) )
                         lines_cpp.append( '%sTLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(%s) << ", received value: " << int(*m_type);' %  (self.getIndentation(2), param_val_const) )

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvUnknown.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvUnknown.yaml
@@ -1,0 +1,12 @@
+#
+---
+_namespace: ieee1905_1
+
+tlvUnknown:
+  _type: class
+  _is_tlv_class : True
+  type: uint8_t
+  length: uint16_t
+  data:
+    _type: uint8_t
+    _length: []


### PR DESCRIPTION
Where ever parsing multiap cmdu, there is need to check what is the next tlv that is needed to be parse, and then parse it, and repeat it untill the next tlv is EndOfMessage.
It may happen that cmdu handler function will receive unexpected tlv.
If such thing happens, temporary implementation can be one of:
    1.The parser function will iterate over it infinite times causing the process to stuck. This since the tlv is not added to the cmdu.
    2.The handler function may stop handling the cmdu by return statment. This means that the cmdu will be thrown.

New class tlvUnknown was added to skip unexpected tlv. Use
msg.addClass<tlvUnknown>() to skip tlv.

Signed-off-by: Yuriy Masechko <yuriy.masechko@globallogic.com>