### PR TITLE
platform_manager: remove hardcoded platform checks for arp and dhcp monitors

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -12,8 +12,13 @@ file(GLOB_RECURSE bwl_common_sources ${MODULE_PATH}/common/*.c*)
 # Support more permissive c++ language
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
-# Default BWL Type
+# Default defaults
 set(BWL_TYPE "DUMMY")
+set(BEEROCKS_TMP_PATH "/tmp/beerocks")
+if(TARGET_PLATFORM STREQUAL "linux")
+    set(BEEROCKS_TMP_PATH "/tmp/$ENV{USER}/beerocks")
+endif()
+add_definitions(-DBEEROCKS_TMP_PATH="${BEEROCKS_TMP_PATH}")
 
 # UGW
 if (TARGET_PLATFORM STREQUAL "ugw")
@@ -36,12 +41,6 @@ elseif(TARGET_PLATFORM STREQUAL "rdkb")
     list(APPEND BWL_LIBS rt dl)
     # Extre directories
     include_directories(${PLATFORM_INCLUDE_DIR}/wav-dpal)
-
-# Linux
-elseif(TARGET_PLATFORM STREQUAL "linux")
-    set(BWL_TYPE "DUMMY")
-    set(BEEROCKS_TMP_PATH "/tmp/$ENV{USER}/beerocks")
-    add_definitions(-DBEEROCKS_TMP_PATH="${BEEROCKS_TMP_PATH}")
 
 # Turris Omnia
 elseif(TARGET_PLATFORM STREQUAL "turris-omnia")

--- a/framework/platform/bpl/include/bpl/bpl_err.h
+++ b/framework/platform/bpl/include/bpl/bpl_err.h
@@ -28,6 +28,8 @@ extern "C" {
 
 #define FOREACH_ERROR_CODE(ERROR_CODE)                                                             \
     ERROR_CODE(BPL_ERR_NONE)                                                                       \
+    ERROR_CODE(BPL_ERR_UNKNOWN)                                                                    \
+    ERROR_CODE(BPL_ERR_OPERATION_NOT_SUPPORTED)                                                    \
     ERROR_CODE(BPL_ERR_BH_READING_DATA_FROM_THE_BRIDGE)                                            \
     ERROR_CODE(BPL_ERR_BH_TIMEOUT_ATTACHING_TO_WPA_SUPPLICANT)                                     \
     ERROR_CODE(BPL_ERR_BH_SCAN_FAILED_TO_INITIATE_SCAN)                                            \

--- a/framework/platform/bpl/include/bpl/bpl_err.h
+++ b/framework/platform/bpl/include/bpl/bpl_err.h
@@ -27,69 +27,71 @@ extern "C" {
 /* Beerocks Error Codes */
 
 #define FOREACH_ERROR_CODE(ERROR_CODE)                                                             \
-    /* 00 */ ERROR_CODE(BPL_ERR_NONE)                                                              \
-                                                                                                   \
-        /* 01 */ ERROR_CODE(BPL_ERR_BH_READING_DATA_FROM_THE_BRIDGE) /* 02 */                      \
-        ERROR_CODE(BPL_ERR_BH_TIMEOUT_ATTACHING_TO_WPA_SUPPLICANT) /* 03 */ ERROR_CODE(            \
-            BPL_ERR_BH_SCAN_FAILED_TO_INITIATE_SCAN) /* 04 */                                      \
-        ERROR_CODE(BPL_ERR_BH_SCAN_TIMEOUT) /* 05 */ ERROR_CODE(                                   \
-            BPL_ERR_BH_FAILED_TO_RETRIEVE_SCAN_RESULTS) /* 06 */                                   \
-        ERROR_CODE(BPL_ERR_BH_SCAN_EXCEEDED_MAXIMUM_FAILED_SCAN_ATTEMPTS) /* 07 */ ERROR_CODE(     \
-            BPL_ERR_BH_OBTAINING_DHCP_BRIDGE_INTERFACE) /* 08 */                                   \
-        ERROR_CODE(BPL_ERR_BH_OBTAINING_DHCP_BRIDGE_INTERFACE_MAX_ATTEMPTS) /* 09 */ ERROR_CODE(   \
-            BPL_ERR_BH_CONNECTING_TO_MASTER) /* 10 */                                              \
-        ERROR_CODE(BPL_ERR_BH_CONNECTING_TO_MASTER_USING_UDS) /* 11 */ ERROR_CODE(                 \
-            BPL_ERR_BH_DEVICE_QUERY_TIMEOUT) /* 12 */                                              \
-        ERROR_CODE(BPL_ERR_BH_ASSOCIATE_3ADDR) /* 13 */ ERROR_CODE(                                \
-            BPL_ERR_BH_ASSOCIATE_3ADDR_TIMEOUT) /* 14 */                                           \
-        ERROR_CODE(BPL_ERR_BH_ASSOCIATE_4ADDR_TIMEOUT) /* 15 */ ERROR_CODE(                        \
-            BPL_ERR_BH_ASSOCIATE_4ADDR_FAILURE) /* 16 */                                           \
-        ERROR_CODE(BPL_ERR_BH_TRANSITION_FROM_3ADDR_TO_4ADDR) /* 17 */ ERROR_CODE(                 \
-            BPL_ERR_BH_ROAMING) /* 18 */ ERROR_CODE(BPL_ERR_BH_DISCONNECTED) /* 19 */              \
-        ERROR_CODE(BPL_ERR_BH_WPA_SUPPLICANT_TERMINATED) /* 20 */ ERROR_CODE(                      \
-            BPL_ERR_BH_MASTER_SOCKET_DISCONNECTED) /* 21 */                                        \
-        ERROR_CODE(BPL_ERR_BH_SLAVE_SOCKET_DISCONNECTED) /* 22 */ ERROR_CODE(                      \
-            BPL_ERR_BH_OPEN_UDP_SOCKET_FAILURE) /* 23 */ ERROR_CODE(BPL_ERR_BH_STOPPED) /* 24 */   \
-        ERROR_CODE(BPL_ERR_SLAVE_CONNECTING_TO_BACKHAUL_MANAGER)                        /* 25 */   \
-        ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_GET_WLAN_READY_STATUS_REQUEST) /* 26 */ ERROR_CODE(       \
-            BPL_ERR_SLAVE_TIMEOUT_WIFI_CREDENTIALS_SET_REQUEST) /* 27 */                           \
-        ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_IFACE_ENABLE_REQUEST) /* 28 */ ERROR_CODE(                \
-            BPL_ERR_SLAVE_TIMEOUT_IFACE_DISABLE_REQUEST) /* 29 */                                  \
-        ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_IFACE_RESTORE_REQUEST) /* 30 */ ERROR_CODE(               \
-            BPL_ERR_SLAVE_TIMEOUT_IFACE_RESTART_REQUEST) /* 31 */                                  \
-        ERROR_CODE(BPL_ERR_SLAVE_MASTER_KEEP_ALIVE_TIMEOUT) /* 32 */ ERROR_CODE(                   \
-            BPL_ERR_SLAVE_INVALID_MASTER_SOCKET) /* 33 */                                          \
-        ERROR_CODE(BPL_ERR_SLAVE_IFACE_CHANGE_STATE_FAILED) /* 34 */ ERROR_CODE(                   \
-            BPL_ERR_SLAVE_IFACE_RESTORE_FAILED) /* 35 */                                           \
-        ERROR_CODE(BPL_ERR_SLAVE_WIFI_CREDENTIALS_SET_FAILED) /* 36 */ ERROR_CODE(                 \
-            BPL_ERR_SLAVE_POST_INIT_CONFIG_FAILED) /* 37 */                                        \
-        ERROR_CODE(BPL_ERR_SLAVE_TX_CHANGE_STATE_FAILED) /* 38 */ ERROR_CODE(                      \
-            BPL_ERR_SLAVE_UPDATE_CREDENTIALS_FAILED) /* 39 */                                      \
-        ERROR_CODE(BPL_ERR_SLAVE_FAILED_CONNECT_TO_PLATFORM_MANAGER) /* 40 */ ERROR_CODE(          \
-            BPL_ERR_SLAVE_PLATFORM_MANAGER_REGISTER_TIMEOUT) /* 41 */                              \
-        ERROR_CODE(BPL_ERR_SLAVE_SLAVE_BACKHAUL_MANAGER_DISCONNECTED) /* 42 */ ERROR_CODE(         \
-            BPL_ERR_SLAVE_STOPPED) /* 43 */ ERROR_CODE(BPL_ERR_AP_MANAGER_START) /* 44 */          \
-        ERROR_CODE(BPL_ERR_AP_MANAGER_DISCONNECTED)                              /* 45 */          \
-        ERROR_CODE(BPL_ERR_AP_MANAGER_HOSTAP_DISABLED) /* 46 */ ERROR_CODE(                        \
-            BPL_ERR_AP_MANAGER_ATTACH_FAIL) /* 47 */                                               \
-        ERROR_CODE(BPL_ERR_AP_MANAGER_SUDDEN_DETACH) /* 48 */ ERROR_CODE(                          \
-            BPL_ERR_AP_MANAGER_HAL_DISCONNECTED) /* 49 */                                          \
-        ERROR_CODE(BPL_ERR_AP_MANAGER_CAC_TIMEOUT) /* 50 */ ERROR_CODE(                            \
-            BPL_ERR_MONITOR_DISCONNECTED) /* 51 */                                                 \
-        ERROR_CODE(BPL_ERR_MONITOR_HOSTAP_DISABLED) /* 52 */ ERROR_CODE(                           \
-            BPL_ERR_MONITOR_ATTACH_FAIL) /* 53 */                                                  \
-        ERROR_CODE(BPL_ERR_MONITOR_SUDDEN_DETACH) /* 54 */ ERROR_CODE(                             \
-            BPL_ERR_MONITOR_HAL_DISCONNECTED) /* 55 */                                             \
-        ERROR_CODE(BPL_ERR_MONITOR_REPORT_PROCESS_FAIL) /* 56 */ ERROR_CODE(                       \
-            BPL_ERR_CONFIG_PLATFORM_REPORTED_INVALID_CONFIGURATION) /* 57 */                       \
-        ERROR_CODE(BPL_ERR_CONFIG_BACKHAUL_WIRED_INTERFACE_IS_UNSUPPORTED) /* 58 */ ERROR_CODE(    \
-            BPL_ERR_CONFIG_BACKHAUL_WIRELESS_INTERFACE_IS_UNSUPPORTED) /* 59 */                    \
-        ERROR_CODE(BPL_ERR_CONFIG_NO_VALID_BACKHAUL_INTERFACE) /* 60 */ ERROR_CODE(                \
-            BPL_ERR_CONFIG_BRIDGE_INTERFACE_IS_EMPTY) /* 61 */                                     \
-        ERROR_CODE(BPL_ERR_WIFI_CONFIGURATION_CHANGE_TIMEOUT) /* 62 */ ERROR_CODE(                 \
-            BPL_ERR_WATCHDOG_PROCESS_STUCK) /* 63 */ ERROR_CODE(BPL_ERR_WATCHDOG_PROCESS_ZOMBIE)   \
-                                                                                                   \
-        /* 74 */ ERROR_CODE(BPL_ERR_LAST)
+    ERROR_CODE(BPL_ERR_NONE)                                                                       \
+    ERROR_CODE(BPL_ERR_BH_READING_DATA_FROM_THE_BRIDGE)                                            \
+    ERROR_CODE(BPL_ERR_BH_TIMEOUT_ATTACHING_TO_WPA_SUPPLICANT)                                     \
+    ERROR_CODE(BPL_ERR_BH_SCAN_FAILED_TO_INITIATE_SCAN)                                            \
+    ERROR_CODE(BPL_ERR_BH_SCAN_TIMEOUT)                                                            \
+    ERROR_CODE(BPL_ERR_BH_FAILED_TO_RETRIEVE_SCAN_RESULTS)                                         \
+    ERROR_CODE(BPL_ERR_BH_SCAN_EXCEEDED_MAXIMUM_FAILED_SCAN_ATTEMPTS)                              \
+    ERROR_CODE(BPL_ERR_BH_OBTAINING_DHCP_BRIDGE_INTERFACE)                                         \
+    ERROR_CODE(BPL_ERR_BH_OBTAINING_DHCP_BRIDGE_INTERFACE_MAX_ATTEMPTS)                            \
+    ERROR_CODE(BPL_ERR_BH_CONNECTING_TO_MASTER)                                                    \
+    ERROR_CODE(BPL_ERR_BH_CONNECTING_TO_MASTER_USING_UDS)                                          \
+    ERROR_CODE(BPL_ERR_BH_DEVICE_QUERY_TIMEOUT)                                                    \
+    ERROR_CODE(BPL_ERR_BH_ASSOCIATE_3ADDR)                                                         \
+    ERROR_CODE(BPL_ERR_BH_ASSOCIATE_3ADDR_TIMEOUT)                                                 \
+    ERROR_CODE(BPL_ERR_BH_ASSOCIATE_4ADDR_TIMEOUT)                                                 \
+    ERROR_CODE(BPL_ERR_BH_ASSOCIATE_4ADDR_FAILURE)                                                 \
+    ERROR_CODE(BPL_ERR_BH_TRANSITION_FROM_3ADDR_TO_4ADDR)                                          \
+    ERROR_CODE(BPL_ERR_BH_ROAMING)                                                                 \
+    ERROR_CODE(BPL_ERR_BH_DISCONNECTED)                                                            \
+    ERROR_CODE(BPL_ERR_BH_WPA_SUPPLICANT_TERMINATED)                                               \
+    ERROR_CODE(BPL_ERR_BH_MASTER_SOCKET_DISCONNECTED)                                              \
+    ERROR_CODE(BPL_ERR_BH_SLAVE_SOCKET_DISCONNECTED)                                               \
+    ERROR_CODE(BPL_ERR_BH_OPEN_UDP_SOCKET_FAILURE)                                                 \
+    ERROR_CODE(BPL_ERR_BH_STOPPED)                                                                 \
+    ERROR_CODE(BPL_ERR_SLAVE_CONNECTING_TO_BACKHAUL_MANAGER)                                       \
+    ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_GET_WLAN_READY_STATUS_REQUEST)                                \
+    ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_WIFI_CREDENTIALS_SET_REQUEST)                                 \
+    ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_IFACE_ENABLE_REQUEST)                                         \
+    ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_IFACE_DISABLE_REQUEST)                                        \
+    ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_IFACE_RESTORE_REQUEST)                                        \
+    ERROR_CODE(BPL_ERR_SLAVE_TIMEOUT_IFACE_RESTART_REQUEST)                                        \
+    ERROR_CODE(BPL_ERR_SLAVE_MASTER_KEEP_ALIVE_TIMEOUT)                                            \
+    ERROR_CODE(BPL_ERR_SLAVE_INVALID_MASTER_SOCKET)                                                \
+    ERROR_CODE(BPL_ERR_SLAVE_IFACE_CHANGE_STATE_FAILED)                                            \
+    ERROR_CODE(BPL_ERR_SLAVE_IFACE_RESTORE_FAILED)                                                 \
+    ERROR_CODE(BPL_ERR_SLAVE_WIFI_CREDENTIALS_SET_FAILED)                                          \
+    ERROR_CODE(BPL_ERR_SLAVE_POST_INIT_CONFIG_FAILED)                                              \
+    ERROR_CODE(BPL_ERR_SLAVE_TX_CHANGE_STATE_FAILED)                                               \
+    ERROR_CODE(BPL_ERR_SLAVE_UPDATE_CREDENTIALS_FAILED)                                            \
+    ERROR_CODE(BPL_ERR_SLAVE_FAILED_CONNECT_TO_PLATFORM_MANAGER)                                   \
+    ERROR_CODE(BPL_ERR_SLAVE_PLATFORM_MANAGER_REGISTER_TIMEOUT)                                    \
+    ERROR_CODE(BPL_ERR_SLAVE_SLAVE_BACKHAUL_MANAGER_DISCONNECTED)                                  \
+    ERROR_CODE(BPL_ERR_SLAVE_STOPPED)                                                              \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_START)                                                           \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_DISCONNECTED)                                                    \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_HOSTAP_DISABLED)                                                 \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_ATTACH_FAIL)                                                     \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_SUDDEN_DETACH)                                                   \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_HAL_DISCONNECTED)                                                \
+    ERROR_CODE(BPL_ERR_AP_MANAGER_CAC_TIMEOUT)                                                     \
+    ERROR_CODE(BPL_ERR_MONITOR_DISCONNECTED)                                                       \
+    ERROR_CODE(BPL_ERR_MONITOR_HOSTAP_DISABLED)                                                    \
+    ERROR_CODE(BPL_ERR_MONITOR_ATTACH_FAIL)                                                        \
+    ERROR_CODE(BPL_ERR_MONITOR_SUDDEN_DETACH)                                                      \
+    ERROR_CODE(BPL_ERR_MONITOR_HAL_DISCONNECTED)                                                   \
+    ERROR_CODE(BPL_ERR_MONITOR_REPORT_PROCESS_FAIL)                                                \
+    ERROR_CODE(BPL_ERR_CONFIG_PLATFORM_REPORTED_INVALID_CONFIGURATION)                             \
+    ERROR_CODE(BPL_ERR_CONFIG_BACKHAUL_WIRED_INTERFACE_IS_UNSUPPORTED)                             \
+    ERROR_CODE(BPL_ERR_CONFIG_BACKHAUL_WIRELESS_INTERFACE_IS_UNSUPPORTED)                          \
+    ERROR_CODE(BPL_ERR_CONFIG_NO_VALID_BACKHAUL_INTERFACE)                                         \
+    ERROR_CODE(BPL_ERR_CONFIG_BRIDGE_INTERFACE_IS_EMPTY)                                           \
+    ERROR_CODE(BPL_ERR_WIFI_CONFIGURATION_CHANGE_TIMEOUT)                                          \
+    ERROR_CODE(BPL_ERR_WATCHDOG_PROCESS_STUCK)                                                     \
+    ERROR_CODE(BPL_ERR_WATCHDOG_PROCESS_ZOMBIE)                                                    \
+    ERROR_CODE(BPL_ERR_LAST)
 
 // States ENUM
 enum eErrorCode { FOREACH_ERROR_CODE(GENERATE_ERROR_ENUM) };

