### PR TITLE
Feature/AP Radio Basic Capabilities and Channel Preference Report

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4230,6 +4230,20 @@ bool slave_thread::send_cmdu_to_controller(ieee1905_1::CmduMessageTx &cmdu_tx)
 }
 
 /**
+ * @param[in] None
+ * @return Map of Operating classes and matching supported channels
+ */
+std::map<uint8_t, std::set<uint8_t>> slave_thread::get_supported_channels_map()
+{
+    auto channels_list = hostap_params.supported_channels;
+    std::set<uint8_t> channels_set;
+    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+        channels_set.insert(channels_list[i].channel);
+    }
+    return wireless_utils::channel_set_to_operating_classes(channels_set);
+}
+
+/**
  * @brief Diffie-Hellman public key exchange keys calculation
  *        class member params authkey and keywrapauth are computed
  *        on success.

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -233,6 +233,8 @@ private:
     beerocks_message::sNodeHostap hostap_params;
     beerocks_message::sApChannelSwitch hostap_cs_params;
 
+    std::map<uint8_t, std::set<uint8_t>> get_supported_channels_map();
+
     SocketClient *platform_manager_socket = nullptr;
     SocketClient *backhaul_manager_socket = nullptr;
     SocketClient *master_socket           = nullptr;

--- a/common/beerocks/bcl/include/beerocks/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/son/son_wireless_utils.h
@@ -13,6 +13,7 @@
 #include "../beerocks_message_structs.h"
 
 #include <iostream>
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -248,6 +249,8 @@ private:
         {1300, 189}, {1350, 157}, {1560, 196}, {1620, 202}, {1755, 208}, {1800, 161}, {2160, 213},
         {2340, 241}, {2430, 220}, {2633, 169}, {2700, 232}, {2925, 189}, {3240, 237}, {3510, 251},
         {3600, 246}, {3900, 328}, {4680, 251}, {5265, 253}, {5850, 261}, {7020, 266}, {7800, 266}};
+
+    static const std::map<uint8_t, std::set<uint8_t>> operating_class_to_channels_map;
 };
 } // namespace son
 

--- a/common/beerocks/bcl/include/beerocks/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/son/son_wireless_utils.h
@@ -111,6 +111,8 @@ public:
                                                                beerocks::eWiFiBandwidth bw,
                                                                uint16_t vht_center_frequency);
     static std::set<uint8_t> operating_class_to_channel_set(uint8_t operating_class);
+    static std::map<uint8_t, std::set<uint8_t>>
+    channel_set_to_operating_classes(std::set<uint8_t> channels);
 
 private:
     enum eAntennaFactor {

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -24,6 +24,43 @@ constexpr wireless_utils::sPhyRateTableEntry
 constexpr wireless_utils::sPhyRateBitRateEntry
     wireless_utils::bit_rate_max_table_mbps[BIT_RATE_MAX_TABLE_SIZE];
 
+const std::map<uint8_t, std::set<uint8_t>> wireless_utils::operating_class_to_channels_map = {
+    {81, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+    {82, {14}},
+    {83, {1, 2, 3, 4, 5, 6, 7, 8, 9}},
+    // TODO channels for operating classes 85,96,87 should be taken from the regulatory domain
+    {94, {133, 137}},
+    {95, {132, 134, 136, 138}},
+    {96, {131, 132, 133, 134, 135, 136, 137, 138}},
+    {101, {21, 25}},
+    {102, {11, 13, 15, 17, 19}},
+    {103, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+    {104, {184, 192}},
+    {105, {188, 196}},
+    {106, {191, 195}},
+    {107, {189, 191, 193, 195, 197}},
+    {108, {188, 189, 190, 191, 192, 193, 194, 195, 196, 197}},
+    {109, {184, 188, 192, 196}},
+    {110, {183, 184, 185, 186, 187, 189}},
+    {111, {182, 183, 184, 185, 186, 187, 189}},
+    {112, {8, 12, 16}},
+    {113, {7, 8, 9, 10, 11}},
+    {114, {6, 7, 8, 9, 10, 11}},
+    {115, {36, 40, 44, 48}},
+    {116, {36, 44}},
+    {117, {40, 48}},
+    {118, {52, 56, 60, 64}},
+    {119, {52, 60}},
+    {120, {56, 64}},
+    {121, {100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144}},
+    {122, {100, 108, 116, 124, 132, 140}},
+    {123, {104, 112, 120, 128, 136, 144}},
+    {124, {149, 153, 157, 161}},
+    {125, {149, 153, 157, 161, 165, 169}},
+    {126, {149, 157}},
+    {127, {153, 161}},
+    {180, {1, 2, 3, 4, 5, 6}}};
+
 wireless_utils::sPhyUlParams
 wireless_utils::estimate_ul_params(int ul_rssi, uint16_t sta_phy_tx_rate_100kb,
                                    const beerocks::message::sRadioCapabilities *sta_capabilities,
@@ -464,45 +501,8 @@ std::vector<uint8_t> wireless_utils::calc_5g_20MHz_subband_channels(
  */
 std::set<uint8_t> wireless_utils::operating_class_to_channel_set(uint8_t operating_class)
 {
-    static const std::map<uint8_t, std::set<uint8_t>> operating_class_to_channel_set = {
-        {81, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
-        {82, {14}},
-        {83, {1, 2, 3, 4, 5, 6, 7, 8, 9}},
-        // TODO channels for operating classes 85,96,87 should be taken from the regulatory domain
-        {94, {133, 137}},
-        {95, {132, 134, 136, 138}},
-        {96, {131, 132, 133, 134, 135, 136, 137, 138}},
-        {101, {21, 25}},
-        {102, {11, 13, 15, 17, 19}},
-        {103, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-        {104, {184, 192}},
-        {105, {188, 196}},
-        {106, {191, 195}},
-        {107, {189, 191, 193, 195, 197}},
-        {108, {188, 189, 190, 191, 192, 193, 194, 195, 196, 197}},
-        {109, {184, 188, 192, 196}},
-        {110, {183, 184, 185, 186, 187, 189}},
-        {111, {182, 183, 184, 185, 186, 187, 189}},
-        {112, {8, 12, 16}},
-        {113, {7, 8, 9, 10, 11}},
-        {114, {6, 7, 8, 9, 10, 11}},
-        {115, {36, 40, 44, 48}},
-        {116, {36, 44}},
-        {117, {40, 48}},
-        {118, {52, 56, 60, 64}},
-        {119, {52, 60}},
-        {120, {56, 64}},
-        {121, {100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144}},
-        {122, {100, 108, 116, 124, 132, 140}},
-        {123, {104, 112, 120, 128, 136, 144}},
-        {124, {149, 153, 157, 161}},
-        {125, {149, 153, 157, 161, 165, 169}},
-        {126, {149, 157}},
-        {127, {153, 161}},
-        {180, {1, 2, 3, 4, 5, 6}}};
-
-    auto it = operating_class_to_channel_set.find(operating_class);
-    if (it == operating_class_to_channel_set.end()) {
+    auto it = operating_class_to_channels_map.find(operating_class);
+    if (it == operating_class_to_channels_map.end()) {
         LOG(ERROR) << "reserved operating class " << int(operating_class);
         return std::set<uint8_t>();
     }

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -493,6 +493,32 @@ std::vector<uint8_t> wireless_utils::calc_5g_20MHz_subband_channels(
     return channels;
 }
 
+std::map<uint8_t, std::set<uint8_t>>
+wireless_utils::channel_set_to_operating_classes(std::set<uint8_t> channels)
+{
+    std::map<uint8_t, std::set<uint8_t>> map_result;
+    for (auto &ch : channels) {
+        for (auto it = operating_class_to_channels_map.begin();
+             it != operating_class_to_channels_map.end(); ++it) {
+            if (it->second.find(ch) != it->second.end()) {
+                auto op_class = it->first;
+                //check if operating class is already in the result map
+                auto search = map_result.find(op_class);
+                //if it does, insert the current channel to map_result
+                if (search != map_result.end()) {
+                    search->second.insert(ch);
+                    //else create a key
+                } else {
+                    std::set<uint8_t> s;
+                    s.insert(ch);
+                    map_result.insert({op_class, s});
+                }
+            }
+        }
+    }
+    return map_result;
+}
+
 /**
  * @brief convert operating class to channel set based on Table 4-E in the ieee 802.11 specification
  *


### PR DESCRIPTION
When the controller sends a Channel Preference Query, the agent should send
a Channel Preference Report that corresponds to the actual behavior of the AP.

Currently, the agent fills the Channel Preference Report with a dummy
operating class and dummies channels. Therefore, Change it so the
Channel Preference Report contains actual operating classes. 

Please note that this PR is depended on #457.
The part of setting the inoperable channels in Radio Basic Capabilities TLV will be done after #457 is implemented.