### PR TITLE
tlvf: add support for optional MultiAP-Ext in M1

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -5301,6 +5301,23 @@ bool slave_thread::autoconfig_wsc_add_m1()
         hostap_params.iface_is_5ghz ? WSC::WSC_RF_BAND_5GHZ : WSC::WSC_RF_BAND_2GHZ;
     tlvWscM1->primary_device_type_attr().sub_category_id = WSC::WSC_DEV_NETWORK_INFRA_AP;
 
+    auto vendor_ext = tlvWscM1->create_vendor_ext();
+    if (!vendor_ext) {
+        LOG(ERROR) << "Failed to create the vendor_ext attribute";
+        return false;
+    }
+
+    if (!vendor_ext->alloc_vs_data(sizeof(WSC::sWscAttrVersion2))) {
+        LOG(ERROR) << "buffer allocation failed for version2 attribute";
+        return false;
+    }
+
+    WSC::sWscAttrVersion2 version2;
+    version2.struct_swap();
+    uint8_t *version2_buf = reinterpret_cast<uint8_t *>(&version2);
+    std::copy(version2_buf, version2_buf + sizeof(version2), vendor_ext->vs_data());
+    tlvWscM1->add_vendor_ext(vendor_ext);
+
     // encryption support - diffie-helman key-exchange
     dh = std::make_unique<mapf::encryption::diffie_hellman>();
     std::copy(dh->pubkey(), dh->pubkey() + dh->pubkey_length(), tlvWscM1->public_key_attr().data);

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -624,6 +624,8 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
         return false;
     if (!tlvWscM2->set_serial_number("prpl12345"))
         return false;
