### PR TITLE
tlvf: CmduMessageRx: automatic tlv parse support 

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message.h
@@ -60,13 +60,13 @@ public:
 
     template <class T> static std::shared_ptr<T> get_vs_class(ieee1905_1::CmduMessage &cmdu)
     {
-        return cmdu.getClass<T>(2);
+        return std::dynamic_pointer_cast<T>(cmdu.getClass(2));
     }
 
     static std::shared_ptr<beerocks_message::cACTION_HEADER>
     get_vs_class_header(ieee1905_1::CmduMessage &cmdu)
     {
-        return cmdu.getClass<beerocks_message::cACTION_HEADER>(1);
+        return std::dynamic_pointer_cast<beerocks_message::cACTION_HEADER>(cmdu.getClass(1));
     }
 
     template <class T>

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -57,13 +57,13 @@ public:
 
     template <class T> static std::shared_ptr<T> get_vs_class(ieee1905_1::CmduMessage &cmdu)
     {
-        return cmdu.getClass<T>(2);
+        return std::dynamic_pointer_cast<T>(cmdu.getClass(2));
     }
 
     static std::shared_ptr<beerocks_message::cACTION_HEADER>
     get_vs_class_header(ieee1905_1::CmduMessage &cmdu)
     {
-        return cmdu.getClass<beerocks_message::cACTION_HEADER>(1);
+        return std::dynamic_pointer_cast<beerocks_message::cACTION_HEADER>(cmdu.getClass(1));
     }
 
     template <class T>

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -125,6 +125,7 @@ public:
     uint16_t getNextTlvLength() const;
     uint8_t *getNextTlvData() const;
     void swap();
+    bool swap_needed() {return m_swap; }
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
     eMessageType getMessageType();

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -55,11 +55,64 @@ public:
 
     static uint16_t getCmduHeaderLength() { return kCmduHeaderLength; }
 
+    /**
+     * @brief Get the Class object at index idx in the all classes array
+     * 
+     * @param idx index in the all classes array
+     * @return std::shared_ptr<BaseClass> to the class object at index idx, nullptr if not found
+     */
     std::shared_ptr<BaseClass> getClass(size_t idx) const;
 
+    /**
+     * @brief Get the (first) Class object
+     * 
+     * @tparam T class template
+     * @return std::shared_ptr<T> to the first object found of type T, nullptr if not found
+     */
+    template <class T> std::shared_ptr<T> getClass() const
+    {
+        for (size_t idx = 0; idx < getClassCount(); idx++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(idx)))
+                return c;
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Get a class object of type T in index `idx` in the logical array containing
+     *        all classes of type T.
+     * 
+     * @tparam T class template
+     * @param idx index in the class T array
+     * @return std::shared_ptr<T> to the T class at index `idx` in the class T array
+     */
     template <class T> std::shared_ptr<T> getClass(size_t idx) const
     {
-        return std::dynamic_pointer_cast<T>(getClass(idx));
+        size_t idx_ = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+                if (idx_++ == idx)
+                    return c;
+            }
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Get the number of classes of type T
+     * 
+     * @tparam T class template
+     * @return size_t number of classes of type T
+     */
+    template <class T> size_t getClassCount() const
+    {
+        size_t count = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+                count++;
+            }
+        }
+        return count;
     }
 
     size_t getClassCount() const;

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -123,6 +123,7 @@ public:
     bool getNextTlvType(eTlvType &tlvType) const;
     int getNextTlvType() const;
     uint16_t getNextTlvLength() const;
+    uint8_t *getNextTlvData() const;
     void swap();
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessageRx.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessageRx.h
@@ -12,12 +12,15 @@
 #ifndef _CmduMessageRX_H_
 #define _CmduMessageRX_H_
 
-#include "ieee_1905_1/cCmduHeader.h"
-#include "ieee_1905_1/tlvVendorSpecific.h"
+#include <tlvf/ieee_1905_1/cCmduHeader.h>
+#include <tlvf/CmduMessage.h>
 
