### PR TITLE
TLVF: Refactoring of STD dynamic lists getter (return buffer pointer instead of tuple)

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -851,8 +851,7 @@ bool slave_thread::handle_cmdu_control_message(
                 LOG(ERROR) << "Failed buffer allocation to size=" << int(request->size());
                 break;
             }
-            auto data_tuple = response->data(0);
-            memset(&std::get<1>(data_tuple), 0, response->size());
+            memset(request->data(), 0, request->data_length());
         }
         send_cmdu_to_controller(cmdu_tx);
         break;
@@ -880,8 +879,7 @@ bool slave_thread::handle_cmdu_control_message(
                     LOG(ERROR) << "Failed buffer allocation to size=" << int(request->size());
                     break;
                 }
-                auto data_tuple = request->data(0);
-                memset(&std::get<1>(data_tuple), 0, request->size());
+                memset(request->data(), 0, request->data_length());
             }
             send_cmdu_to_controller(cmdu_tx);
         }
@@ -4841,14 +4839,13 @@ bool slave_thread::handle_channel_preference_query(Socket *sd, ieee1905_1::CmduM
             LOG(ERROR) << "alloc_channel_list() has failed!";
             return false;
         }
-        auto channel_idx   = op_class_channels->channel_list_length();
-        auto channel_tuple = op_class_channels->channel_list(channel_idx - 1);
-        if (!std::get<0>(channel_tuple)) {
+        auto channel_idx = op_class_channels->channel_list_length();
+        auto channel     = op_class_channels->channel_list(channel_idx - 1);
+        if (!channel) {
             LOG(ERROR) << "getting channel entry has failed!";
             return false;
         }
-        auto &channel = std::get<1>(channel_tuple);
-        channel       = ch;
+        *channel = ch;
     }
 
     // Update channel list flags
