### PR TITLE
encryption: use pkcs#7 padding

### DIFF
--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -446,8 +446,12 @@ bool master_thread::autoconfig_wsc_add_m2_encrypted_settings(
     // Calculate length of data to encrypt
     // (= plaintext length + 64 bits HMAC aligned to 16 bytes boundary)
     // The Key Wrap Authenticator is 96 bits long
-    size_t len = (config_data.getLen() + sizeof(WSC::sWscAttrKeyWrapAuthenticator) + 31) & ~0xFU;
+    size_t len = (config_data.getLen() + sizeof(WSC::sWscAttrKeyWrapAuthenticator) + 15) & ~0xFU;
     uint8_t pkcs7_padding = len - config_data.getLen() - sizeof(WSC::sWscAttrKeyWrapAuthenticator);
+    if (!pkcs7_padding) {
+        pkcs7_padding = 16;
+        len += 16;
+    }
     LOG(DEBUG) << "plaintext len: " << config_data.getLen() + sizeof(WSC::sWscAttrKeyWrapAuthenticator);
     LOG(DEBUG) << "plaintext + padding len: " << len;
     LOG(DEBUG) << "padding len: " << len - config_data.getLen() - sizeof(WSC::sWscAttrKeyWrapAuthenticator);

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -446,9 +446,12 @@ bool master_thread::autoconfig_wsc_add_m2_encrypted_settings(
     // Calculate length of data to encrypt
     // (= plaintext length + 64 bits HMAC aligned to 16 bytes boundary)
     // The Key Wrap Authenticator is 96 bits long
-    size_t len = (config_data.getLen() + sizeof(WSC::sWscAttrKeyWrapAuthenticator) + 15) & ~0xFU;
+    size_t len = (config_data.getLen() + sizeof(WSC::sWscAttrKeyWrapAuthenticator) + 31) & ~0xFU;
     uint8_t pkcs7_padding = len - config_data.getLen() - sizeof(WSC::sWscAttrKeyWrapAuthenticator);
-
+    LOG(DEBUG) << "plaintext len: " << config_data.getLen() + sizeof(WSC::sWscAttrKeyWrapAuthenticator);
+    LOG(DEBUG) << "plaintext + padding len: " << len;
+    LOG(DEBUG) << "padding len: " << len - config_data.getLen() - sizeof(WSC::sWscAttrKeyWrapAuthenticator);
+    LOG(DEBUG) << "padding value:" << int(pkcs7_padding);
     auto encrypted_settings = m2->create_encrypted_settings();
     if (!encrypted_settings)
         return false;


### PR DESCRIPTION
DO NOT MERGE YET

mapf::encryption::aes_encrypt() implementation disables automatic
padding to be done by openssl API, and instead relies on the user to
make sure that the plaintext is aligned to the underlying aes cbc block
size which is 16 bytes (aes128).

For that, the controller encrypted settings in the WSC M2 TLV includes
zero padding of the config data to 16 bytes boundary.

However, this is not a valid padding and therefore may result with
in decryption failures as seen with some reference golden agents in some
configurations.

TODO - verify that if no padding needed, it always
works

To fix that, we can either replace the encryption implementation to let
the underlying library perform the padding, or select a padding
ourselves.

The most common padding scheme is CMS (Cryptographic Message Syntax).
This pads with the same value as the number of padding bytes. Defined in
RFC 5652, PKCS#5, PKCS#7 (X.509 certificate) and RFC 1423 PEM.

According to [2], "There are multiple methods to pad data, which can
completely undermine the compatibility of a given encryption program
with others. The most used padding method in symmetric ciphers and mode
of operation is certainly PKCS#7".

Therfore, this commit changes the padding from zero padding to PKCS#7.
The result is that encryption is finally correct when tested with online
aes encrption/decryptioni [4].

References:
[1] https://www.di-mgt.com.au/cryptopad.html
[2] https://crypto.stackexchange.com/questions/48628/why-is-padding-used-in-cbc-mode
[3] https://asecuritysite.com/encryption/padding
[4] http://aes.online-domain-tools.com/

Fixes #195 
Fixes Qualcomm M3 issue (couldn't find an open issue)

TODO - verify!
Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>