### PR TITLE
controller:add higher layer data payload handler

### DIFF
--- a/controller/src/beerocks/master/beerocks_master_mrouter.cpp
+++ b/controller/src/beerocks/master/beerocks_master_mrouter.cpp
@@ -57,6 +57,7 @@ bool master_mrouter::init()
         ieee1905_1::eMessageType::CHANNEL_SELECTION_RESPONSE_MESSAGE,
         ieee1905_1::eMessageType::OPERATING_CHANNEL_REPORT_MESSAGE,
         ieee1905_1::eMessageType::TOPOLOGY_DISCOVERY_MESSAGE,
+        ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE,
         ieee1905_1::eMessageType::ACK_MESSAGE,
     }));
 }

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -42,6 +42,7 @@
 #include <tlvf/wfa_map/tlvApRadioIdentifier.h>
 #include <tlvf/wfa_map/tlvChannelPreference.h>
 #include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
+#include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvOperatingChannelReport.h>
 #include <tlvf/wfa_map/tlvRadioOperationRestriction.h>
 #include <tlvf/wfa_map/tlvSearchedService.h>
@@ -229,6 +230,8 @@ bool master_thread::handle_cmdu_1905_1_message(Socket *sd, ieee1905_1::CmduMessa
         return handle_cmdu_1905_operating_channel_report(sd, cmdu_rx);
     case ieee1905_1::eMessageType::TOPOLOGY_DISCOVERY_MESSAGE:
         return handle_cmdu_1905_topology_discovery(sd, cmdu_rx);
+    case ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE:
+        return handle_cmdu_1905_higher_layer_data_message(sd, cmdu_rx);
     default:
         break;
     }
@@ -1117,6 +1120,33 @@ bool master_thread::handle_cmdu_1905_topology_discovery(Socket *sd,
     database.set_node_socket(al_mac, sd);
 
     return true;
+}
+
+bool master_thread::handle_cmdu_1905_higher_layer_data_message(Socket *sd,
+                                                               ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    const auto mid = cmdu_rx.getMessageId();
+    LOG(DEBUG) << "Received HIGHER_LAYER_DATA_MESSAGE , mid=" << std::hex << int(mid);
+
+    auto tlvHigherLayerData = cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
+    if (!tlvHigherLayerData) {
+        LOG(ERROR) << "addClass wfa_map::tlvHigherLayerData failed";
+        return false;
+    }
+
+    const auto protocol       = tlvHigherLayerData->protocol();
+    const auto payload_length = tlvHigherLayerData->payload_length();
+    LOG(DEBUG) << "protocol: " << std::hex << protocol;
+    LOG(DEBUG) << "payload length: " << int(payload_length);
+
+    // build ACK message CMDU
+    auto cmdu_tx_header = cmdu_tx.create(mid, ieee1905_1::eMessageType::ACK_MESSAGE);
+    if (!cmdu_tx_header) {
+        LOG(ERROR) << "cmdu creation of type ACK_MESSAGE, has failed";
+        return false;
+    }
+    LOG(DEBUG) << "sending ACK message to the agent, mid=" << std::hex << int(mid);
+    return son_actions::send_cmdu_to_agent(sd, cmdu_tx);
 }
 
 bool master_thread::handle_intel_slave_join(

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -71,6 +71,7 @@ private:
     bool handle_cmdu_1905_operating_channel_report(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_topology_discovery(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_higher_layer_data_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool autoconfig_wsc_parse_radio_caps(
         std::string radio_mac, std::shared_ptr<wfa_map::tlvApRadioBasicCapabilities> radio_caps);
     // Autoconfig encryption support


### PR DESCRIPTION
According to section 5.10.2 in the EasyMesh Test Plan v1.0 [1],
CTT agent 1 sends a Higher Layer Data message to the MCUT.
When the message is received by the MCUT, an ACK message
 needs to be sent back to the agent.

To make sure the higher layer data message was received by the agent:

1. The controller subscribes to a message of type :
   HIGHER_LAYER_DATA_MESSAGE.

2. Add handle_cmdu_1905_higher_layer_data_message method which print "Received
   HIGHER_LAYER_DATA_MESSAGE" when the message is received in the controller.
   In addition, create an ACK CMDU to send back to the
   agent.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>