### PR TITLE
Remove maptools reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To build prplMesh, you need (on Ubuntu) the following packages:
 ```bash
 sudo apt install curl gcc cmake binutils git autoconf autogen libtool pkg-config \
      libreadline-dev libncurses-dev libssl-dev libjson-c-dev libnl-genl-3-dev libzmq3-dev \
-     python python-yaml python-paramiko repo bridge-utils clang-format
+     python python-yaml python-paramiko repo bridge-utils clang-format ninja
 ```
 
 If you haven't done so already, set up your git configuration:
@@ -43,30 +43,33 @@ repo forall -p -c 'git checkout $REPO_RREV'
 
 ## Build Instructions
 
-Each component can be built with CMAKE, or use the [tools/maptools.py](tools/README.md) build command.
+Use standard CMake to build prplMesh, with a configure-build-install cycle.
 
-To build prplMesh in debug mode (for being able to debug with gdb), with all features and tests, run
-
-```bash
-./prplMesh/tools/maptools.py build map -f MSGLIB=zmq BUILD_TESTS=ON CMAKE_BUILD_TYPE=Debug
-```
-
-Subsequent builds don't need to repeat all of these options:
+To build prplMesh natively in debug mode (for being able to debug with gdb), with all features and tests, and installed in a local directory, run
 
 ```bash
-./prplMesh/tools/maptools.py build map
+cmake -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../build/install -H . -B ../build -G Ninja
+ninja -C ../build install
 ```
 
-Run `./prplMesh/tools/maptools.py build --help` for more options.
+If you prefer, `make` can be used instead of `ninja` by removing the `-G Ninja` part.
 
-Note - to build with Docker, see provided [building with docker](tools/docker/README.md)
+For system-level install, the standard DESTDIR approach can be used for installing prplMesh as a package.
+
+```bash
+DESTDIR=/tmp/prplMesh-install ninja install
+```
+
+Alternatively, [tools/maptools.py](tools/README.md) can be used to build and install prplMesh with a single command.
+
+Note - to build and run with Docker, see provided [building with docker](tools/docker/README.md)
 
 ## Running Instructions
 
 Once built, prplMesh controller, agent and framework can be started using `prplmesh_utils.sh`:
 
 ```bash
-cd <path/to/prplmesh_root>/build/install/scripts
+cd <path/to/install/dir>/scripts
 sudo ./prplmesh_utils.sh start
 ```
 

--- a/framework/common/test/messages/CMakeLists.txt
+++ b/framework/common/test/messages/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(dummy_messages SHARED dummy1.cpp dummy2.cpp)
 target_link_libraries(dummy_messages PRIVATE common)
-install(TARGETS dummy_messages DESTINATION lib)
+install(TARGETS dummy_messages DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/framework/transport/ieee1905_transport/CMakeLists.txt
+++ b/framework/transport/ieee1905_transport/CMakeLists.txt
@@ -4,7 +4,6 @@ add_library(ieee1905_transport_lib SHARED ieee1905_transport.cpp ieee1905_transp
 set_target_properties(ieee1905_transport_lib PROPERTIES VERSION ${${PROJECT}_VERSION_STRING} SOVERSION ${${PROJECT}_VERSION_MAJOR})
 target_link_libraries(ieee1905_transport_lib PUBLIC ieee1905_transport_messages common PRIVATE mapf::elpp)
 target_include_directories(ieee1905_transport_lib PUBLIC include/)
-install(TARGETS ieee1905_transport_lib DESTINATION lib)
 
 add_library(ieee1905_transport_messages SHARED ieee1905_transport_messages.cpp)
 set_target_properties(ieee1905_transport_messages PROPERTIES VERSION ${${PROJECT}_VERSION_STRING} SOVERSION ${${PROJECT}_VERSION_MAJOR})
@@ -12,13 +11,13 @@ target_link_libraries(ieee1905_transport_messages PUBLIC common PRIVATE mapf::el
 target_include_directories(ieee1905_transport_messages PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
-install(TARGETS ieee1905_transport_messages
-    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(ieee1905_transport main.cpp)
 target_link_libraries(ieee1905_transport PUBLIC ieee1905_transport_lib PRIVATE mapf::elpp)
-install(TARGETS ieee1905_transport DESTINATION bin)
+
+install(TARGETS ieee1905_transport_messages ieee1905_transport_lib ieee1905_transport
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_subdirectory(test)


### PR DESCRIPTION
While checking that it really works when building with normal cmake, I noticed that some libraries are installed in the wrong place and are not found by the
dynamic linker, so fix that as well.