### PR TITLE
Bugfix/ TLVF: empty class member initialization

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/BaseClass.h
@@ -31,6 +31,7 @@ public:
 
     size_t getLen();
     bool isInitialized();
+    virtual bool isPostInitSucceeded() { return true; };
     virtual void class_swap() = 0;
 
 protected:
@@ -39,7 +40,7 @@ protected:
     const size_t m_buff_len__;
     const bool m_parse__;
     const bool m_swap__;
-    bool m_init_succeeded;
+    bool m_init_succeeded = false;
     static const size_t kMinimumLength = 3; // tlv header length
 };
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
@@ -88,6 +88,7 @@ class tlvWscM1 : public BaseClass
         WSC::sWscAttrDevicePasswordID& device_password_id_attr();
         WSC::sWscAttrConfigurationError& configuration_error_attr();
         WSC::sWscAttrOsVersion& os_version_attr();
+        bool isPostInitSucceeded();
         std::shared_ptr<WSC::cWscVendorExtWfa> create_vendor_ext();
         bool add_vendor_ext(std::shared_ptr<WSC::cWscVendorExtWfa> ptr);
         std::shared_ptr<WSC::cWscVendorExtWfa> vendor_ext() { return m_vendor_ext_ptr; }
@@ -138,6 +139,7 @@ class tlvWscM1 : public BaseClass
         WSC::sWscAttrOsVersion* m_os_version_attr = nullptr;
         WSC::cWscVendorExtWfa *m_vendor_ext = nullptr;
         std::shared_ptr<WSC::cWscVendorExtWfa> m_vendor_ext_ptr = nullptr;
+        bool m_vendor_ext_init = false;
         bool m_lock_allocation__ = false;
 };
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
@@ -88,6 +88,7 @@ class tlvWscM2 : public BaseClass
         WSC::sWscAttrDevicePasswordID& device_password_id_attr();
         WSC::sWscAttrOsVersion& os_version_attr();
         WSC::sWscAttrVersion2& version2_attr();
+        bool isPostInitSucceeded();
         std::shared_ptr<WSC::cWscAttrEncryptedSettings> create_encrypted_settings();
         bool add_encrypted_settings(std::shared_ptr<WSC::cWscAttrEncryptedSettings> ptr);
         std::shared_ptr<WSC::cWscAttrEncryptedSettings> encrypted_settings() { return m_encrypted_settings_ptr; }
@@ -139,6 +140,7 @@ class tlvWscM2 : public BaseClass
         WSC::sWscAttrVersion2* m_version2_attr = nullptr;
         WSC::cWscAttrEncryptedSettings *m_encrypted_settings = nullptr;
         std::shared_ptr<WSC::cWscAttrEncryptedSettings> m_encrypted_settings_ptr = nullptr;
+        bool m_encrypted_settings_init = false;
         bool m_lock_allocation__ = false;
         WSC::sWscAttrAuthenticator* m_authenticator = nullptr;
 };

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -51,6 +51,9 @@ class tlvTestVarList : public BaseClass
         std::shared_ptr<cInner> create_var1();
         bool add_var1(std::shared_ptr<cInner> ptr);
         std::shared_ptr<cInner> var1() { return m_var1_ptr; }
+        std::shared_ptr<cInner> create_var3();
+        bool add_var3(std::shared_ptr<cInner> ptr);
+        std::shared_ptr<cInner> var3() { return m_var3_ptr; }
         uint32_t& var2();
         size_t unknown_length_list_length();
         std::tuple<bool, cInner&> unknown_length_list(size_t idx);
@@ -79,6 +82,9 @@ class tlvTestVarList : public BaseClass
         cInner *m_var1 = nullptr;
         std::shared_ptr<cInner> m_var1_ptr = nullptr;
         bool m_var1_init = false;
