### PR TITLE
controller: DEV_SET_CONFIG: remove old configs for AL-MAC 

### DIFF
--- a/controller/src/beerocks/master/controller_ucc_listener.cpp
+++ b/controller/src/beerocks/master/controller_ucc_listener.cpp
@@ -110,6 +110,11 @@ bool controller_ucc_listener::handle_dev_set_config(
             m_database.clear_bss_info_configuration(mac);
             al_mac_cleared_conf.insert(mac);
         }
+
+        //If SSID is empty, tear down - do not add bss_info_conf to database.
+        if (bss_info_conf.ssid.empty()) {
+            continue;
+        }
         m_database.add_bss_info_configuration(mac, bss_info_conf);
     }
     return true;

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -3190,6 +3190,8 @@ std::list<db::bss_info_conf_t> &db::get_bss_info_configuration(const sMacAddr &a
 
 void db::clear_bss_info_configuration() { bss_infos.clear(); }
 
+void db::clear_bss_info_configuration(const sMacAddr &al_mac) { bss_infos[al_mac].clear(); }
+
 //
 // PRIVATE FUNCTIONS
 //   must be used from a thread safe context

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -529,6 +529,7 @@ public:
     void add_bss_info_configuration(const sMacAddr &al_mac, const bss_info_conf_t &bss_info);
     std::list<db::bss_info_conf_t> &get_bss_info_configuration(const sMacAddr &al_mac);
     void clear_bss_info_configuration();
+    void clear_bss_info_configuration(const sMacAddr &al_mac);
 
     //
     // tasks

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -638,7 +638,7 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
         config_data.multiap_attr().subelement_value = bss_info_conf->bss_type;
 
         LOG(DEBUG) << "WSC config_data:" << std::hex << std::endl
-                   << "     ssid: " << config_data.ssid() << std::endl
+                   << "     ssid: " << config_data.ssid_str() << std::endl
                    << "     authentication_type: "
                    << int(config_data.authentication_type_attr().data) << std::endl
                    << "     encryption_type: " << int(config_data.encryption_type_attr().data)


### PR DESCRIPTION
currently, test 5.4.2 keeps on failing with the following message :

![image](https://user-images.githubusercontent.com/38204874/68112282-aaf4ea00-fef9-11e9-99b1-8b5a464aa524.png)


It means that the SSID was not changed as it was supposed to.
The solution is to remove all old configs for the AL-MAC address when we
get a DEV_SET_CONFIG command.

After this change, it was verified that the AP configuration renew
succeeded and the SSID was changed as required.
Fixes #195 

In addition, this PR is also fixed #199, by adding a validation check for the 
bss_info_conf content.


Signed-off-by: Coral Malachi <coral.malachi@intel.com>