### PR TITLE
tlvf: Fix wrong UUID_R value

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -93,7 +93,7 @@ typedef struct sWscAttrUuidR {
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&data_length));
     }
     void struct_init(){
-        attribute_type = ATTR_UUID_E;
+        attribute_type = ATTR_UUID_R;
         data_length = WSC_UUID_LENGTH;
     }
 } __attribute__((packed)) sWscAttrUuidR;

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -49,7 +49,7 @@ sWscAttrUuidR:
   _type: struct
   attribute_type:
     _type: eWscAttributes
-    _value: ATTR_UUID_E
+    _value: ATTR_UUID_R
   data_length:
     _type: uint16_t
     _value: WSC_UUID_LENGTH


### PR DESCRIPTION
UUID_R attribute uses UUID_E type, so fix that.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>