### PR TITLE
tools/docker: add a route to the gateway

### DIFF
--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -36,9 +36,12 @@ iprand(){
     echo "$ip_rand"
 }
 
+gateway_ip() {
+    echo $(docker network inspect "$1" | jq -r '.[0].IPAM.Config'[0].Gateway)
+}
+
 generate_container_random_ip() {
-    gateway_ip=$(docker network inspect $1 | jq -r '.[0].IPAM.Config'[0].Gateway)
-    echo $(iprand ${gateway_ip})
+    echo $(iprand $(gateway_ip "$1"))
 }
 
 main() {
@@ -115,7 +118,7 @@ main() {
         fi
     fi
     
-    run docker container run ${DOCKEROPTS} prplmesh-runner$TAG $IPADDR "$BASE_MAC" "$@"
+    run docker container run ${DOCKEROPTS} prplmesh-runner$TAG $IPADDR "$BASE_MAC" "$(gateway_ip $NETWORK)" "$@"
 }
 
 VERBOSE=false

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -13,6 +13,7 @@ run() {
 
 bridge_ip="$1"; shift
 base_mac="$1"; shift
+gateway_ip="$1"; shift
 
 run ip link add          br-lan   address "${base_mac}:00:00" type bridge
 run ip link add          wlan0    address "${base_mac}:00:10" type dummy
@@ -28,6 +29,7 @@ run ip link set      dev wlan0    up
 run ip link set      dev wlan2    up
 run ip address add   dev br-lan "$bridge_ip"
 run ip link set      dev br-lan   up
+run ip route add "$gateway_ip" dev br-lan
 
 cd ${INSTALL_DIR}
 exec /bin/bash "$@"


### PR DESCRIPTION
Add a route to the gateway so that beerocks_cli is able to
communicate with a local beerocks_analyzer.

Signed-off-by: Raphaël Mélotte <raphael.melotte@essensium.com>