### PR TITLE
common: prplmesh_utils.sh fix platform init

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -41,6 +41,8 @@ killall_program() {
 
 platform_init() {
     echo "platform init..."
+    [ -z "$DATA_IFACE" ] && err "DATA_IFACE not set, abort" && exit 1
+    [ -z "$CONTROL_IFACE" ] && err "CONTROL_IFACE not set, abort" && exit 1
     base_mac=46:55:66:77
     bridge_ip=192.168.100.140
     control_ip=192.168.250.140
@@ -65,6 +67,8 @@ platform_init() {
 
 platform_deinit() {
     echo "platform deinit"
+    [ -z "$DATA_IFACE" ] && err "DATA_IFACE not set, abort" && exit 1
+    [ -z "$CONTROL_IFACE" ] && err "CONTROL_IFACE not set, abort" && exit 1
     for iface in wlan0 wlan2 @BEEROCKS_BH_WIRE_IFACE@ $DATA_IFACE
     do
         echo "remove $iface from @BEEROCKS_BRIDGE_IFACE@"
@@ -262,8 +266,8 @@ main() {
 VERBOSE=false
 PLATFORM_INIT=@BEEROCKS_PLATFORM_INIT@
 DELETE_LOGS=false
-CONTROL_IFACE=enp0s25
-DATA_IFACE=enx00ee22aa28ef
+CONTROL_IFACE=
+DATA_IFACE=
 PRPLMESH_MODE="CA" # CA = Controller & Agent, A = Agent only, C = Controller only
 
 # Export MultiAP libs folder

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -207,11 +207,11 @@ status_function() {
 }
 
 usage() {
-    echo "usage: $(basename $0) {start|stop|restart|status} [-hvsmdCD]"
+    echo "usage: $(basename $0) {start|stop|restart|status} [-hvpmdCD]"
 }
 
 main() {
-    OPTS=`getopt -o 'hvm:sdC:D:' --long verbose,help,mode:skip-platform,delete-logs,iface-ctrl,iface-data -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvm:pdC:D:' --long verbose,help,mode:platform-init,delete-logs,iface-ctrl,iface-data -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -222,7 +222,7 @@ main() {
             -v | --verbose)       VERBOSE=true; shift ;;
             -h | --help)          usage; exit 0; shift ;;
             -m | --mode)          PRPLMESH_MODE="$2"; shift; shift ;;
-            -s | --skip-platform) PLATFORM_INIT=false; shift ;;
+            -p | --platform-init) PLATFORM_INIT=true; shift ;;
             -d | --delete-logs)   DELETE_LOGS=true; shift ;;
             -C | --iface-ctrl)    CONTROL_IFACE="$2"; shift; shift ;;
             -D | --iface-data)    DATA_IFACE="$2"; shift; shift ;;

--- a/tools/docker/runner/start-agent
+++ b/tools/docker/runner/start-agent
@@ -5,5 +5,5 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 ###############################################################
-${INSTALL_DIR}/scripts/prplmesh_utils.sh start -s -m a
+${INSTALL_DIR}/scripts/prplmesh_utils.sh start -m a
 tail -f /dev/null # hack so the script will not exit forcing the container to stop

--- a/tools/docker/runner/start-controller
+++ b/tools/docker/runner/start-controller
@@ -5,5 +5,5 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 ###############################################################
-${INSTALL_DIR}/scripts/prplmesh_utils.sh start -s -m c
+${INSTALL_DIR}/scripts/prplmesh_utils.sh start -m c
 tail -f /dev/null # hack so the script will not exit forcing the container to stop

--- a/tools/docker/runner/start-controller-agent
+++ b/tools/docker/runner/start-controller-agent
@@ -5,5 +5,5 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 ###############################################################
-${INSTALL_DIR}/scripts/prplmesh_utils.sh start -s
+${INSTALL_DIR}/scripts/prplmesh_utils.sh start
 tail -f /dev/null # hack so the script will not exit forcing the container to stop


### PR DESCRIPTION
commit ec20238c set BEEROCKS_PLATFORM_INIT=false by default, which is
fine for most cases except for when running prplmesh controller on a
real laptop / NUC - then we do need the dummy platform init.
For this case, replace the flag in prplmesh_utils.sh from
--skip-platform-init which sets PLATFORM_INIT=false and now can never
change anything to -p | --platform-init which sets PLATFORM_INIT=true.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>