### PR TITLE
controller:wfa_ca: handle non hex tlv_value

### DIFF
--- a/controller/src/beerocks/master/wfa_ca.cpp
+++ b/controller/src/beerocks/master/wfa_ca.cpp
@@ -16,6 +16,7 @@
 #include <easylogging++.h>
 
 #include <algorithm>
+#include <iomanip>
 
 #define FORBIDDEN_CHARS "$#&*()[];/\\<>?|`~=+"
 
@@ -74,6 +75,50 @@ static bool validate_hex_notation(const std::string &str, uint8_t expected_octet
         return false;
     }
 
+    return true;
+}
+
+/**
+ * @brief Checks that the given string is in binary notation
+ * 
+ * @param[in] str String to check binary notation.
+ * @return true if string is in valid binary notation, else false.
+ */
+static bool validate_binary_notation(const std::string &str)
+{
+    // Each value must start with 0b
+    if (str.substr(0, 2) != "0b") {
+        return false;
+    }
+
+    if ((str.size() - 2) % 8 != 0) {
+        return false;
+    }
+
+    // Check if string contains not only 0 and 1
+    if (str.find_first_not_of("01", 2) != std::string::npos) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @brief Checks that the given string is in decimal notation
+ * 
+ * @param[in] str String to check decimal notation.
+ * @return true if string is in valid decimal notation, else false.
+ */
+static bool validate_decimal_notation(const std::string &str)
+{
+    // Each value must start with 0b
+    if (str.substr(0, 2) != "0d") {
+        return false;
+    }
+
+    // Check if string has non-decimal character
+    if (str.find_first_not_of("0123456789", 2) != std::string::npos) {
+        return false;
+    }
     return true;
 }
 
@@ -820,10 +865,11 @@ bool wfa_ca::get_send_1905_1_tlv_hex_list(std::list<tlv_hex_t> &tlv_hex_list,
 
                 // Validate hex notation on list of values separated by space
                 auto values = string_utils::str_split(it->second, ' ');
-                for (const auto &value : values) {
-                    if (!validate_hex_notation(value)) {
+                for (auto &value : values) {
+                    if (!(validate_hex_notation(value) || net::network_utils::is_valid_mac(value) ||
+                          validate_binary_notation(value) || validate_decimal_notation(value))) {
                         err_string =
-                            "param name '" + lookup_str + "' has invalid hex notation value";
+                            "param name '" + lookup_str + "' has value with invalid format";
                         return false;
                     }
                 }
@@ -852,6 +898,91 @@ bool wfa_ca::get_send_1905_1_tlv_hex_list(std::list<tlv_hex_t> &tlv_hex_list,
     LOG(ERROR) << "Reached stop condition";
     err_string = err_internal;
     return false;
+}
+
+/**
+ * @brief Writes hex string into the class buffer.
+ * 
+ * @param[in] value string in hex notation.
+ * @param[out] length Length of current tlv.
+ * @return false if length smaller than data, else true.
+ */
+bool tlvPrefilledData::add_tlv_value_hex_string(const std::string &value, uint16_t &length)
+{
+    // iterate every two chars (1 octet) and write it to buffer
+    // start with char_idx = 2 to skip "0x"
+    for (size_t char_idx = 2; char_idx < value.size(); char_idx += 2) {
+        if (length == 0) {
+            return false;
+        }
+        *m_buff_ptr__ = std::stoi(value.substr(char_idx, 2), nullptr, 16);
+        m_buff_ptr__++;
+        length--;
+    }
+    return true;
+}
+
+/**
+ * @brief Writes a decimal string into the class buffer.
+ * 
+ * @param[in] value Decimal string.
+ * @param[out] length Length of current tlv.
+ * @return false if length smaller than data, else true.
+ */
+bool tlvPrefilledData::add_tlv_value_decimal_string(const std::string &value, uint16_t &length)
+{
+    // Convert to hex string
+    std::stringstream ss;
+    size_t num_of_bytes = 1;
+    // We don't really know how to identify if it is one or two (or more) bytes.
+    // Assume 2 bytes if it has more than 3 digits
+    if (value.size() > 5) {
+        num_of_bytes++;
+    }
+    ss << "0x" << std::setw(num_of_bytes * 2) << std::setfill('0') << std::hex
+       << std::stoi(value.substr(2, value.length()));
+
+    return add_tlv_value_hex_string(ss.str(), length);
+}
+
+/**
+ * @brief Writes a binary string into the class buffer.
+ * 
+ * @param[in] value Binary string.
+ * @param[out] length Length of current tlv.
+ * @return false if length smaller than data, else true.
+ */
+bool tlvPrefilledData::add_tlv_value_binary_string(const std::string &value, uint16_t &length)
+{
+    for (size_t char_idx = 2; char_idx < value.size(); char_idx += 8) {
+        if (length == 0) {
+            return false;
+        }
+        *m_buff_ptr__ = std::stoi(value.substr(char_idx, 8), nullptr, 2);
+        m_buff_ptr__++;
+        length--;
+    }
+    return true;
+}
+
+/**
+ * @brief Writes a mac string into the class buffer.
+ * 
+ * @param[in] value mac address.
+ * @param[out] length of current tlv.
+ * @return false if length smaller than data, else true.
+ */
+bool tlvPrefilledData::add_tlv_value_mac(const std::string &value, uint16_t &length)
+{
+    for (size_t char_idx = 0; char_idx < value.size(); char_idx += 3) {
+        if (length == 0) {
+            return false;
+        }
+        *m_buff_ptr__ = std::stoi(value.substr(char_idx, 2), nullptr, 16);
+        m_buff_ptr__++;
+        length--;
+    }
+    return true;
 }
 
 /**
@@ -885,16 +1016,27 @@ bool tlvPrefilledData::add_tlvs_from_list(std::list<wfa_ca::tlv_hex_t> &tlv_hex_
 
         auto values = string_utils::str_split(*tlv.value, ' ');
         for (auto value : values) {
-            // iterate every to chars (1 octet) and write it to buffer
-            // start with char_idx = 2 to skip "0x"
-            for (size_t char_idx = 2; char_idx < value.size(); char_idx += 2) {
-                if (length == 0) {
+            //Do conversion if needed
+            if (value[1] == 'x') {
+                if (!add_tlv_value_hex_string(value, length)) {
                     err_string = "length smaller than data";
                     return false;
                 }
-                *m_buff_ptr__ = std::stoi(value.substr(char_idx, 2), nullptr, 16);
-                m_buff_ptr__++;
-                length--;
+            } else if (value[2] == ':') {
+                if (!add_tlv_value_mac(value, length)) {
+                    err_string = "length smaller than data";
+                    return false;
+                }
+            } else if (value[1] == 'd') {
+                if (!add_tlv_value_decimal_string(value, length)) {
+                    err_string = "length smaller than data";
+                    return false;
+                }
+            } else if (value[1] == 'b') {
+                if (!add_tlv_value_binary_string(value, length)) {
+                    err_string = "length smaller than data";
+                    return false;
+                }
             }
         }
 

--- a/controller/src/beerocks/master/wfa_ca.h
+++ b/controller/src/beerocks/master/wfa_ca.h
@@ -80,6 +80,10 @@ public:
     void class_swap(){};
     static size_t get_initial_size() { return 0; };
 
+    bool add_tlv_value_hex_string(const std::string &value, uint16_t &length);
+    bool add_tlv_value_decimal_string(const std::string &value, uint16_t &length);
+    bool add_tlv_value_binary_string(const std::string &value, uint16_t &length);
+    bool add_tlv_value_mac(const std::string &value, uint16_t &length);
     bool add_tlvs_from_list(std::list<wfa_ca::tlv_hex_t> &tlv_hex_list, std::string &err_string);
 };
 


### PR DESCRIPTION
Currently, the DEV_SEND_1905 CAPI command handler supports tlv_value only in
hex notation. But after checking via UCC,  it turned out that the
DEV_SEND_1905 contains tlv_value in different format "00:1E:23:1A:67:DF".

For that reason, add support to the required notations: binary, decimal and mac address.

#309 

Signed-off-by: Coral Malachi <coral.malachi@intel.com>