### PR TITLE
cmake: allow any hostapd variant

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -44,7 +44,7 @@ elseif(TARGET_PLATFORM STREQUAL "openwrt")
     set(BWL_TYPE "NL80211")
 
     # hostapd directory
-    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd-full*/hostapd-*")
+    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd*/hostapd-*")
     find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS "${HOSTAPD_SEARCH_PATHS}" NO_CMAKE_FIND_ROOT_PATH)
     set(HOSTAPD_DIR "${HOSTAPD_INCLUDE_DIR}")
 


### PR DESCRIPTION
When building with OpenWRT, it's possible to use different variant of
hostapd: hostapd, hostapd-full, hostapd-mini, and so on.

This commit makes it possible to use those different variants, and not
only hostapd-full.