### PR TITLE
controller: db: pass sMacAddr by value instead of by reference

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -58,8 +58,8 @@ bool db::add_virtual_node(sMacAddr mac, sMacAddr real_node_mac)
     return true;
 }
 
-bool db::add_node(const sMacAddr &mac, const sMacAddr &parent_mac, beerocks::eType type,
-                  const sMacAddr &radio_identifier)
+bool db::add_node(sMacAddr mac, sMacAddr parent_mac, beerocks::eType type,
+                  sMacAddr radio_identifier)
 {
     if (mac == network_utils::ZERO_MAC) {
         LOG(ERROR) << "can't insert node with empty mac";
@@ -120,7 +120,7 @@ bool db::add_node(const sMacAddr &mac, const sMacAddr &parent_mac, beerocks::eTy
     return true;
 }
 
-bool db::remove_node(const sMacAddr &mac)
+bool db::remove_node(sMacAddr mac)
 {
     int i;
     for (i = 0; i < HIERARCHY_MAX; i++) {

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -156,11 +156,10 @@ public:
     bool has_node(sMacAddr mac);
 
     bool add_virtual_node(sMacAddr mac, sMacAddr real_node_mac);
-    bool add_node(const sMacAddr &mac,
-                  const sMacAddr &parent_mac       = beerocks::net::network_utils::ZERO_MAC,
-                  beerocks::eType type             = beerocks::TYPE_CLIENT,
-                  const sMacAddr &radio_identifier = beerocks::net::network_utils::ZERO_MAC);
-    bool remove_node(const sMacAddr &mac);
+    bool add_node(sMacAddr mac, sMacAddr parent_mac = beerocks::net::network_utils::ZERO_MAC,
+                  beerocks::eType type      = beerocks::TYPE_CLIENT,
+                  sMacAddr radio_identifier = beerocks::net::network_utils::ZERO_MAC);
+    bool remove_node(sMacAddr mac);
 
     bool set_node_type(std::string mac, beerocks::eType type);
     beerocks::eType get_node_type(std::string mac);


### PR DESCRIPTION
According to CppCoreGuideline F.16, a small object should be passed by
value instead of const-ref. "Small" is not objectively defined, but it
would be two-three words. Since sMacAddr is 6 bytes, it is less than two
words even on a 32-bit architecture, so definitely small.

Therefore, change `add_node` and `remove_node` to take their arguments by
value instead of by const-ref.

This should have been part of #291 but I forgot to commit my changes before pushing/merging.