--- a/framework/platform/bpl/linux/bpl_arp.cpp
+++ b/framework/platform/bpl/linux/bpl_arp.cpp
@@ -17,7 +17,7 @@
 
 using namespace beerocks::bpl;
 
-int bpl_arp_mon_start(BPL_ARP_MON_CTX *ctx, const char *iface) { return 0; }
+int bpl_arp_mon_start(BPL_ARP_MON_CTX *ctx, const char *iface) { return -2; }
 
 int bpl_arp_mon_stop(BPL_ARP_MON_CTX ctx) { return 0; }
 

--- a/framework/platform/bpl/linux/bpl_dhcp_mon.c
+++ b/framework/platform/bpl/linux/bpl_dhcp_mon.c
@@ -8,7 +8,7 @@
 
 #include <bpl/bpl_dhcp.h>
 
-int bpl_dhcp_mon_start(bpl_dhcp_mon_cb cb) { return -1; }
+int bpl_dhcp_mon_start(bpl_dhcp_mon_cb cb) { return -2; }
 
 int bpl_dhcp_mon_handle_event() { return 0; }
 


### PR DESCRIPTION
Remove hard coded #ifdefs which doesn't start arp and dhcp monitors when
the BPL backend is Linux, where arp and dhcp monitors are not
implemented.
Instead, update the init_arp_monitor and init_dhcp_monitor functions to
return true if the BPL backend does not support monitoring.

While at it, also make dummy BWL available for non Linux platforms. This is useful in cases where initial bringup on a different OS (UGW, OpenWRT, etc.) should be done without WLAN bring up, and integration of the BWL can come later, like what will be done for the Nighthawk (RAX40) platform.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>