### PR TITLE
bwl: dummy: add infra for simulating events

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -36,6 +36,8 @@ elseif(TARGET_PLATFORM STREQUAL "rdkb")
 # Linux
 elseif(TARGET_PLATFORM STREQUAL "linux")
     set(BWL_TYPE_DEFAULT "DUMMY")
+    set(BEEROCKS_TMP_PATH "/tmp/$ENV{USER}/beerocks")
+    add_definitions(-DBEEROCKS_TMP_PATH="${BEEROCKS_TMP_PATH}")
 endif()
 
 set(BWL_TYPE ${BWL_TYPE_DEFAULT} CACHE STRING "Which BWL backend to use")

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -117,7 +117,29 @@ bool base_wlan_hal_dummy::refresh_vap_info(int vap_id) { return true; }
 
 bool base_wlan_hal_dummy::refresh_vaps_info(int id) { return true; }
 
-bool base_wlan_hal_dummy::process_ext_events() { return true; }
+/**
+ * @brief process simulated events
+ *        events are expected to be simulated by writing the event
+ *        string to the event pipe (/tmp/$BEEROCKS_TMP_PATH/bwl-event-wlanX).
+ *        For example, simulating client connected event:
+ *        echo "STA_CONNECTED,11:22:33:44:55:66" > /tmp/$BEEROCKS_TMP_PATH/bwl-event-wlanX
+ *
+ * @return true on success
+ * @return false on failure
+ */
+bool base_wlan_hal_dummy::process_ext_events()
+{
+    if (m_fd_ext_events <= 0)
+        return true;
+
+    char buf[1024];
+    size_t len = read(m_fd_ext_events, buf, sizeof(buf));
+
+    LOG(DEBUG) << "Received event, len: " << len << ", data: " << std::string(buf, len);
+
+    // TODO Handle event
+    return true;
+}
 
 std::string base_wlan_hal_dummy::get_radio_mac()
 {

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -14,7 +14,6 @@
 #include <beerocks/bcl/son/son_wireless_utils.h>
 
 #include <easylogging++.h>
-#include <sys/eventfd.h>
 
 #define UNHANDLED_EVENTS_LOGS 20
 
@@ -82,10 +81,7 @@ base_wlan_hal_dummy::base_wlan_hal_dummy(HALType type, std::string iface_name, b
         });
     }
 
-    // Set up dummy external events fd
-    if ((m_fd_ext_events = eventfd(0, EFD_SEMAPHORE)) < 0) {
-        LOG(FATAL) << "Failed creating eventfd: " << strerror(errno);
-    }
+    m_fd_ext_events = 0;
 
     // Initialize the FSM
     fsm_setup();

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
@@ -48,6 +48,12 @@ mon_wlan_hal_dummy::mon_wlan_hal_dummy(std::string iface_name, hal_event_cb_t ca
     : base_wlan_hal(bwl::HALType::Monitor, iface_name, IfaceType::Intel, false, callback),
       base_wlan_hal_dummy(bwl::HALType::Monitor, iface_name, false, callback, BUFFER_SIZE)
 {
+    std::string event_file = std::string(BEEROCKS_TMP_PATH) + "/bwl-event-mon-" + get_iface_name();
+    mkfifo(event_file.c_str(), 0666);
+    m_fd_ext_events = open(event_file.c_str(), O_RDWR); // Open in read write so it won't block
+    if (m_fd_ext_events < 0) {
+        LOG(FATAL) << "Failed creating m_fd_ext_events: " << strerror(errno);
+    }
 }
 
 mon_wlan_hal_dummy::~mon_wlan_hal_dummy() {}


### PR DESCRIPTION
This commit adds basic infrastructure for events simulation by writing
the event string to the event pipe at <BEEROCKS_TMP_PATH>/bwl-event-<ifname>.

For that, a named pipe is created at init for each bwl radio instance,
and is opened for both reading and writing which provides a way to
listen on the pipe in a non blocking manner.

The file descriptor is saved in m_fd_ext_events which is used in the
select loop by the parent class.

Simulating an event is done by simply writing into the pipe -
For example, simulating a STA with MAC 11:22:33:44:55:66 is connected to
wlan0 AP is done as follows:
echo "STA_CONNECTED,11:22:33:44:55:66" >
/tmp/$USER/beerocks/bwl-event-wlan0

Note that currently, no handling is done, this commit provides
infrastructure only. Events handling will be done in separate PRs.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>