### PR TITLE
master: WSC: ignore authentication and encryption flags

### DIFF
--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -772,13 +772,15 @@ bool master_thread::handle_cmdu_1905_autoconfiguration_WSC(Socket *sd,
         }
         if (!(tlvwscM1->authentication_type_flags_attr().data &
               uint16_t(bss_info_conf.authentication_type))) {
-            LOG(INFO) << "Skipping " << bss_info_conf.ssid << " due to auth mismatch";
-            continue;
+            LOG(INFO) << std::hex << "Auth mismatch for " << bss_info_conf.ssid << ": get 0x"
+                      << tlvwscM1->authentication_type_flags_attr().data << " need 0x"
+                      << uint16_t(bss_info_conf.authentication_type);
         }
         if (!(tlvwscM1->encryption_type_flags_attr().data &
               uint16_t(bss_info_conf.encryption_type))) {
-            LOG(INFO) << "Skipping " << bss_info_conf.ssid << " due to encr mismatch";
-            continue;
+            LOG(INFO) << std::hex << "Encr mismatch for " << bss_info_conf.ssid << ": get 0x"
+                      << tlvwscM1->encryption_type_flags_attr().data << " need 0x"
+                      << uint16_t(bss_info_conf.encryption_type);
         }
         if (num_bsss >= radio_basic_caps->maximum_number_of_bsss_supported()) {
             LOG(INFO) << "Configured #BSS exceeds maximum for " << al_mac << " radio " << ruid;


### PR DESCRIPTION
The WSC specification seems to claim that the authentication and
encryption flags in the M1 message should indicate which authentication
and encryption types are supported by the enrollee. However, actual
implementations don't seem to follow this: we've seen agents that don't
report support for WPA2PSK (even though MultiAP mandates WPA2PSK), and
we've seen agent that don't set any flags at all.

Therefore, ignore the autentication and encryption flags. An
informational message with all details is still sent to the logs.