### PR TITLE
Bugfix/Ap Metrics TLV with single unknown length list

### DIFF
--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -745,6 +745,7 @@ private:
     * Map is Used in TYPE_GW/TYPE_IRE nodes.
     * Map created empty in all other nodes.
     */
+    //TODO: This map should be moved to the agent nodes instead of being a separate map.
     std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, son::node::link_metrics_data>>
         m_link_metric_data;
 
@@ -753,6 +754,7 @@ private:
     * Map is Used in TYPE_GW/TYPE_IRE nodes.
     * Map created empty in all other nodes.
     */
+    //TODO:  This map should be moved to the BSS nodes (which currently don't exist) instead of being a separate map.
     std::unordered_map<sMacAddr, son::node::ap_metrics_data> m_ap_metric_data;
 
     // certification

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -350,28 +350,19 @@ bool node::ap_metrics_data::add_ap_metric_data(std::shared_ptr<wfa_map::tlvApMet
     channel_utilization                 = ApMetricData->channel_utilization();
     number_of_stas_currently_associated = ApMetricData->number_of_stas_currently_associated();
 
-    if (ApMetricData->estimated_service_parameters().include_ac_be) {
-        std::copy(ApMetricData->estimated_service_info_field_ac_be(),
-                  ApMetricData->estimated_service_info_field_ac_be() + 3,
-                  estimated_service_info_field_ac_be);
-    }
-
+    //copy all fields to database vector
+    std::copy(ApMetricData->estimated_service_info_field(),
+              ApMetricData->estimated_service_info_field() +
+                  ApMetricData->estimated_service_info_field_length(),
+              std::back_inserter(estimated_service_info_fields));
     if (ApMetricData->estimated_service_parameters().include_ac_bk) {
-        std::copy(ApMetricData->estimated_service_info_field_ac_bk(),
-                  ApMetricData->estimated_service_info_field_ac_bk() + 3,
-                  estimated_service_info_field_ac_bk);
+        include_ac_bk = true;
     }
-
     if (ApMetricData->estimated_service_parameters().include_ac_vo) {
-        std::copy(ApMetricData->estimated_service_info_field_ac_vo(),
-                  ApMetricData->estimated_service_info_field_ac_vo() + 3,
-                  estimated_service_info_field_ac_vo);
+        include_ac_vo = true;
     }
-
     if (ApMetricData->estimated_service_parameters().include_ac_vi) {
-        std::copy(ApMetricData->estimated_service_info_field_ac_vi(),
-                  ApMetricData->estimated_service_info_field_ac_vi() + 3,
-                  estimated_service_info_field_ac_vi);
+        include_ac_vi = true;
     }
     return true;
 }

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -212,10 +212,10 @@ public:
         sMacAddr bssid;
         uint8_t channel_utilization;
         uint16_t number_of_stas_currently_associated;
-        uint8_t estimated_service_info_field_ac_be[3];
-        uint8_t estimated_service_info_field_ac_bk[3];
-        uint8_t estimated_service_info_field_ac_vo[3];
-        uint8_t estimated_service_info_field_ac_vi[3];
+        std::vector<uint8_t> estimated_service_info_fields;
+        bool include_ac_vo = false;
+        bool include_ac_bk = false;
+        bool include_ac_vi = false;
 
         bool add_ap_metric_data(std::shared_ptr<wfa_map::tlvApMetric> ApMetricData);
     };

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1408,15 +1408,22 @@ bool master_thread::construct_combined_infra_metric()
         ap_metrics_tlv->channel_utilization() = metric_data_per_agent.channel_utilization;
         ap_metrics_tlv->number_of_stas_currently_associated() =
             metric_data_per_agent.number_of_stas_currently_associated;