+    if (!tlvWscM2->set_device_name("prplMesh-controller"))
+        return false;
     tlvWscM2->primary_device_type_attr().sub_category_id = WSC::WSC_DEV_NETWORK_INFRA_GATEWAY;
 
     // TODO Maybe the band should be taken from bss_info_conf.operating_class instead?

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -40,6 +40,7 @@
 namespace WSC {
 
 class cWscAttrEncryptedSettings;
+class cWscVendorExtWfa;
 typedef struct sWscAttrVersion {
     eWscAttributes attribute_type;
     uint16_t data_length;
@@ -356,6 +357,19 @@ typedef struct sWscAttrVersion2 {
     }
 } __attribute__((packed)) sWscAttrVersion2;
 
+typedef struct sWscIeVersion2 {
+    uint8_t subelement_id;
+    uint8_t subelement_length;
+    uint8_t subelement_value;
+    void struct_swap(){
+    }
+    void struct_init(){
+        subelement_id = 0x0;
+        subelement_length = 0x1;
+        subelement_value = WSC_VERSION2;
+    }
+} __attribute__((packed)) sWscIeVersion2;
+
 typedef struct sWscAttrVendorExtMultiAp {
     eWscAttributes attribute_type;
     uint16_t data_length;
@@ -533,6 +547,36 @@ class cWscAttrEncryptedSettings : public BaseClass
         int m_lock_order_counter__ = 0;
         char* m_encrypted_settings = nullptr;
         size_t m_encrypted_settings_idx__ = 0;
+};
+
+class cWscVendorExtWfa : public BaseClass
+{
+    public:
+        cWscVendorExtWfa(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
+        cWscVendorExtWfa(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        ~cWscVendorExtWfa();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint8_t& vendor_id_0();
+        uint8_t& vendor_id_1();
+        uint8_t& vendor_id_2();
+        size_t vs_data_length() { return m_vs_data_idx__ * sizeof(uint8_t); }
+        uint8_t* vs_data(size_t idx = 0);
+        bool alloc_vs_data(size_t count = 1);
+        void class_swap();
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_vendor_id_0 = nullptr;
+        uint8_t* m_vendor_id_1 = nullptr;
+        uint8_t* m_vendor_id_2 = nullptr;
+        uint8_t* m_vs_data = nullptr;
+        size_t m_vs_data_idx__ = 0;
+        int m_lock_order_counter__ = 0;
 };
 
 }; // close namespace: WSC

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
@@ -88,7 +88,9 @@ class tlvWscM1 : public BaseClass
         WSC::sWscAttrDevicePasswordID& device_password_id_attr();
         WSC::sWscAttrConfigurationError& configuration_error_attr();
         WSC::sWscAttrOsVersion& os_version_attr();
-        WSC::sWscAttrVersion2& version2_attr();
+        std::shared_ptr<WSC::cWscVendorExtWfa> create_vendor_ext();
+        bool add_vendor_ext(std::shared_ptr<WSC::cWscVendorExtWfa> ptr);
+        std::shared_ptr<WSC::cWscVendorExtWfa> vendor_ext() { return m_vendor_ext_ptr; }
         void class_swap();
         static size_t get_initial_size();
 
@@ -134,7 +136,9 @@ class tlvWscM1 : public BaseClass
         WSC::sWscAttrDevicePasswordID* m_device_password_id_attr = nullptr;
         WSC::sWscAttrConfigurationError* m_configuration_error_attr = nullptr;
         WSC::sWscAttrOsVersion* m_os_version_attr = nullptr;
-        WSC::sWscAttrVersion2* m_version2_attr = nullptr;
+        WSC::cWscVendorExtWfa *m_vendor_ext = nullptr;
+        std::shared_ptr<WSC::cWscVendorExtWfa> m_vendor_ext_ptr = nullptr;
+        bool m_lock_allocation__ = false;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
@@ -75,6 +75,13 @@ class tlvWscM2 : public BaseClass
         bool set_serial_number(const char buffer[], size_t size);
         bool alloc_serial_number(size_t count = 1);
         WSC::sWscAttrPrimaryDeviceType& primary_device_type_attr();
+        WSC::eWscAttributes& device_name_type();
+        uint16_t& device_name_length();
+        std::string device_name_str();
+        char* device_name(size_t length = 0);
+        bool set_device_name(const std::string& str);
+        bool set_device_name(const char buffer[], size_t size);
+        bool alloc_device_name(size_t count = 1);
         WSC::sWscAttrRfBands& rf_bands_attr();
         WSC::sWscAttrAssociationState& association_state_attr();
         WSC::sWscAttrConfigurationError& configuration_error_attr();
@@ -120,6 +127,10 @@ class tlvWscM2 : public BaseClass
         char* m_serial_number = nullptr;
         size_t m_serial_number_idx__ = 0;
         WSC::sWscAttrPrimaryDeviceType* m_primary_device_type_attr = nullptr;
+        WSC::eWscAttributes* m_device_name_type = nullptr;
+        uint16_t* m_device_name_length = nullptr;
+        char* m_device_name = nullptr;
+        size_t m_device_name_idx__ = 0;
         WSC::sWscAttrRfBands* m_rf_bands_attr = nullptr;
         WSC::sWscAttrAssociationState* m_association_state_attr = nullptr;
         WSC::sWscAttrConfigurationError* m_configuration_error_attr = nullptr;

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -401,4 +401,122 @@ bool cWscAttrEncryptedSettings::init()
     return true;
 }
 
+cWscVendorExtWfa::cWscVendorExtWfa(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
+    BaseClass(buff, buff_len, parse, swap_needed) {
+    m_init_succeeded = init();
+}
+cWscVendorExtWfa::cWscVendorExtWfa(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+    m_init_succeeded = init();
+}
+cWscVendorExtWfa::~cWscVendorExtWfa() {
+}
+eWscAttributes& cWscVendorExtWfa::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscVendorExtWfa::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t& cWscVendorExtWfa::vendor_id_0() {
+    return (uint8_t&)(*m_vendor_id_0);
+}
+
+uint8_t& cWscVendorExtWfa::vendor_id_1() {
+    return (uint8_t&)(*m_vendor_id_1);
+}
+
+uint8_t& cWscVendorExtWfa::vendor_id_2() {
+    return (uint8_t&)(*m_vendor_id_2);
+}
+
+uint8_t* cWscVendorExtWfa::vs_data(size_t idx) {
+    if ( (m_vs_data_idx__ <= 0) || (m_vs_data_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_vs_data[idx]);
+}
+
+bool cWscVendorExtWfa::alloc_vs_data(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list vs_data, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_vs_data;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_vs_data_idx__ += count;
+    if (!buffPtrIncrementSafe(len)) { return false; }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscVendorExtWfa::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+size_t cWscVendorExtWfa::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint8_t); // vendor_id_0
+    class_size += sizeof(uint8_t); // vendor_id_1
+    class_size += sizeof(uint8_t); // vendor_id_2
+    return class_size;
+}
+
+bool cWscVendorExtWfa::init()
+{
+    if (getBuffRemainingBytes() < kMinimumLength) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_VENDOR_EXTENSION;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    m_vendor_id_0 = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_vendor_id_0 = WSC_VENDOR_ID_WFA_1;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_vendor_id_1 = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_vendor_id_1 = WSC_VENDOR_ID_WFA_2;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_vendor_id_2 = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_vendor_id_2 = WSC_VENDOR_ID_WFA_3;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_vs_data = (uint8_t*)m_buff_ptr__;
+    if (m_length && m_parse__) {
+        size_t len = *m_length;
+        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
+        m_vs_data_idx__ = len/sizeof(uint8_t);
+        if (!buffPtrIncrementSafe(len)) { return false; }
+    }
+    if (m_parse__ && m_swap__) { class_swap(); }
+    return true;
+}
+
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -136,6 +136,9 @@ bool tlvWscM2::alloc_manufacturer(size_t count) {
     m_serial_number_length = (uint16_t *)((uint8_t *)(m_serial_number_length) + len);
     m_serial_number = (char *)((uint8_t *)(m_serial_number) + len);
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType *)((uint8_t *)(m_primary_device_type_attr) + len);
+    m_device_name_type = (WSC::eWscAttributes *)((uint8_t *)(m_device_name_type) + len);
+    m_device_name_length = (uint16_t *)((uint8_t *)(m_device_name_length) + len);
+    m_device_name = (char *)((uint8_t *)(m_device_name) + len);
     m_rf_bands_attr = (WSC::sWscAttrRfBands *)((uint8_t *)(m_rf_bands_attr) + len);
     m_association_state_attr = (WSC::sWscAttrAssociationState *)((uint8_t *)(m_association_state_attr) + len);
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError *)((uint8_t *)(m_configuration_error_attr) + len);
@@ -211,6 +214,9 @@ bool tlvWscM2::alloc_model_name(size_t count) {
     m_serial_number_length = (uint16_t *)((uint8_t *)(m_serial_number_length) + len);
     m_serial_number = (char *)((uint8_t *)(m_serial_number) + len);
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType *)((uint8_t *)(m_primary_device_type_attr) + len);
+    m_device_name_type = (WSC::eWscAttributes *)((uint8_t *)(m_device_name_type) + len);
+    m_device_name_length = (uint16_t *)((uint8_t *)(m_device_name_length) + len);
+    m_device_name = (char *)((uint8_t *)(m_device_name) + len);
     m_rf_bands_attr = (WSC::sWscAttrRfBands *)((uint8_t *)(m_rf_bands_attr) + len);
     m_association_state_attr = (WSC::sWscAttrAssociationState *)((uint8_t *)(m_association_state_attr) + len);
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError *)((uint8_t *)(m_configuration_error_attr) + len);
@@ -283,6 +289,9 @@ bool tlvWscM2::alloc_model_number(size_t count) {
     m_serial_number_length = (uint16_t *)((uint8_t *)(m_serial_number_length) + len);
     m_serial_number = (char *)((uint8_t *)(m_serial_number) + len);
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType *)((uint8_t *)(m_primary_device_type_attr) + len);
+    m_device_name_type = (WSC::eWscAttributes *)((uint8_t *)(m_device_name_type) + len);
+    m_device_name_length = (uint16_t *)((uint8_t *)(m_device_name_length) + len);
+    m_device_name = (char *)((uint8_t *)(m_device_name) + len);
     m_rf_bands_attr = (WSC::sWscAttrRfBands *)((uint8_t *)(m_rf_bands_attr) + len);
     m_association_state_attr = (WSC::sWscAttrAssociationState *)((uint8_t *)(m_association_state_attr) + len);
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError *)((uint8_t *)(m_configuration_error_attr) + len);
@@ -352,6 +361,9 @@ bool tlvWscM2::alloc_serial_number(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType *)((uint8_t *)(m_primary_device_type_attr) + len);
+    m_device_name_type = (WSC::eWscAttributes *)((uint8_t *)(m_device_name_type) + len);
+    m_device_name_length = (uint16_t *)((uint8_t *)(m_device_name_length) + len);
+    m_device_name = (char *)((uint8_t *)(m_device_name) + len);
     m_rf_bands_attr = (WSC::sWscAttrRfBands *)((uint8_t *)(m_rf_bands_attr) + len);
     m_association_state_attr = (WSC::sWscAttrAssociationState *)((uint8_t *)(m_association_state_attr) + len);
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError *)((uint8_t *)(m_configuration_error_attr) + len);
@@ -369,6 +381,74 @@ bool tlvWscM2::alloc_serial_number(size_t count) {
 
 WSC::sWscAttrPrimaryDeviceType& tlvWscM2::primary_device_type_attr() {
     return (WSC::sWscAttrPrimaryDeviceType&)(*m_primary_device_type_attr);
+}
+
+WSC::eWscAttributes& tlvWscM2::device_name_type() {
+    return (WSC::eWscAttributes&)(*m_device_name_type);
+}
+
+uint16_t& tlvWscM2::device_name_length() {
+    return (uint16_t&)(*m_device_name_length);
+}
+
+std::string tlvWscM2::device_name_str() {
+    char *device_name_ = device_name();
+    if (!device_name_) { return std::string(); }
+    return std::string(device_name_, m_device_name_idx__);
+}
+
+char* tlvWscM2::device_name(size_t length) {
+    if( (m_device_name_idx__ <= 0) || (m_device_name_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "device_name length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_device_name);
+}
+
+bool tlvWscM2::set_device_name(const std::string& str) { return set_device_name(str.c_str(), str.size()); }
+bool tlvWscM2::set_device_name(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_device_name received an empty string.";
+        return false;
+    }
+    if (!alloc_device_name(size)) { return false; }
+    std::copy(str, str + size, m_device_name);
+    return true;
+}
+bool tlvWscM2::alloc_device_name(size_t count) {
+    if (m_lock_order_counter__ > 4) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list device_name, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 4;
+    uint8_t *src = (uint8_t *)&m_device_name[*m_device_name_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_rf_bands_attr = (WSC::sWscAttrRfBands *)((uint8_t *)(m_rf_bands_attr) + len);
+    m_association_state_attr = (WSC::sWscAttrAssociationState *)((uint8_t *)(m_association_state_attr) + len);
+    m_configuration_error_attr = (WSC::sWscAttrConfigurationError *)((uint8_t *)(m_configuration_error_attr) + len);
+    m_device_password_id_attr = (WSC::sWscAttrDevicePasswordID *)((uint8_t *)(m_device_password_id_attr) + len);
+    m_os_version_attr = (WSC::sWscAttrOsVersion *)((uint8_t *)(m_os_version_attr) + len);
+    m_version2_attr = (WSC::sWscAttrVersion2 *)((uint8_t *)(m_version2_attr) + len);
+    m_encrypted_settings = (WSC::cWscAttrEncryptedSettings *)((uint8_t *)(m_encrypted_settings) + len);
+    m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
+    m_device_name_idx__ += count;
+    *m_device_name_length += count;
+    if (!buffPtrIncrementSafe(len)) { return false; }
+    if(m_length){ (*m_length) += len; }
+    return true;
 }
 
 WSC::sWscAttrRfBands& tlvWscM2::rf_bands_attr() {
@@ -396,7 +476,7 @@ WSC::sWscAttrVersion2& tlvWscM2::version2_attr() {
 }
 
 std::shared_ptr<WSC::cWscAttrEncryptedSettings> tlvWscM2::create_encrypted_settings() {
-    if (m_lock_order_counter__ > 4) {
+    if (m_lock_order_counter__ > 5) {
         TLVF_LOG(ERROR) << "Out of order allocation for variable length list encrypted_settings, abort!";
         return nullptr;
     }
@@ -405,7 +485,7 @@ std::shared_ptr<WSC::cWscAttrEncryptedSettings> tlvWscM2::create_encrypted_setti
         TLVF_LOG(ERROR) << "Not enough available space on buffer";
         return nullptr;
     }
-    m_lock_order_counter__ = 4;
+    m_lock_order_counter__ = 5;
     m_lock_allocation__ = true;
     uint8_t *src = (uint8_t *)m_encrypted_settings;
     if (!m_parse__) {
@@ -470,6 +550,8 @@ void tlvWscM2::class_swap()
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_serial_number_type));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_serial_number_length));
     m_primary_device_type_attr->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_device_name_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_device_name_length));
     m_rf_bands_attr->struct_swap();
     m_association_state_attr->struct_swap();
     m_configuration_error_attr->struct_swap();
