### PR TITLE
TLVF/POC: automatic parsing of TLV-like structures

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
@@ -16,9 +16,6 @@
 #include <cstddef>
 #include <stdint.h>
 #include <tlvf/swap.h>
-#include <string.h>
-#include <memory>
-#include <tlvf/BaseClass.h>
 #include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <tlvf/ieee_1905_1/tlvAlMacAddressType.h>
 #include <tlvf/ieee_1905_1/tlvMacAddress.h>
@@ -77,20 +74,12 @@
 
 namespace ieee1905_1 {
 
+class tlvParser 
 
-class tlvParser : public BaseClass
 {
     public:
-        tlvParser(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvParser(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
-        ~tlvParser();
-
-        void class_swap();
-        static size_t get_initial_size();
-
-    private:
-        bool init();
 };
+        static void ParseTlv(CmduMessageRx cmdu_rx);
 
 }; // close namespace: ieee1905_1
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
@@ -52,14 +52,10 @@
 #include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvApCapability.h>
 
-namespace ieee1905_1 {
-
 class tlvParser 
 {
     public:
-        static void ParseTlv(CmduMessageRx cmdu_rx);
+        static std::shared_ptr<BaseClass> parseTlv(ieee1905_1::CmduMessageRx &cmdu_rx);
 };
-
-}; // close namespace: ieee1905_1
 
 #endif //_TLVF/IEEE_1905_1_TLVPARSER_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
@@ -16,12 +16,13 @@
 #include <cstddef>
 #include <stdint.h>
 #include <tlvf/swap.h>
+#include <tlvf/CmduMessageRx.h>
 #include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <tlvf/ieee_1905_1/tlvAlMacAddressType.h>
 #include <tlvf/ieee_1905_1/tlvMacAddress.h>
 #include <tlvf/ieee_1905_1/tlvDeviceInformation.h>
 #include <tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h>
-#include <tlvf/ieee_1905_1/tlvNon1905NeighborDeviceList.h>
+#include <tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h>
 #include <tlvf/ieee_1905_1/tlv1905NeighborDevice.h>
 #include <tlvf/ieee_1905_1/tlvLinkMetricQuery.h>
 #include <tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h>
@@ -32,54 +33,32 @@
 #include <tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h>
 #include <tlvf/ieee_1905_1/tlvSupportedRole.h>
 #include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
-#include <tlvf/ieee_1905_1/tlvWsc.h>
 #include <tlvf/ieee_1905_1/tlvPushButtonEventNotification.h>
 #include <tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h>
 #include <tlvf/wfa_map/tlvSupportedService.h>
 #include <tlvf/wfa_map/tlvSearchedService.h>
 #include <tlvf/wfa_map/tlvApRadioIdentifier.h>
-#include <tlvf/wfa_map/tlvApOperationalBss.h>
-#include <tlvf/wfa_map/tlvAssociatedClients.h>
 #include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
-#include <tlvf/wfa_map/tlvApHtCapabilities.h>
-#include <tlvf/wfa_map/tlvApVhtCapabilities.h>
-#include <tlvf/wfa_map/tlvApHeCapabilities.h>
-#include <tlvf/wfa_map/tlvSteeringPolicy.h>
-#include <tlvf/wfa_map/tlvMetricReportingPolicy.h>
 #include <tlvf/wfa_map/tlvChannelPreference.h>
 #include <tlvf/wfa_map/tlvRadioOperationRestriction.h>
 #include <tlvf/wfa_map/tlvTransmitPowerLimit.h>
 #include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
 #include <tlvf/wfa_map/tlvOperatingChannelReport.h>
-#include <tlvf/wfa_map/tlvClientInfo.h>
-#include <tlvf/wfa_map/tlvClientCapabilityReport.h>
 #include <tlvf/wfa_map/tlvClientAssociationEvent.h>
 #include <tlvf/wfa_map/tlvApMetricQuery.h>
-#include <tlvf/wfa_map/tlvApMetric.h>
-#include <tlvf/wfa_map/tlvStamacAddressType.h>
-#include <tlvf/wfa_map/tlvAssociatedStaLinkMetrics.h>
-#include <tlvf/wfa_map/tlvUnassociatedStaLinkMetricsQuery.h>
-#include <tlvf/wfa_map/tlvUnassociatedStaLinkMetricsResponse.h>
-#include <tlvf/wfa_map/tlvBeaconMetricsQuery.h>
-#include <tlvf/wfa_map/tlvBeaconMetricsResponse.h>
 #include <tlvf/wfa_map/tlvSteeringRequest.h>
-#include <tlvf/wfa_map/tlvSteeringBtmReport.h>
+#include <tlvf/wfa_map/tlvSteeringBTMReport.h>
 #include <tlvf/wfa_map/tlvClientAssociationControlRequest.h>
-#include <tlvf/wfa_map/tlvBackhaulSteeringRequest.h>
-#include <tlvf/wfa_map/tlvBackhaulSteeringResponse.h>
 #include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvApCapability.h>
-#include <tlvf/wfa_map/tlvAssociatedStaTrafficStats.h>
-#include <tlvf/wfa_map/tlvErrorCode.h>
 
 namespace ieee1905_1 {
 
 class tlvParser 
-
 {
     public:
-};
         static void ParseTlv(CmduMessageRx cmdu_rx);
+};
 
 }; // close namespace: ieee1905_1
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
@@ -1,0 +1,97 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_IEEE_1905_1_TLVPARSER_H_
+#define _TLVF_IEEE_1905_1_TLVPARSER_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
+#include <tlvf/ieee_1905_1/tlvAlMacAddressType.h>
+#include <tlvf/ieee_1905_1/tlvMacAddress.h>
+#include <tlvf/ieee_1905_1/tlvDeviceInformation.h>
+#include <tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h>
+#include <tlvf/ieee_1905_1/tlvNon1905NeighborDeviceList.h>
+#include <tlvf/ieee_1905_1/tlv1905NeighborDevice.h>
+#include <tlvf/ieee_1905_1/tlvLinkMetricQuery.h>
+#include <tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvReceiverLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvVendorSpecific.h>
+#include <tlvf/ieee_1905_1/tlvLinkMetricResultCode.h>
+#include <tlvf/ieee_1905_1/tlvSearchedRole.h>
+#include <tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvSupportedRole.h>
+#include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvWsc.h>
+#include <tlvf/ieee_1905_1/tlvPushButtonEventNotification.h>
+#include <tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h>
+#include <tlvf/wfa_map/tlvSupportedService.h>
+#include <tlvf/wfa_map/tlvSearchedService.h>
+#include <tlvf/wfa_map/tlvApRadioIdentifier.h>
+#include <tlvf/wfa_map/tlvApOperationalBss.h>
+#include <tlvf/wfa_map/tlvAssociatedClients.h>
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
+#include <tlvf/wfa_map/tlvApHtCapabilities.h>
+#include <tlvf/wfa_map/tlvApVhtCapabilities.h>
+#include <tlvf/wfa_map/tlvApHeCapabilities.h>
+#include <tlvf/wfa_map/tlvSteeringPolicy.h>
+#include <tlvf/wfa_map/tlvMetricReportingPolicy.h>
+#include <tlvf/wfa_map/tlvChannelPreference.h>
+#include <tlvf/wfa_map/tlvRadioOperationRestriction.h>
+#include <tlvf/wfa_map/tlvTransmitPowerLimit.h>
+#include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
+#include <tlvf/wfa_map/tlvOperatingChannelReport.h>
+#include <tlvf/wfa_map/tlvClientInfo.h>
+#include <tlvf/wfa_map/tlvClientCapabilityReport.h>
+#include <tlvf/wfa_map/tlvClientAssociationEvent.h>
+#include <tlvf/wfa_map/tlvApMetricQuery.h>
+#include <tlvf/wfa_map/tlvApMetric.h>
+#include <tlvf/wfa_map/tlvStamacAddressType.h>
+#include <tlvf/wfa_map/tlvAssociatedStaLinkMetrics.h>
+#include <tlvf/wfa_map/tlvUnassociatedStaLinkMetricsQuery.h>
+#include <tlvf/wfa_map/tlvUnassociatedStaLinkMetricsResponse.h>
+#include <tlvf/wfa_map/tlvBeaconMetricsQuery.h>
+#include <tlvf/wfa_map/tlvBeaconMetricsResponse.h>
+#include <tlvf/wfa_map/tlvSteeringRequest.h>
+#include <tlvf/wfa_map/tlvSteeringBtmReport.h>
+#include <tlvf/wfa_map/tlvClientAssociationControlRequest.h>
+#include <tlvf/wfa_map/tlvBackhaulSteeringRequest.h>
+#include <tlvf/wfa_map/tlvBackhaulSteeringResponse.h>
+#include <tlvf/wfa_map/tlvHigherLayerData.h>
+#include <tlvf/wfa_map/tlvApCapability.h>
+#include <tlvf/wfa_map/tlvAssociatedStaTrafficStats.h>
+#include <tlvf/wfa_map/tlvErrorCode.h>
+
+namespace ieee1905_1 {
+
+
+class tlvParser : public BaseClass
+{
+    public:
+        tlvParser(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        tlvParser(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~tlvParser();
+
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_TLVF/IEEE_1905_1_TLVPARSER_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvParser.h
@@ -56,6 +56,7 @@ class tlvParser
 {
     public:
         static std::shared_ptr<BaseClass> parseTlv(ieee1905_1::CmduMessageRx &cmdu_rx);
+        static std::shared_ptr<BaseClass> parseWsc(ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 
 #endif //_TLVF/IEEE_1905_1_TLVPARSER_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
@@ -1,0 +1,278 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/ieee_1905_1/tlvParser.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace ieee1905_1;
+
+tlvParser::tlvParser(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+tlvParser::tlvParser(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+tlvParser::~tlvParser() {
+}
+void tlvParser::class_swap()
+{
+}
+
+size_t tlvParser::get_initial_size()
+{
+    size_t class_size = 0;
+    return class_size;
+}
+
+bool tlvParser::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    return true;
+}
+
+
+void Parse(CmduMessageRx cmdu_rx)
+{
+    switch(cmdu_rx.getNextTlvType())
+    {
+        case (0):{
+        cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
+        return;
+        }
+        case (1):{
+        cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
+        return;
+        }
+        case (2):{
+        cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
+        return;
+        }
+        case (3):{
+        cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
+        return;
+        }
+        case (4):{
+        cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
+        return;
+        }
+        case (6):{
+        cmdu_rx.addClass<ieee1905_1::tlvNon1905NeighborDeviceList>();
+        return;
+        }
+        case (7):{
+        cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
+        return;
+        }
+        case (8):{
+        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
+        return;
+        }
+        case (9):{
+        cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
+        return;
+        }
+        case (10):{
+        cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
+        return;
+        }
+        case (11):{
+        cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
+        return;
+        }
+        case (12):{
+        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
+        return;
+        }
+        case (13):{
+        cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
+        return;
+        }
+        case (14):{
+        cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
+        return;
+        }
+        case (15):{
+        cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
+        return;
+        }
+        case (16):{
+        cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
+        return;
+        }
+        case (17):{
+        cmdu_rx.addClass<ieee1905_1::tlvWsc>();
+        return;
+        }
+        case (18):{
+        cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
+        return;
+        }
+        case (19):{
+        cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
+        return;
+        }
+        case (128):{
+        cmdu_rx.addClass<wfa_map::tlvSupportedService>();
+        return;
+        }
+        case (129):{
+        cmdu_rx.addClass<wfa_map::tlvSearchedService>();
+        return;
+        }
+        case (130):{
+        cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
+        return;
+        }
+        case (131):{
+        cmdu_rx.addClass<wfa_map::tlvApOperationalBss>();
+        return;
+        }
+        case (132):{
+        cmdu_rx.addClass<wfa_map::tlvAssociatedClients>();
+        return;
+        }
+        case (133):{
+        cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+        return;
+        }
+        case (134):{
+        cmdu_rx.addClass<wfa_map::tlvApHtCapabilities>();
+        return;
+        }
+        case (135):{
+        cmdu_rx.addClass<wfa_map::tlvApVhtCapabilities>();
+        return;
+        }
+        case (136):{
+        cmdu_rx.addClass<wfa_map::tlvApHeCapabilities>();
+        return;
+        }
+        case (137):{
+        cmdu_rx.addClass<wfa_map::tlvSteeringPolicy>();
+        return;
+        }
+        case (138):{
+        cmdu_rx.addClass<wfa_map::tlvMetricReportingPolicy>();
+        return;
+        }
+        case (139):{
+        cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
+        return;
+        }
+        case (140):{
+        cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
+        return;
+        }
+        case (141):{
+        cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
+        return;
+        }
+        case (142):{
+        cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
+        return;
+        }
+        case (143):{
+        cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
+        return;
+        }
+        case (144):{
+        cmdu_rx.addClass<wfa_map::tlvClientInfo>();
+        return;
+        }
+        case (145):{
+        cmdu_rx.addClass<wfa_map::tlvClientCapabilityReport>();
+        return;
+        }
+        case (146):{
+        cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
+        return;
+        }
+        case (147):{
+        cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
+        return;
+        }
+        case (148):{
+        cmdu_rx.addClass<wfa_map::tlvApMetric>();
+        return;
+        }
+        case (149):{
+        cmdu_rx.addClass<wfa_map::tlvStamacAddressType>();
+        return;
+        }
+        case (150):{
+        cmdu_rx.addClass<wfa_map::tlvAssociatedStaLinkMetrics>();
+        return;
+        }
+        case (151):{
+        cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsQuery>();
+        return;
+        }
+        case (152):{
+        cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsResponse>();
+        return;
+        }
+        case (153):{
+        cmdu_rx.addClass<wfa_map::tlvBeaconMetricsQuery>();
+        return;
+        }
+        case (154):{
+        cmdu_rx.addClass<wfa_map::tlvBeaconMetricsResponse>();
+        return;
+        }
+        case (155):{
+        cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
+        return;
+        }
+        case (156):{
+        cmdu_rx.addClass<wfa_map::tlvSteeringBtmReport>();
+        return;
+        }
+        case (157):{
+        cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
+        return;
+        }
+        case (158):{
+        cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringRequest>();
+        return;
+        }
+        case (159):{
+        cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringResponse>();
+        return;
+        }
+        case (160):{
+        cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
+        return;
+        }
+        case (161):{
+        cmdu_rx.addClass<wfa_map::tlvApCapability>();
+        return;
+        }
+        case (162):{
+        cmdu_rx.addClass<wfa_map::tlvAssociatedStaTrafficStats>();
+        return;
+        }
+        case (163):{
+        cmdu_rx.addClass<wfa_map::tlvErrorCode>();
+        return;
+        }
+        }
+}

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
@@ -12,145 +12,111 @@
 
 #include "tlvParser.h"
 
-void ParseTlv(ieee1905_1::CmduMessageRx cmdu_rx)
+std::shared_ptr<BaseClass> ParseTlv(ieee1905_1::CmduMessageRx cmdu_rx)
 {
     switch(cmdu_rx.getNextTlvType())
     {
         case (0):{
-        cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
         }
         case (1):{
-        cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
         }
         case (2):{
-        cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
         }
         case (3):{
-        cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
         }
         case (4):{
-        cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
         }
         case (6):{
-        cmdu_rx.addClass<ieee1905_1::tlvNon1905neighborDeviceList>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvNon1905neighborDeviceList>();
         }
         case (7):{
-        cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
         }
         case (8):{
-        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
         }
         case (9):{
-        cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
         }
         case (10):{
-        cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
         }
         case (11):{
-        cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
         }
         case (12):{
-        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
         }
         case (13):{
-        cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
         }
         case (14):{
-        cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
         }
         case (15):{
-        cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
         }
         case (16):{
-        cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
         }
         case (18):{
-        cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
         }
         case (19):{
-        cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
-        return;
+        return cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
         }
         case (128):{
-        cmdu_rx.addClass<wfa_map::tlvSupportedService>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvSupportedService>();
         }
         case (129):{
-        cmdu_rx.addClass<wfa_map::tlvSearchedService>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvSearchedService>();
         }
         case (130):{
-        cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
         }
         case (133):{
-        cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
         }
         case (139):{
-        cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
         }
         case (140):{
-        cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
         }
         case (141):{
-        cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
         }
         case (142):{
-        cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
         }
         case (143):{
-        cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
         }
         case (146):{
-        cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
         }
         case (147):{
-        cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
         }
         case (155):{
-        cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
         }
         case (156):{
-        cmdu_rx.addClass<wfa_map::tlvSteeringBTMReport>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvSteeringBTMReport>();
         }
         case (157):{
-        cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
         }
         case (160):{
-        cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
         }
         case (161):{
-        cmdu_rx.addClass<wfa_map::tlvApCapability>();
-        return;
+        return cmdu_rx.addClass<wfa_map::tlvApCapability>();
         }
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
@@ -12,232 +12,145 @@
 
 #include "tlvParser.h"
 
-class tlvParser {
-
-    void ParseTlv(CmduMessageRx cmdu_rx)
+void ParseTlv(ieee1905_1::CmduMessageRx cmdu_rx)
+{
+    switch(cmdu_rx.getNextTlvType())
     {
-        switch(cmdu_rx.getNextTlvType())
-        {
-            case (0):{
-            cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
-            return;
-            }
-            case (1):{
-            cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
-            return;
-            }
-            case (2):{
-            cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
-            return;
-            }
-            case (3):{
-            cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
-            return;
-            }
-            case (4):{
-            cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
-            return;
-            }
-            case (6):{
-            cmdu_rx.addClass<ieee1905_1::tlvNon1905NeighborDeviceList>();
-            return;
-            }
-            case (7):{
-            cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
-            return;
-            }
-            case (8):{
-            cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
-            return;
-            }
-            case (9):{
-            cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
-            return;
-            }
-            case (10):{
-            cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
-            return;
-            }
-            case (11):{
-            cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
-            return;
-            }
-            case (12):{
-            cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
-            return;
-            }
-            case (13):{
-            cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
-            return;
-            }
-            case (14):{
-            cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
-            return;
-            }
-            case (15):{
-            cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
-            return;
-            }
-            case (16):{
-            cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
-            return;
-            }
-            case (17):{
-            cmdu_rx.addClass<ieee1905_1::tlvWsc>();
-            return;
-            }
-            case (18):{
-            cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
-            return;
-            }
-            case (19):{
-            cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
-            return;
-            }
-            case (128):{
-            cmdu_rx.addClass<wfa_map::tlvSupportedService>();
-            return;
-            }
-            case (129):{
-            cmdu_rx.addClass<wfa_map::tlvSearchedService>();
-            return;
-            }
-            case (130):{
-            cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
-            return;
-            }
-            case (131):{
-            cmdu_rx.addClass<wfa_map::tlvApOperationalBss>();
-            return;
-            }
-            case (132):{
-            cmdu_rx.addClass<wfa_map::tlvAssociatedClients>();
-            return;
-            }
-            case (133):{
-            cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
-            return;
-            }
-            case (134):{
-            cmdu_rx.addClass<wfa_map::tlvApHtCapabilities>();
-            return;
-            }
-            case (135):{
-            cmdu_rx.addClass<wfa_map::tlvApVhtCapabilities>();
-            return;
-            }
-            case (136):{
-            cmdu_rx.addClass<wfa_map::tlvApHeCapabilities>();
-            return;
-            }
-            case (137):{
-            cmdu_rx.addClass<wfa_map::tlvSteeringPolicy>();
-            return;
-            }
-            case (138):{
-            cmdu_rx.addClass<wfa_map::tlvMetricReportingPolicy>();
-            return;
-            }
-            case (139):{
-            cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
-            return;
-            }
-            case (140):{
-            cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
-            return;
-            }
-            case (141):{
-            cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
-            return;
-            }
-            case (142):{
-            cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
-            return;
-            }
-            case (143):{
-            cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
-            return;
-            }
-            case (144):{
-            cmdu_rx.addClass<wfa_map::tlvClientInfo>();
-            return;
-            }
-            case (145):{
-            cmdu_rx.addClass<wfa_map::tlvClientCapabilityReport>();
-            return;
-            }
-            case (146):{
-            cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
-            return;
-            }
-            case (147):{
-            cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
-            return;
-            }
-            case (148):{
-            cmdu_rx.addClass<wfa_map::tlvApMetric>();
-            return;
-            }
-            case (149):{
-            cmdu_rx.addClass<wfa_map::tlvStamacAddressType>();
-            return;
-            }
-            case (150):{
-            cmdu_rx.addClass<wfa_map::tlvAssociatedStaLinkMetrics>();
-            return;
-            }
-            case (151):{
-            cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsQuery>();
-            return;
-            }
-            case (152):{
-            cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsResponse>();
-            return;
-            }
-            case (153):{
-            cmdu_rx.addClass<wfa_map::tlvBeaconMetricsQuery>();
-            return;
-            }
-            case (154):{
-            cmdu_rx.addClass<wfa_map::tlvBeaconMetricsResponse>();
-            return;
-            }
-            case (155):{
-            cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
-            return;
-            }
-            case (156):{
-            cmdu_rx.addClass<wfa_map::tlvSteeringBtmReport>();
-            return;
-            }
-            case (157):{
-            cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
-            return;
-            }
-            case (158):{
-            cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringRequest>();
-            return;
-            }
-            case (159):{
-            cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringResponse>();
-            return;
-            }
-            case (160):{
-            cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
-            return;
-            }
-            case (161):{
-            cmdu_rx.addClass<wfa_map::tlvApCapability>();
-            return;
-            }
-            case (162):{
-            cmdu_rx.addClass<wfa_map::tlvAssociatedStaTrafficStats>();
-            return;
-            }
-            case (163):{
-            cmdu_rx.addClass<wfa_map::tlvErrorCode>();
-            return;
-            }
+        case (0):{
+        cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
+        return;
+        }
+        case (1):{
+        cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
+        return;
+        }
+        case (2):{
+        cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
+        return;
+        }
+        case (3):{
+        cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
+        return;
+        }
+        case (4):{
+        cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
+        return;
+        }
+        case (6):{
+        cmdu_rx.addClass<ieee1905_1::tlvNon1905neighborDeviceList>();
+        return;
+        }
+        case (7):{
+        cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
+        return;
+        }
+        case (8):{
+        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
+        return;
+        }
+        case (9):{
+        cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
+        return;
+        }
+        case (10):{
+        cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
+        return;
+        }
+        case (11):{
+        cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
+        return;
+        }
+        case (12):{
+        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
+        return;
+        }
+        case (13):{
+        cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
+        return;
+        }
+        case (14):{
+        cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
+        return;
+        }
+        case (15):{
+        cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
+        return;
+        }
+        case (16):{
+        cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
+        return;
+        }
+        case (18):{
+        cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
+        return;
+        }
+        case (19):{
+        cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
+        return;
+        }
+        case (128):{
+        cmdu_rx.addClass<wfa_map::tlvSupportedService>();
+        return;
+        }
+        case (129):{
+        cmdu_rx.addClass<wfa_map::tlvSearchedService>();
+        return;
+        }
+        case (130):{
+        cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
+        return;
+        }
+        case (133):{
+        cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+        return;
+        }
+        case (139):{
+        cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
+        return;
+        }
+        case (140):{
+        cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
+        return;
+        }
+        case (141):{
+        cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
+        return;
+        }
+        case (142):{
+        cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
+        return;
+        }
+        case (143):{
+        cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
+        return;
+        }
+        case (146):{
+        cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
+        return;
+        }
+        case (147):{
+        cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
+        return;
+        }
+        case (155):{
+        cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
+        return;
+        }
+        case (156):{
+        cmdu_rx.addClass<wfa_map::tlvSteeringBTMReport>();
+        return;
+        }
+        case (157):{
+        cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
+        return;
+        }
+        case (160):{
+        cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
+        return;
+        }
+        case (161):{
+        cmdu_rx.addClass<wfa_map::tlvApCapability>();
+        return;
         }
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
@@ -10,9 +10,9 @@
  * See LICENSE file for more details.
  */
 
-#include "tlvParser.h"
+#include <tlvf/ieee_1905_1/tlvParser.h>
 
-std::shared_ptr<BaseClass> ParseTlv(ieee1905_1::CmduMessageRx cmdu_rx)
+std::shared_ptr<BaseClass> tlvParser::parseTlv(ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     switch(cmdu_rx.getNextTlvType())
     {
@@ -119,4 +119,5 @@ std::shared_ptr<BaseClass> ParseTlv(ieee1905_1::CmduMessageRx cmdu_rx)
         return cmdu_rx.addClass<wfa_map::tlvApCapability>();
         }
     }
+    return nullptr; // unknown tlv
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvParser.cpp
@@ -10,269 +10,234 @@
  * See LICENSE file for more details.
  */
 
-#include <tlvf/ieee_1905_1/tlvParser.h>
-#include <tlvf/tlvflogging.h>
+#include "tlvParser.h"
 
-using namespace ieee1905_1;
+class tlvParser {
 
-tlvParser::tlvParser(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
-    m_init_succeeded = init();
-}
-tlvParser::tlvParser(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
-    m_init_succeeded = init();
-}
-tlvParser::~tlvParser() {
-}
-void tlvParser::class_swap()
-{
-}
-
-size_t tlvParser::get_initial_size()
-{
-    size_t class_size = 0;
-    return class_size;
-}
-
-bool tlvParser::init()
-{
-    if (getBuffRemainingBytes() < kMinimumLength) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_buff_ptr__ - m_buff__ > ssize_t(m_buff_len__)) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    if (m_parse__ && m_swap__) { class_swap(); }
-    return true;
-}
-
-
-void Parse(CmduMessageRx cmdu_rx)
-{
-    switch(cmdu_rx.getNextTlvType())
+    void ParseTlv(CmduMessageRx cmdu_rx)
     {
-        case (0):{
-        cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
-        return;
+        switch(cmdu_rx.getNextTlvType())
+        {
+            case (0):{
+            cmdu_rx.addClass<ieee1905_1::tlvEndOfMessage>();
+            return;
+            }
+            case (1):{
+            cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
+            return;
+            }
+            case (2):{
+            cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
+            return;
+            }
+            case (3):{
+            cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
+            return;
+            }
+            case (4):{
+            cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
+            return;
+            }
+            case (6):{
+            cmdu_rx.addClass<ieee1905_1::tlvNon1905NeighborDeviceList>();
+            return;
+            }
+            case (7):{
+            cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
+            return;
+            }
+            case (8):{
+            cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
+            return;
+            }
+            case (9):{
+            cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
+            return;
+            }
+            case (10):{
+            cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
+            return;
+            }
+            case (11):{
+            cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
+            return;
+            }
+            case (12):{
+            cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
+            return;
+            }
+            case (13):{
+            cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
+            return;
+            }
+            case (14):{
+            cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
+            return;
+            }
+            case (15):{
+            cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
+            return;
+            }
+            case (16):{
+            cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
+            return;
+            }
+            case (17):{
+            cmdu_rx.addClass<ieee1905_1::tlvWsc>();
+            return;
+            }
+            case (18):{
+            cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
+            return;
+            }
+            case (19):{
+            cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
+            return;
+            }
+            case (128):{
+            cmdu_rx.addClass<wfa_map::tlvSupportedService>();
+            return;
+            }
+            case (129):{
+            cmdu_rx.addClass<wfa_map::tlvSearchedService>();
+            return;
+            }
+            case (130):{
+            cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
+            return;
+            }
+            case (131):{
+            cmdu_rx.addClass<wfa_map::tlvApOperationalBss>();
+            return;
+            }
+            case (132):{
+            cmdu_rx.addClass<wfa_map::tlvAssociatedClients>();
+            return;
+            }
+            case (133):{
+            cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+            return;
+            }
+            case (134):{
+            cmdu_rx.addClass<wfa_map::tlvApHtCapabilities>();
+            return;
+            }
+            case (135):{
+            cmdu_rx.addClass<wfa_map::tlvApVhtCapabilities>();
+            return;
+            }
+            case (136):{
+            cmdu_rx.addClass<wfa_map::tlvApHeCapabilities>();
+            return;
+            }
+            case (137):{
+            cmdu_rx.addClass<wfa_map::tlvSteeringPolicy>();
+            return;
+            }
+            case (138):{
+            cmdu_rx.addClass<wfa_map::tlvMetricReportingPolicy>();
+            return;
+            }
+            case (139):{
+            cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
+            return;
+            }
+            case (140):{
+            cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
+            return;
+            }
+            case (141):{
+            cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
+            return;
+            }
+            case (142):{
+            cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
+            return;
+            }
+            case (143):{
+            cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
+            return;
+            }
+            case (144):{
+            cmdu_rx.addClass<wfa_map::tlvClientInfo>();
+            return;
+            }
+            case (145):{
+            cmdu_rx.addClass<wfa_map::tlvClientCapabilityReport>();
+            return;
+            }
+            case (146):{
+            cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
+            return;
+            }
+            case (147):{
+            cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
+            return;
+            }
+            case (148):{
+            cmdu_rx.addClass<wfa_map::tlvApMetric>();
+            return;
+            }
+            case (149):{
+            cmdu_rx.addClass<wfa_map::tlvStamacAddressType>();
+            return;
+            }
+            case (150):{
+            cmdu_rx.addClass<wfa_map::tlvAssociatedStaLinkMetrics>();
+            return;
+            }
+            case (151):{
+            cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsQuery>();
+            return;
+            }
+            case (152):{
+            cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsResponse>();
+            return;
+            }
+            case (153):{
+            cmdu_rx.addClass<wfa_map::tlvBeaconMetricsQuery>();
+            return;
+            }
+            case (154):{
+            cmdu_rx.addClass<wfa_map::tlvBeaconMetricsResponse>();
+            return;
+            }
+            case (155):{
+            cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
+            return;
+            }
+            case (156):{
+            cmdu_rx.addClass<wfa_map::tlvSteeringBtmReport>();
+            return;
+            }
+            case (157):{
+            cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
+            return;
+            }
+            case (158):{
+            cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringRequest>();
+            return;
+            }
+            case (159):{
+            cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringResponse>();
+            return;
+            }
+            case (160):{
+            cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
+            return;
+            }
+            case (161):{
+            cmdu_rx.addClass<wfa_map::tlvApCapability>();
+            return;
+            }
+            case (162):{
+            cmdu_rx.addClass<wfa_map::tlvAssociatedStaTrafficStats>();
+            return;
+            }
+            case (163):{
+            cmdu_rx.addClass<wfa_map::tlvErrorCode>();
+            return;
+            }
         }
-        case (1):{
-        cmdu_rx.addClass<ieee1905_1::tlvAlMacAddressType>();
-        return;
-        }
-        case (2):{
-        cmdu_rx.addClass<ieee1905_1::tlvMacAddress>();
-        return;
-        }
-        case (3):{
-        cmdu_rx.addClass<ieee1905_1::tlvDeviceInformation>();
-        return;
-        }
-        case (4):{
-        cmdu_rx.addClass<ieee1905_1::tlvDeviceBridgingCapability>();
-        return;
-        }
-        case (6):{
-        cmdu_rx.addClass<ieee1905_1::tlvNon1905NeighborDeviceList>();
-        return;
-        }
-        case (7):{
-        cmdu_rx.addClass<ieee1905_1::tlv1905NeighborDevice>();
-        return;
-        }
-        case (8):{
-        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricQuery>();
-        return;
-        }
-        case (9):{
-        cmdu_rx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
-        return;
-        }
-        case (10):{
-        cmdu_rx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
-        return;
-        }
-        case (11):{
-        cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
-        return;
-        }
-        case (12):{
-        cmdu_rx.addClass<ieee1905_1::tlvLinkMetricResultCode>();
-        return;
-        }
-        case (13):{
-        cmdu_rx.addClass<ieee1905_1::tlvSearchedRole>();
-        return;
-        }
-        case (14):{
-        cmdu_rx.addClass<ieee1905_1::tlvAutoconfigFreqBand>();
-        return;
-        }
-        case (15):{
-        cmdu_rx.addClass<ieee1905_1::tlvSupportedRole>();
-        return;
-        }
-        case (16):{
-        cmdu_rx.addClass<ieee1905_1::tlvSupportedFreqBand>();
-        return;
-        }
-        case (17):{
-        cmdu_rx.addClass<ieee1905_1::tlvWsc>();
-        return;
-        }
-        case (18):{
-        cmdu_rx.addClass<ieee1905_1::tlvPushButtonEventNotification>();
-        return;
-        }
-        case (19):{
-        cmdu_rx.addClass<ieee1905_1::tlvPushButtonJoinNotification>();
-        return;
-        }
-        case (128):{
-        cmdu_rx.addClass<wfa_map::tlvSupportedService>();
-        return;
-        }
-        case (129):{
-        cmdu_rx.addClass<wfa_map::tlvSearchedService>();
-        return;
-        }
-        case (130):{
-        cmdu_rx.addClass<wfa_map::tlvApRadioIdentifier>();
-        return;
-        }
-        case (131):{
-        cmdu_rx.addClass<wfa_map::tlvApOperationalBss>();
-        return;
-        }
-        case (132):{
-        cmdu_rx.addClass<wfa_map::tlvAssociatedClients>();
-        return;
-        }
-        case (133):{
-        cmdu_rx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
-        return;
-        }
-        case (134):{
-        cmdu_rx.addClass<wfa_map::tlvApHtCapabilities>();
-        return;
-        }
-        case (135):{
-        cmdu_rx.addClass<wfa_map::tlvApVhtCapabilities>();
-        return;
-        }
-        case (136):{
-        cmdu_rx.addClass<wfa_map::tlvApHeCapabilities>();
-        return;
-        }
-        case (137):{
-        cmdu_rx.addClass<wfa_map::tlvSteeringPolicy>();
-        return;
-        }
-        case (138):{
-        cmdu_rx.addClass<wfa_map::tlvMetricReportingPolicy>();
-        return;
-        }
-        case (139):{
-        cmdu_rx.addClass<wfa_map::tlvChannelPreference>();
-        return;
-        }
-        case (140):{
-        cmdu_rx.addClass<wfa_map::tlvRadioOperationRestriction>();
-        return;
-        }
-        case (141):{
-        cmdu_rx.addClass<wfa_map::tlvTransmitPowerLimit>();
-        return;
-        }
-        case (142):{
-        cmdu_rx.addClass<wfa_map::tlvChannelSelectionResponse>();
-        return;
-        }
-        case (143):{
-        cmdu_rx.addClass<wfa_map::tlvOperatingChannelReport>();
-        return;
-        }
-        case (144):{
-        cmdu_rx.addClass<wfa_map::tlvClientInfo>();
-        return;
-        }
-        case (145):{
-        cmdu_rx.addClass<wfa_map::tlvClientCapabilityReport>();
-        return;
-        }
-        case (146):{
-        cmdu_rx.addClass<wfa_map::tlvClientAssociationEvent>();
-        return;
-        }
-        case (147):{
-        cmdu_rx.addClass<wfa_map::tlvApMetricQuery>();
-        return;
-        }
-        case (148):{
-        cmdu_rx.addClass<wfa_map::tlvApMetric>();
-        return;
-        }
-        case (149):{
-        cmdu_rx.addClass<wfa_map::tlvStamacAddressType>();
-        return;
-        }
-        case (150):{
-        cmdu_rx.addClass<wfa_map::tlvAssociatedStaLinkMetrics>();
-        return;
-        }
-        case (151):{
-        cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsQuery>();
-        return;
-        }
-        case (152):{
-        cmdu_rx.addClass<wfa_map::tlvUnassociatedStaLinkMetricsResponse>();
-        return;
-        }
-        case (153):{
-        cmdu_rx.addClass<wfa_map::tlvBeaconMetricsQuery>();
-        return;
-        }
-        case (154):{
-        cmdu_rx.addClass<wfa_map::tlvBeaconMetricsResponse>();
-        return;
-        }
-        case (155):{
-        cmdu_rx.addClass<wfa_map::tlvSteeringRequest>();
-        return;
-        }
-        case (156):{
-        cmdu_rx.addClass<wfa_map::tlvSteeringBtmReport>();
-        return;
-        }
-        case (157):{
-        cmdu_rx.addClass<wfa_map::tlvClientAssociationControlRequest>();
-        return;
-        }
-        case (158):{
-        cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringRequest>();
-        return;
-        }
-        case (159):{
-        cmdu_rx.addClass<wfa_map::tlvBackhaulSteeringResponse>();
-        return;
-        }
-        case (160):{
-        cmdu_rx.addClass<wfa_map::tlvHigherLayerData>();
-        return;
-        }
-        case (161):{
-        cmdu_rx.addClass<wfa_map::tlvApCapability>();
-        return;
-        }
-        case (162):{
-        cmdu_rx.addClass<wfa_map::tlvAssociatedStaTrafficStats>();
-        return;
-        }
-        case (163):{
-        cmdu_rx.addClass<wfa_map::tlvErrorCode>();
-        return;
-        }
-        }
+    }
 }

--- a/framework/tlvf/CMakeLists.txt
+++ b/framework/tlvf/CMakeLists.txt
@@ -23,6 +23,7 @@ execute_process(
     OUTPUT_VARIABLE TLVF_DEPENDENCIES
     RESULT_VARIABLE RET
 )
+message("TLVF_DEPENDENCIES: ${TLVF_DEPENDENCIES}")
 if(NOT RET EQUAL 0)
     message(FATAL_ERROR "-- ${TLVF_COMMAND} --print-dependencies failed!")
 endif()
@@ -33,6 +34,7 @@ execute_process(
     OUTPUT_VARIABLE TLVF_OUTPUTS
     RESULT_VARIABLE RET
 )
+message("TLVF_OUTPUTS: ${TLVF_OUTPUTS}")
 if(NOT RET EQUAL 0)
     message(FATAL_ERROR "-- ${TLVF_COMMAND} --print-outputs failed!")
 endif()

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -519,12 +519,12 @@ int test_all()
     auto tlv3 = std::dynamic_pointer_cast<tlvWscM2>(tlvParser::parseTlv(received_message));
     if (tlv3 != nullptr) {
         MAPF_DBG("TLV3 LENGTH AFTER INIT: " << tlv3->length());
+        if (!parse_encrypted_settings(tlv3, keywrapkey, iv)) {
+            MAPF_ERR("TLV3 parse encrypted settings failed");
+            errors++;
+        }
     } else {
         MAPF_ERR("TLV3 IS NULL");
-        errors++;
-    }
-    if (!parse_encrypted_settings(tlv3, keywrapkey, iv)) {
-        MAPF_ERR("TLV3 parse encrypted settings failed");
         errors++;
     }
 

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -6,6 +6,7 @@
  * See LICENSE file for more details.
  */
 
+#include "tlvf/ieee_1905_1/tlvParser.h"
 #include "tlvf/CmduMessageRx.h"
 #include "tlvf/CmduMessageTx.h"
 #include <cstring>
@@ -478,15 +479,7 @@ int test_all()
     CmduMessageRx received_message;
     received_message.parse(recv_buffer, sizeof(recv_buffer), true);
 
-    eTlvType type;
-    if (received_message.getNextTlvType(type) &&
-        type == eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) {
-        MAPF_DBG("SUCCESS");
-    }
-
-    MAPF_DBG("size: " << received_message.getNextTlvLength());
-
-    auto tlv1 = received_message.addClass<tlvNon1905neighborDeviceList>();
+    auto tlv1 = std::dynamic_pointer_cast<tlvNon1905neighborDeviceList>(tlvParser::parseTlv(received_message));
     if (tlv1 != nullptr) {
         MAPF_DBG("LENGTH AFTER INIT: " << tlv1->length());
         //tlv1->alloc_mac_non_1905_device(3);
@@ -515,15 +508,7 @@ int test_all()
         errors++;
     }
 
-    if (received_message.getNextTlvType(type) && type == eTlvType::TLV_LINK_METRIC_QUERY) {
-        MAPF_DBG("SUCCESS");
-    } else {
-        errors++;
-    }
-
-    MAPF_DBG("size: " << received_message.getNextTlvLength());
-
-    auto tlv2 = received_message.addClass<tlvLinkMetricQuery>();
+    auto tlv2 = std::dynamic_pointer_cast<tlvLinkMetricQuery>(tlvParser::parseTlv(received_message));
     if (tlv2 != nullptr) {
         MAPF_DBG("TLV2 LENGTH AFTER INIT: " << tlv2->length());
     } else {
@@ -531,13 +516,7 @@ int test_all()
         errors++;
     }
 
-    if (received_message.getNextTlvType(type) && type == eTlvType::TLV_WSC) {
-        MAPF_DBG("SUCCESS");
-    } else {
-        errors++;
-    }
-
-    auto tlv3 = received_message.addClass<tlvWscM2>();
+    auto tlv3 = std::dynamic_pointer_cast<tlvWscM2>(tlvParser::parseTlv(received_message));
     if (tlv3 != nullptr) {
         MAPF_DBG("TLV3 LENGTH AFTER INIT: " << tlv3->length());
     } else {
@@ -681,6 +660,7 @@ int test_all()
         MAPF_DBG("HEADER PROTECTION SUCCESS");
     }
 
+    eTlvType type;
     if (!received_message.getNextTlvType(type)) {
         MAPF_DBG("TYPE PROTECTION SUCCESS");
     }

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -85,6 +85,7 @@ class TypeInfo:
     ENUM_CLASS = "ENUM_CLASS"
     STRUCT = "STRUCT"
     CLASS = "CLASS"
+    CUSTOM = "CUSTOM"
     STRUCT_SWAP_FUNCTION_NAME = "struct_swap()"
     STRUCT_INIT_FUNCTION_NAME = "struct_init()"
     CLASS_SWAP_FUNCTION_NAME = "class_swap()"
@@ -122,6 +123,8 @@ class TypeInfo:
                 self.type = TypeInfo.CHAR
             elif self.type_str == "enum_class":
                 self.type = TypeInfo.ENUM_CLASS
+            elif self.type_str == "custom":
+                self.type = TypeInfo.CUSTOM
             elif self.type_str == "size_t":
                 self.type = TypeInfo.ERROR
             elif len(self.type_str) > 2 and (str(self.type_str[1]).isupper() or str(self.type_str[1]).isdigit()):
@@ -150,6 +153,7 @@ class MetaData:
     TYPE_STRUCT = "struct"
     TYPE_ENUM   = "enum"
     TYPE_ENUM_CLASS   = "enum_class"
+    TYPE_CUSTOM = "custom"
     META_PREFIX = "_"
     KEY_TYPE = "_type"
     KEY_ENUM_STORAGE = "_enum_storage"
@@ -497,7 +501,8 @@ class TlvF:
                     if (param_type_info.type == TypeInfo.ENUM or
                         param_type_info.type == TypeInfo.STRUCT or
                         param_type_info.type == TypeInfo.CLASS or
-                        param_type_info.type == TypeInfo.ENUM_CLASS):
+                        param_type_info.type == TypeInfo.ENUM_CLASS or
+                        param_type_info.type == TypeInfo.CUSTOM):
                         if (self.db_yaml_paths.__contains__(param_type)):
                             self.include_list.append('"' + self.db_yaml_paths[param_type] + "/" + param_type + ".h" + '"')
                         else:
@@ -1335,9 +1340,9 @@ class TlvF:
             insert_name   = ""
             insert_marker = self.CODE_END_INSERT
             
-        elif root_obj_meta.type == MetaData.TYPE_CLASS:
+        elif root_obj_meta.type == MetaData.TYPE_CLASS or root_obj_meta.type==MetaData.TYPE_CUSTOM:
             insert_name = name
-            if obj_meta.type == MetaData.TYPE_CLASS and obj_meta.name == root_obj_meta.name:
+            if (obj_meta.type == MetaData.TYPE_CLASS or obj_meta.type==MetaData.TYPE_CUSTOM) and obj_meta.name == root_obj_meta.name:
                 insert_marker = self.CODE_CLASS_PUBLIC_VARS_END_INSERT + "_" + root_obj_meta.name
                 self.insertLineH(root_obj_meta.name, self.CODE_CLASS_PUBLIC_VARS_END_INSERT, insert_marker + "_" + insert_name)
             elif obj_meta.type == MetaData.TYPE_CLASS:

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -440,7 +440,7 @@ class TlvF:
             self.closeFile()
 
         logConsole("Done\n")
-    def generateTlvParser(self):
+    def generateTlvParser(self,insert_name,insert_marker,name):
 
         yaml_config = [[self.db[('eTlvType','eTlvType')],self.tlvTypeDefaultConverter,self.db[('eTlvType','_namespace')],self.tlvDefaultAddClass],
         [self.db[('eTlvTypeMap','eTlvTypeMap')],self.tlvTypeDefaultConverter,self.db[('eTlvTypeMap','_namespace')],self.tlvDefaultAddClass]]
@@ -452,7 +452,28 @@ class TlvF:
                     continue
                 if namespace == 'ieee1905_1': namespace = 'ieee_1905_1'
                 self.include_list.append(f"<tlvf/{namespace}/{converter(key)}.h>")
-        self.generateParseFunction('Parse','CmduMessageRx',"cmdu_rx",yaml_config,'cmdu_rx.getNextTlvType()',self.appendLineCpp,0)
+                
+       
+        self.insertLineH(insert_name, insert_marker,"%sclass %s " % (self.getIndentation(0), name))
+        self.insertLineH(insert_name, insert_marker, "")
+        self.insertLineH(insert_name, insert_marker, "{" )
+        # self.insertLineH(insert_name, insert_marker, "%s%s_%s" % (self.getIndentation(1), self.CODE_CLASS_START, name) )
+        func_name = 'ParseTlv'
+        self.insertLineH(insert_name, insert_marker, "%spublic:" % self.getIndentation(1))
+        self.appendLineH(f"{self.getIndentation(2)}static void {func_name}(CmduMessageRx cmdu_rx);")
+
+        #class end
+        self.insertLineH(insert_name, insert_marker, "%s%s_%s" % (self.getIndentation(1), self.CODE_CLASS_END, name))
+        self.insertLineH(insert_name, insert_marker, "};")
+
+        # cpp file
+        self.appendLineCpp(f'#include "{name}.h"')
+        self.appendLineCpp('')
+        self.appendLineCpp("%sclass %s {" % (self.getIndentation(0), name))
+        self.appendLineCpp('')
+        self.generateParseFunction(func_name,'CmduMessageRx',"cmdu_rx",yaml_config,'cmdu_rx.getNextTlvType()',self.appendLineCpp,1)
+        self.appendLineCpp('}')
+
     def processDeceleration(self, obj_name, dict_value):
         if obj_name == MetaData.DECELERATION_NAMESPACE:
             self.openNamespace(dict_value)

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -1901,8 +1901,12 @@ class TlvF:
                 appendLine(ind,"}")
         appendLine(ind,"}")
     
-
-        self.appendLineCpp("}")
+    def generateParseFunction(self,name,param_type,param_name, config,switch_parameter,appendline_function,indent):
+        appendLine = lambda ind,s: appendline_function(self.getIndentation(indent+ind)+s)
+        appendLine(0,f"void {name}({param_type} {param_name})")
+        appendLine(0,"{")
+        self.generateParseSwitch(param_name,config,switch_parameter,appendline_function,indent+1)
+        appendLine(0,"}")
 
 def test(conf, output, print_dependencies, print_outputs):
     code_c = r'''

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -432,7 +432,7 @@ class TlvF:
                 if self.root_obj_meta == None: self.root_obj_meta = obj_meta
 
                 self.generateObject(obj_meta, dict_value)
-
+                if fname == 'tlvParser': self.generateTlvParser()
                 self.closeObject(obj_meta)
             self.closeFile()
 

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -436,7 +436,6 @@ class TlvF:
                 if self.root_obj_meta == None: self.root_obj_meta = obj_meta
 
                 self.generateObject(obj_meta, dict_value)
-                if fname == 'tlvParser': self.generateTlvParser()
                 self.closeObject(obj_meta)
             self.closeFile()
 
@@ -1379,6 +1378,8 @@ class TlvF:
             self.addEnumCode(insert_name, insert_marker, name, obj_meta.enum_storage)
         elif obj_meta.type == MetaData.TYPE_ENUM_CLASS:
             self.addEnumClassCode(insert_name, insert_marker, name, obj_meta.enum_storage)
+        elif obj_meta.type == MetaData.TYPE_CUSTOM:
+            if name == 'tlvParser': self.generateTlvParser(insert_name,insert_marker,name)
         else:
             self.abort("%s.yaml --> error in _type=%s" % (self.yaml_fname, dict_value))
     

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -1929,13 +1929,14 @@ class TlvF:
                 #clarification for basic case of extracting tlvs from cmdu:
                 #parsed_obj is usually cmdu_rx
                 #add_func is addClass<T>
-                #converter converts UPPER_CASE_UNDERSCORE to camelCase so TLV_END_OF_MESSAGE ->tlvEndOfMessage
+                #converter converts UPPER_SNAKE_CASE to lowerCamelCase so TLV_END_OF_MESSAGE ->tlvEndOfMessage
                 #so the following line appends:  return {cmdu_rx}.{addClass<{ieee1905_1::tlvEndOfMessage}>()};
                 #(curly braces whenever it's a result of a function)
                 
                 appendLine(ind,f"{parsed_obj}.{add_func(namespace + '::' + converter(key))};")
                 appendLine(ind,"return;")
                 appendLine(ind,"}")
+        ind -=1
         appendLine(ind,"}")
     
     def generateParseFunction(self,name,param_type,param_name, config,switch_parameter,appendline_function,indent):

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -1947,18 +1947,18 @@ class TlvF:
                 #converter converts UPPER_SNAKE_CASE to lowerCamelCase so TLV_END_OF_MESSAGE ->tlvEndOfMessage
                 #so the following line appends:  return {cmdu_rx}.{addClass<{ieee1905_1::tlvEndOfMessage}>()};
                 #(curly braces whenever it's a result of a function)
-                
-                appendLine(ind,f"{parsed_obj}.{add_func(namespace + '::' + name)};")
-                appendLine(ind,"return;")
+                appendLine(ind,f"{add_func(case_action,parsed_obj,namespace+'::'+name)};")
+                # appendLine(ind,f"{parsed_obj}.{add_func(namespace + '::' + name,'return')};")
+                # appendLine(ind,"return;")
                 appendLine(ind,"}")
         ind -=1
         appendLine(ind,"}")
     
     def generateParseFunction(self,name,param_type,param_name, config,switch_parameter,appendline_function,indent):
         appendLine = lambda ind,s: appendline_function(self.getIndentation(indent+ind)+s)
-        appendLine(0,f"void {name}({param_type} {param_name})")
+        appendLine(0,f"std::shared_ptr<BaseClass> {name}({param_type} {param_name})")
         appendLine(0,"{")
-        self.generateParseSwitch(param_name,config,switch_parameter,appendline_function,indent+1)
+        self.generateParseSwitch(param_name,config,switch_parameter,appendline_function,"return",indent+1)
         appendLine(0,"}")
 
 def test(conf, output, print_dependencies, print_outputs):

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -437,7 +437,19 @@ class TlvF:
             self.closeFile()
 
         logConsole("Done\n")
+    def generateTlvParser(self):
 
+        yaml_config = [[self.db[('eTlvType','eTlvType')],self.tlvTypeDefaultConverter,self.db[('eTlvType','_namespace')],self.tlvDefaultAddClass],
+        [self.db[('eTlvTypeMap','eTlvTypeMap')],self.tlvTypeDefaultConverter,self.db[('eTlvTypeMap','_namespace')],self.tlvDefaultAddClass]]
+        
+        #add references to header file
+        for yaml, converter, namespace, add_func in yaml_config:
+            for key, val in yaml.items():
+                if key.startswith(MetaData.META_PREFIX):
+                    continue
+                if namespace == 'ieee1905_1': namespace = 'ieee_1905_1'
+                self.include_list.append(f"<tlvf/{namespace}/{converter(key)}.h>")
+        self.generateParseFunction('Parse','CmduMessageRx',"cmdu_rx",yaml_config,'cmdu_rx.getNextTlvType()',self.appendLineCpp,0)
     def processDeceleration(self, obj_name, dict_value):
         if obj_name == MetaData.DECELERATION_NAMESPACE:
             self.openNamespace(dict_value)

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -1899,7 +1899,11 @@ class TlvF:
         self.logger.error(msg)
         
         sys.exit(1)
-    def tlvTypeDefaultConverter(self, input):
+    def tlvDefaultConverter(self, input):
+        if input == 'ieee1905_1':
+            return 'ieee_1905_1'
+        if not ('tlv' in input.lower()):
+            return input
         out = input.split('_')
         out = ''.join(x for x in input.title() if x.isalnum())
         return out[0].lower()+out[1:]

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -327,6 +327,7 @@ class TlvF:
         self.CODE_NAMESPACE_INSERT                  = "//~namespace_insert"
         self.CODE_CLASS_START                       = "//~class_start"
         self.CODE_CLASS_END                         = "//~class_end"
+        #TODO: fix typos
         self.CODE_CLASS_CONSTRACTOR                 = "//~class_constractor"
         self.CODE_CLASS_DISTRACTOR                  = "//~class_distractor"
         self.CODE_CLASS_PUBLIC_VARS_INSERT          = "//~class_public_vars_insert"

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -1842,6 +1842,13 @@ class TlvF:
         self.logger.error(msg)
         
         sys.exit(1)
+    def tlvTypeDefaultConverter(self, input):
+        out = input.split('_')
+        out = ''.join(x for x in input.title() if x.isalnum())
+        return out[0].lower()+out[1:]
+        
+    def tlvDefaultAddClass(self, input):
+        return f"addClass<{input}>()"
     
     def generateParseSwitch(self,parsed_obj, yaml_config,switch_parameter):
         """

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -1385,7 +1385,6 @@ class TlvF:
                     param_meta = MetaData(self.yaml_fname, param_name, param_dict)
                     if param_meta.error: self.abort(param_meta.error)
                     self.addClassParam(obj_meta, param_name, param_meta.type, param_meta.type_info, param_meta)
-
         elif obj_meta.type == MetaData.TYPE_STRUCT:
             self.addStructCode(insert_name, insert_marker, name)
             if obj_meta.bit_field:
@@ -1416,7 +1415,6 @@ class TlvF:
         self.addClassPublicMembers(insert_name, insert_marker, name)
         self.addClassSwapMethod(insert_name, insert_marker, name)
         self.addClassSizeMethod(insert_name, insert_marker, name)
-
         self.insertLineH(insert_name, insert_marker, "" )
         self.insertLineH(insert_name, insert_marker, "%sprivate:" % self.getIndentation(1))
 

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -440,6 +440,25 @@ class TlvF:
             self.closeFile()
 
         logConsole("Done\n")
+    def trimAndFixFileList(self, yaml, converter):
+        result = []
+        for key, val in yaml.items():
+            if key.startswith(MetaData.META_PREFIX):
+                    continue
+            filename = converter(key)
+            #skip if the file does not exist
+            keylist = list(map(lambda x: x[0], self.db.keys()))
+            lowerkeylist = list(map(lambda x: x.lower(), keylist))
+            if converter(key) not in keylist:
+                #TODO: some tlvs are not in camel case format
+                if converter(key).lower() in lowerkeylist:  
+                    #this is a dirty, dirty workaround
+                    realfilename = list(filter(lambda k: k.lower() == converter(key).lower(),keylist))[0]
+                    result.append((realfilename,val))
+                continue
+            result.append((filename,val))
+        return result
+
     def generateTlvParser(self,insert_name,insert_marker,name):
 
         yaml_config = [[self.db[('eTlvType','eTlvType')],self.tlvTypeDefaultConverter,self.db[('eTlvType','_namespace')],self.tlvDefaultAddClass],

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvParser.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvParser.yaml
@@ -2,4 +2,4 @@
 _namespace: ieee1905_1
 tlvParser:
   
-  _type: class
+  _type: custom

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvParser.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvParser.yaml
@@ -1,0 +1,5 @@
+---
+_namespace: ieee1905_1
+tlvParser:
+  
+  _type: class

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvParser.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvParser.yaml
@@ -1,5 +1,5 @@
 ---
-_namespace: ieee1905_1
+#_namespace: ieee1905_1
 tlvParser:
   
   _type: custom


### PR DESCRIPTION
This pull request suggests a solution approach that addresses #160 and #318 as per the design document that will follow these notes I thought were worth mentioning:
* currently the generated class, `TlvParser` allows the automatic parsing of a single TLV for each call of the function.
* the build should fail, as the changes to `tlvf.py` are written in python 3, and although as of #426 it **_is_** supported in the docker builder image, I did not get to implementing it. (this is still a draft PR)
* this was pretty much a proof of concept feature, spanning over several weeks (and a holiday period), therefore it involves a lot of overwriting and a hefty amount of commits.
* the next steps are to:
    - create a second function, along the lines of `generateFullParseFunction()`, which will iterate over all tlvs in a cmdu and add them to a multimap, using the id as the key.
    - update the docker builder image to build using python 3


## Automatic parsing of TLV-like structures

### Issue

Based on enum files such as `eTlvType`, `eTlvTypeMap` and `eWscAttributes` which describe structures sent on the network, we would like to have the ability to automatically generate a parsing mechanism with a switch statement based on the type of structure we received.
This is my suggested solution.

### General Idea

Firstly, a tlvf method, `generateParseSwitch()`  generates a switch satement based on a few parameters, mainly:

* The list of enum values and keys, i.e. `TLV_AL_MAC_ADDRESS_TYPE: 0x01`
* A conversion function that fits the enum key to the appropriate class/struct name i.e.`TLV_AL_MAC_ADDRESS_TYPE` &longleftrightarrow; `tlvAlMacAddressType`

There's a whole bunch of metadata being inputted as well.

Then, a second method, `generateParseFunction()` wraps the switch statement in a function that iterates over all of the available structures and parses them, probably storing them all in a data collection of sort.

Lastly, a method generates a class (technically a static one) that will contain the parse function, which can be called by the parsing structure, i.e. `cmdu_rx`.

To access the parsed classes, a function similar to `addClass<T>` can be added to `cmdu_rx` that finds the first TLV of the requested type and casts it to the correct class.

### Additional notes

* It's possible to have a single class with many parsing mechanisms as well, the main thing to note is that `generateParseSwitch()` and `generateParseFunction()` are completely type, namespace and class structure agnostic, and in order to implement them on non-tlv structure types the only things needed to be written are conversion functions and some syntax modifications over the current `tlvTypeDefaultConverter()` (converts `UPPER_SNAKE_CASE` to `lowerCamelCase`) and `tlvDefaultAddClass` (returns a formatted string of the form `addClass<`***yourClassHere***>`()`)

* The last method mentioned, currently being `generateTlvParser()` for the TLV parsing file, needs to be written specifically for each structure enum being parsed, in order to include the relevant headers in the output file and to tailor each of the input parameters for `generateParseSwitch()`. 