-        for (int i = 0; i < 3; ++i) {
-            *ap_metrics_tlv->estimated_service_info_field_ac_be(i) =
-                metric_data_per_agent.estimated_service_info_field_ac_be[i];
-            *ap_metrics_tlv->estimated_service_info_field_ac_bk(i) =
-                metric_data_per_agent.estimated_service_info_field_ac_bk[i];
-            *ap_metrics_tlv->estimated_service_info_field_ac_vo(i) =
-                metric_data_per_agent.estimated_service_info_field_ac_vo[i];
-            *ap_metrics_tlv->estimated_service_info_field_ac_vi(i) =
-                metric_data_per_agent.estimated_service_info_field_ac_vi[i];
+        auto len = metric_data_per_agent.estimated_service_info_fields.size();
+        if (!ap_metrics_tlv->alloc_estimated_service_info_field(len)) {
+            LOG(ERROR) << "alloc_estimated_service_info_field() has failed!";
+            return false;
+        }
+        std::copy(metric_data_per_agent.estimated_service_info_fields.begin(),
+                  metric_data_per_agent.estimated_service_info_fields.end(),
+                  ap_metrics_tlv->estimated_service_info_field());
+        if (metric_data_per_agent.include_ac_bk) {
+            ap_metrics_tlv->estimated_service_parameters().include_ac_bk = 0x1;
+        }
+        if (metric_data_per_agent.include_ac_vi) {
+            ap_metrics_tlv->estimated_service_parameters().include_ac_vi = 0x1;
+        }
+        if (metric_data_per_agent.include_ac_vo) {
+            ap_metrics_tlv->estimated_service_parameters().include_ac_vo = 0x1;
         }
     }
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1194,6 +1194,7 @@ print_ap_metric_map(std::unordered_map<sMacAddr, son::node::ap_metrics_data> &ap
 {
     LOG(DEBUG) << "Print Ap Metrics data map";
     for (auto const &pair_agent : ap_metric_data) {
+        auto len = pair_agent.second.estimated_service_info_fields.size();
         LOG(DEBUG) << std::endl
                    << "  Ap Metrics from agent with bssid= "
                    << network_utils::mac_to_string(pair_agent.first) << std::endl
@@ -1202,21 +1203,22 @@ print_ap_metric_map(std::unordered_map<sMacAddr, son::node::ap_metrics_data> &ap
                    << "  number_of_stas_currently_associated="
                    << int(pair_agent.second.number_of_stas_currently_associated) << std::endl
                    << "  estimated_service_info_field_ac_be = 0x" << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_be[0]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_be[1]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_be[2]) << std::endl
-                   << "  estimated_service_info_field_ac_bk = 0x" << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_bk[0]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_bk[1]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_bk[2]) << std::endl
-                   << "  estimated_service_info_field_ac_vo = 0x" << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_vo[0]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_vo[1]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_vo[2]) << std::endl
-                   << "  estimated_service_info_field_ac_vi = 0x" << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_vi[0]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_vi[1]) << std::hex
-                   << int(pair_agent.second.estimated_service_info_field_ac_vi[2]);
+                   << int(pair_agent.second.estimated_service_info_fields[0])
+                   << int(pair_agent.second.estimated_service_info_fields[1])
+                   << int(pair_agent.second.estimated_service_info_fields[2]) << std::endl;
+        if (len > 3) {
+            int lists_count = (len - 3) / 3;
+            int i           = 3;
+            for (int k = 0; k < lists_count; k++) {
+
+                LOG(DEBUG) << "  estimated_service_info_field_ac_** = 0x" << std::hex
+                           << int(pair_agent.second.estimated_service_info_fields[i])
+                           << int(pair_agent.second.estimated_service_info_fields[i + 1])
+                           << int(pair_agent.second.estimated_service_info_fields[i + 2])
+                           << std::endl;
+                i = i + 3;
+            }
+        }
     }
 }
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetric.h
@@ -63,10 +63,9 @@ class tlvApMetric : public BaseClass
         uint8_t& channel_utilization();
         uint16_t& number_of_stas_currently_associated();
         sEstimatedService& estimated_service_parameters();
-        uint8_t* estimated_service_info_field_ac_be(size_t idx = 0);
-        uint8_t* estimated_service_info_field_ac_bk(size_t idx = 0);
-        uint8_t* estimated_service_info_field_ac_vo(size_t idx = 0);
-        uint8_t* estimated_service_info_field_ac_vi(size_t idx = 0);
+        size_t estimated_service_info_field_length() { return m_estimated_service_info_field_idx__ * sizeof(uint8_t); }
+        uint8_t* estimated_service_info_field(size_t idx = 0);
+        bool alloc_estimated_service_info_field(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
 
@@ -78,15 +77,9 @@ class tlvApMetric : public BaseClass
         uint8_t* m_channel_utilization = nullptr;
         uint16_t* m_number_of_stas_currently_associated = nullptr;
         sEstimatedService* m_estimated_service_parameters = nullptr;
-        uint8_t* m_estimated_service_info_field_ac_be = nullptr;
-        size_t m_estimated_service_info_field_ac_be_idx__ = 0;
+        uint8_t* m_estimated_service_info_field = nullptr;
+        size_t m_estimated_service_info_field_idx__ = 0;
         int m_lock_order_counter__ = 0;
-        uint8_t* m_estimated_service_info_field_ac_bk = nullptr;
-        size_t m_estimated_service_info_field_ac_bk_idx__ = 0;
-        uint8_t* m_estimated_service_info_field_ac_vo = nullptr;
-        size_t m_estimated_service_info_field_ac_vo_idx__ = 0;
-        uint8_t* m_estimated_service_info_field_ac_vi = nullptr;
-        size_t m_estimated_service_info_field_ac_vi_idx__ = 0;
 };
 
 }; // close namespace: wfa_map

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApMetric.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApMetric.yaml
@@ -13,18 +13,9 @@ tlvApMetric:
   channel_utilization: uint8_t
   number_of_stas_currently_associated: uint16_t
   estimated_service_parameters: sEstimatedService
-  estimated_service_info_field_ac_be:
+  estimated_service_info_field:
     _type: uint8_t
-    _length: [3]
-  estimated_service_info_field_ac_bk:
-    _type: uint8_t
-    _length: [3]
-  estimated_service_info_field_ac_vo:
-    _type: uint8_t
-    _length: [3]
-  estimated_service_info_field_ac_vi:
-    _type: uint8_t
-    _length: [3]
+    _length: []
 
 sEstimatedService:
   _type: struct


### PR DESCRIPTION
According to specification (17.2.2 AP Metrics TLV format), Ap Metrics TLV
may contain the Estimated Service Parameters Information field for AC=BK,
AC=VO, AC=VI (always contains a field for AC=BE).

Since there is no guarantee that all fields will always be sent by an AP,
it's wrong to initialize the Ap Metric TLV to contain all of them from
the beginning.

The TLVF cannot accommodate more than one unknown length list OR an
unknown length list which is not the last member in the TLV.
Therefore, replace all the Estimated Service Parameters Information
fields with a single unknown length list.

Fixes #473
Verified on the testbed.