@@ -504,6 +586,8 @@ size_t tlvWscM2::get_initial_size()
     class_size += sizeof(WSC::eWscAttributes); // serial_number_type
     class_size += sizeof(uint16_t); // serial_number_length
     class_size += sizeof(WSC::sWscAttrPrimaryDeviceType); // primary_device_type_attr
+    class_size += sizeof(WSC::eWscAttributes); // device_name_type
+    class_size += sizeof(uint16_t); // device_name_length
     class_size += sizeof(WSC::sWscAttrRfBands); // rf_bands_attr
     class_size += sizeof(WSC::sWscAttrAssociationState); // association_state_attr
     class_size += sizeof(WSC::sWscAttrConfigurationError); // configuration_error_attr
@@ -622,6 +706,19 @@ bool tlvWscM2::init()
     if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPrimaryDeviceType); }
     if (!m_parse__) { m_primary_device_type_attr->struct_init(); }
+    m_device_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_device_name_type = WSC::ATTR_DEV_NAME;
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
+    m_device_name_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_device_name_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_device_name = (char*)m_buff_ptr__;
+    uint16_t device_name_length = *m_device_name_length;
+    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
+    m_device_name_idx__ = device_name_length;
+    if (!buffPtrIncrementSafe(sizeof(char)*(device_name_length))) { return false; }
     m_rf_bands_attr = (WSC::sWscAttrRfBands*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) { return false; }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRfBands); }

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -265,6 +265,18 @@ sWscAttrVersion2:
     _type: uint8_t
     _value: WSC_VERSION2
 
