### PR TITLE
build: cmake: remove -DDEBUG

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -80,8 +80,6 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -z noexecstack -z relro -z now -pie")
-else()
-    add_definitions(-DDEBUG)
 endif()
 
 message(STATUS "Build Type=${CMAKE_BUILD_TYPE}")

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -31,8 +31,6 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -z noexecstack -z relro -z now -pie")
-else()
-    add_definitions(-DDEBUG)
 endif()
 message("-- Build Type=${CMAKE_BUILD_TYPE}")
 


### PR DESCRIPTION
Remove -DDEBUG from common and framework CMakeLists.txt since it
is not used, and since it clashes with other DEBUG macros defined
in the UCI BPL when compiling for RDKB or UGW.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>