-#include "CmduMessage.h"
+#include <list>
+#include <memory>
 
 namespace ieee1905_1 {
+
+class CmduParser;
 
 class CmduMessageRx : public CmduMessage {
 
@@ -25,10 +28,11 @@ public:
     CmduMessageRx();
     CmduMessageRx(CmduMessageRx &original);
     ~CmduMessageRx();
-
-public:
-    std::shared_ptr<cCmduHeader> parse(uint8_t *buff, size_t buff_len, bool swap_needed = true);
+    bool parse(uint8_t *buff, size_t buff_len, bool swap_needed = true, bool parse_tlvs = false);
     CmduMessageRx &operator=(const CmduMessageRx &) = delete;
+
+private:
+    std::list<std::shared_ptr<CmduParser>> parsers_;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduParser.h
@@ -1,0 +1,34 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _CmduParser_H_
+#define _CmduParser_H_
+
+namespace ieee1905_1 {
+
+class CmduMessageRx;
+
+class CmduParser {
+
+public:
+    CmduParser() = delete;
+    CmduParser(CmduMessageRx &cmdu) : cmdu_(cmdu) {}
+    ~CmduParser() {};
+    virtual bool parse() = 0;
+    CmduParser &operator=(const CmduParser &) = delete;
+
+protected:
+    CmduMessageRx &cmdu_;
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_CmduParser_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduTlvParser.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduTlvParser.h
@@ -1,0 +1,38 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _CmduTlvParser_H_
+#define _CmduTlvParser_H_
+
+#include <tlvf/CmduParser.h>
+#include <tlvf/BaseClass.h>
+
+#include <memory>
+
+namespace ieee1905_1 {
+
+class CmduTlvParser : public CmduParser {
+
+public:
+    CmduTlvParser() = delete;
+    CmduTlvParser(CmduMessageRx &cmdu);
+    ~CmduTlvParser();
+    virtual bool parse();
+    CmduTlvParser &operator=(const CmduTlvParser &) = delete;
+
+private:
+    std::shared_ptr<BaseClass> parseWscTlv();
+    std::shared_ptr<BaseClass> parseNextTlv();
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_CmduTlvParser_H_

--- a/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessage.cpp
@@ -83,6 +83,19 @@ uint16_t CmduMessage::getNextTlvLength() const
     return tlvLength;
 }
 
+uint8_t *CmduMessage::getNextTlvData() const
+{
+    uint8_t *tlvData = nullptr;
+    if (m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() > kTlvHeaderLength)) {
+        if (m_class_vector.size() == 0) {
+            tlvData = m_cmdu_header->getBuffPtr() + sizeof(uint8_t) + sizeof(uint16_t);
+        } else {
+            tlvData = m_class_vector.back()->getBuffPtr() + sizeof(uint8_t) + sizeof(uint16_t);
+        }
+    }
+    return tlvData;
+}
+
 size_t CmduMessage::getClassCount() const { return m_class_vector.size(); }
 
 const std::vector<std::shared_ptr<BaseClass>> &CmduMessage::getClassVector() const

--- a/framework/tlvf/AutoGenerated/src/CmduMessageRx.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessageRx.cpp
@@ -10,10 +10,15 @@
  */
 
 #include <tlvf/CmduMessageRx.h>
+#include <tlvf/CmduParser.h>
+#include <tlvf/CmduTlvParser.h>
 
 using namespace ieee1905_1;
 
-CmduMessageRx::CmduMessageRx() : CmduMessage() {}
+CmduMessageRx::CmduMessageRx() : CmduMessage()
+{
+    parsers_.emplace_back(std::make_shared<CmduTlvParser>(*this)); // default parser
+}
 
 CmduMessageRx::CmduMessageRx(CmduMessageRx &original) : CmduMessage()
 {
@@ -34,12 +39,7 @@ CmduMessageRx::~CmduMessageRx()
     }
 }
 
-/*
- * TODO
- * change all pointer arguments to const type where applicable
- */
-
-std::shared_ptr<cCmduHeader> CmduMessageRx::parse(uint8_t *buff, size_t buff_len, bool swap_needed)
+bool CmduMessageRx::parse(uint8_t *buff, size_t buff_len, bool swap_needed, bool parse_tlvs)
 {
     reset();
     m_parse       = true;
@@ -49,7 +49,17 @@ std::shared_ptr<cCmduHeader> CmduMessageRx::parse(uint8_t *buff, size_t buff_len
     m_cmdu_header = std::make_shared<cCmduHeader>(buff, buff_len, true, false);
     if (!m_cmdu_header || m_cmdu_header->isInitialized() == false) {
         m_cmdu_header = nullptr;
+        return false;
+    }
+    
+    if (!parse_tlvs)
+        return true;
+
+    for (auto parser : parsers_) {
+        if (parser->parse())
+            return true;
     }
 
-    return m_cmdu_header;
+    
+    return false;
 }

--- a/framework/tlvf/AutoGenerated/src/CmduTlvParser.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduTlvParser.cpp
@@ -1,0 +1,219 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/CmduMessageRx.h>
+#include <tlvf/CmduTlvParser.h>
+#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
+#include <tlvf/ieee_1905_1/tlvAlMacAddressType.h>
+#include <tlvf/ieee_1905_1/tlvMacAddress.h>
+#include <tlvf/ieee_1905_1/tlvDeviceInformation.h>
+#include <tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h>
+#include <tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h>
+#include <tlvf/ieee_1905_1/tlv1905NeighborDevice.h>
+#include <tlvf/ieee_1905_1/tlvLinkMetricQuery.h>
+#include <tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvReceiverLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvVendorSpecific.h>
+#include <tlvf/ieee_1905_1/tlvLinkMetricResultCode.h>
+#include <tlvf/ieee_1905_1/tlvSearchedRole.h>
+#include <tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvSupportedRole.h>
+#include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvPushButtonEventNotification.h>
+#include <tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h>
+#include <tlvf/ieee_1905_1/tlvUnknown.h>
+#include <tlvf/wfa_map/tlvSupportedService.h>
+#include <tlvf/wfa_map/tlvSearchedService.h>
+#include <tlvf/wfa_map/tlvApRadioIdentifier.h>
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
+#include <tlvf/wfa_map/tlvChannelPreference.h>
+#include <tlvf/wfa_map/tlvRadioOperationRestriction.h>
+#include <tlvf/wfa_map/tlvTransmitPowerLimit.h>
+#include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
+#include <tlvf/wfa_map/tlvOperatingChannelReport.h>
+#include <tlvf/wfa_map/tlvClientAssociationEvent.h>
+#include <tlvf/wfa_map/tlvApMetricQuery.h>
+#include <tlvf/wfa_map/tlvSteeringRequest.h>
+#include <tlvf/wfa_map/tlvSteeringBTMReport.h>
+#include <tlvf/wfa_map/tlvClientAssociationControlRequest.h>
+#include <tlvf/wfa_map/tlvHigherLayerData.h>
+#include <tlvf/wfa_map/tlvApCapability.h>
+
+#include <tlvf/WSC/eWscAttributes.h>
+#include <tlvf/ieee_1905_1/tlvWscM2.h>
+#include <tlvf/ieee_1905_1/tlvWscM1.h>
+#include <iostream>
+
+using namespace ieee1905_1;
+
+CmduTlvParser::CmduTlvParser(CmduMessageRx &cmdu) : CmduParser(cmdu) {}
+
+CmduTlvParser::~CmduTlvParser() {}
+
+// TODO - Remove once #471 is implemented
+class wscAttr {
+        uint16_t type_;
+        uint16_t length_;
+    public:
+        uint16_t type(bool swap) { return swap ? ntohs(type_) : type_; }
+        wscAttr *next(bool swap)
+        {
+            return reinterpret_cast<wscAttr*>(reinterpret_cast<uint8_t*>(this) + size(swap));
+        }
+        uint8_t *data() { return reinterpret_cast<uint8_t*>(this) + sizeof(wscAttr); }
+        size_t size(bool swap) { return sizeof(wscAttr) + (swap ? ntohs(length_) : length_); }
+};
+
+std::shared_ptr<BaseClass> CmduTlvParser::parseWscTlv()
+{
+    if (eTlvType(cmdu_.getNextTlvType()) != eTlvType::TLV_WSC)
+        return nullptr;
+
+    bool swap = cmdu_.swap_needed();
+    wscAttr *wsc = reinterpret_cast<wscAttr*>(cmdu_.getNextTlvData());
+    uint16_t type = wsc->type(swap);
+    while (type != WSC::ATTR_MSG_TYPE) {
+        wsc = wsc->next(swap);
+        type = wsc->type(swap);
+    }
+    if (*wsc->data() == WSC::WSC_MSG_TYPE_M2)
+        return cmdu_.addClass<tlvWscM2>();
+    else
+        return cmdu_.addClass<tlvWscM1>();
+
+    return nullptr;
+}
+
+std::shared_ptr<BaseClass> CmduTlvParser::parseNextTlv()
+{
+    switch(cmdu_.getNextTlvType())
+    {
+        case (0):{
+        return cmdu_.addClass<tlvEndOfMessage>();
+        }
+        case (1):{
+        return cmdu_.addClass<tlvAlMacAddressType>();
+        }
+        case (2):{
+        return cmdu_.addClass<tlvMacAddress>();
+        }
+        case (3):{
+        return cmdu_.addClass<tlvDeviceInformation>();
+        }
+        case (4):{
+        return cmdu_.addClass<tlvDeviceBridgingCapability>();
+        }
+        case (6):{
+        return cmdu_.addClass<tlvNon1905neighborDeviceList>();
+        }
+        case (7):{
+        return cmdu_.addClass<tlv1905NeighborDevice>();
+        }
+        case (8):{
+        return cmdu_.addClass<tlvLinkMetricQuery>();
+        }
+        case (9):{
+        return cmdu_.addClass<tlvTransmitterLinkMetric>();
+        }
+        case (10):{
+        return cmdu_.addClass<tlvReceiverLinkMetric>();
+        }
+        case (11):{
+        return cmdu_.addClass<tlvVendorSpecific>();
+        }
+        case (12):{
+        return cmdu_.addClass<tlvLinkMetricResultCode>();
+        }
+        case (13):{
+        return cmdu_.addClass<tlvSearchedRole>();
+        }
+        case (14):{
+        return cmdu_.addClass<tlvAutoconfigFreqBand>();
+        }
+        case (15):{
+        return cmdu_.addClass<tlvSupportedRole>();
+        }
+        case (16):{
+        return cmdu_.addClass<tlvSupportedFreqBand>();
+        }
+        case (17): {
+            return parseWscTlv(); // TODO change once #471 is implemented
+        }
+        case (18):{
+        return cmdu_.addClass<tlvPushButtonEventNotification>();
+        }
+        case (19):{
+        return cmdu_.addClass<tlvPushButtonJoinNotification>();
+        }
+        case (128):{
+        return cmdu_.addClass<wfa_map::tlvSupportedService>();
+        }
+        case (129):{
+        return cmdu_.addClass<wfa_map::tlvSearchedService>();
+        }
+        case (130):{
+        return cmdu_.addClass<wfa_map::tlvApRadioIdentifier>();
+        }
+        case (133):{
+        return cmdu_.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+        }
+        case (139):{
+        return cmdu_.addClass<wfa_map::tlvChannelPreference>();
+        }
+        case (140):{
+        return cmdu_.addClass<wfa_map::tlvRadioOperationRestriction>();
+        }
+        case (141):{
+        return cmdu_.addClass<wfa_map::tlvTransmitPowerLimit>();
+        }
+        case (142):{
+        return cmdu_.addClass<wfa_map::tlvChannelSelectionResponse>();
+        }
+        case (143):{
+        return cmdu_.addClass<wfa_map::tlvOperatingChannelReport>();
+        }
+        case (146):{
+        return cmdu_.addClass<wfa_map::tlvClientAssociationEvent>();
+        }
+        case (147):{
+        return cmdu_.addClass<wfa_map::tlvApMetricQuery>();
+        }
+        case (155):{
+        return cmdu_.addClass<wfa_map::tlvSteeringRequest>();
+        }
+        case (156):{
+        return cmdu_.addClass<wfa_map::tlvSteeringBTMReport>();
+        }
+        case (157):{
+        return cmdu_.addClass<wfa_map::tlvClientAssociationControlRequest>();
+        }
+        case (160):{
+        return cmdu_.addClass<wfa_map::tlvHigherLayerData>();
+        }
+        case (161):{
+        return cmdu_.addClass<wfa_map::tlvApCapability>();
+        }
+        default:{
+        return cmdu_.addClass<tlvUnknown>();
+        }
+    }
+}
+
+bool CmduTlvParser::parse()
+{
+    while (auto tlv = parseNextTlv()) {
+        if (std::dynamic_pointer_cast<tlvEndOfMessage>(tlv)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -52,11 +52,64 @@ public:
 
     static uint16_t getCmduHeaderLength() { return kCmduHeaderLength; }
 
+    /**
+     * @brief Get the Class object at index idx in the all classes array
+     * 
+     * @param idx index in the all classes array
+     * @return std::shared_ptr<BaseClass> to the class object at index idx, nullptr if not found
+     */
     std::shared_ptr<BaseClass> getClass(size_t idx) const;
 
+    /**
+     * @brief Get the (first) Class object
+     * 
+     * @tparam T class template
+     * @return std::shared_ptr<T> to the first object found of type T, nullptr if not found
+     */
+    template <class T> std::shared_ptr<T> getClass() const
+    {
+        for (size_t idx = 0; idx < getClassCount(); idx++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(idx)))
+                return c;
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Get a class object of type T in index `idx` in the logical array containing
+     *        all classes of type T.
+     * 
+     * @tparam T class template
+     * @param idx index in the class T array
+     * @return std::shared_ptr<T> to the T class at index `idx` in the class T array
+     */
     template <class T> std::shared_ptr<T> getClass(size_t idx) const
     {
-        return std::dynamic_pointer_cast<T>(getClass(idx));
+        size_t idx_ = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+                if (idx_++ == idx)
+                    return c;
+            }
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Get the number of classes of type T
+     * 
+     * @tparam T class template
+     * @return size_t number of classes of type T
+     */
+    template <class T> size_t getClassCount() const
+    {
+        size_t count = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+                count++;
+            }
+        }
+        return count;
     }
 
     size_t getClassCount() const;

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -122,6 +122,7 @@ public:
     uint16_t getNextTlvLength() const;
     uint8_t *getNextTlvData() const;
     void swap();
+    bool swap_needed() {return m_swap; }
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
     eMessageType getMessageType();

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -120,6 +120,7 @@ public:
     bool getNextTlvType(eTlvType &tlvType) const;
     int getNextTlvType() const;
     uint16_t getNextTlvLength() const;
+    uint8_t *getNextTlvData() const;
     void swap();
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };

--- a/framework/tlvf/src/include/tlvf/CmduMessageRx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageRx.h
@@ -9,12 +9,15 @@
 #ifndef _CmduMessageRX_H_
 #define _CmduMessageRX_H_
 
-#include "ieee_1905_1/cCmduHeader.h"
-#include "ieee_1905_1/tlvVendorSpecific.h"
+#include <tlvf/ieee_1905_1/cCmduHeader.h>
+#include <tlvf/CmduMessage.h>
 
-#include "CmduMessage.h"
+#include <list>
+#include <memory>
 
 namespace ieee1905_1 {
+
+class CmduParser;
 
 class CmduMessageRx : public CmduMessage {
 
@@ -22,10 +25,11 @@ public:
     CmduMessageRx();
     CmduMessageRx(CmduMessageRx &original);
     ~CmduMessageRx();
-
-public:
-    std::shared_ptr<cCmduHeader> parse(uint8_t *buff, size_t buff_len, bool swap_needed = true);
+    bool parse(uint8_t *buff, size_t buff_len, bool swap_needed = true, bool parse_tlvs = false);
     CmduMessageRx &operator=(const CmduMessageRx &) = delete;
+
+private:
+    std::list<std::shared_ptr<CmduParser>> parsers_;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/src/include/tlvf/CmduParser.h
+++ b/framework/tlvf/src/include/tlvf/CmduParser.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _CmduParser_H_
+#define _CmduParser_H_
+
+namespace ieee1905_1 {
+
+class CmduMessageRx;
+
+class CmduParser {
+
+public:
+    CmduParser() = delete;
+    CmduParser(CmduMessageRx &cmdu) : cmdu_(cmdu) {}
+    ~CmduParser() {};
+    virtual bool parse() = 0;
+    CmduParser &operator=(const CmduParser &) = delete;
+
+protected:
+    CmduMessageRx &cmdu_;
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_CmduParser_H_

--- a/framework/tlvf/src/include/tlvf/CmduTlvParser.h
+++ b/framework/tlvf/src/include/tlvf/CmduTlvParser.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _CmduTlvParser_H_
+#define _CmduTlvParser_H_
+
+#include <tlvf/CmduParser.h>
+#include <tlvf/BaseClass.h>
+
+#include <memory>
+
+namespace ieee1905_1 {
+
+class CmduTlvParser : public CmduParser {
+
+public:
+    CmduTlvParser() = delete;
+    CmduTlvParser(CmduMessageRx &cmdu);
+    ~CmduTlvParser();
+    virtual bool parse();
+    CmduTlvParser &operator=(const CmduTlvParser &) = delete;
+
+private:
+    std::shared_ptr<BaseClass> parseWscTlv();
+    std::shared_ptr<BaseClass> parseNextTlv();
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_CmduTlvParser_H_

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -80,6 +80,19 @@ uint16_t CmduMessage::getNextTlvLength() const
     return tlvLength;
 }
 
+uint8_t *CmduMessage::getNextTlvData() const
+{
+    uint8_t *tlvData = nullptr;
+    if (m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() > kTlvHeaderLength)) {
+        if (m_class_vector.size() == 0) {
+            tlvData = m_cmdu_header->getBuffPtr() + sizeof(uint8_t) + sizeof(uint16_t);
+        } else {
+            tlvData = m_class_vector.back()->getBuffPtr() + sizeof(uint8_t) + sizeof(uint16_t);
+        }
+    }
+    return tlvData;
+}
+
 size_t CmduMessage::getClassCount() const { return m_class_vector.size(); }
 
 const std::vector<std::shared_ptr<BaseClass>> &CmduMessage::getClassVector() const

--- a/framework/tlvf/src/src/CmduTlvParser.cpp
+++ b/framework/tlvf/src/src/CmduTlvParser.cpp
@@ -1,0 +1,216 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/CmduMessageRx.h>
+#include <tlvf/CmduTlvParser.h>
+#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
+#include <tlvf/ieee_1905_1/tlvAlMacAddressType.h>
+#include <tlvf/ieee_1905_1/tlvMacAddress.h>
+#include <tlvf/ieee_1905_1/tlvDeviceInformation.h>
+#include <tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h>
+#include <tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h>
+#include <tlvf/ieee_1905_1/tlv1905NeighborDevice.h>
+#include <tlvf/ieee_1905_1/tlvLinkMetricQuery.h>
+#include <tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvReceiverLinkMetric.h>
+#include <tlvf/ieee_1905_1/tlvVendorSpecific.h>
+#include <tlvf/ieee_1905_1/tlvLinkMetricResultCode.h>
+#include <tlvf/ieee_1905_1/tlvSearchedRole.h>
+#include <tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvSupportedRole.h>
+#include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvPushButtonEventNotification.h>
+#include <tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h>
+#include <tlvf/ieee_1905_1/tlvUnknown.h>
+#include <tlvf/wfa_map/tlvSupportedService.h>
+#include <tlvf/wfa_map/tlvSearchedService.h>
+#include <tlvf/wfa_map/tlvApRadioIdentifier.h>
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
+#include <tlvf/wfa_map/tlvChannelPreference.h>
+#include <tlvf/wfa_map/tlvRadioOperationRestriction.h>
+#include <tlvf/wfa_map/tlvTransmitPowerLimit.h>
+#include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
+#include <tlvf/wfa_map/tlvOperatingChannelReport.h>
+#include <tlvf/wfa_map/tlvClientAssociationEvent.h>
+#include <tlvf/wfa_map/tlvApMetricQuery.h>
+#include <tlvf/wfa_map/tlvSteeringRequest.h>
+#include <tlvf/wfa_map/tlvSteeringBTMReport.h>
+#include <tlvf/wfa_map/tlvClientAssociationControlRequest.h>
+#include <tlvf/wfa_map/tlvHigherLayerData.h>
+#include <tlvf/wfa_map/tlvApCapability.h>
+
+#include <tlvf/WSC/eWscAttributes.h>
+#include <tlvf/ieee_1905_1/tlvWscM2.h>
+#include <tlvf/ieee_1905_1/tlvWscM1.h>
+#include <iostream>
+
+using namespace ieee1905_1;
+
+CmduTlvParser::CmduTlvParser(CmduMessageRx &cmdu) : CmduParser(cmdu) {}
+
+CmduTlvParser::~CmduTlvParser() {}
+
+// TODO - Remove once #471 is implemented
+class wscAttr {
+        uint16_t type_;
+        uint16_t length_;
+    public:
+        uint16_t type(bool swap) { return swap ? ntohs(type_) : type_; }
+        wscAttr *next(bool swap)
+        {
+            return reinterpret_cast<wscAttr*>(reinterpret_cast<uint8_t*>(this) + size(swap));
+        }
+        uint8_t *data() { return reinterpret_cast<uint8_t*>(this) + sizeof(wscAttr); }
+        size_t size(bool swap) { return sizeof(wscAttr) + (swap ? ntohs(length_) : length_); }
+};
+
+std::shared_ptr<BaseClass> CmduTlvParser::parseWscTlv()
+{
+    if (eTlvType(cmdu_.getNextTlvType()) != eTlvType::TLV_WSC)
+        return nullptr;
+
+    bool swap = cmdu_.swap_needed();
+    wscAttr *wsc = reinterpret_cast<wscAttr*>(cmdu_.getNextTlvData());
+    uint16_t type = wsc->type(swap);
+    while (type != WSC::ATTR_MSG_TYPE) {
+        wsc = wsc->next(swap);
+        type = wsc->type(swap);
+    }
+    if (*wsc->data() == WSC::WSC_MSG_TYPE_M2)
+        return cmdu_.addClass<tlvWscM2>();
+    else
+        return cmdu_.addClass<tlvWscM1>();
+
+    return nullptr;
+}
+
+std::shared_ptr<BaseClass> CmduTlvParser::parseNextTlv()
+{
+    switch(cmdu_.getNextTlvType())
+    {
+        case (0):{
+        return cmdu_.addClass<tlvEndOfMessage>();
+        }
+        case (1):{
+        return cmdu_.addClass<tlvAlMacAddressType>();
+        }
+        case (2):{
+        return cmdu_.addClass<tlvMacAddress>();
+        }
+        case (3):{
+        return cmdu_.addClass<tlvDeviceInformation>();
+        }
+        case (4):{
+        return cmdu_.addClass<tlvDeviceBridgingCapability>();
+        }
+        case (6):{
+        return cmdu_.addClass<tlvNon1905neighborDeviceList>();
+        }
+        case (7):{
+        return cmdu_.addClass<tlv1905NeighborDevice>();
+        }
+        case (8):{
+        return cmdu_.addClass<tlvLinkMetricQuery>();
+        }
+        case (9):{
+        return cmdu_.addClass<tlvTransmitterLinkMetric>();
+        }
+        case (10):{
+        return cmdu_.addClass<tlvReceiverLinkMetric>();
+        }
+        case (11):{
+        return cmdu_.addClass<tlvVendorSpecific>();
+        }
+        case (12):{
+        return cmdu_.addClass<tlvLinkMetricResultCode>();
+        }
+        case (13):{
+        return cmdu_.addClass<tlvSearchedRole>();
+        }
+        case (14):{
+        return cmdu_.addClass<tlvAutoconfigFreqBand>();
+        }
+        case (15):{
+        return cmdu_.addClass<tlvSupportedRole>();
+        }
+        case (16):{
+        return cmdu_.addClass<tlvSupportedFreqBand>();
+        }
+        case (17): {
+            return parseWscTlv(); // TODO change once #471 is implemented
+        }
+        case (18):{
+        return cmdu_.addClass<tlvPushButtonEventNotification>();
+        }
+        case (19):{
+        return cmdu_.addClass<tlvPushButtonJoinNotification>();
+        }
+        case (128):{
+        return cmdu_.addClass<wfa_map::tlvSupportedService>();
+        }
+        case (129):{
+        return cmdu_.addClass<wfa_map::tlvSearchedService>();
+        }
+        case (130):{
+        return cmdu_.addClass<wfa_map::tlvApRadioIdentifier>();
+        }
+        case (133):{
+        return cmdu_.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+        }
+        case (139):{
+        return cmdu_.addClass<wfa_map::tlvChannelPreference>();
+        }
+        case (140):{
+        return cmdu_.addClass<wfa_map::tlvRadioOperationRestriction>();
+        }
+        case (141):{
+        return cmdu_.addClass<wfa_map::tlvTransmitPowerLimit>();
+        }
+        case (142):{
+        return cmdu_.addClass<wfa_map::tlvChannelSelectionResponse>();
+        }
+        case (143):{
+        return cmdu_.addClass<wfa_map::tlvOperatingChannelReport>();
+        }
+        case (146):{
+        return cmdu_.addClass<wfa_map::tlvClientAssociationEvent>();
+        }
+        case (147):{
+        return cmdu_.addClass<wfa_map::tlvApMetricQuery>();
+        }
+        case (155):{
+        return cmdu_.addClass<wfa_map::tlvSteeringRequest>();
+        }
+        case (156):{
+        return cmdu_.addClass<wfa_map::tlvSteeringBTMReport>();
+        }
+        case (157):{
+        return cmdu_.addClass<wfa_map::tlvClientAssociationControlRequest>();
+        }
+        case (160):{
+        return cmdu_.addClass<wfa_map::tlvHigherLayerData>();
+        }
+        case (161):{
+        return cmdu_.addClass<wfa_map::tlvApCapability>();
+        }
+        default:{
+        return cmdu_.addClass<tlvUnknown>();
+        }
+    }
+}
+
+bool CmduTlvParser::parse()
+{
+    while (auto tlv = parseNextTlv()) {
+        if (std::dynamic_pointer_cast<tlvEndOfMessage>(tlv)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -40,6 +40,9 @@ include_source_path: {
   "src/CmduMessageTx.cpp",
   "include/tlvf/CmduMessageRx.h",
   "src/CmduMessageRx.cpp",
+  "include/tlvf/CmduParser.h",
+  "include/tlvf/CmduTlvParser.h",
+  "src/CmduTlvParser.cpp",
   "include/tlvf/ieee_1905_1/sVendorOUI.h",
 }
 

--- a/tools/prplMesh.code-workspace
+++ b/tools/prplMesh.code-workspace
@@ -86,7 +86,8 @@
 			"map": "cpp",
 			"memory_resource": "cpp",
 			"set": "cpp",
-			"string": "cpp"
+			"string": "cpp",
+			"random": "cpp"
 		}
 	}
 }


### PR DESCRIPTION
CmduMessageRx provides a `parse` API which as for now parses only the
CMDU header. Users are then expected to call `addClass` for each TLV manually.
This commit adds support for parse_tlvs option to the class's parse API,
disabled by default for backward compatability:
When parse_tlvs is true, the `parse` API goes through all the TLVs in
the CMDU and calls addClass for each found TLV.
If Unknown TLVs are encountered, addClass<unknownTlv> is called.
Parsing ends successfully only once tlvEndOfMessage is found and added.

This option is intended to be used only for standard CMDUs, such as the
ones defined in the MultiAP and 1905.1a specifications, since it is
using the TLV type for the casting.

Note that for WSC TLV, we support only M1 and M2 which are required by
the MultiAP specification. The two WSC types are differenciated via the
MSG_TYPE attribute. In the future, this will be also handled
automatically by the parser by adding each attribute manually without
using the tlvWscMx.yaml files which are wrong since they assume that the
attributes have to be the same order they are defined in the yaml.

Also add a test in tlvf_test which verifies the new functionality works. No effect on other components.