+sWscIeVersion2:
+  _type: struct
+  subelement_id:
+    _type: uint8_t
+    _value: 0x0
+  subelement_length:
+    _type: uint8_t
+    _value: 0x1
+  subelement_value:
+    _type: uint8_t
+    _value: WSC_VERSION2
+
 sWscAttrVendorExtMultiAp:
   _type: struct
   attribute_type:
@@ -394,4 +406,26 @@ cWscAttrEncryptedSettings:
     _length: [WSC_ENCRYPTED_SETTINGS_IV_LENGTH]
   encrypted_settings:
     _type: char
+    _length: []
+
+cWscVendorExtWfa:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_VENDOR_EXTENSION
+  length:
+    _type: uint16_t
+    _length_var: True
+  vendor_id_0:
+    _type: uint8_t
+    _value: WSC_VENDOR_ID_WFA_1
+  vendor_id_1:
+    _type: uint8_t
+    _value: WSC_VENDOR_ID_WFA_2
+  vendor_id_2:
+    _type: uint8_t
+    _value: WSC_VENDOR_ID_WFA_3
+  vs_data:
+    _type: uint8_t
     _length: []

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM1.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM1.yaml
@@ -89,4 +89,4 @@ tlvWscM1:
   device_password_id_attr: WSC::sWscAttrDevicePasswordID
   configuration_error_attr: WSC::sWscAttrConfigurationError
   os_version_attr: WSC::sWscAttrOsVersion
