### PR TITLE
tlvf: add static type assertion for addclass

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/CmduMessage.h
@@ -27,8 +27,9 @@ public:
 
 public:
     std::shared_ptr<cCmduHeader> getCmduHeader() const;
-
-    template <class T> std::shared_ptr<T> addClass()
+    
+    template <class T, class = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
+    std::shared_ptr<T> addClass()
     {
         std::shared_ptr<T> ptr;
         if (m_cmdu_header) {

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -24,8 +24,9 @@ public:
 
 public:
     std::shared_ptr<cCmduHeader> getCmduHeader() const;
-
-    template <class T> std::shared_ptr<T> addClass()
+    
+    template <class T, class = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
+    std::shared_ptr<T> addClass()
     {
         std::shared_ptr<T> ptr;
         if (m_cmdu_header) {


### PR DESCRIPTION
Similarly to the `cast_class()<T>` function of `BaseClass` as modified in #481,
add a change to `addClass<T>()` to assert the types of objects the template
function is called on are derived from `BaseClass`.
Currently the *compile script* fails when `addClass()` is called on a unsupported objects that don't implement _certain methods_ being called.
The more proper way to implement a mechanism for type matching is the following change, which checks for them at compile time, and on any compilation environment.
The line
`template <class T, class = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>` 
(courtesy of @LiorAmram) prevents the compilation immediately in case the template class doesn't inherit from `BaseClass`. 

