### PR TITLE
autoconfig: WSC: Change config data network key to be dynamic

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -39,30 +39,17 @@ char* cACTION_BACKHAUL_REGISTER_REQUEST::sta_iface(size_t length) {
     return ((char*)m_sta_iface);
 }
 
-bool cACTION_BACKHAUL_REGISTER_REQUEST::set_sta_iface(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_sta_iface received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_sta_iface, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_REGISTER_REQUEST::set_sta_iface(const std::string& str) { return set_sta_iface(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_REGISTER_REQUEST::set_sta_iface(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_sta_iface received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_sta_iface, str, size + 1);
-    m_sta_iface[size] = '\0';
+    std::copy(str, str + size, m_sta_iface);
     return true;
 }
 std::string cACTION_BACKHAUL_REGISTER_REQUEST::hostap_iface_str() {
@@ -79,30 +66,17 @@ char* cACTION_BACKHAUL_REGISTER_REQUEST::hostap_iface(size_t length) {
     return ((char*)m_hostap_iface);
 }
 
-bool cACTION_BACKHAUL_REGISTER_REQUEST::set_hostap_iface(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_hostap_iface received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_hostap_iface, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_REGISTER_REQUEST::set_hostap_iface(const std::string& str) { return set_hostap_iface(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_REGISTER_REQUEST::set_hostap_iface(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_hostap_iface received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_hostap_iface, str, size + 1);
-    m_hostap_iface[size] = '\0';
+    std::copy(str, str + size, m_hostap_iface);
     return true;
 }
 uint8_t& cACTION_BACKHAUL_REGISTER_REQUEST::local_master() {
@@ -252,30 +226,17 @@ char* cACTION_BACKHAUL_ENABLE::bridge_iface(size_t length) {
     return ((char*)m_bridge_iface);
 }
 
-bool cACTION_BACKHAUL_ENABLE::set_bridge_iface(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_bridge_iface received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_bridge_iface, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_ENABLE::set_bridge_iface(const std::string& str) { return set_bridge_iface(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_ENABLE::set_bridge_iface(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_bridge_iface received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_bridge_iface, str, size + 1);
-    m_bridge_iface[size] = '\0';
+    std::copy(str, str + size, m_bridge_iface);
     return true;
 }
 sMacAddr& cACTION_BACKHAUL_ENABLE::iface_mac() {
@@ -300,30 +261,17 @@ char* cACTION_BACKHAUL_ENABLE::wire_iface(size_t length) {
     return ((char*)m_wire_iface);
 }
 
-bool cACTION_BACKHAUL_ENABLE::set_wire_iface(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_wire_iface received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_wire_iface, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_ENABLE::set_wire_iface(const std::string& str) { return set_wire_iface(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_ENABLE::set_wire_iface(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_wire_iface received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_wire_iface, str, size + 1);
-    m_wire_iface[size] = '\0';
+    std::copy(str, str + size, m_wire_iface);
     return true;
 }
 std::string cACTION_BACKHAUL_ENABLE::sta_iface_str() {
@@ -340,30 +288,17 @@ char* cACTION_BACKHAUL_ENABLE::sta_iface(size_t length) {
     return ((char*)m_sta_iface);
 }
 
-bool cACTION_BACKHAUL_ENABLE::set_sta_iface(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_sta_iface received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_sta_iface, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_ENABLE::set_sta_iface(const std::string& str) { return set_sta_iface(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_ENABLE::set_sta_iface(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_sta_iface received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_sta_iface, str, size + 1);
-    m_sta_iface[size] = '\0';
+    std::copy(str, str + size, m_sta_iface);
     return true;
 }
 std::string cACTION_BACKHAUL_ENABLE::ap_iface_str() {
@@ -380,30 +315,17 @@ char* cACTION_BACKHAUL_ENABLE::ap_iface(size_t length) {
     return ((char*)m_ap_iface);
 }
 
-bool cACTION_BACKHAUL_ENABLE::set_ap_iface(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_ap_iface received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_ap_iface, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_ENABLE::set_ap_iface(const std::string& str) { return set_ap_iface(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_ENABLE::set_ap_iface(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_ap_iface received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_ap_iface, str, size + 1);
-    m_ap_iface[size] = '\0';
+    std::copy(str, str + size, m_ap_iface);
     return true;
 }
 std::string cACTION_BACKHAUL_ENABLE::ssid_str() {
@@ -420,30 +342,17 @@ char* cACTION_BACKHAUL_ENABLE::ssid(size_t length) {
     return ((char*)m_ssid);
 }
 
-bool cACTION_BACKHAUL_ENABLE::set_ssid(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_ssid received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::WIFI_SSID_MAX_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_ssid, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_ENABLE::set_ssid(const std::string& str) { return set_ssid(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_ENABLE::set_ssid(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_ssid received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::WIFI_SSID_MAX_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::WIFI_SSID_MAX_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_ssid, str, size + 1);
-    m_ssid[size] = '\0';
+    std::copy(str, str + size, m_ssid);
     return true;
 }
 std::string cACTION_BACKHAUL_ENABLE::pass_str() {
@@ -460,30 +369,17 @@ char* cACTION_BACKHAUL_ENABLE::pass(size_t length) {
     return ((char*)m_pass);
 }
 
-bool cACTION_BACKHAUL_ENABLE::set_pass(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_pass received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::WIFI_PASS_MAX_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_pass, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BACKHAUL_ENABLE::set_pass(const std::string& str) { return set_pass(str.c_str(), str.size()); }
 bool cACTION_BACKHAUL_ENABLE::set_pass(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_pass received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::WIFI_PASS_MAX_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::WIFI_PASS_MAX_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_pass, str, size + 1);
-    m_pass[size] = '\0';
+    std::copy(str, str + size, m_pass);
     return true;
 }
 uint32_t& cACTION_BACKHAUL_ENABLE::security_type() {

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -137,24 +137,14 @@ char* cACTION_BML_NW_MAP_RESPONSE::buffer(size_t length) {
     return ((char*)m_buffer);
 }
 
-bool cACTION_BML_NW_MAP_RESPONSE::set_buffer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_buffer received an empty string.";
-        return false;
-    }
-    if (!alloc_buffer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_NW_MAP_RESPONSE::set_buffer(const std::string& str) { return set_buffer(str.c_str(), str.size()); }
 bool cACTION_BML_NW_MAP_RESPONSE::set_buffer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_buffer received an empty string.";
         return false;
     }
-    if (!alloc_buffer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str, size + 1);
-    m_buffer[size] = '\0';
+    if (!alloc_buffer(size)) { return false; }
+    std::copy(str, str + size, m_buffer);
     return true;
 }
 bool cACTION_BML_NW_MAP_RESPONSE::alloc_buffer(size_t count) {
@@ -250,24 +240,14 @@ char* cACTION_BML_NW_MAP_UPDATE::buffer(size_t length) {
     return ((char*)m_buffer);
 }
 
-bool cACTION_BML_NW_MAP_UPDATE::set_buffer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_buffer received an empty string.";
-        return false;
-    }
-    if (!alloc_buffer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_NW_MAP_UPDATE::set_buffer(const std::string& str) { return set_buffer(str.c_str(), str.size()); }
 bool cACTION_BML_NW_MAP_UPDATE::set_buffer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_buffer received an empty string.";
         return false;
     }
-    if (!alloc_buffer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str, size + 1);
-    m_buffer[size] = '\0';
+    if (!alloc_buffer(size)) { return false; }
+    std::copy(str, str + size, m_buffer);
     return true;
 }
 bool cACTION_BML_NW_MAP_UPDATE::alloc_buffer(size_t count) {
@@ -363,24 +343,14 @@ char* cACTION_BML_STATS_UPDATE::buffer(size_t length) {
     return ((char*)m_buffer);
 }
 
-bool cACTION_BML_STATS_UPDATE::set_buffer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_buffer received an empty string.";
-        return false;
-    }
-    if (!alloc_buffer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_STATS_UPDATE::set_buffer(const std::string& str) { return set_buffer(str.c_str(), str.size()); }
 bool cACTION_BML_STATS_UPDATE::set_buffer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_buffer received an empty string.";
         return false;
     }
-    if (!alloc_buffer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str, size + 1);
-    m_buffer[size] = '\0';
+    if (!alloc_buffer(size)) { return false; }
+    std::copy(str, str + size, m_buffer);
     return true;
 }
 bool cACTION_BML_STATS_UPDATE::alloc_buffer(size_t count) {
@@ -472,24 +442,14 @@ char* cACTION_BML_EVENTS_UPDATE::buffer(size_t length) {
     return ((char*)m_buffer);
 }
 
-bool cACTION_BML_EVENTS_UPDATE::set_buffer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_buffer received an empty string.";
-        return false;
-    }
-    if (!alloc_buffer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_EVENTS_UPDATE::set_buffer(const std::string& str) { return set_buffer(str.c_str(), str.size()); }
 bool cACTION_BML_EVENTS_UPDATE::set_buffer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_buffer received an empty string.";
         return false;
     }
-    if (!alloc_buffer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str, size + 1);
-    m_buffer[size] = '\0';
+    if (!alloc_buffer(size)) { return false; }
+    std::copy(str, str + size, m_buffer);
     return true;
 }
 bool cACTION_BML_EVENTS_UPDATE::alloc_buffer(size_t count) {
@@ -3193,24 +3153,14 @@ char* cACTION_BML_STEERING_EVENTS_UPDATE::buffer(size_t length) {
     return ((char*)m_buffer);
 }
 
-bool cACTION_BML_STEERING_EVENTS_UPDATE::set_buffer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_buffer received an empty string.";
-        return false;
-    }
-    if (!alloc_buffer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_STEERING_EVENTS_UPDATE::set_buffer(const std::string& str) { return set_buffer(str.c_str(), str.size()); }
 bool cACTION_BML_STEERING_EVENTS_UPDATE::set_buffer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_buffer received an empty string.";
         return false;
     }
-    if (!alloc_buffer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str, size + 1);
-    m_buffer[size] = '\0';
+    if (!alloc_buffer(size)) { return false; }
+    std::copy(str, str + size, m_buffer);
     return true;
 }
 bool cACTION_BML_STEERING_EVENTS_UPDATE::alloc_buffer(size_t count) {
@@ -3385,24 +3335,14 @@ char* cACTION_BML_WFA_CA_CONTROLLER_REQUEST::command(size_t length) {
     return ((char*)m_command);
 }
 
-bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::set_command(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_command received an empty string.";
-        return false;
-    }
-    if (!alloc_command(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_command, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::set_command(const std::string& str) { return set_command(str.c_str(), str.size()); }
 bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::set_command(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_command received an empty string.";
         return false;
     }
-    if (!alloc_command(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_command, str, size + 1);
-    m_command[size] = '\0';
+    if (!alloc_command(size)) { return false; }
+    std::copy(str, str + size, m_command);
     return true;
 }
 bool cACTION_BML_WFA_CA_CONTROLLER_REQUEST::alloc_command(size_t count) {
@@ -3490,24 +3430,14 @@ char* cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::reply(size_t length) {
     return ((char*)m_reply);
 }
 
-bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::set_reply(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_reply received an empty string.";
-        return false;
-    }
-    if (!alloc_reply(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_reply, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::set_reply(const std::string& str) { return set_reply(str.c_str(), str.size()); }
 bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::set_reply(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_reply received an empty string.";
         return false;
     }
-    if (!alloc_reply(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_reply, str, size + 1);
-    m_reply[size] = '\0';
+    if (!alloc_reply(size)) { return false; }
+    std::copy(str, str + size, m_reply);
     return true;
 }
 bool cACTION_BML_WFA_CA_CONTROLLER_RESPONSE::alloc_reply(size_t count) {

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -236,24 +236,14 @@ char* cACTION_CLI_RESPONSE_STR::buffer(size_t length) {
     return ((char*)m_buffer);
 }
 
-bool cACTION_CLI_RESPONSE_STR::set_buffer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_buffer received an empty string.";
-        return false;
-    }
-    if (!alloc_buffer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_CLI_RESPONSE_STR::set_buffer(const std::string& str) { return set_buffer(str.c_str(), str.size()); }
 bool cACTION_CLI_RESPONSE_STR::set_buffer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_buffer received an empty string.";
         return false;
     }
-    if (!alloc_buffer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_buffer, str, size + 1);
-    m_buffer[size] = '\0';
+    if (!alloc_buffer(size)) { return false; }
+    std::copy(str, str + size, m_buffer);
     return true;
 }
 bool cACTION_CLI_RESPONSE_STR::alloc_buffer(size_t count) {

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -39,30 +39,17 @@ char* cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::slave_version(size_t length) {
     return ((char*)m_slave_version);
 }
 
-bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::set_slave_version(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_slave_version received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::VERSION_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_slave_version, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::set_slave_version(const std::string& str) { return set_slave_version(str.c_str(), str.size()); }
 bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::set_slave_version(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_slave_version received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::VERSION_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::VERSION_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_slave_version, str, size + 1);
-    m_slave_version[size] = '\0';
+    std::copy(str, str + size, m_slave_version);
     return true;
 }
 sPlatformSettings& cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::platform_settings() {
@@ -195,30 +182,17 @@ char* cACTION_CONTROL_SLAVE_JOINED_RESPONSE::master_version(size_t length) {
     return ((char*)m_master_version);
 }
 
-bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::set_master_version(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_master_version received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::VERSION_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_master_version, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::set_master_version(const std::string& str) { return set_master_version(str.c_str(), str.size()); }
 bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::set_master_version(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_master_version received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::VERSION_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::VERSION_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_master_version, str, size + 1);
-    m_master_version[size] = '\0';
+    std::copy(str, str + size, m_master_version);
     return true;
 }
 uint8_t& cACTION_CONTROL_SLAVE_JOINED_RESPONSE::err_code() {
@@ -2664,30 +2638,17 @@ char* cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::name(size_t length) {
     return ((char*)m_name);
 }
 
-bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::set_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::NODE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::set_name(const std::string& str) { return set_name(str.c_str(), str.size()); }
 bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::set_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::NODE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::NODE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_name, str, size + 1);
-    m_name[size] = '\0';
+    std::copy(str, str + size, m_name);
     return true;
 }
 void cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::class_swap()

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -76,30 +76,17 @@ char* cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::iface_name(size_t length) {
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 void cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::class_swap()
@@ -206,30 +193,17 @@ char* cACTION_PLATFORM_POST_INIT_CONFIG_REQUEST::iface_name(size_t length) {
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_POST_INIT_CONFIG_REQUEST::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_POST_INIT_CONFIG_REQUEST::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_POST_INIT_CONFIG_REQUEST::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 void cACTION_PLATFORM_POST_INIT_CONFIG_REQUEST::class_swap()
@@ -411,30 +385,17 @@ char* cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::hostname(size_t length) {
     return ((char*)m_hostname);
 }
 
-bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::set_hostname(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_hostname received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::NODE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_hostname, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::set_hostname(const std::string& str) { return set_hostname(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::set_hostname(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_hostname received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::NODE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::NODE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_hostname, str, size + 1);
-    m_hostname[size] = '\0';
+    std::copy(str, str + size, m_hostname);
     return true;
 }
 void cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::class_swap()
@@ -727,30 +688,17 @@ char* cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::iface_name(size_t length) {
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 void cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::class_swap()
@@ -878,30 +826,17 @@ char* cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::iface_name(size_t length) {
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 std::string cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::ssid_str() {
@@ -918,30 +853,17 @@ char* cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::ssid(size_t length) {
     return ((char*)m_ssid);
 }
 
-bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_ssid(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_ssid received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::WIFI_SSID_MAX_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_ssid, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_ssid(const std::string& str) { return set_ssid(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_ssid(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_ssid received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::WIFI_SSID_MAX_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::WIFI_SSID_MAX_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_ssid, str, size + 1);
-    m_ssid[size] = '\0';
+    std::copy(str, str + size, m_ssid);
     return true;
 }
 std::string cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::pass_str() {
@@ -958,30 +880,17 @@ char* cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::pass(size_t length) {
     return ((char*)m_pass);
 }
 
-bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_pass(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_pass received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::WIFI_PASS_MAX_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_pass, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_pass(const std::string& str) { return set_pass(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_pass(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_pass received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::WIFI_PASS_MAX_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::WIFI_PASS_MAX_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_pass, str, size + 1);
-    m_pass[size] = '\0';
+    std::copy(str, str + size, m_pass);
     return true;
 }
 std::string cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::security_type_str() {
@@ -998,30 +907,17 @@ char* cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::security_type(size_t length
     return ((char*)m_security_type);
 }
 
-bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_security_type(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_security_type received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_security_type, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_security_type(const std::string& str) { return set_security_type(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::set_security_type(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_security_type received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_security_type, str, size + 1);
-    m_security_type[size] = '\0';
+    std::copy(str, str + size, m_security_type);
     return true;
 }
 void cACTION_PLATFORM_WIFI_CREDENTIALS_SET_REQUEST::class_swap()
@@ -1084,30 +980,17 @@ char* cACTION_PLATFORM_WIFI_CREDENTIALS_SET_RESPONSE::iface_name(size_t length) 
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_RESPONSE::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_RESPONSE::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_SET_RESPONSE::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 uint8_t& cACTION_PLATFORM_WIFI_CREDENTIALS_SET_RESPONSE::success() {
@@ -1622,30 +1505,17 @@ char* cACTION_PLATFORM_WIFI_SET_IFACE_STATE_REQUEST::iface_name(size_t length) {
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_REQUEST::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_REQUEST::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_REQUEST::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 int8_t& cACTION_PLATFORM_WIFI_SET_IFACE_STATE_REQUEST::iface_operation() {
@@ -1703,30 +1573,17 @@ char* cACTION_PLATFORM_WIFI_SET_IFACE_STATE_RESPONSE::iface_name(size_t length) 
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_RESPONSE::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_RESPONSE::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_SET_IFACE_STATE_RESPONSE::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 int8_t& cACTION_PLATFORM_WIFI_SET_IFACE_STATE_RESPONSE::iface_operation() {
@@ -1791,30 +1648,17 @@ char* cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_REQUEST::iface_name(size_t length
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_REQUEST::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_REQUEST::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_REQUEST::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 uint8_t& cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_REQUEST::enable() {
@@ -1872,30 +1716,17 @@ char* cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_RESPONSE::iface_name(size_t lengt
     return ((char*)m_iface_name);
 }
 
-bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_RESPONSE::set_iface_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_RESPONSE::set_iface_name(const std::string& str) { return set_iface_name(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_RESPONSE::set_iface_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name, str, size + 1);
-    m_iface_name[size] = '\0';
+    std::copy(str, str + size, m_iface_name);
     return true;
 }
 uint8_t& cACTION_PLATFORM_WIFI_SET_RADIO_TX_STATE_RESPONSE::enable() {
@@ -2119,30 +1950,17 @@ char* cACTION_PLATFORM_ERROR_NOTIFICATION::data(size_t length) {
     return ((char*)m_data);
 }
 
-bool cACTION_PLATFORM_ERROR_NOTIFICATION::set_data(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_data received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > 256) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_data, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_ERROR_NOTIFICATION::set_data(const std::string& str) { return set_data(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_ERROR_NOTIFICATION::set_data(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_data received an empty string.";
         return false;
     }
-    if (size + 1 > 256) { // +1 for null terminator
+    if (size > 256) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_data, str, size + 1);
-    m_data[size] = '\0';
+    std::copy(str, str + size, m_data);
     return true;
 }
 void cACTION_PLATFORM_ERROR_NOTIFICATION::class_swap()
@@ -2197,30 +2015,17 @@ char* cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::iface_name_ap(size_t 
     return ((char*)m_iface_name_ap);
 }
 
-bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::set_iface_name_ap(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name_ap received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name_ap, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::set_iface_name_ap(const std::string& str) { return set_iface_name_ap(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::set_iface_name_ap(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name_ap received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name_ap, str, size + 1);
-    m_iface_name_ap[size] = '\0';
+    std::copy(str, str + size, m_iface_name_ap);
     return true;
 }
 std::string cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::iface_name_bh_str() {
@@ -2237,30 +2042,17 @@ char* cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::iface_name_bh(size_t 
     return ((char*)m_iface_name_bh);
 }
 
-bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::set_iface_name_bh(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_iface_name_bh received an empty string.";
-        return false;
-    }
-    if (str_size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
-        TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
-        return false;
-    }
-    tlvf_copy_string(m_iface_name_bh, str.c_str(), str_size + 1);
-    return true;
-}
+bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::set_iface_name_bh(const std::string& str) { return set_iface_name_bh(str.c_str(), str.size()); }
 bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::set_iface_name_bh(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_iface_name_bh received an empty string.";
         return false;
     }
-    if (size + 1 > beerocks::message::IFACE_NAME_LENGTH) { // +1 for null terminator
+    if (size > beerocks::message::IFACE_NAME_LENGTH) {
         TLVF_LOG(ERROR) << "Received buffer size is smaller than string length";
         return false;
     }
-    tlvf_copy_string(m_iface_name_bh, str, size + 1);
-    m_iface_name_bh[size] = '\0';
+    std::copy(str, str + size, m_iface_name_bh);
     return true;
 }
 uint8_t& cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::status_ap() {

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -625,9 +625,7 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
         config_data.set_ssid(bss_info_conf->ssid);
         config_data.authentication_type_attr().data = bss_info_conf->authentication_type;
         config_data.encryption_type_attr().data     = bss_info_conf->encryption_type;
-        std::copy(bss_info_conf->network_key.c_str(),
-                  bss_info_conf->network_key.c_str() + bss_info_conf->network_key.size(),
-                  config_data.network_key_attr().data);
+        config_data.set_network_key(bss_info_conf->network_key);
         config_data.multiap_attr().subelement_value = bss_info_conf->bss_type;
 
         LOG(DEBUG) << "WSC config_data:" << std::hex << std::endl

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -427,20 +427,6 @@ typedef struct sWscAttrEncryptionType {
     }
 } __attribute__((packed)) sWscAttrEncryptionType;
 
-typedef struct sWscAttrNetworkKey {
-    eWscAttributes attribute_type;
-    uint16_t data_length;
-    char data[WSC_MAX_NETWORK_KEY_LENGTH];
-    void struct_swap(){
-        tlvf_swap(16, reinterpret_cast<uint8_t*>(&attribute_type));
-        tlvf_swap(16, reinterpret_cast<uint8_t*>(&data_length));
-    }
-    void struct_init(){
-        attribute_type = ATTR_NETWORK_KEY;
-        data_length = WSC_MAX_NETWORK_KEY_LENGTH;
-    }
-} __attribute__((packed)) sWscAttrNetworkKey;
-
 typedef struct sWscAttrBssid {
     eWscAttributes attribute_type;
     uint16_t data_length;
@@ -487,7 +473,13 @@ class cConfigData : public BaseClass
         bool alloc_ssid(size_t count = 1);
         sWscAttrAuthenticationType& authentication_type_attr();
         sWscAttrEncryptionType& encryption_type_attr();
-        sWscAttrNetworkKey& network_key_attr();
+        eWscAttributes& network_key_type();
+        uint16_t& network_key_length();
+        std::string network_key_str();
+        char* network_key(size_t length = 0);
+        bool set_network_key(const std::string& str);
+        bool set_network_key(const char buffer[], size_t size);
+        bool alloc_network_key(size_t count = 1);
         sWscAttrBssid& bssid_attr();
         sWscAttrVendorExtMultiAp& multiap_attr();
         void class_swap();
@@ -502,7 +494,10 @@ class cConfigData : public BaseClass
         int m_lock_order_counter__ = 0;
         sWscAttrAuthenticationType* m_authentication_type_attr = nullptr;
         sWscAttrEncryptionType* m_encryption_type_attr = nullptr;
-        sWscAttrNetworkKey* m_network_key_attr = nullptr;
+        eWscAttributes* m_network_key_type = nullptr;
+        uint16_t* m_network_key_length = nullptr;
+        char* m_network_key = nullptr;
+        size_t m_network_key_idx__ = 0;
         sWscAttrBssid* m_bssid_attr = nullptr;
         sWscAttrVendorExtMultiAp* m_multiap_attr = nullptr;
 };

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -99,24 +99,14 @@ char* tlvWscM1::manufacturer(size_t length) {
     return ((char*)m_manufacturer);
 }
 
-bool tlvWscM1::set_manufacturer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_manufacturer received an empty string.";
-        return false;
-    }
-    if (!alloc_manufacturer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_manufacturer, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM1::set_manufacturer(const std::string& str) { return set_manufacturer(str.c_str(), str.size()); }
 bool tlvWscM1::set_manufacturer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_manufacturer received an empty string.";
         return false;
     }
-    if (!alloc_manufacturer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_manufacturer, str, size + 1);
-    m_manufacturer[size] = '\0';
+    if (!alloc_manufacturer(size)) { return false; }
+    std::copy(str, str + size, m_manufacturer);
     return true;
 }
 bool tlvWscM1::alloc_manufacturer(size_t count) {
@@ -188,24 +178,14 @@ char* tlvWscM1::model_name(size_t length) {
     return ((char*)m_model_name);
 }
 
-bool tlvWscM1::set_model_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_model_name received an empty string.";
-        return false;
-    }
-    if (!alloc_model_name(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM1::set_model_name(const std::string& str) { return set_model_name(str.c_str(), str.size()); }
 bool tlvWscM1::set_model_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_model_name received an empty string.";
         return false;
     }
-    if (!alloc_model_name(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_name, str, size + 1);
-    m_model_name[size] = '\0';
+    if (!alloc_model_name(size)) { return false; }
+    std::copy(str, str + size, m_model_name);
     return true;
 }
 bool tlvWscM1::alloc_model_name(size_t count) {
@@ -274,24 +254,14 @@ char* tlvWscM1::model_number(size_t length) {
     return ((char*)m_model_number);
 }
 
-bool tlvWscM1::set_model_number(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_model_number received an empty string.";
-        return false;
-    }
-    if (!alloc_model_number(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_number, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM1::set_model_number(const std::string& str) { return set_model_number(str.c_str(), str.size()); }
 bool tlvWscM1::set_model_number(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_model_number received an empty string.";
         return false;
     }
-    if (!alloc_model_number(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_number, str, size + 1);
-    m_model_number[size] = '\0';
+    if (!alloc_model_number(size)) { return false; }
+    std::copy(str, str + size, m_model_number);
     return true;
 }
 bool tlvWscM1::alloc_model_number(size_t count) {
@@ -357,24 +327,14 @@ char* tlvWscM1::serial_number(size_t length) {
     return ((char*)m_serial_number);
 }
 
-bool tlvWscM1::set_serial_number(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_serial_number received an empty string.";
-        return false;
-    }
-    if (!alloc_serial_number(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_serial_number, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM1::set_serial_number(const std::string& str) { return set_serial_number(str.c_str(), str.size()); }
 bool tlvWscM1::set_serial_number(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_serial_number received an empty string.";
         return false;
     }
-    if (!alloc_serial_number(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_serial_number, str, size + 1);
-    m_serial_number[size] = '\0';
+    if (!alloc_serial_number(size)) { return false; }
+    std::copy(str, str + size, m_serial_number);
     return true;
 }
 bool tlvWscM1::alloc_serial_number(size_t count) {
@@ -441,24 +401,14 @@ char* tlvWscM1::device_name(size_t length) {
     return ((char*)m_device_name);
 }
 
-bool tlvWscM1::set_device_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_device_name received an empty string.";
-        return false;
-    }
-    if (!alloc_device_name(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_device_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM1::set_device_name(const std::string& str) { return set_device_name(str.c_str(), str.size()); }
 bool tlvWscM1::set_device_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_device_name received an empty string.";
         return false;
     }
-    if (!alloc_device_name(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_device_name, str, size + 1);
-    m_device_name[size] = '\0';
+    if (!alloc_device_name(size)) { return false; }
+    std::copy(str, str + size, m_device_name);
     return true;
 }
 bool tlvWscM1::alloc_device_name(size_t count) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -95,24 +95,14 @@ char* tlvWscM2::manufacturer(size_t length) {
     return ((char*)m_manufacturer);
 }
 
-bool tlvWscM2::set_manufacturer(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_manufacturer received an empty string.";
-        return false;
-    }
-    if (!alloc_manufacturer(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_manufacturer, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM2::set_manufacturer(const std::string& str) { return set_manufacturer(str.c_str(), str.size()); }
 bool tlvWscM2::set_manufacturer(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_manufacturer received an empty string.";
         return false;
     }
-    if (!alloc_manufacturer(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_manufacturer, str, size + 1);
-    m_manufacturer[size] = '\0';
+    if (!alloc_manufacturer(size)) { return false; }
+    std::copy(str, str + size, m_manufacturer);
     return true;
 }
 bool tlvWscM2::alloc_manufacturer(size_t count) {
@@ -183,24 +173,14 @@ char* tlvWscM2::model_name(size_t length) {
     return ((char*)m_model_name);
 }
 
-bool tlvWscM2::set_model_name(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_model_name received an empty string.";
-        return false;
-    }
-    if (!alloc_model_name(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_name, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM2::set_model_name(const std::string& str) { return set_model_name(str.c_str(), str.size()); }
 bool tlvWscM2::set_model_name(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_model_name received an empty string.";
         return false;
     }
-    if (!alloc_model_name(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_name, str, size + 1);
-    m_model_name[size] = '\0';
+    if (!alloc_model_name(size)) { return false; }
+    std::copy(str, str + size, m_model_name);
     return true;
 }
 bool tlvWscM2::alloc_model_name(size_t count) {
@@ -268,24 +248,14 @@ char* tlvWscM2::model_number(size_t length) {
     return ((char*)m_model_number);
 }
 
-bool tlvWscM2::set_model_number(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_model_number received an empty string.";
-        return false;
-    }
-    if (!alloc_model_number(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_number, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM2::set_model_number(const std::string& str) { return set_model_number(str.c_str(), str.size()); }
 bool tlvWscM2::set_model_number(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_model_number received an empty string.";
         return false;
     }
-    if (!alloc_model_number(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_model_number, str, size + 1);
-    m_model_number[size] = '\0';
+    if (!alloc_model_number(size)) { return false; }
+    std::copy(str, str + size, m_model_number);
     return true;
 }
 bool tlvWscM2::alloc_model_number(size_t count) {
@@ -350,24 +320,14 @@ char* tlvWscM2::serial_number(size_t length) {
     return ((char*)m_serial_number);
 }
 
-bool tlvWscM2::set_serial_number(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_serial_number received an empty string.";
-        return false;
-    }
-    if (!alloc_serial_number(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_serial_number, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvWscM2::set_serial_number(const std::string& str) { return set_serial_number(str.c_str(), str.size()); }
 bool tlvWscM2::set_serial_number(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_serial_number received an empty string.";
         return false;
     }
-    if (!alloc_serial_number(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_serial_number, str, size + 1);
-    m_serial_number[size] = '\0';
+    if (!alloc_serial_number(size)) { return false; }
+    std::copy(str, str + size, m_serial_number);
     return true;
 }
 bool tlvWscM2::alloc_serial_number(size_t count) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -104,24 +104,14 @@ char* tlvTestVarList::test_string(size_t length) {
     return ((char*)m_test_string);
 }
 
-bool tlvTestVarList::set_test_string(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_test_string received an empty string.";
-        return false;
-    }
-    if (!alloc_test_string(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_test_string, str.c_str(), str_size + 1);
-    return true;
-}
+bool tlvTestVarList::set_test_string(const std::string& str) { return set_test_string(str.c_str(), str.size()); }
 bool tlvTestVarList::set_test_string(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_test_string received an empty string.";
         return false;
     }
-    if (!alloc_test_string(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_test_string, str, size + 1);
-    m_test_string[size] = '\0';
+    if (!alloc_test_string(size)) { return false; }
+    std::copy(str, str + size, m_test_string);
     return true;
 }
 bool tlvTestVarList::alloc_test_string(size_t count) {
@@ -570,24 +560,14 @@ char* cInner::unknown_length_list_inner(size_t length) {
     return ((char*)m_unknown_length_list_inner);
 }
 
-bool cInner::set_unknown_length_list_inner(const std::string& str) {
-    size_t str_size = str.size();
-    if (str_size == 0) {
-        TLVF_LOG(WARNING) << "set_unknown_length_list_inner received an empty string.";
-        return false;
-    }
-    if (!alloc_unknown_length_list_inner(str_size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_unknown_length_list_inner, str.c_str(), str_size + 1);
-    return true;
-}
+bool cInner::set_unknown_length_list_inner(const std::string& str) { return set_unknown_length_list_inner(str.c_str(), str.size()); }
 bool cInner::set_unknown_length_list_inner(const char str[], size_t size) {
-    if (str == nullptr || size == 0) { 
+    if (str == nullptr || size == 0) {
         TLVF_LOG(WARNING) << "set_unknown_length_list_inner received an empty string.";
         return false;
     }
-    if (!alloc_unknown_length_list_inner(size + 1)) { return false; } // +1 for null terminator
-    tlvf_copy_string(m_unknown_length_list_inner, str, size + 1);
-    m_unknown_length_list_inner[size] = '\0';
+    if (!alloc_unknown_length_list_inner(size)) { return false; }
+    std::copy(str, str + size, m_unknown_length_list_inner);
     return true;
 }
 bool cInner::alloc_unknown_length_list_inner(size_t count) {

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -216,14 +216,16 @@ bool add_encrypted_settings(std::shared_ptr<tlvWscM2> m2, uint8_t *keywrapkey, u
     config_data.set_ssid("test_ssid");
     config_data.authentication_type_attr().data = WSC::eWscAuth::WSC_AUTH_WPA2; //DUMMY
     config_data.encryption_type_attr().data     = WSC::eWscEncr::WSC_ENCR_AES;
-    std::fill(config_data.network_key_attr().data,
-              config_data.network_key_attr().data + config_data.network_key_attr().data_length,
-              0xaa); //DUMMY
+    config_data.set_network_key("test1234");
 
     LOG(DEBUG) << "WSC config_data:" << std::endl
                << "     ssid: " << config_data.ssid() << std::endl
                << "     authentication_type: " << int(config_data.authentication_type_attr().data)
                << std::endl
+               << "     network_key: "
+               << std::string(config_data.network_key(), config_data.network_key_length())
+               << std::endl
+               << "     network_key length: " << int(config_data.network_key_length()) << std::endl
                << "     encryption_type: " << int(config_data.encryption_type_attr().data)
                << std::endl;
     config_data.class_swap();

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -168,7 +168,7 @@ int test_complex_list()
         MAPF_ERR("TLV4 is NULL");
         return ++errors;
     }
-    if (!tlv4->test_string_str().compare("1234567")) {
+    if (tlv4->test_string_str().compare("1234567")) {
         MAPF_ERR("FAIL, expected  \"1234567\", received " << tlv4->test_string_str());
         errors++;
     }
@@ -196,7 +196,7 @@ int test_complex_list()
 
     auto str = std::string(tlv4->var1()->unknown_length_list_inner(),
                            tlv4->var1()->unknown_length_list_inner_length());
-    if (!str.compare("prplMesh")) {
+    if (str.compare("prplMesh")) {
         MAPF_ERR("unknown length list failure - expected \"prplMesh\", received " << str);
         errors++;
     }

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -938,38 +938,22 @@ class TlvF:
                 lines_cpp.append( "" )
 
                 lines_h.append( "bool set_%s(const std::string& str);" % (param_name) )
-                lines_cpp.append( "bool %s::set_%s(const std::string& str) {" % (obj_meta.name, param_name) )
-                lines_cpp.append( "%ssize_t str_size = str.size();" % (self.getIndentation(1)))
-                lines_cpp.append( "%sif (str_size == 0) {" % (self.getIndentation(1)))
-                lines_cpp.append( '%sTLVF_LOG(WARNING) << "set_%s received an empty string.";' %  (self.getIndentation(2), param_name) )
-                lines_cpp.append( "%sreturn false;" % self.getIndentation(2))
-                lines_cpp.append( "%s}" % self.getIndentation(1) )
-                if is_const_len or is_int_len:
-                    lines_cpp.append( "%sif (str_size + 1 > %s) { // +1 for null terminator"  % (self.getIndentation(1), param_length))
-                    lines_cpp.append( '%sTLVF_LOG(ERROR) << "Received buffer size is smaller than string length";' %  self.getIndentation(2) )
-                    lines_cpp.append( "%sreturn false;" % self.getIndentation(2))
-                    lines_cpp.append( "%s}" % self.getIndentation(1) )
-                else:
-                    lines_cpp.append( "%sif (!alloc_%s(str_size + 1)) { return false; } // +1 for null terminator" % (self.getIndentation(1), param_name))
-                lines_cpp.append( "%stlvf_copy_string(m_%s, str.c_str(), str_size + 1);" % (self.getIndentation(1), param_name))
-                lines_cpp.append( "%sreturn true;" % (self.getIndentation(1)))
-                lines_cpp.append( "}")
+                lines_cpp.append( "bool %s::set_%s(const std::string& str) { return set_%s(str.c_str(), str.size()); }" % (obj_meta.name, param_name, param_name) )
 
                 lines_h.append( "bool set_%s(const char buffer[], size_t size);" % (param_name) )
                 lines_cpp.append( "bool %s::set_%s(const char str[], size_t size) {" % (obj_meta.name, param_name) )
-                lines_cpp.append( "%sif (str == nullptr || size == 0) { " % self.getIndentation(1))
+                lines_cpp.append( "%sif (str == nullptr || size == 0) {" % self.getIndentation(1))
                 lines_cpp.append( '%sTLVF_LOG(WARNING) << "set_%s received an empty string.";' %  (self.getIndentation(2), param_name) )
                 lines_cpp.append( "%sreturn false;" % self.getIndentation(2))
                 lines_cpp.append( "%s}" % self.getIndentation(1) )
                 if is_const_len or is_int_len:
-                    lines_cpp.append( "%sif (size + 1 > %s) { // +1 for null terminator"  % (self.getIndentation(1), param_length))
+                    lines_cpp.append( "%sif (size > %s) {"  % (self.getIndentation(1), param_length))
                     lines_cpp.append( '%sTLVF_LOG(ERROR) << "Received buffer size is smaller than string length";' %  self.getIndentation(2) )
                     lines_cpp.append( "%sreturn false;" % self.getIndentation(2))
                     lines_cpp.append( "%s}" % self.getIndentation(1) )
                 else:
-                    lines_cpp.append( "%sif (!alloc_%s(size + 1)) { return false; } // +1 for null terminator"  % (self.getIndentation(1), param_name))
-                lines_cpp.append( "%stlvf_copy_string(m_%s, str, size + 1);"  % (self.getIndentation(1), param_name))
-                lines_cpp.append( "%sm_%s[size] = '\\0';"  % (self.getIndentation(1), param_name))
+                    lines_cpp.append( "%sif (!alloc_%s(size)) { return false; }"  % (self.getIndentation(1), param_name))
+                lines_cpp.append( "%sstd::copy(str, str + size, m_%s);" % (self.getIndentation(1), param_name))
                 lines_cpp.append( "%sreturn true;" % self.getIndentation(1))
                 lines_cpp.append( "}")
 

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -330,18 +330,6 @@ sWscAttrEncryptionType:
     _type: eWscEncr
     _value: eWscEncr::WSC_ENCR_AES
 
-sWscAttrNetworkKey:
-  _type: struct
-  attribute_type:
-    _type: eWscAttributes
-    _value: ATTR_NETWORK_KEY
-  data_length:
-    _type: uint16_t
-    _value: WSC_MAX_NETWORK_KEY_LENGTH
-  data:
-    _type: char
-    _length: [ WSC_MAX_NETWORK_KEY_LENGTH ]
-
 sWscAttrBssid:
   _type: struct
   attribute_type:
@@ -379,7 +367,16 @@ cConfigData:
     _length_max: WSC_MAX_SSID_LENGTH
   authentication_type_attr: sWscAttrAuthenticationType
   encryption_type_attr: sWscAttrEncryptionType
-  network_key_attr: sWscAttrNetworkKey
+  network_key_type:
+    _type: eWscAttributes
+    _value: ATTR_NETWORK_KEY
+  network_key_length:
+    _type: uint16_t
+    _length_var: True
+  network_key:
+    _type: char
+    _length: [ network_key_length ]
+    _length_max: WSC_MAX_NETWORK_KEY_LENGTH
   bssid_attr: sWscAttrBssid
   multiap_attr: sWscAttrVendorExtMultiAp
 


### PR DESCRIPTION
Currently, test 5.6.2 keeps failing when using Marvell as CTT Agent.

The reason for this is that we send the M2 with a fixed-length attribute
for the password. In cases that the actual password is shorter than the maximum,
the agent may use zeroes at the end.

In order to solve this, the network_key attribute is added manually to cConfigData in the WSC_Attributes YAML file.
Also, sWscAttrNetworkKey is removed since it is not needed anymore.

Fixes #449 

Signed-off-by: Coral Malachi <coral.malachi@intel.com>