+        cInner *m_var3 = nullptr;
+        std::shared_ptr<cInner> m_var3_ptr = nullptr;
+        bool m_var3_init = false;
         uint32_t* m_var2 = nullptr;
         cInner* m_unknown_length_list = nullptr;
         size_t m_unknown_length_list_idx__ = 0;

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -47,6 +47,7 @@ class tlvTestVarList : public BaseClass
         std::tuple<bool, cInner&> complex_list(size_t idx);
         std::shared_ptr<cInner> create_complex_list();
         bool add_complex_list(std::shared_ptr<cInner> ptr);
+        bool isPostInitSucceeded();
         std::shared_ptr<cInner> create_var1();
         bool add_var1(std::shared_ptr<cInner> ptr);
         std::shared_ptr<cInner> var1() { return m_var1_ptr; }
@@ -77,6 +78,7 @@ class tlvTestVarList : public BaseClass
         bool m_lock_allocation__ = false;
         cInner *m_var1 = nullptr;
         std::shared_ptr<cInner> m_var1_ptr = nullptr;
+        bool m_var1_init = false;
         uint32_t* m_var2 = nullptr;
         cInner* m_unknown_length_list = nullptr;
         size_t m_unknown_length_list_idx__ = 0;

--- a/framework/tlvf/AutoGenerated/src/BaseClass.cpp
+++ b/framework/tlvf/AutoGenerated/src/BaseClass.cpp
@@ -13,7 +13,7 @@
 
 BaseClass::BaseClass(uint8_t *buff, const size_t buff_len, const bool parse, const bool swap_needed)
     : m_buff__(buff), m_buff_ptr__(buff), m_buff_len__(buff_len), m_parse__(parse),
-      m_swap__(swap_needed), m_init_succeeded(false)
+      m_swap__(swap_needed)
 {
 }
 BaseClass::~BaseClass() {}

