### PR TITLE
tlvf: add class_cast for tlv casting support

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
@@ -16,6 +16,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string>
+#include <memory>
 
 class BaseClass {
 protected:
@@ -32,6 +33,14 @@ public:
     size_t getLen();
     bool isInitialized();
     virtual void class_swap() = 0;
+    template <class T> std::shared_ptr<T> class_cast()
+    {
+        if (!m_parse__)
+            return nullptr;
+        if (m_swap__)
+            class_swap();
+        return std::make_shared<T>(m_buff__, m_buff_len__, true, m_swap__);
+    }
 
 protected:
     uint8_t *m_buff__;

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -31,7 +31,7 @@ class tlvTestVarList : public BaseClass
         tlvTestVarList(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
         ~tlvTestVarList();
 
-        const uint16_t& type();
+        const uint8_t& type();
         const uint16_t& length();
         uint16_t& var0();
         uint8_t& simple_list_length();
@@ -60,7 +60,7 @@ class tlvTestVarList : public BaseClass
 
     private:
         bool init();
-        uint16_t* m_type = nullptr;
+        uint8_t* m_type = nullptr;
         uint16_t* m_length = nullptr;
         uint16_t* m_var0 = nullptr;
         uint8_t* m_simple_list_length = nullptr;

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -23,8 +23,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 tlvTestVarList::~tlvTestVarList() {
 }
-const uint16_t& tlvTestVarList::type() {
-    return (const uint16_t&)(*m_type);
+const uint8_t& tlvTestVarList::type() {
+    return (const uint8_t&)(*m_type);
 }
 
 const uint16_t& tlvTestVarList::length() {
@@ -354,7 +354,6 @@ bool tlvTestVarList::add_unknown_length_list(std::shared_ptr<cInner> ptr) {
 
 void tlvTestVarList::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_var0));
     for (size_t i = 0; i < (size_t)*m_simple_list_length; i++){
@@ -373,7 +372,7 @@ void tlvTestVarList::class_swap()
 size_t tlvTestVarList::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(uint16_t); // type
+    class_size += sizeof(uint8_t); // type
     class_size += sizeof(uint16_t); // length
     class_size += sizeof(uint16_t); // var0
     class_size += sizeof(uint8_t); // simple_list_length
@@ -389,9 +388,9 @@ bool tlvTestVarList::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_type = (uint16_t*)m_buff_ptr__;
-    if (!m_parse__) *m_type = 0x1;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    m_type = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_type = 0xff;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
@@ -474,8 +473,8 @@ bool tlvTestVarList::init()
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
-        if (*m_type != 0x1) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0x1) << ", received value: " << int(*m_type);
+        if (*m_type != 0xff) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0xff) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string>
+#include <memory>
 
 class BaseClass {
 protected:
@@ -29,6 +30,14 @@ public:
     size_t getLen();
     bool isInitialized();
     virtual void class_swap() = 0;
+    template <class T> std::shared_ptr<T> class_cast()
+    {
+        if (!m_parse__)
+            return nullptr;
+        if (m_swap__)
+            class_swap();
+        return std::make_shared<T>(m_buff__, m_buff_len__, true, m_swap__);
+    }
 
 protected:
     uint8_t *m_buff__;

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -10,10 +10,10 @@
 #define _BaseClass_H_
 
 #include <cstddef>
+#include <memory>
 #include <stddef.h>
 #include <stdint.h>
 #include <string>
-#include <memory>
 
 class BaseClass {
 protected:
@@ -30,7 +30,9 @@ public:
     size_t getLen();
     bool isInitialized();
     virtual void class_swap() = 0;
-    template <class T> std::shared_ptr<T> class_cast()
+    //this following line assures the template class is derived from BaseClass
+    template <class T, class = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
+    std::shared_ptr<T> class_cast()
     {
         if (!m_parse__)
             return nullptr;

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -305,6 +305,9 @@ int test_parser()
     auto tlv1 = msg.addClass<tlvNon1905neighborDeviceList>();
     auto tlv2 = msg.addClass<tlvLinkMetricQuery>();
     auto tlv3 = msg.addClass<tlvWscM1>();
+    auto tlv4 = msg.addClass<tlvTestVarList>();
+    // TODO https://github.com/prplfoundation/prplMesh/issues/480
+    tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
     msg.finalize(true);
@@ -324,6 +327,9 @@ int test_parser()
         errors++;
     auto tlv3_ = received_message.getClass<tlvWscM1>();
     if (!tlv3_)
+        errors++;
+    auto tlv4_ = received_message.getClass<tlvUnknown>();
+    if (!tlv4_)
         errors++;
 
     MAPF_INFO(__FUNCTION__ << " Finished, errors = " << errors << std::endl);

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -320,17 +320,31 @@ int test_parser()
     CmduMessageRx received_message;
     received_message.parse(recv_buffer, sizeof(recv_buffer), true, true);
     auto tlv1_ = received_message.getClass<tlvNon1905neighborDeviceList>();
-    if (!tlv1_)
+    if (!tlv1_) {
+        LOG(ERROR) << "get class tlvNon1905neighborDeviceList";
         errors++;
+    }
     auto tlv2_ = received_message.getClass<tlvLinkMetricQuery>();
-    if (!tlv2_)
+    if (!tlv2_) {
+        LOG(ERROR) << "get class tlvLinkMetricQuery";
         errors++;
+    }
     auto tlv3_ = received_message.getClass<tlvWscM1>();
-    if (!tlv3_)
+    if (!tlv3_) {
+        LOG(ERROR) << "get class tlvWscM1";
         errors++;
+    }
     auto tlv4_ = received_message.getClass<tlvUnknown>();
-    if (!tlv4_)
+    if (!tlv4_) {
+        LOG(ERROR) << "get class tlvUnknown";
         errors++;
+    } else {
+        auto tlv4_cast = tlv4_->class_cast<tlvTestVarList>();;
+        if (!tlv4_cast) {
+            LOG(ERROR) << "castFrom failed";
+            errors++;
+        }
+    }
 
     MAPF_INFO(__FUNCTION__ << " Finished, errors = " << errors << std::endl);
     return errors;

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -336,7 +336,7 @@ class TlvF:
         self.CODE_CLASS_PUBLIC_FUNC_INSERT          = "//~class_public_func_insert"
         self.CODE_CLASS_PRIVATE_FUNC_INSERT         = "//~class_private_func_insert"
         self.CODE_CLASS_INIT_FUNC_INSERT            = "//~class_init_func_insert"
-        self.CODE_CLASS_INIT_FUNC_SWAP_INSERT            = "//~class_init_func_swap_insert"
+        self.CODE_CLASS_INIT_FUNC_SWAP_INSERT       = "//~class_init_func_swap_insert"
         self.CODE_CLASS_SWAP_FUNC_INSERT            = "//~class_swap_func_insert"
         self.CODE_CLASS_SIZE_FUNC_INSERT            = "//~class_size_func_insert"
         self.CODE_ENUM_INSERT                       = "//~enum_insert"
@@ -1454,7 +1454,7 @@ class TlvF:
         self.insertLineCpp(insert_name, insert_marker, "%sreturn true;" % (self.getIndentation(1)))
         self.insertLineCpp(insert_name, insert_marker, "}")
         self.insertLineCpp(insert_name, insert_marker, "")
-
+    
     def addClassSwapMethod(self, insert_name, insert_marker, name):
         self.insertLineH(insert_name, insert_marker, "%svoid class_swap();" % self.getIndentation(2))
 

--- a/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
+++ b/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
@@ -6,8 +6,8 @@ tlvTestVarList:
   _is_tlv_class : True
   # TODO tlvf currently requires type to be first field
   type:
-    _type: uint16_t
-    _value_const: 1
+    _type: uint8_t
+    _value_const: 255
   # TODO tlvf currently requires length to be second field
   length: uint16_t
   var0: uint16_t


### PR DESCRIPTION
In order to support automatic parsing for unknown TLVs - for example, VS TLVs which are part of a normal TLV, we need a castTlv API. 
This is because the tlvParser is not aware of beerocks messages for example, for which automatic parsing support can be added but is overkill (they all contain a single VS TLV with the beerocks action header).

Consider the WSC simple Autoconfiguration CMDU for example. It contains standard TLVs which includes the M1 and radio basic capabilities TLVs (in the agent -> controller flow), but also the VS TLV in the Intel agent case which adds extra configuration parameters which are needed only by the Intel controller functionality.

The automatic parser will add the VS TLV as an Unkown TLV, which is fine for most, but not for Intel - since we need the VS TLV itself.

For this reason, this PR adds support for TLV casting, a static function in every TLV class which accepts a base class pointer as input, and returns the casted TLV to its own type.
It does so by simply taking the start buffer pointer from the source TLV, its full length, and calls its own constructor.