@@ -4922,27 +4919,26 @@ bool slave_thread::handle_channel_selection_request(Socket *sd, ieee1905_1::Cmdu
 
                 auto channel_list_length = op_class_channels.channel_list_length();
                 for (int ch_idx = 0; ch_idx < channel_list_length; ch_idx++) {
-                    auto channel_tuple = op_class_channels.channel_list(ch_idx);
-                    if (!std::get<0>(channel_tuple)) {
+                    auto channel = op_class_channels.channel_list(ch_idx);
+                    if (!channel) {
                         LOG(ERROR) << "getting channel entry has failed!";
                         return false;
                     }
 
-                    auto channel = std::get<1>(channel_tuple);
-                    ss << int(channel);
+                    ss << int(*channel);
 
                     // add comma if not last channel in the list, else close list by add curl brackets
                     ss << (((ch_idx + 1) != channel_list_length) ? "," : "}");
 
                     // mark first supported non-dfs channel as selected channel
                     // TODO: need to check that selected channel does not violate radio restriction
-                    if (preference == 0 || wireless_utils::is_dfs_channel(channel)) {
+                    if (preference == 0 || wireless_utils::is_dfs_channel(*channel)) {
                         continue;
                     }
 
                     LOG(INFO) << "selected_operating_class=" << int(operating_class);
-                    LOG(INFO) << "selected_channel=" << int(channel);
-                    selected_channel         = channel;
+                    LOG(INFO) << "selected_channel=" << int(*channel);
+                    selected_channel         = *channel;
                     selected_operating_class = operating_class;
 
                     // TODO: check that the data is parsed properly after fixing the following bug:

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli.h
@@ -497,7 +497,7 @@ class cACTION_CLI_CLIENT_BEACON_11K_REQUEST : public BaseClass
         }
         sMacAddr& client_mac();
         sMacAddr& bssid();
-        std::tuple<bool, uint8_t&> ssid(size_t idx);
+        uint8_t* ssid(size_t idx = 0);
         uint8_t& use_optional_ssid();
         uint8_t& channel();
         uint8_t& measurement_mode();

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -162,7 +162,7 @@ class cACTION_CONTROL_CONTROLLER_PING_REQUEST : public BaseClass
         uint16_t& seq();
         uint16_t& size();
         size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
-        std::tuple<bool, uint8_t&> data(size_t idx);
+        uint8_t* data(size_t idx = 0);
         bool alloc_data(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
@@ -192,7 +192,7 @@ class cACTION_CONTROL_CONTROLLER_PING_RESPONSE : public BaseClass
         uint16_t& seq();
         uint16_t& size();
         size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
-        std::tuple<bool, uint8_t&> data(size_t idx);
+        uint8_t* data(size_t idx = 0);
         bool alloc_data(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
@@ -222,7 +222,7 @@ class cACTION_CONTROL_AGENT_PING_REQUEST : public BaseClass
         uint16_t& seq();
         uint16_t& size();
         size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
-        std::tuple<bool, uint8_t&> data(size_t idx);
+        uint8_t* data(size_t idx = 0);
         bool alloc_data(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
@@ -252,7 +252,7 @@ class cACTION_CONTROL_AGENT_PING_RESPONSE : public BaseClass
         uint16_t& seq();
         uint16_t& size();
         size_t data_length() { return m_data_idx__ * sizeof(uint8_t); }
-        std::tuple<bool, uint8_t&> data(size_t idx);
+        uint8_t* data(size_t idx = 0);
         bool alloc_data(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -1117,13 +1117,12 @@ sMacAddr& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::bssid() {
     return (sMacAddr&)(*m_bssid);
 }
 
-std::tuple<bool, uint8_t&> cACTION_CLI_CLIENT_BEACON_11K_REQUEST::ssid(size_t idx) {
-    bool ret_success = ( (m_ssid_idx__ > 0) && (m_ssid_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cACTION_CLI_CLIENT_BEACON_11K_REQUEST::ssid(size_t idx) {
+    if ( (m_ssid_idx__ <= 0) || (m_ssid_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_ssid[ret_idx]);
+    return &(m_ssid[idx]);
 }
 
 uint8_t& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::use_optional_ssid() {

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -413,13 +413,12 @@ uint16_t& cACTION_CONTROL_CONTROLLER_PING_REQUEST::size() {
     return (uint16_t&)(*m_size);
 }
 
-std::tuple<bool, uint8_t&> cACTION_CONTROL_CONTROLLER_PING_REQUEST::data(size_t idx) {
-    bool ret_success = ( (m_data_idx__ > 0) && (m_data_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cACTION_CONTROL_CONTROLLER_PING_REQUEST::data(size_t idx) {
+    if ( (m_data_idx__ <= 0) || (m_data_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_data[ret_idx]);
+    return &(m_data[idx]);
 }
 
 bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::alloc_data(size_t count) {
@@ -507,13 +506,12 @@ uint16_t& cACTION_CONTROL_CONTROLLER_PING_RESPONSE::size() {
     return (uint16_t&)(*m_size);
 }
 
-std::tuple<bool, uint8_t&> cACTION_CONTROL_CONTROLLER_PING_RESPONSE::data(size_t idx) {
-    bool ret_success = ( (m_data_idx__ > 0) && (m_data_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cACTION_CONTROL_CONTROLLER_PING_RESPONSE::data(size_t idx) {
+    if ( (m_data_idx__ <= 0) || (m_data_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_data[ret_idx]);
+    return &(m_data[idx]);
 }
 
 bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::alloc_data(size_t count) {
@@ -601,13 +599,12 @@ uint16_t& cACTION_CONTROL_AGENT_PING_REQUEST::size() {
     return (uint16_t&)(*m_size);
 }
 
-std::tuple<bool, uint8_t&> cACTION_CONTROL_AGENT_PING_REQUEST::data(size_t idx) {
-    bool ret_success = ( (m_data_idx__ > 0) && (m_data_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cACTION_CONTROL_AGENT_PING_REQUEST::data(size_t idx) {
+    if ( (m_data_idx__ <= 0) || (m_data_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_data[ret_idx]);
+    return &(m_data[idx]);
 }
 
 bool cACTION_CONTROL_AGENT_PING_REQUEST::alloc_data(size_t count) {
@@ -695,13 +692,12 @@ uint16_t& cACTION_CONTROL_AGENT_PING_RESPONSE::size() {
     return (uint16_t&)(*m_size);
 }
 
-std::tuple<bool, uint8_t&> cACTION_CONTROL_AGENT_PING_RESPONSE::data(size_t idx) {
-    bool ret_success = ( (m_data_idx__ > 0) && (m_data_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cACTION_CONTROL_AGENT_PING_RESPONSE::data(size_t idx) {
+    if ( (m_data_idx__ <= 0) || (m_data_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_data[ret_idx]);
+    return &(m_data[idx]);
 }
 
 bool cACTION_CONTROL_AGENT_PING_RESPONSE::alloc_data(size_t count) {

--- a/controller/src/beerocks/cli/beerocks_cli_socket.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_socket.cpp
@@ -845,7 +845,7 @@ int cli_socket::client_beacon_11k_req(std::string client_mac, std::string bssid,
 
     if (!ssid.empty()) {
         request->use_optional_ssid() = true;
-        string_utils::copy_string((char *)&std::get<1>(request->ssid(0)), ssid.c_str(),
+        string_utils::copy_string((char *)request->ssid(), ssid.c_str(),
                                   message::WIFI_SSID_MAX_LENGTH);
     }
     wait_response = true;

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -80,8 +80,7 @@ void son_management::handle_cli_message(Socket *sd,
                 isOK = false;
                 break;
             }
-            auto data_tuple = request->data(0);
-            memset(&std::get<1>(data_tuple), 0, size_left);
+            memset(request->data(), 0, request->data_length());
             if (!database.update_node_last_ping_sent(slave)) {
                 LOG(DEBUG) << "PING_MSG_REQUEST received for slave " << slave
                            << " , can't update last ping sent time for ";
@@ -128,8 +127,7 @@ void son_management::handle_cli_message(Socket *sd,
             break;
         }
 
-        auto data_tuple = request->data(0);
-        memset(&std::get<1>(data_tuple), 0, size_left);
+        memset(request->data(), 0, request->data_length());
 
         auto slaves = database.get_active_hostaps();
         for (const auto &slave : slaves) {
@@ -508,8 +506,7 @@ void son_management::handle_cli_message(Socket *sd,
         // Optional:
         if (cli_request->use_optional_ssid()) {
             request->params().use_optional_ssid = 1; // bool
-            string_utils::copy_string((char *)request->params().ssid,
-                                      (char *)&std::get<1>(cli_request->ssid(0)),
+            string_utils::copy_string((char *)request->params().ssid, (char *)cli_request->ssid(),
                                       beerocks::message::WIFI_SSID_MAX_LENGTH);
         } else {
             request->params().use_optional_ssid = 0;

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -874,14 +874,13 @@ bool master_thread::handle_cmdu_1905_channel_preference_report(Socket *sd,
 
                 auto channel_list_length = op_class_channels_rx.channel_list_length();
                 for (int ch_idx = 0; ch_idx < channel_list_length; ch_idx++) {
-                    auto channel_tuple_rx = op_class_channels_rx.channel_list(ch_idx);
-                    if (!std::get<0>(channel_tuple_rx)) {
+                    auto channel_rx = op_class_channels_rx.channel_list(ch_idx);
+                    if (!channel_rx) {
                         LOG(ERROR) << "getting channel entry has failed!";
                         return false;
                     }
 
-                    auto channel_rx = std::get<1>(channel_tuple_rx);
-                    ss << int(channel_rx);
+                    ss << int(*channel_rx);
 
                     // add comma if not last channel in the list, else close list by add curl brackets
                     ss << (((ch_idx + 1) != channel_list_length) ? "," : "}");
@@ -892,13 +891,13 @@ bool master_thread::handle_cmdu_1905_channel_preference_report(Socket *sd,
                     const auto &ruid = channel_preference_tlv_rx->radio_uid();
 
                     if (std::find(ruid_list.begin(), ruid_list.end(), ruid) != ruid_list.end() ||
-                        preference == 0 || wireless_utils::is_dfs_channel(channel_rx)) {
+                        preference == 0 || wireless_utils::is_dfs_channel(*channel_rx)) {
                         continue;
                     }
 
                     LOG(INFO) << "ruid=" << network_utils::mac_to_string(ruid);
                     LOG(INFO) << "selected_operating_class=" << std::dec << int(operating_class);
-                    LOG(INFO) << "selected_channel=" << int(channel_rx);
+                    LOG(INFO) << "selected_channel=" << int(*channel_rx);
 
                     ruid_list.push_back(ruid);
 
@@ -933,14 +932,13 @@ bool master_thread::handle_cmdu_1905_channel_preference_report(Socket *sd,
                         LOG(ERROR) << "alloc_channel_list() has failed!";
                         return false;
                     }
-                    auto channel_idx      = op_class_channels_tx->channel_list_length();
-                    auto channel_tuple_tx = op_class_channels_tx->channel_list(channel_idx - 1);
-                    if (!std::get<0>(channel_tuple_tx)) {
+                    auto channel_idx = op_class_channels_tx->channel_list_length();
+                    auto channel_tx  = op_class_channels_tx->channel_list(channel_idx - 1);
+                    if (!channel_tx) {
                         LOG(ERROR) << "getting channel entry has failed!";
                         return false;
                     }
-                    auto &channel_tx = std::get<1>(channel_tuple_tx);
-                    channel_tx       = channel_rx;
+                    *channel_tx = *channel_rx;
 
                     op_class_channels_tx->flags() = op_class_channels_rx.flags();
 
@@ -1692,10 +1690,9 @@ bool master_thread::autoconfig_wsc_parse_radio_caps(
             op_class.statically_non_operable_channels_list_length();
         std::vector<uint8_t> non_operable_channels;
         for (int ch_idx = 0; ch_idx < non_oper_channels_list_length; ch_idx++) {
-            auto ch_tuple = op_class.statically_non_operable_channels_list(ch_idx);
-            auto channel  = std::get<1>(ch_tuple);
-            ss << int(channel) << " ";
-            non_operable_channels.push_back(channel);
+            auto channel = op_class.statically_non_operable_channels_list(ch_idx);
+            ss << int(*channel) << " ";
+            non_operable_channels.push_back(*channel);
         }
         ss << " }" << std::endl;
         LOG(DEBUG) << ss.str();
@@ -2337,8 +2334,7 @@ bool master_thread::handle_cmdu_control_message(
                 LOG(ERROR) << "Failed buffer allocation to size=" << int(response->size());
                 break;
             }
-            auto data_tuple = request->data(0);
-            memset(&std::get<1>(data_tuple), 0, response->size());
+            memset(request->data(), 0, request->data_length());
         }
 
         son_actions::send_cmdu_to_agent(sd, cmdu_tx, hostap_mac);
@@ -2382,8 +2378,7 @@ bool master_thread::handle_cmdu_control_message(
                     LOG(ERROR) << "Failed buffer allocation to size=" << int(response->size());
                     break;
                 }
-                auto data_tuple = request->data(0);
-                memset(&std::get<1>(data_tuple), 0, response->size());
+                memset(request->data(), 0, request->data_length());
                 if (!database.update_node_last_ping_sent(hostap_mac)) {
                     LOG(DEBUG) << "sending PING_MSG_REQUEST for slave " << hostap_mac
                                << " , can't update last ping sent time for ";

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -35,7 +35,7 @@ class tlvTestVarList : public BaseClass
         const uint16_t& length();
         uint16_t& var0();
         uint8_t& simple_list_length();
-        std::tuple<bool, uint16_t&> simple_list(size_t idx);
+        uint16_t* simple_list(size_t idx = 0);
         bool alloc_simple_list(size_t count = 1);
         uint8_t& test_string_length();
         std::string test_string_str();
@@ -93,7 +93,7 @@ class cInner : public BaseClass
         const uint16_t& type();
         const uint16_t& length();
         uint8_t& list_length();
-        std::tuple<bool, uint8_t&> list(size_t idx);
+        uint8_t* list(size_t idx = 0);
         bool alloc_list(size_t count = 1);
         uint32_t& var1();
         size_t unknown_length_list_inner_length() { return m_unknown_length_list_inner_idx__ * sizeof(char); }

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioBasicCapabilities.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioBasicCapabilities.h
@@ -70,7 +70,7 @@ class cOperatingClassesInfo : public BaseClass
         uint8_t& operating_class();
         uint8_t& maximum_transmit_power_dbm();
         uint8_t& statically_non_operable_channels_list_length();
-        std::tuple<bool, uint8_t&> statically_non_operable_channels_list(size_t idx);
+        uint8_t* statically_non_operable_channels_list(size_t idx = 0);
         bool alloc_statically_non_operable_channels_list(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
@@ -98,7 +98,7 @@ class cPreferenceOperatingClasses : public BaseClass
         
         uint8_t& operating_class();
         uint8_t& channel_list_length();
-        std::tuple<bool, uint8_t&> channel_list(size_t idx);
+        uint8_t* channel_list(size_t idx = 0);
         bool alloc_channel_list(size_t count = 1);
         sFlags& flags();
         void class_swap();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvHigherLayerData.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvHigherLayerData.h
@@ -40,7 +40,7 @@ class tlvHigherLayerData : public BaseClass
         const uint16_t& length();
         eProtocol& protocol();
         size_t payload_length() { return m_payload_idx__ * sizeof(uint8_t); }
-        std::tuple<bool, uint8_t&> payload(size_t idx);
+        uint8_t* payload(size_t idx = 0);
         bool alloc_payload(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -39,13 +39,12 @@ uint8_t& tlvTestVarList::simple_list_length() {
     return (uint8_t&)(*m_simple_list_length);
 }
 
-std::tuple<bool, uint16_t&> tlvTestVarList::simple_list(size_t idx) {
-    bool ret_success = ( (m_simple_list_idx__ > 0) && (m_simple_list_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint16_t* tlvTestVarList::simple_list(size_t idx) {
+    if ( (m_simple_list_idx__ <= 0) || (m_simple_list_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_simple_list[ret_idx]);
+    return &(m_simple_list[idx]);
 }
 
 bool tlvTestVarList::alloc_simple_list(size_t count) {
@@ -519,13 +518,12 @@ uint8_t& cInner::list_length() {
     return (uint8_t&)(*m_list_length);
 }
 
-std::tuple<bool, uint8_t&> cInner::list(size_t idx) {
-    bool ret_success = ( (m_list_idx__ > 0) && (m_list_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cInner::list(size_t idx) {
+    if ( (m_list_idx__ <= 0) || (m_list_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_list[ret_idx]);
+    return &(m_list[idx]);
 }
 
 bool cInner::alloc_list(size_t count) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -204,13 +204,12 @@ uint8_t& cOperatingClassesInfo::statically_non_operable_channels_list_length() {
     return (uint8_t&)(*m_statically_non_operable_channels_list_length);
 }
 
-std::tuple<bool, uint8_t&> cOperatingClassesInfo::statically_non_operable_channels_list(size_t idx) {
-    bool ret_success = ( (m_statically_non_operable_channels_list_idx__ > 0) && (m_statically_non_operable_channels_list_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cOperatingClassesInfo::statically_non_operable_channels_list(size_t idx) {
+    if ( (m_statically_non_operable_channels_list_idx__ <= 0) || (m_statically_non_operable_channels_list_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_statically_non_operable_channels_list[ret_idx]);
+    return &(m_statically_non_operable_channels_list[idx]);
 }
 
 bool cOperatingClassesInfo::alloc_statically_non_operable_channels_list(size_t count) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -192,13 +192,12 @@ uint8_t& cPreferenceOperatingClasses::channel_list_length() {
     return (uint8_t&)(*m_channel_list_length);
 }
 
-std::tuple<bool, uint8_t&> cPreferenceOperatingClasses::channel_list(size_t idx) {
-    bool ret_success = ( (m_channel_list_idx__ > 0) && (m_channel_list_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* cPreferenceOperatingClasses::channel_list(size_t idx) {
+    if ( (m_channel_list_idx__ <= 0) || (m_channel_list_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_channel_list[ret_idx]);
+    return &(m_channel_list[idx]);
 }
 
 bool cPreferenceOperatingClasses::alloc_channel_list(size_t count) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -37,13 +37,12 @@ tlvHigherLayerData::eProtocol& tlvHigherLayerData::protocol() {
     return (eProtocol&)(*m_protocol);
 }
 
-std::tuple<bool, uint8_t&> tlvHigherLayerData::payload(size_t idx) {
-    bool ret_success = ( (m_payload_idx__ > 0) && (m_payload_idx__ > idx) );
-    size_t ret_idx = ret_success ? idx : 0;
-    if (!ret_success) {
+uint8_t* tlvHigherLayerData::payload(size_t idx) {
+    if ( (m_payload_idx__ <= 0) || (m_payload_idx__ <= idx) ) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
     }
-    return std::forward_as_tuple(ret_success, m_payload[ret_idx]);
+    return &(m_payload[idx]);
 }
 
 bool tlvHigherLayerData::alloc_payload(size_t count) {

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -103,8 +103,8 @@ int test_complex_list()
         MAPF_ERR("Failed to allocate simple list");
         errors++;
     }
-    std::get<1>(fourthTlv->simple_list(0)) = 0x0bb0;
-    std::get<1>(fourthTlv->simple_list(1)) = 0x0bb1;
+    *(fourthTlv->simple_list(0)) = 0x0bb0;
+    *(fourthTlv->simple_list(1)) = 0x0bb1;
 
     if (true == fourthTlv->set_test_string("1234567890")) {
         LOG(ERROR) << "FAIL test maximum size string";
@@ -120,9 +120,9 @@ int test_complex_list()
         auto cmplx    = fourthTlv->create_complex_list();
         cmplx->var1() = 0xbbbbaaaa;
         cmplx->alloc_list(3);
-        std::get<1>(cmplx->list(0)) = 0xc0;
-        std::get<1>(cmplx->list(1)) = 0xc1;
-        std::get<1>(cmplx->list(2)) = 0xc2;
+        *(cmplx->list(0)) = 0xc0;
+        *(cmplx->list(1)) = 0xc1;
+        *(cmplx->list(2)) = 0xc2;
         if (!fourthTlv->add_complex_list(cmplx)) {
             LOG(ERROR) << "Failed to add complex list";
             errors++;
@@ -406,21 +406,21 @@ int test_all()
     fourthTlv->var0()  = 0xa0;
     allocation_succeed = fourthTlv->alloc_simple_list(2);
     mapf_assert(allocation_succeed);
-    std::get<1>(fourthTlv->simple_list(0)) = 0x0bb0;
-    std::get<1>(fourthTlv->simple_list(1)) = 0x0bb1;
+    *(fourthTlv->simple_list(0)) = 0x0bb0;
+    *(fourthTlv->simple_list(1)) = 0x0bb1;
 
     auto cmplx = fourthTlv->create_complex_list();
     cmplx->alloc_list(3);
-    std::get<1>(cmplx->list(0)) = 0xc0;
-    std::get<1>(cmplx->list(1)) = 0xc1;
-    std::get<1>(cmplx->list(2)) = 0xc2;
-    cmplx->var1()               = 0xd00d;
+    *(cmplx->list(0)) = 0xc0;
+    *(cmplx->list(1)) = 0xc1;
+    *(cmplx->list(2)) = 0xc2;
+    cmplx->var1()     = 0xd00d;
     cmplx->alloc_list();
-    std::get<1>(cmplx->list(3)) = 0xc3;
+    *(cmplx->list(3)) = 0xc3;
     cmplx->alloc_list();
-    std::get<1>(cmplx->list(4)) = 0xc4;
+    *(cmplx->list(4)) = 0xc4;
     cmplx->alloc_list();
-    std::get<1>(cmplx->list(5)) = 0xc5;
+    *(cmplx->list(5)) = 0xc5;
     if (!fourthTlv->add_complex_list(cmplx)) { //first entry
         LOG(ERROR) << "Failed to add complex list";
         errors++;
@@ -559,13 +559,13 @@ int test_all()
         }
         for (uint8_t list_idx = 0; list_idx < tlv4->simple_list_length(); list_idx++) {
             uint16_t expected = 0x0bb0;
-            if (!std::get<0>(tlv4->simple_list(list_idx))) {
+            if (!tlv4->simple_list(list_idx)) {
                 MAPF_ERR("TLV4 has no simple " << list_idx);
                 errors++;
             } else {
-                auto value = std::get<1>(tlv4->simple_list(list_idx));
-                if (value != expected + list_idx) {
-                    MAPF_ERR("TLV4 simple ") << list_idx << " has value " << std::hex << value
+                auto value = tlv4->simple_list(list_idx);
+                if (*value != expected + list_idx) {
+                    MAPF_ERR("TLV4 simple ") << list_idx << " has value " << std::hex << *value
                                              << " instead of " << std::hex << expected + list_idx;
                     errors++;
                 }
@@ -599,14 +599,14 @@ int test_all()
             }
             uint8_t expected = 0xc0;
             for (uint8_t list_idx = 0; list_idx < cmplx.list_length(); list_idx++) {
-                if (!std::get<0>(cmplx.list(list_idx))) {
+                if (!cmplx.list(list_idx)) {
                     MAPF_ERR("TLV4 complex 0 has no list[" << list_idx << "]");
                     errors++;
                 } else {
-                    auto value = std::get<1>(cmplx.list(list_idx));
-                    if (value != expected + list_idx) {
+                    auto value = cmplx.list(list_idx);
+                    if (*value != expected + list_idx) {
                         MAPF_ERR("TLV4 complex 0 list ")
-                            << list_idx << " has value " << std::hex << value << " instead of "
+                            << list_idx << " has value " << std::hex << *value << " instead of "
                             << std::hex << expected + list_idx;
                         errors++;
                     }

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -972,6 +972,16 @@ class TlvF:
                 lines_cpp.append( "%sreturn true;" % self.getIndentation(1))
                 lines_cpp.append( "}")
 
+            elif param_type_info.type == TypeInfo.STD:
+                lines_h.append( "%s* %s(size_t idx = 0);" % (param_type, param_name) )
+                lines_cpp.append( "%s* %s::%s(size_t idx) {" % (param_type_full, obj_meta.name, param_name) )
+                lines_cpp.append( "%sif ( (m_%s_idx__ <= 0) || (m_%s_idx__ <= idx) ) {" % (self.getIndentation(1), param_name, param_name) )
+                lines_cpp.append( '%sTLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";' %  self.getIndentation(2) )
+                lines_cpp.append( '%sreturn nullptr;' %  self.getIndentation(2) )
+                lines_cpp.append( "%s}" % self.getIndentation(1) )
+                lines_cpp.append( "%sreturn &(m_%s[idx]);" % (self.getIndentation(1), param_name) )
+                lines_cpp.append( "}" )
+                lines_cpp.append( "" )
             else:
                 #add function to get reference
                 lines_h.append( "std::tuple<bool, %s&> %s(size_t idx);" % (param_type, param_name) )


### PR DESCRIPTION
Issue #156 
Currently, only char types lists (dynamic/variable length) include a getter function to return a pointer to the buffer. For any other list type, the getter function returns a tuple with reference to the element. In case of STD types, normally they are simple buffers - so this getter function forces the user to write complex code. The better approach will be to return buffer pointer for STD type lists instead of tuple. TLVF changed to generate getter function which returns buffer pointer in case of STD types. In case requested index is out of range nullptr will be returned. Updated code which used changed API.