-  version2_attr: WSC::sWscAttrVersion2
+  vendor_ext: WSC::cWscVendorExtWfa

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM2.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM2.yaml
@@ -71,6 +71,17 @@ tlvWscM2:
     _length: [ serial_number_length ]
 
   primary_device_type_attr: WSC::sWscAttrPrimaryDeviceType
+
+  device_name_type:
+    _type: WSC::eWscAttributes
+    _value: WSC::ATTR_DEV_NAME
+  device_name_length:
+    _type: uint16_t
+    _length_var: True
+  device_name:
+    _type: char
+    _length: [ device_name_length ]
+
   rf_bands_attr: WSC::sWscAttrRfBands
   association_state_attr: WSC::sWscAttrAssociationState
   configuration_error_attr: WSC::sWscAttrConfigurationError


### PR DESCRIPTION
This is a first attempt at adding support for an optional
MultiAP-Extension attribute in the vendor extension of M1/M2.

First, sWscAttrVersion2 is renamed to sWscVExtAttrVersion2. It will
not be used as part of the M1 anymore, but it may still be used
somewhere else, like in the M2.

Second, a new sWscAttrVersion2 attribute is added. It contains only
the Version2 subitems, and not the whole vendor extension.

A new class is also added: cWscVendorExt. It contains both the vendor
extension fields, and unknown length list vs_data, which may contain
the version2 and/or MultiAP-Extension items.

son_slave_thread.cpp also needs to be modified. Now that the vendor
extension uses an unknown length list, it no longer contains the
default value for the Version2 attribute, so they have to be added
manually.

Fixes #490
Fixes #213

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>
Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>