### PR TITLE
bpl: linux: enable band steering and client roaming

### DIFF
--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -139,13 +139,13 @@ int bpl_cfg_is_wired_backhaul()
 
 int bpl_cfg_get_rdkb_extensions() { return 0; }
 
-int bpl_cfg_get_band_steering() { return 0; }
+int bpl_cfg_get_band_steering() { return 1; }
 
 int bpl_cfg_get_dfs_reentry() { return 0; }
 
 int bpl_cfg_get_passive_mode() { return 0; }
 
-int bpl_cfg_get_client_roaming() { return 0; }
+int bpl_cfg_get_client_roaming() { return 1; }
 
 int bpl_cfg_get_device_info(BPL_DEVICE_INFO *device_info) { return RETURN_ERR; }
 


### PR DESCRIPTION
If we want to use the optimal path task in the controller, the bpl
configuration (in the agent) has to support band steering and roaming.

There's no real reason to make this configurable for the linux implementation, so just always enable.