### PR TITLE
tools: docker: add python3 to the images

### DIFF
--- a/tools/docker/all/Dockerfile
+++ b/tools/docker/all/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y \
 	libzmq3-dev \
 	python \
 	python-yaml \
+	python3 \
+	python3-yaml \
 	vim \
 	net-tools \
 	bridge-utils \

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y \
 	libzmq3-dev \
 	python \
 	python-yaml \
+	python3 \
+	python3-yaml \
 	vim \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/runner/Dockerfile
+++ b/tools/docker/runner/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
 	libzmq3-dev \
 	python \
 	python-yaml \
+	python3 \
+	python3-yaml \
 	vim \
 	net-tools \
 	bridge-utils \


### PR DESCRIPTION
We will switch our Python scripts to use Python3 (only). Therefore, the
docker images should have Python3 available.

For backward compatibility, Python2 is kept for the time being. Once
everything is converted it can be removed again.