### PR TITLE
controller: support empty temp_path in config

### DIFF
--- a/common/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/common/beerocks/bcl/source/beerocks_config_file.cpp
@@ -135,7 +135,7 @@ bool config_file::read_master_config_file(std::string config_file_path, sConfigM
                     read_log_section(config_file_path, conf.sLog));
 
     // check temp_path has trailing slash
-    if (conf.temp_path.back() != '/') {
+    if (ret_val && !conf.temp_path.empty() && conf.temp_path.back() != '/') {
         conf.temp_path += '/';
     }
     return ret_val;


### PR DESCRIPTION
The behavior of back() is undefined if empty() == true.
read_master_config_file uses this to append a / to temp_path. In GCC 9,
this "undefined behavior" in fact leads to a SEGV. Fix this by checking
that temp_path is not empty first. Also, it is anyway only relevant if
there was a config file, so check ret_val as well.