### PR TITLE
Controller:master:db use sMacaddr instead of std::string

### DIFF
--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -13,6 +13,7 @@
 
 #include <beerocks/bcl/beerocks_defines.h>
 #include <beerocks/bcl/beerocks_logging.h>
+#include <beerocks/bcl/network/network_utils.h>
 
 #include <tlvf/WSC/eWscAuth.h>
 #include <tlvf/WSC/eWscEncr.h>
@@ -155,10 +156,11 @@ public:
     bool has_node(sMacAddr mac);
 
     bool add_virtual_node(sMacAddr mac, sMacAddr real_node_mac);
-    bool add_node(std::string mac, std::string parent_mac = std::string(),
-                  beerocks::eType type         = beerocks::TYPE_CLIENT,
-                  std::string radio_identifier = std::string());
-    bool remove_node(std::string mac);
+    bool add_node(const sMacAddr &mac,
+                  const sMacAddr &parent_mac       = beerocks::net::network_utils::ZERO_MAC,
+                  beerocks::eType type             = beerocks::TYPE_CLIENT,
+                  const sMacAddr &radio_identifier = beerocks::net::network_utils::ZERO_MAC);
+    bool remove_node(const sMacAddr &mac);
 
     bool set_node_type(std::string mac, beerocks::eType type);
     beerocks::eType get_node_type(std::string mac);

--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -126,7 +126,8 @@ bool son_actions::add_node_to_default_location(db &database, std::string client_
     }
 
     //LOG(DEBUG) << "adding node " << client_mac << " to db, after getting ARP_MONITOR_NOTIFICATION from source " << int(notification->params.source);
-    if (!database.add_node(client_mac, gw_lan_switch)) {
+    if (!database.add_node(network_utils::mac_from_string(client_mac),
+                           network_utils::mac_from_string(gw_lan_switch))) {
         LOG(ERROR) << "add_node_to_default_location - add_node failed";
         return false;
     }

--- a/controller/src/beerocks/master/tasks/client_locating_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_locating_task.cpp
@@ -139,11 +139,15 @@ void client_locating_task::work()
                         // update node
                         if (database.get_node_type(client_mac) == beerocks::TYPE_IRE) {
                             auto ire_backhaul = database.get_node_parent_backhaul(client_mac);
-                            database.add_node(ire_backhaul, eth_sw_mac,
+                            database.add_node(network_utils::mac_from_string(ire_backhaul),
+                                              network_utils::mac_from_string(eth_sw_mac),
                                               beerocks::TYPE_IRE_BACKHAUL);
-                            database.add_node(client_mac, ire_backhaul, beerocks::TYPE_IRE);
+                            database.add_node(network_utils::mac_from_string(client_mac),
+                                              network_utils::mac_from_string(ire_backhaul),
+                                              beerocks::TYPE_IRE);
                         } else {
-                            database.add_node(client_mac, eth_sw_mac);
+                            database.add_node(network_utils::mac_from_string(client_mac),
+                                              network_utils::mac_from_string(eth_sw_mac));
                             database.set_node_state(client_mac, beerocks::STATE_CONNECTED);
                         }
 


### PR DESCRIPTION
The master database son::db uses std::string types to represent MAC
addresses. This leads to a lot of conversions to sMacAddr structures,
and carries a risk that a string sneaks in somewhere that is not a
valid MAC address.

Changed std::string to sMacAddr for son::db::add_node and remove_node
function.

Signed-off-by: Maksym Bielan <maksym.bielan@globallogic.com>