### PR TITLE
bwl: dummy: add infrastructure for simulating events

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -36,6 +36,8 @@ elseif(TARGET_PLATFORM STREQUAL "rdkb")
 # Linux
 elseif(TARGET_PLATFORM STREQUAL "linux")
     set(BWL_TYPE_DEFAULT "DUMMY")
+    set(BEEROCKS_TMP_PATH "/tmp/$ENV{USER}/beerocks")
+    add_definitions(-DBEEROCKS_TMP_PATH="${BEEROCKS_TMP_PATH}")
 endif()
 
 set(BWL_TYPE ${BWL_TYPE_DEFAULT} CACHE STRING "Which BWL backend to use")

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -14,6 +14,7 @@
 #include <beerocks/bcl/son/son_wireless_utils.h>
 
 #include <easylogging++.h>
+#include <limits.h>
 #include <sys/inotify.h>
 
 #define UNHANDLED_EVENTS_LOGS 20
@@ -89,6 +90,8 @@ base_wlan_hal_dummy::base_wlan_hal_dummy(HALType type, std::string iface_name, b
     // inotify_init1 not available with older kernels, consequently inotify reads block.
     // inotify_init1 allows directory events to complete immediately, avoiding buffering delays. In practice,
     // this significantly improves monotiring of newly created subdirectories.
+    // Note that IN_NONBLOCK is not defined in old kernels so we get to the #else and call inotify_init()
+    // in this case.
 #ifdef IN_NONBLOCK
     m_fd_ext_events = inotify_init1(IN_NONBLOCK);
 #else
@@ -98,6 +101,10 @@ base_wlan_hal_dummy::base_wlan_hal_dummy(HALType type, std::string iface_name, b
     if (m_fd_ext_events < 0) {
         LOG(FATAL) << "Failed creating m_fd_ext_events: " << strerror(errno);
     }
+
+    std::string path = std::string(BEEROCKS_TMP_PATH) + "/" + get_iface_name();
+    mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    inotify_add_watch(m_fd_ext_events, path.c_str(), (IN_CREATE | IN_DELETE | IN_MODIFY));
 
     // Initialize the FSM
     fsm_setup();
@@ -133,7 +140,55 @@ bool base_wlan_hal_dummy::refresh_vap_info(int vap_id) { return true; }
 
 bool base_wlan_hal_dummy::refresh_vaps_info(int id) { return true; }
 
-bool base_wlan_hal_dummy::process_ext_events() { return true; }
+/**
+ * @brief process simulated events
+ *        events are expected to be simulated by writing the event
+ *        string to the first line in the EVENT file.
+ *        For example, simulating client connected event:
+ *        echo "STA_CONNECTED,11:22:33:44:55:66"
+ *
+ * @return true on success
+ * @return false on failure
+ */
+bool base_wlan_hal_dummy::process_ext_events()
+{
+    // From http://man7.org/linux/man-pages/man7/inotify.7.html:
+    // The behavior when the buffer given to read(2) is too small to return
+    // information about the next event depends on the kernel version: in
+    // kernels before 2.6.21, read(2) returns 0; since kernel 2.6.21,
+    // read(2) fails with the error EINVAL.  Specifying a buffer of size
+    // sizeof(struct inotify_event) + NAME_MAX + 1
+    // will be sufficient to read at least one event.
+    const size_t event_size = sizeof(struct inotify_event) + NAME_MAX + 1;
+    // Use a static buffer big enough to hold up to 128 events
+    // We don't actually read the events.
+    // The purpose is to always be able to clear all events with a single read.
+    static char buffer[128 * event_size];
+
+    LOG(DEBUG) << "in process external events";
+
+    // dummy read to clear event
+    int length = read(m_fd_ext_events, buffer, sizeof(buffer));
+    if (length < 0) {
+        LOG(ERROR) << "Failed to read from m_fd_ext_events";
+        return false;
+    }
+
+    std::string event_file = std::string(BEEROCKS_TMP_PATH) + "/" + get_iface_name() + "/EVENT";
+    std::ifstream stream;
+    stream.open(event_file);
+    if (!stream.is_open()) {
+        LOG(DEBUG) << "Invalid event, missing " << event_file << " file";
+        return true;
+    }
+    std::string event;
+    std::getline(stream, event);
+    LOG(DEBUG) << "Received event " << event;
+
+    // TODO Handle event
+    stream.close();
+    return true;
+}
 
 std::string base_wlan_hal_dummy::get_radio_mac()
 {


### PR DESCRIPTION
Currently, we are using a dummy eventfd for external events which does
nothing but being added to the user's select.
Replace that with inotify, still unconfigured, as the base grounds for
adding external events simulation via files.

The second commit adds basic infrastructure for events simulation by writing
the event string to the EVENT file in <BEEROCKS_TMP_PATH>/<ifname>/EVENT.

The way this is implemented is by using inotify to monitor changes in the EVENT file directory, but not actually processing the inotify event but only using it to be notified that *something* changed.
The reason for that is to simplify the implementation - only the first line in the EVENT file will be parsed.

For example, simulating a STA with MAC 11:22:33:44:55:66 is connected to wlan0 AP is done as follows:

```bash
echo "STA_CONNECTED,11:22:33:44:55:66" > /tmp/$USER/beerocks/wlan0/EVENT
```
Note that currently, no handling is done, this commit provides
infrastructure only. Events handling will be done in separate PRs.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>