### PR TITLE
tlvf: WSC attributes: add default encr and auth types

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -407,6 +407,7 @@ typedef struct sWscAttrAuthenticationType {
     void struct_init(){
         attribute_type = ATTR_AUTH_TYPE;
         data_length = 0x2;
+        data = eWscAuth::WSC_AUTH_WPA2PSK;
     }
 } __attribute__((packed)) sWscAttrAuthenticationType;
 
@@ -422,6 +423,7 @@ typedef struct sWscAttrEncryptionType {
     void struct_init(){
         attribute_type = ATTR_ENCR_TYPE;
         data_length = 0x2;
+        data = eWscEncr::WSC_ENCR_AES;
     }
 } __attribute__((packed)) sWscAttrEncryptionType;
 

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -2,6 +2,7 @@
 ---
 _include: {
   tlvf/WSC/eWscLengths.h,
+  tlvf/WSC/eWscAuth.h,
   tlvf/WSC/eWscVendorId.h,
   tlvf/WSC/eWscVendorExt.h,
   tlvf/WSC/eWscDev.h,
@@ -315,6 +316,7 @@ sWscAttrAuthenticationType:
     _value: 2
   data:
     _type: eWscAuth
+    _value: eWscAuth::WSC_AUTH_WPA2PSK
 
 sWscAttrEncryptionType:
   _type: struct
@@ -326,6 +328,7 @@ sWscAttrEncryptionType:
     _value: 2
   data:
     _type: eWscEncr
+    _value: eWscEncr::WSC_ENCR_AES
 
 sWscAttrNetworkKey:
   _type: struct


### PR DESCRIPTION
Add default values for WSC_Attributes:
sWscAttrAuthenticationType --> eWscAuth::WSC_AUTH_WPA2PSK
sWscAttrEncryptionType --> eWscEncr::WSC_ENCR_AES

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>