### PR TITLE
Hotfix/fix nl80211 compilation

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -44,7 +44,7 @@ elseif(TARGET_PLATFORM STREQUAL "openwrt")
     set(BWL_TYPE "NL80211")
 
     # hostapd directory
-    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd-full*/hostapd-*")
+    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd*/hostapd-*")
     find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS "${HOSTAPD_SEARCH_PATHS}" NO_CMAKE_FIND_ROOT_PATH)
     set(HOSTAPD_DIR "${HOSTAPD_INCLUDE_DIR}")
 

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -153,7 +153,7 @@ bool ap_wlan_hal_nl80211::sta_allow(const std::string &mac)
     return true;
 }
 
-bool ap_wlan_hal_nl80211::sta_deny(const std::string &mac, int reject_sta)
+bool ap_wlan_hal_nl80211::sta_deny(const std::string &mac)
 {
     LOG(TRACE) << __func__ << " mac: " << mac;
 

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
@@ -38,7 +38,7 @@ public:
     virtual bool set_start_disabled(bool enable, int vap_id = beerocks::IFACE_RADIO_ID) override;
     virtual bool set_channel(int chan, int bw, int center_channel) override;
     virtual bool sta_allow(const std::string &mac) override;
-    virtual bool sta_deny(const std::string &mac, int reject_sta) override;
+    virtual bool sta_deny(const std::string &mac) override;
     virtual bool sta_disassoc(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_deauth(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_bss_steer(const std::string &mac, const std::string &bssid, int chan,


### PR DESCRIPTION
Since commit dfe30fae1e0de29c0acb0f42af3c8ffbbf867ef9 (common: bwl:
move reject status handle to bwl), the reject_sta argument of the
sta_deny function was removed from the base ap_wlan_hal class.

Because it was not removed in the nl80211 implementation, the
compilation currently fails with:
error: 'virtual bool bwl::nl80211::ap_wlan_hal_nl80211::sta_deny(const
     string&, int)' marked 'override', but does not override virtual
     bool sta_deny(const std::string &mac, int reject_sta) override;

Since the current nl80211 implementation of sta_deny makes no use of
reject_sta, remove it.