--- a/framework/tlvf/AutoGenerated/src/CmduMessageTx.cpp
+++ b/framework/tlvf/AutoGenerated/src/CmduMessageTx.cpp
@@ -88,6 +88,10 @@ bool CmduMessageTx::finalize(bool swap_needed)
 
     // Update vendor specific length which is seperated to 3 classes
     for (auto class_it = m_class_vector.begin(); class_it != m_class_vector.end(); class_it++) {
+        if(!(*class_it)->isPostInitSucceeded()){
+            TLVF_LOG(ERROR) << "TLV post init failed";
+            return false;
+        }
         // Type is the first byte in the tlv buffer
         uint8_t tlv_type = *(*class_it)->getStartBuffPtr();
         if (tlv_type == uint8_t(eTlvType::TLV_VENDOR_SPECIFIC)) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -465,6 +465,14 @@ WSC::sWscAttrOsVersion& tlvWscM1::os_version_attr() {
     return (WSC::sWscAttrOsVersion&)(*m_os_version_attr);
 }
 
+bool tlvWscM1::isPostInitSucceeded() {
+    if (!m_vendor_ext_init) {
+        TLVF_LOG(ERROR) << "vendor_ext is not initialized";
+        return false;
+    }
+    return true; 
+}
+
 std::shared_ptr<WSC::cWscVendorExtWfa> tlvWscM1::create_vendor_ext() {
     if (m_lock_order_counter__ > 5) {
         TLVF_LOG(ERROR) << "Out of order allocation for variable length list vendor_ext, abort!";
@@ -504,6 +512,7 @@ bool tlvWscM1::add_vendor_ext(std::shared_ptr<WSC::cWscVendorExtWfa> ptr) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer";
         return false;
     }
+    m_vendor_ext_init = true;
     size_t len = ptr->getLen();
     m_vendor_ext_ptr = ptr;
     if (!buffPtrIncrementSafe(len)) { return false; }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -475,6 +475,14 @@ WSC::sWscAttrVersion2& tlvWscM2::version2_attr() {
     return (WSC::sWscAttrVersion2&)(*m_version2_attr);
 }
 
+bool tlvWscM2::isPostInitSucceeded() {
+    if (!m_encrypted_settings_init) {
+        TLVF_LOG(ERROR) << "encrypted_settings is not initialized";
+        return false;
+    }
+    return true; 
+}
+
 std::shared_ptr<WSC::cWscAttrEncryptedSettings> tlvWscM2::create_encrypted_settings() {
     if (m_lock_order_counter__ > 5) {
         TLVF_LOG(ERROR) << "Out of order allocation for variable length list encrypted_settings, abort!";
@@ -515,6 +523,7 @@ bool tlvWscM2::add_encrypted_settings(std::shared_ptr<WSC::cWscAttrEncryptedSett
         TLVF_LOG(ERROR) << "Not enough available space on buffer";
         return false;
     }
+    m_encrypted_settings_init = true;
     size_t len = ptr->getLen();
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len - ptr->get_initial_size());
     m_encrypted_settings_ptr = ptr;

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -225,6 +225,14 @@ bool tlvTestVarList::add_complex_list(std::shared_ptr<cInner> ptr) {
     return true;
 }
 
+bool tlvTestVarList::isPostInitSucceeded() {
+    if (!m_var1_init) {
+        TLVF_LOG(ERROR) << "var1 is not initialized";
+        return false;
+    }
+    return true; 
+}
+
 std::shared_ptr<cInner> tlvTestVarList::create_var1() {
     if (m_lock_order_counter__ > 3) {
         TLVF_LOG(ERROR) << "Out of order allocation for variable length list var1, abort!";
@@ -266,6 +274,7 @@ bool tlvTestVarList::add_var1(std::shared_ptr<cInner> ptr) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer";
         return false;
     }
+    m_var1_init = true;
     size_t len = ptr->getLen();
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len - ptr->get_initial_size());
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len - ptr->get_initial_size());

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -28,6 +28,7 @@ public:
 
     size_t getLen();
     bool isInitialized();
+    virtual bool isPostInitSucceeded() { return true; };
     virtual void class_swap() = 0;
 
 protected:
@@ -36,7 +37,7 @@ protected:
     const size_t m_buff_len__;
     const bool m_parse__;
     const bool m_swap__;
-    bool m_init_succeeded;
+    bool m_init_succeeded = false;
     static const size_t kMinimumLength = 3; // tlv header length
 };
 

--- a/framework/tlvf/src/src/BaseClass.cpp
+++ b/framework/tlvf/src/src/BaseClass.cpp
@@ -10,7 +10,7 @@
 
 BaseClass::BaseClass(uint8_t *buff, const size_t buff_len, const bool parse, const bool swap_needed)
     : m_buff__(buff), m_buff_ptr__(buff), m_buff_len__(buff_len), m_parse__(parse),
-      m_swap__(swap_needed), m_init_succeeded(false)
+      m_swap__(swap_needed)
 {
 }
 BaseClass::~BaseClass() {}

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -85,6 +85,10 @@ bool CmduMessageTx::finalize(bool swap_needed)
 
     // Update vendor specific length which is seperated to 3 classes
     for (auto class_it = m_class_vector.begin(); class_it != m_class_vector.end(); class_it++) {
+        if(!(*class_it)->isPostInitSucceeded()){
+            TLVF_LOG(ERROR) << "TLV post init failed";
+            return false;
+        }
         // Type is the first byte in the tlv buffer
         uint8_t tlv_type = *(*class_it)->getStartBuffPtr();
         if (tlv_type == uint8_t(eTlvType::TLV_VENDOR_SPECIFIC)) {

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -303,7 +303,10 @@ int test_parser()
     // tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
-    msg.finalize(true);
+    if (!msg.finalize(true)) {
+        LOG(ERROR) << "Finalize step failed";
+        errors++;
+    }
 
     LOG(DEBUG) << "TX: " << std::endl << utils::dump_buffer(tx_buffer, msg.getMessageLength());
 

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -300,7 +300,7 @@ int test_parser()
     tlv3->add_vendor_ext(tlv3->create_vendor_ext());
     auto tlv4 = msg.addClass<tlvTestVarList>();
     // TODO https://github.com/prplfoundation/prplMesh/issues/480
-    // tlv4->add_var1(tlv4->create_var1());
+    tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
     if (!msg.finalize(true)) {

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -300,7 +300,7 @@ int test_parser()
     tlv3->add_vendor_ext(tlv3->create_vendor_ext());
     auto tlv4 = msg.addClass<tlvTestVarList>();
     // TODO https://github.com/prplfoundation/prplMesh/issues/480
-    tlv4->add_var1(tlv4->create_var1());
+    // tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
     msg.finalize(true);

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -140,11 +140,21 @@ int test_complex_list()
         errors++;
     }
 
+    cmplx         = fourthTlv->create_var3();
+    cmplx->var1() = 0xb11b;
+    if (!fourthTlv->add_var3(cmplx)) {
+        LOG(ERROR) << "Failed to add var3";
+        errors++;
+    }
+
     LOG(DEBUG) << "TLV 4 length " << fourthTlv->length();
 
     LOG(DEBUG) << "Finalize";
     //MANDATORY - swaps to little indian.
-    msg.finalize(true);
+    if (!msg.finalize(true)) {
+        LOG(ERROR) << "Finalize step failed";
+        errors++;
+    }
 
     LOG(DEBUG) << "TX: " << std::endl << utils::dump_buffer(tx_buffer, msg.getMessageLength());
 
@@ -302,6 +312,13 @@ int test_parser()
     // TODO https://github.com/prplfoundation/prplMesh/issues/480
     tlv4->add_var1(tlv4->create_var1());
 
+    LOG(DEBUG) << "Finalize";
+    if (msg.finalize(true)) {
+        LOG(ERROR) << "Finalize should fail since the CMDU is not fully initialized";
+        errors++;
+    }
+
+    tlv4->add_var3(tlv4->create_var3());
     LOG(DEBUG) << "Finalize";
     if (!msg.finalize(true)) {
         LOG(ERROR) << "Finalize step failed";
@@ -509,6 +526,18 @@ int test_all()
         errors++;
     }
 
+    cmplx         = fourthTlv->create_var3();
+    cmplx->var1() = 0xeeee;
+
+    if (!fourthTlv->add_var3(cmplx)) {
+        LOG(ERROR) << "Failed to add var3";
+        errors++;
+    }
+    if (fourthTlv->add_var3(cmplx)) {
+        LOG(ERROR) << "Could add var3 a second time";
+        errors++;
+    }
+
     LOG(DEBUG) << "TLV 4 length " << fourthTlv->length();
     auto unknown    = fourthTlv->create_unknown_length_list();
     unknown->var1() = 0xbbbbaaaa;
@@ -521,7 +550,10 @@ int test_all()
 
     LOG(DEBUG) << "Finalize";
     //MANDATORY - swaps to little indian.
-    msg.finalize(true);
+    if (!msg.finalize(true)) {
+        LOG(ERROR) << "Finalize step failed";
+        errors++;
+    }
 
     LOG(DEBUG) << "TX: " << std::endl << utils::dump_buffer(tx_buffer, msg.getMessageLength());
 

--- a/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
+++ b/framework/tlvf/yaml/tlvf/test/tlvVarList.yaml
@@ -31,6 +31,7 @@ tlvTestVarList:
     _length: [ complex_list_length ]
 
   var1: cInner
+  var3: cInner
   var2: uint32_t
   unknown_length_list:
     _type: cInner


### PR DESCRIPTION
When a TLV contains a class member (lets call it var1), since it might
contain a variable-length/unknown-length lists, its its init() function
doesn't create var1 when it is first created in a CmduMessageTx (m_parse == false).

However, when the same TLV is created in a CmduMessageRx (m_parse == true),
var1 is created automatically by the init() function since its length is
already known.

Due to this, when creating a CmduMessageTx containing a class member, the
caller needs to create-add it even if it is not used.

In the next commits, Finalize will fail with a clear
error message if any TLV inside the CMDU is not fully initialized.

In order to illustrate the situation of an error case, remove the
manually adding of var1, and change the finalize() to fail if not each of the members of the type class in TLV is fully initialized

Fixes #480 