### PR TITLE
bwl: dummy: add simulated events support

### DIFF
--- a/common/beerocks/bwl/dummy/README.md
+++ b/common/beerocks/bwl/dummy/README.md
@@ -1,0 +1,57 @@
+# BWL Dummy
+
+Dummy BWL implementation for Linux (not using actual WiFi radios).
+
+## Simulating Events
+
+The BWL Dummy implementation provides simple events simulation support using text file modification, specifically for simulated client connect - disconnect.
+
+The way this is implemented is using `inotify` support in Linux to watch a file named EVENT in each radio agent:
+
+```bash
+/tmp/$USER/beerocks/wlan0/EVENT
+/tmp/$USER/beerocks/wlan2/EVENT
+```
+
+The dummy BWL implementation reads the first line of the EVENT file each time it is modified (or created), and parse the event, then act on it.
+
+This allows simulating WLAN events simply by writing the event as it would have been received from hostapd into this file - according to  [upstream hostapd](https://w1.fi/wpa_supplicant/devel/ctrl_iface_page.html).
+For example, simulating client connected event to the 2.4G radio (wlan0):
+
+```bash
+echo "AP-STA-CONNECTED 11:22:33:44:55:66" > /tmp/$USER/beerocks/wlan0/EVENT
+```
+
+This results with the event picked by the BWL dummy implementation:
+
+```bash
+INFO 11:42:21:311 <140309100766976> ap_manager_thread.cpp[909] --> STA_Connected mac = 11:22:33:44:55:66
+TRACE 11:42:21:311 <140309101423488> son_slave_thread.cpp[2509] --> received ACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION
+INFO 11:42:21:311 <140309101423488> son_slave_thread.cpp[2520] --> client associated sta_mac=11:22:33:44:55:66
+```
+
+Then in the controller:
+
+```bash
+INFO 11:42:21:312 <140688433724288> son_master_thread.cpp[2451] --> client associated, mac=11:22:33:44:55:66 hostap mac=00:11:22:33:00:10 setting to channel=1 
+```
+
+Which can be seen in `bml_conn_map`:
+
+```bash
+beerocks_cli -c bml_conn_map
+
+bml_connect: return value is: BML_RET_OK, Success status
+bml_nw_map_query: return value is: BML_RET_OK, Success status
+
+GW_BRIDGE: name: GW_MASTER, mac: 00:11:22:33:00:00, ipv4: 172.18.0.234
+    ETHERNET: mac: 00:11:22:33:00:01
+    RADIO: wlan0 mac: 00:11:22:33:00:10, ch: 1, bw: 80L, freq: 2412MHz
+        fVAP[0]: wlan0.0 bssid: 00:11:22:33:00:10, ssid: N/A
+            CLIENT: mac: 11:22:33:44:55:66, ipv4: 0.0.0.0, name: N/A, ch: 1, bw: 80L, rx_rssi: -127
+    RADIO: wlan2 mac: 00:11:22:33:00:20, ch: 149, bw: 80L, freq: 5745MHz
+        fVAP[0]: wlan2.0 bssid: 00:11:22:33:00:20, ssid: N/A
+bml_disconnect: return value is: BML_RET_OK, Success status
+```
+
+Using this new capability in DUMMY mode, development of flows involving stations such as steering can be tested more thoroughly. In addition, this provides the basis for Agent support in DUMMY mode.

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -218,7 +218,7 @@ bool ap_wlan_hal_dummy::get_vap_enable(const std::string &iface_name, bool &enab
 
 std::string ap_wlan_hal_dummy::get_radio_driver_version() { return std::string("dummy"); }
 
-bool ap_wlan_hal_dummy::process_dummy_event(char *buffer, int bufLen, const std::string &opcode)
+bool ap_wlan_hal_dummy::process_dummy_event(parsed_obj_map_t &parsed_obj)
 {
     return true;
 }

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
@@ -67,7 +67,7 @@ public:
 
     // Protected methods:
 protected:
-    virtual bool process_dummy_event(char *buffer, int bufLen, const std::string &opcode) override;
+    virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;
 
     // Overload for AP events
     bool event_queue_push(ap_wlan_hal::Event event, std::shared_ptr<void> data = {})

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -289,6 +289,8 @@ bool base_wlan_hal_dummy::refresh_radio_info()
     if (get_iface_name() == "wlan2") {
         m_radio_info.is_5ghz = true;
     }
+    beerocks::net::network_utils::linux_iface_get_mac(
+        m_radio_info.iface_name, m_radio_info.available_vaps[beerocks::IFACE_VAP_ID_MIN].mac);
     return true;
 }
 

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
@@ -16,12 +16,19 @@
 #include <chrono>
 #include <memory>
 
+#define DUMMY_EVENT_KEYLESS_PARAM_OPCODE "_opcode"
+#define DUMMY_EVENT_KEYLESS_PARAM_MAC "_mac"
+#define DUMMY_EVENT_KEYLESS_PARAM_IFACE "_iface"
+
 namespace bwl {
 namespace dummy {
 
 enum class dummy_fsm_state { Delay, Init, GetRadioInfo, Attach, Operational, Detach };
 
 enum class dummy_fsm_event { Attach, Detach };
+
+typedef std::unordered_map<std::string, std::string> parsed_obj_map_t;
+typedef std::list<parsed_obj_map_t> parsed_obj_listed_map_t;
 
 /*!
  * Base class for the dummy abstraction layer.
@@ -47,8 +54,15 @@ protected:
     base_wlan_hal_dummy(HALType type, std::string iface_name, bool acs_enabled,
                         hal_event_cb_t callback, int wpa_ctrl_buffer_size);
 
+    void parsed_obj_debug(parsed_obj_map_t &obj);
+    void parsed_obj_debug(parsed_obj_listed_map_t &obj);
+
+    bool dummy_obj_read_int(const std::string &key, parsed_obj_map_t &obj, int64_t &value,
+                            bool ignore_unknown = false);
+    bool dummy_obj_read_str(const std::string &key, parsed_obj_map_t &obj, char **value);
+
     // Process dummy event
-    virtual bool process_dummy_event(char *buffer, int bufLen, const std::string &opcode) = 0;
+    virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) = 0;
 
     bool dummy_send_cmd(const std::string &cmd, char **reply); // for external process
     bool dummy_send_cmd(const std::string &cmd);

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
@@ -95,8 +95,14 @@ bool mon_wlan_hal_dummy::sta_link_measurements_11k_request(const std::string &st
     return true;
 }
 
-bool mon_wlan_hal_dummy::process_dummy_event(char *buffer, int bufLen, const std::string &opcode)
+bool mon_wlan_hal_dummy::process_dummy_event(parsed_obj_map_t &parsed_obj)
 {
+    // Filter out empty events
+    std::string opcode;
+    if (!(parsed_obj.find(DUMMY_EVENT_KEYLESS_PARAM_OPCODE) != parsed_obj.end() &&
+          !(opcode = parsed_obj[DUMMY_EVENT_KEYLESS_PARAM_OPCODE]).empty())) {
+        return true;
+    }
     LOG(TRACE) << __func__ << " - opcode: |" << opcode << "|";
     return true;
 }

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -42,7 +42,7 @@ public:
 
     // Protected methods:
 protected:
-    virtual bool process_dummy_event(char *buffer, int bufLen, const std::string &opcode) override;
+    virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;
 
     // Overload for Monitor events
     bool event_queue_push(mon_wlan_hal::Event event, std::shared_ptr<void> data = {})


### PR DESCRIPTION
Add support for simulated client connect - disconnect for dummy mode.
The way this is implemented is using `inotify` support in Linux to watch a file named EVENT in each radio agent:
```
/tmp/$USER/beerocks/wlan0/EVENT
/tmp/$USER/beerocks/wlan2/EVENT
```
The dummy BWL implementation reads the first line of the EVENT file each time it is modified (or created), and parse the event, then act on it.

This allows simulating WLAN events simply by writing the event as it would have been received from hostapd into this file - according to  [upstream hostapd](https://w1.fi/wpa_supplicant/devel/ctrl_iface_page.html).
For example, simulating client connected event to the 2.4G radio (wlan0):

```bash
echo "AP-STA-CONNECTED 11:22:33:44:55:66" > /tmp/$USER/beerocks/wlan0/EVENT
```
This results with the event picked by the BWL dummy implementation:

```bash
INFO 11:42:21:311 <140309100766976> ap_manager_thread.cpp[909] --> STA_Connected mac = 11:22:33:44:55:66
TRACE 11:42:21:311 <140309101423488> son_slave_thread.cpp[2509] --> received ACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION
INFO 11:42:21:311 <140309101423488> son_slave_thread.cpp[2520] --> client associated sta_mac=11:22:33:44:55:66
```

Then in the controller:

```bash
INFO 11:42:21:312 <140688433724288> son_master_thread.cpp[2451] --> client associated, mac=11:22:33:44:55:66 hostap mac=00:11:22:33:00:10 setting to channel=1 
```

Which can be seen in `bml_conn_map`:

```bash
root@5a893a8f58b7:/# /home/tbeliyah/work/dev1/build/install/bin/beerocks_cli -c bml_conn_map
bml_connect: return value is: BML_RET_OK, Success status
bml_nw_map_query: return value is: BML_RET_OK, Success status

GW_BRIDGE: name: GW_MASTER, mac: 00:11:22:33:00:00, ipv4: 172.18.0.234
    ETHERNET: mac: 00:11:22:33:00:01
    RADIO: wlan0 mac: 00:11:22:33:00:10, ch: 1, bw: 80L, freq: 2412MHz
        fVAP[0]: wlan0.0 bssid: 00:11:22:33:00:10, ssid: N/A
            CLIENT: mac: 11:22:33:44:55:66, ipv4: 0.0.0.0, name: N/A, ch: 1, bw: 80L, rx_rssi: -127
    RADIO: wlan2 mac: 00:11:22:33:00:20, ch: 149, bw: 80L, freq: 5745MHz
        fVAP[0]: wlan2.0 bssid: 00:11:22:33:00:20, ssid: N/A
bml_disconnect: return value is: BML_RET_OK, Success status
root@5a893a8f58b7:/# 
```

Using this new capability in DUMMY mode, development of flows involving stations such as steering can be tested more thoroughly. In addition, this provides the basis for Agent support in DUMMY mode.