### PR TITLE
tlvf: make tlvVarlist a valid TLV

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -146,7 +146,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/../build/install/bin/tests/tlvf_test",
             "args": [],
-            "stopAtEntry": true,
+            "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
             "externalConsole": false,

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -31,7 +31,7 @@ class tlvTestVarList : public BaseClass
         tlvTestVarList(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
         ~tlvTestVarList();
 
-        const uint16_t& type();
+        const uint8_t& type();
         const uint16_t& length();
         uint16_t& var0();
         uint8_t& simple_list_length();
@@ -60,7 +60,7 @@ class tlvTestVarList : public BaseClass
 
     private:
         bool init();
-        uint16_t* m_type = nullptr;
+        uint8_t* m_type = nullptr;
         uint16_t* m_length = nullptr;
         uint16_t* m_var0 = nullptr;
         uint8_t* m_simple_list_length = nullptr;

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -23,8 +23,8 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
 }
 tlvTestVarList::~tlvTestVarList() {
 }
-const uint16_t& tlvTestVarList::type() {
-    return (const uint16_t&)(*m_type);
+const uint8_t& tlvTestVarList::type() {
+    return (const uint8_t&)(*m_type);
 }
 
 const uint16_t& tlvTestVarList::length() {
@@ -354,7 +354,6 @@ bool tlvTestVarList::add_unknown_length_list(std::shared_ptr<cInner> ptr) {
 
 void tlvTestVarList::class_swap()
 {
-    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_var0));
     for (size_t i = 0; i < (size_t)*m_simple_list_length; i++){
@@ -373,7 +372,7 @@ void tlvTestVarList::class_swap()
 size_t tlvTestVarList::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(uint16_t); // type
+    class_size += sizeof(uint8_t); // type
     class_size += sizeof(uint16_t); // length
     class_size += sizeof(uint16_t); // var0
     class_size += sizeof(uint8_t); // simple_list_length
@@ -389,9 +388,9 @@ bool tlvTestVarList::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_type = (uint16_t*)m_buff_ptr__;
-    if (!m_parse__) *m_type = 0x1;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    m_type = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_type = 0xff;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
     if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
@@ -474,8 +473,8 @@ bool tlvTestVarList::init()
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
-        if (*m_type != 0x1) {
-            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0x1) << ", received value: " << int(*m_type);
+        if (*m_type != 0xff) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0xff) << ", received value: " << int(*m_type);
             return false;
         }
     }

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -296,6 +296,11 @@ int test_parser()
     auto tlv1 = msg.addClass<tlvNon1905neighborDeviceList>();
     auto tlv2 = msg.addClass<tlvLinkMetricQuery>();
     auto tlv3 = msg.addClass<tlvWscM1>();
+    // TODO https://github.com/prplfoundation/prplMesh/issues/480
+    tlv3->add_vendor_ext(tlv3->create_vendor_ext());
+    auto tlv4 = msg.addClass<tlvTestVarList>();
+    // TODO https://github.com/prplfoundation/prplMesh/issues/480
+    tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
     msg.finalize(true);
@@ -307,15 +312,26 @@ int test_parser()
 
     CmduMessageRx received_message;
     received_message.parse(recv_buffer, sizeof(recv_buffer), true, true);
-    auto tlv1_ = received_message.getClass<tlvNon1905neighborDeviceList>();
-    if (!tlv1_)
+    auto tlv4_ = received_message.getClass<tlvUnknown>();
+    if (!tlv4_) {
+        LOG(ERROR) << "getClass<tlvUnknown> failed";
         errors++;
-    auto tlv2_ = received_message.getClass<tlvLinkMetricQuery>();
-    if (!tlv2_)
-        errors++;
+    }
     auto tlv3_ = received_message.getClass<tlvWscM1>();
-    if (!tlv3_)
+    if (!tlv3_) {
+        LOG(ERROR) << "getClass<tlvWscM1> failed";
         errors++;
+    }
+    auto tlv2_ = received_message.getClass<tlvLinkMetricQuery>();
+    if (!tlv2_) {
+        LOG(ERROR) << "getClass<tlvLinkMetricQuery> failed";
+        errors++;
+    }
+    auto tlv1_ = received_message.getClass<tlvNon1905neighborDeviceList>();
+    if (!tlv1_) {
+        LOG(ERROR) << "getClass<tlvNon1905neighborDeviceList> failed";
+        errors++;
+    }
 
     MAPF_INFO(__FUNCTION__ << " Finished, errors = " << errors << std::endl);
     return errors;

--- a/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
+++ b/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
@@ -6,8 +6,8 @@ tlvTestVarList:
   _is_tlv_class : True
   # TODO tlvf currently requires type to be first field
   type:
-    _type: uint16_t
-    _value_const: 1
+    _type: uint8_t
+    _value_const: 255
   # TODO tlvf currently requires length to be second field
   length: uint16_t
   var0: uint16_t


### PR DESCRIPTION
tlvVarList cannot be used in automatic parsing since it is not a valid
TLV - it includes a 2 bytes type instead of 1 byte, and the type value
is 1 which collides with other real TLV - TLV_AL_MAC_ADDRESS_TYPE.

This commit changes the type to be uint8_t and the value to be 255,
which does not and will not collide with any other real TLV, so it can
be used in automatic parsing.

We will use this later on to test various automatic parse
functionalities.