### PR TITLE
Controller:change bss_infos to use sMacAddress as key

### DIFF
--- a/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
@@ -22,6 +22,18 @@ inline bool operator==(sMacAddr const &lhs, sMacAddr const &rhs)
 
 inline bool operator!=(sMacAddr const &lhs, sMacAddr const &rhs) { return !(rhs == lhs); }
 
+template <> struct std::hash<sMacAddr> {
+    size_t operator()(const sMacAddr &m) const
+    {
+        uint64_t value_to_hash = 0;
+        for (size_t byte = 0; byte < sizeof(m.oct); byte++) {
+            value_to_hash <<= 8;
+            value_to_hash += m.oct[byte];
+        }
+        return std::hash<std::uint64_t>()(value_to_hash);
+    }
+};
+
 namespace beerocks {
 namespace net {
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -3157,12 +3157,12 @@ void db::setting_certification_mode(bool en)
     config.certification_mode = true;
 }
 
-void db::add_bss_info_configuration(const std::string &al_mac, const bss_info_conf_t &bss_info)
+void db::add_bss_info_configuration(const sMacAddr &al_mac, const bss_info_conf_t &bss_info)
 {
     bss_infos[al_mac].push_back(bss_info);
 }
 
-std::list<db::bss_info_conf_t> &db::get_bss_info_configuration(const std::string &al_mac)
+std::list<db::bss_info_conf_t> &db::get_bss_info_configuration(const sMacAddr &al_mac)
 {
     // If al_mac not exist, it will be added, and return empty list
     return bss_infos[al_mac];

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -523,8 +523,8 @@ public:
         std::string network_key;
         WSC::eWscVendorExtSubelementBssType bss_type;
     };
-    void add_bss_info_configuration(const std::string &al_mac, const bss_info_conf_t &bss_info);
-    std::list<db::bss_info_conf_t> &get_bss_info_configuration(const std::string &al_mac);
+    void add_bss_info_configuration(const sMacAddr &al_mac, const bss_info_conf_t &bss_info);
+    std::list<db::bss_info_conf_t> &get_bss_info_configuration(const sMacAddr &al_mac);
     void clear_bss_info_configuration();
 
     //
@@ -719,7 +719,7 @@ private:
 
     // certification
     std::shared_ptr<uint8_t> certification_tx_buffer;
-    std::unordered_map<std::string, std::list<bss_info_conf_t>> bss_infos; // key=al_mac
+    std::unordered_map<sMacAddr, std::list<bss_info_conf_t>> bss_infos; // key=al_mac
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -760,7 +760,7 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
 
     tlvRuid->radio_uid() = network_utils::mac_from_string(ruid);
 
-    const auto &bss_info_confs = database.get_bss_info_configuration(al_mac);
+    const auto &bss_info_confs = database.get_bss_info_configuration(tlvwscM1->mac_attr().data);
     uint8_t num_bsss           = 0;
 
     for (const auto &bss_info_conf : bss_info_confs) {

--- a/controller/src/beerocks/master/wfa_ca.cpp
+++ b/controller/src/beerocks/master/wfa_ca.cpp
@@ -709,7 +709,8 @@ void wfa_ca::handle_wfa_ca_message(
                 return;
             }
 
-            database.add_bss_info_configuration(al_mac, bss_info_conf);
+            database.add_bss_info_configuration(net::network_utils::mac_from_string(al_mac),
+                                                bss_info_conf);
         }
 
         // Send back first reply

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -39,9 +39,11 @@ test_initial_ap_config() {
     check docker exec -it repeater1 sh -c \
         'grep -i -q "Controller configuration (WSC M2 Encrypted Settings)" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
 
+    # Regression test: MAC address should be case insensitive
+    MAC_AGENT1=$(echo $mac_agent1 | tr a-z A-Z)
     # Configure the controller and send renew
     eval send_bml_command "bml_wfa_ca_controller \"DEV_RESET_DEFAULT\"" $redirect
-    eval send_bml_command "bml_wfa_ca_controller \\\"DEV_SET_CONFIG,bss_info1,$mac_agent1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1,bss_info2,$mac_agent1 8x Multi-AP-24G-2 0x0020 0x0008 maprocks2 1 0\\\"" $redirect
+    eval send_bml_command "bml_wfa_ca_controller \\\"DEV_SET_CONFIG,bss_info1,$MAC_AGENT1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1,bss_info2,$mac_agent1 8x Multi-AP-24G-2 0x0020 0x0008 maprocks2 1 0\\\"" $redirect
     gw_mac_without_colons="$(printf $mac_gateway | tr -d :)"
     eval send_bml_command "bml_wfa_ca_controller \"DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}\"" $redirect
 


### PR DESCRIPTION
Currently, test 5.4.1 24G keeps failing.

The problem is that the controller sends unnecessary teardown request to
the agent which causing to tear down all BSSes on that radio.

The reason for this is that bss_info is being stored with a string key in the database. 
The UCC sends the MAC address with uppercase hex digits, but the
network_utils::mac_to_string method uses lowercase.

As a result, the value of bss_info_confs is empty, which causes the num_bsss's value 
be zero and that leads to tearing down action : 

`

    if (num_bsss == 0) {
        if (!autoconfig_wsc_add_m2(tlvwscM1, nullptr)) {
            LOG(ERROR) << "Failed setting M2 attributes";
            return false;
        }
    }
`

The solution is to use sMacAddress as the database key instead of a string.

Fixes #334 
Signed-off-by: Coral Malachi <coral.malachi@intel.com>