### PR TITLE
Fix a documentation and logger issue with beerocks_analyzer

### DIFF
--- a/tools/beerocks_analyzer/README.md
+++ b/tools/beerocks_analyzer/README.md
@@ -12,6 +12,7 @@ Using a virtualenv allows to install the dependencies in a local directory, whic
 
 You only need to create the `venv` once. Later on you just need to activate the `venv` to be able to use the application.
 
+Note for *Windows* users: you may need to run the command-line as an administrator depending on your setup.
 
 ### Create a virtualenv to use the application
 
@@ -19,10 +20,20 @@ You only need to create the `venv` once. Later on you just need to activate the 
 python3 -m venv analyzer-venv
 ```
 
+On Windows:
+```sh
+python -m venv analyzer-venv
+```
+
 1.  Activate the environment
 
 ```sh
 source analyzer-venv/bin/activate
+```
+
+On Windows:
+```sh
+analyzer-venv\Scripts\activate.bat
 ```
 
 Your prompt should now have "analyzer-venv" appended to it.

--- a/tools/beerocks_analyzer/README.md
+++ b/tools/beerocks_analyzer/README.md
@@ -72,7 +72,7 @@ To run the analyzer, you need to give the IP of the gateway:
 
 ```sh
 GW_IP=192.168.1.1
-./beerocks_analyzer.py -map -gw_ip="GW_IP"
+./beerocks_analyzer.py -map -gw_ip="$GW_IP"
 ```
 
 Note that currently, the binary path is hard-coded to `/opt/beerocks/bin/beerocks_cli`.

--- a/tools/beerocks_analyzer/beerocks_analyzer.py
+++ b/tools/beerocks_analyzer/beerocks_analyzer.py
@@ -774,7 +774,7 @@ class BeerocksCliThread(threading.Thread):
         command = [str(self.beerocks_cli_path), "-a", str(self.target_ip)]
         if self.docker_container_name:
             command = ["docker", "exec", self.docker_container_name] + command
-        self.logger.debug("Starting '%s'", ' '.join(command))
+        self.logger.debug("Starting '{}'", ' '.join(command))
         self.process = subprocess.Popen(command)
         outs = None
         errs = None

--- a/tools/beerocks_analyzer/logger_setup.py
+++ b/tools/beerocks_analyzer/logger_setup.py
@@ -15,3 +15,19 @@ def setup_logger():
     with open('logger_config.yaml', 'rt') as file:
         config = yaml.safe_load(file.read())
         logging.config.dictConfig(config)
+        logging.setLogRecordFactory(FormatRecordFactory)
+
+
+class FormatRecordFactory(logging.LogRecord):
+    """A factory which formats messages with str.format."""
+    def getMessage(self):
+        """
+        Return the message for this LogRecord, formatted with str.format.
+
+        Return the message for this LogRecord after merging any user-supplied
+        arguments with the message by using str.format.
+        """
+        msg = str(self.msg)
+        if self.args:
+            msg = msg.format(self.args)
+        return msg


### PR DESCRIPTION
The documentation was missing a dollar sign for one of the Bash variables.

There was also an issue with the usage of the new str.format style in the logger messages.