### PR TITLE
Fix build failure with GCC 4.9

### DIFF
--- a/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
+++ b/common/beerocks/bcl/include/beerocks/bcl/network/net_struct.h
@@ -22,7 +22,8 @@ inline bool operator==(sMacAddr const &lhs, sMacAddr const &rhs)
 
 inline bool operator!=(sMacAddr const &lhs, sMacAddr const &rhs) { return !(rhs == lhs); }
 
-template <> struct std::hash<sMacAddr> {
+namespace std {
+template <> struct hash<sMacAddr> {
     size_t operator()(const sMacAddr &m) const
     {
         uint64_t value_to_hash = 0;
@@ -30,9 +31,10 @@ template <> struct std::hash<sMacAddr> {
             value_to_hash <<= 8;
             value_to_hash += m.oct[byte];
         }
-        return std::hash<std::uint64_t>()(value_to_hash);
+        return hash<std::uint64_t>()(value_to_hash);
     }
 };
+} // namespace std
 
 namespace beerocks {
 namespace net {


### PR DESCRIPTION
Namespace and template specialization problem with GCC 4.9