### PR TITLE
tools: add configuration for remote debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,22 @@
             ]
         },
         {
+            "name": "(gdb) Remote debug prplMesh Controller",
+            "type": "gdb",
+            "request": "attach",
+            "executable": "${workspaceFolder}/../build/install/bin/beerocks_controller",
+            "target": "localhost:9999",
+            "remote": true,
+            "cwd": "${workspaceFolder}",
+            "autorun": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true //TODO: pretty printing doesn't seem to work
+                }
+            ]
+        },
+        {
             "name": "(gdb) Attach to prplMesh Agent",
             "type": "cppdbg",
             "request": "attach",
@@ -40,6 +56,22 @@
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Remote debug prplMesh Agent",
+            "type": "gdb",
+            "request": "attach",
+            "executable": "${workspaceFolder}/../build/install/bin/beerocks_agent",
+            "target": "localhost:9999",
+            "remote": true,
+            "cwd": "${workspaceFolder}",
+            "autorun": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true //TODO: pretty printing doesn't seem to work
                 }
             ]
         },
@@ -58,7 +90,22 @@
                 }
             ]
         },
-        
+        {
+            "name": "(gdb) Remote debug prplMesh CLI",
+            "type": "gdb",
+            "request": "attach",
+            "executable": "${workspaceFolder}/../build/install/bin/beerocks_cli",
+            "target": "localhost:9999",
+            "remote": true,
+            "cwd": "${workspaceFolder}",
+            "autorun": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true //TODO: pretty printing doesn't seem to work
+                }
+            ]
+        },
         {
             "name": "(gdb) Launch beerocks_controller",
             "type": "cppdbg",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ cd <path/to/prplmesh_root>/build/install/scripts
 sudo ./prplmesh_utils.sh start
 ```
 
+## Debugging Instructions
+
+To debug prplMesh controller, agent or cli it is needed to install 'Native Debug'
+extension for Visual Studio Code. Also prplMesh solution should be compiled with
+`CMAKE_BUILD_TYPE=Debug` flag.
+Debug instruction: 
+1. Start prplMesh solution(read Running Instructions)
+2. To remote debug it is needed to start gdbserver
+```bash
+gdbserver :9999 --attach <pid of controller/agent/cli>
+```
+2. Go to debug tab in the VSCode and choose one the option from the dropdown list.
+3. Add breakpoint and click start debugging.
+
 ### Log files locations
 
 - framework `/tmp/$USER/mapf`


### PR DESCRIPTION
Using the configurations added to this file, it's now possible to
remotely debug beerocks_controller application. It also need to
install 'Native debug' extension for VSCode.

Signed-off-by: Maksym Bielan <maksym.bielan@globallogic.com>