### PR TITLE
Feature/test for optimal path task

### DIFF
--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -316,6 +316,8 @@ bool ap_wlan_hal_dummy::generate_connected_clients_events() { return true; }
 
 std::string ap_wlan_hal_dummy::get_radio_driver_version() { return std::string("dummy"); }
 
+bool ap_wlan_hal_dummy::process_dummy_data(parsed_obj_map_t &parsed_obj) { return true; }
+
 bool ap_wlan_hal_dummy::process_dummy_event(parsed_obj_map_t &parsed_obj)
 {
     char *tmp_str;

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
@@ -76,6 +76,7 @@ public:
     // Protected methods:
 protected:
     virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;
+    virtual bool process_dummy_data(parsed_obj_map_t &parsed_obj) override;
 
     // Overload for AP events
     bool event_queue_push(ap_wlan_hal::Event event, std::shared_ptr<void> data = {})

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <memory>
 
+#define DUMMY_EVENT_KEYLESS_PARAM_TYPE "_type"
 #define DUMMY_EVENT_KEYLESS_PARAM_OPCODE "_opcode"
 #define DUMMY_EVENT_KEYLESS_PARAM_MAC "_mac"
 #define DUMMY_EVENT_KEYLESS_PARAM_IFACE "_iface"
@@ -63,6 +64,9 @@ protected:
 
     // Process dummy event
     virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) = 0;
+
+    // Process dummy data
+    virtual bool process_dummy_data(parsed_obj_map_t &parsed_obj) = 0;
 
     virtual bool set(const std::string &param, const std::string &value,
                      int vap_id = beerocks::IFACE_RADIO_ID) override;

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
@@ -95,6 +95,8 @@ bool mon_wlan_hal_dummy::sta_link_measurements_11k_request(const std::string &st
     return true;
 }
 
+bool mon_wlan_hal_dummy::process_dummy_data(parsed_obj_map_t &parsed_obj) { return true; }
+
 bool mon_wlan_hal_dummy::process_dummy_event(parsed_obj_map_t &parsed_obj)
 {
     // Filter out empty events

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -43,6 +43,7 @@ public:
     // Protected methods:
 protected:
     virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;
+    virtual bool process_dummy_data(parsed_obj_map_t &parsed_obj) override;
 
     // Overload for Monitor events
     bool event_queue_push(mon_wlan_hal::Event event, std::shared_ptr<void> data = {})

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -20,6 +20,13 @@ namespace dummy {
  */
 class mon_wlan_hal_dummy : public base_wlan_hal_dummy, public mon_wlan_hal {
 
+    // Public definitions
+public:
+    enum class Data {
+        Invalid = 0,
+        STA_Update_Stats
+    };
+
     // Public methods
 public:
     /*!
@@ -56,6 +63,7 @@ protected:
     // Private data-members:
 private:
     std::shared_ptr<char> m_temp_dummy_value;
+    std::unordered_map<std::string, struct SStaStats> m_dummy_stas_map; // key=sta_mac
 };
 
 } // namespace dummy

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -22,10 +22,7 @@ class mon_wlan_hal_dummy : public base_wlan_hal_dummy, public mon_wlan_hal {
 
     // Public definitions
 public:
-    enum class Data {
-        Invalid = 0,
-        STA_Update_Stats
-    };
+    enum class Data { Invalid = 0, STA_Update_Stats, RRM_Update_Beacon_Measurements };
 
     // Public methods
 public:
@@ -63,7 +60,12 @@ protected:
     // Private data-members:
 private:
     std::shared_ptr<char> m_temp_dummy_value;
-    std::unordered_map<std::string, struct SStaStats> m_dummy_stas_map; // key=sta_mac
+    struct sDummyStaStats {
+        SStaStats sta_stats;
+        std::unordered_map<std::string, parsed_obj_map_t> beacon_measurment_events;
+        // key=bssid, value=event object
+    };
+    std::unordered_map<std::string, struct sDummyStaStats> m_dummy_stas_map; // key=sta_mac
 };
 
 } // namespace dummy

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
@@ -63,6 +63,8 @@ std::string sta_wlan_hal_dummy::get_ssid() { return m_active_ssid; }
 
 std::string sta_wlan_hal_dummy::get_bssid() { return m_active_bssid; }
 
+bool sta_wlan_hal_dummy::process_dummy_data(parsed_obj_map_t &parsed_obj) { return true; }
+
 bool sta_wlan_hal_dummy::process_dummy_event(parsed_obj_map_t &parsed_obj) { return true; }
 
 bool sta_wlan_hal_dummy::update_status() { return false; }

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
@@ -60,6 +60,7 @@ public:
     std::string get_bssid() override;
 
 protected:
+    virtual bool process_dummy_data(parsed_obj_map_t &parsed_obj) override;
     virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;
 
     // Overload for Monitor events

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -234,7 +234,7 @@ test_client_association_dummy(){
 
     dbg "Connect dummy STA to wlan0"
     check docker exec repeater1 sh -c \
-        "echo 'AP-STA-CONNECTED ${sta_mac}' >> /tmp/\$USER/beerocks/wlan0/EVENT"
+        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan0/EVENT"
     
     dbg "Send client association control request to the chosen BSSID to steer the client (UNBLOCK) "
     eval send_bml_command "client_allow \"${sta_mac} ${mac_agent1_wlan2}\"" $redirect
@@ -261,7 +261,7 @@ test_client_steering_dummy() {
 
     dbg "Connect dummy STA to wlan0"
     check docker exec repeater1 sh -c \
-        "echo 'AP-STA-CONNECTED ${sta_mac}' >> /tmp/\$USER/beerocks/wlan0/EVENT"
+        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan0/EVENT"
 
     dbg "Send steer request "
     eval send_bml_command "steer_client \"${sta_mac} ${mac_agent1_wlan2}\"" $redirect
@@ -297,13 +297,13 @@ test_client_steering_dummy() {
 
     dbg "Disconnect dummy STA from wlan0"
     check docker exec repeater1 sh -c \
-        "echo 'AP-STA-DISCONNECTED ${sta_mac}' >> /tmp/\$USER/beerocks/wlan0/EVENT"
+        "echo 'EVENT AP-STA-DISCONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan0/EVENT"
 
     #TODO// check for "disconnected after successful steering, proceeding to unblock" message 
 
     dbg "Connect dummy STA to wlan2"
     check docker exec repeater1 sh -c \
-        "echo 'AP-STA-CONNECTED ${sta_mac}' >> /tmp/\$USER/beerocks/wlan2/EVENT"
+        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan2/EVENT"
 
     dbg "Confirm steering success by client connected"
     check docker exec gateway sh -c \


### PR DESCRIPTION
New test for optimal path task was added.
Test has three scenarios:
- test gives 11k response that shows best link quality for current BSS, no steering done
- test gives 11k response that shows best link quality in a different BSS, steer client
- error response to 11k request, optimal path falls back to RSSI measurement

Additionally dhcp events were added as association task
requires sta to be connected with IP. New data path to change sta stats was added as event.

fixes #443 