### PR TITLE
controller: fix endless loop on addClass failure

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4479,8 +4479,10 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
 
     while ((type = cmdu_rx.getNextTlvType()) != int(ieee1905_1::eTlvType::TLV_END_OF_MESSAGE)) {
         if (type == int(wfa_map::eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER)) {
-            LOG(DEBUG) << "Found TLV_AP_RADIO_IDENTIFIER TLV";
             ruid = cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
+            if (!ruid)
+                return false;
+            LOG(DEBUG) << "Found TLV_AP_RADIO_IDENTIFIER TLV";
         } else if (type == int(ieee1905_1::eTlvType::TLV_WSC)) {
             // parse all M2 TLVs
             LOG(DEBUG) << "Found TLV_WSC TLV (assuming M2)";

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -680,11 +680,15 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
 
     while ((type = cmdu_rx.getNextTlvType()) != int(ieee1905_1::eTlvType::TLV_END_OF_MESSAGE)) {
         if (type == int(wfa_map::eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES)) {
-            LOG(DEBUG) << "Found TLV_AP_RADIO_BASIC_CAPABILITIES TLV";
             radio_basic_caps = cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+            if (!radio_basic_caps)
+                return false;
+            LOG(DEBUG) << "Found TLV_AP_RADIO_BASIC_CAPABILITIES TLV";
         } else if (type == int(ieee1905_1::eTlvType::TLV_WSC)) {
-            LOG(DEBUG) << "Found TLV_WSC TLV (assuming M1)";
             tlvwscM1 = cmdu_rx.addClass<ieee1905_1::tlvWscM1>();
+            if (!tlvwscM1)
+                return false;
+            LOG(DEBUG) << "Found TLV_WSC TLV (assuming M1)";
         } else if (type == int(ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC)) {
             // If this is an Intel Agent, it will have VS TLV as the last TLV.
             // Currently, we don't support skipping TLVs, so if we see a VS TLV, we assume
@@ -710,12 +714,12 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         type = cmdu_rx.getNextTlvType();
     }
 
-    if (radio_basic_caps == nullptr) {
+    if (!radio_basic_caps) {
         LOG(ERROR) << "Failed to get APRadioBasicCapabilities TLV";
         return false;
     }
 
-    if (tlvwscM1 == nullptr) {
+    if (!tlvwscM1) {
         LOG(ERROR) << "Failed to get TLV_WSC M1 TLV";
         return false;
     }


### PR DESCRIPTION
When addClass fails, it doesn't increment the buffer pointers so the
next time addClass will fail exactly the same.
This can cause the controller to hang on autoconfig parsing, for example
if the WSC TLV contains anything other than M1.
Fix that by checking the return code of addClass and returning false on
error.

While we're at it - do the same for the agent - there should be NO
addClass without an explicit return code checking.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>