### PR TITLE
agent:backhaul_manager:really parse tlvHigherLayerData

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1653,9 +1653,10 @@ bool main_thread::handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageR
         return false;
     }
 
+    const auto protocol       = tlvHigherLayerData->protocol();
     const auto payload_length = tlvHigherLayerData->payload_length();
-    LOG(DEBUG) << "protocol: " << std::hex << protocol;
-    LOG(DEBUG) << "payload_length: " << int(payload_length);
+    LOG(DEBUG) << "protocol: " << std::hex << int(protocol);
+    LOG(DEBUG) << "payload_length: " << std::hex << int(payload_length);
 
     // build ACK message CMDU
     auto cmdu_tx_header = cmdu_tx.create(mid, ieee1905_1::eMessageType::ACK_MESSAGE);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1653,10 +1653,9 @@ bool main_thread::handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageR
         return false;
     }
 
-    auto protocol     = tlvHigherLayerData->protocol();
-    const auto length = tlvHigherLayerData->length();
+    const auto payload_length = tlvHigherLayerData->payload_length();
     LOG(DEBUG) << "protocol: " << std::hex << protocol;
-    LOG(DEBUG) << "length: " << int(length);
+    LOG(DEBUG) << "payload_length: " << int(payload_length);
 
     // build ACK message CMDU
     auto cmdu_tx_header = cmdu_tx.create(mid, ieee1905_1::eMessageType::ACK_MESSAGE);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1647,7 +1647,7 @@ bool main_thread::handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageR
     const auto mid = cmdu_rx.getMessageId();
     LOG(DEBUG) << "Received HIGHER_LAYER_DATA_MESSAGE , mid=" << std::hex << int(mid);
 
-    auto tlvHigherLayerData = cmdu_tx.addClass<wfa_map::tlvHigherLayerData>();
+    auto tlvHigherLayerData = cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
     if (!tlvHigherLayerData) {
         LOG(ERROR) << "addClass wfa_map::tlvHigherLayerData failed";
         return false;

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -174,6 +174,10 @@ test_higher_layer_data_payload_trigger() {
     dbg "Confirming higher layer data message was received in the agent" 
     docker exec -it repeater1 sh -c 'grep -i -q "HIGHER_LAYER_DATA_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent.log'
 
+    dbg "Confirming matching protocol and payload length"
+    docker exec -it repeater1 sh -c 'grep -i -q "protocol: 0" /tmp/$USER/beerocks/logs/beerocks_agent.log'
+    docker exec -it repeater1 sh -c 'grep -i -q "payload_length: 4b0" /tmp/$USER/beerocks/logs/beerocks_agent.log'
+
     dbg "Confirming ACK message was received in the controller"
     docker exec -it gateway sh -c 'grep -i -q "ACK_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_controller.log'
 }


### PR DESCRIPTION
Fix a bug that has been added in commit d491828.

The problem is addClass is performed not on the right CMDU, but on an
empty CMDU, which causes the payload length to be zero.

Therefore, perform the addClass method on the right CMDU.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>