### PR TITLE
bwl: fix cmake find_path for hostapd

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -32,7 +32,7 @@ elseif(TARGET_PLATFORM STREQUAL "openwrt")
 
     # hostapd directory
     file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd*/hostapd-*")
-    find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS "${HOSTAPD_SEARCH_PATHS}" NO_CMAKE_FIND_ROOT_PATH)
+    find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS ${HOSTAPD_SEARCH_PATHS} NO_CMAKE_FIND_ROOT_PATH)
     set(HOSTAPD_DIR "${HOSTAPD_INCLUDE_DIR}")
 
 endif()


### PR DESCRIPTION
When find_path is passed the quoted "${HOSTAPD_SEARCH_PATHS}", it only
finds wpa_ctrl.h if $HOSTAPD_SEARCH_PATHS contains a single path.

Unquote it so that even if multiple hostapd variants are available,
they are searched by find_path.

This change fixes cross-compiling out-of-tree for the Turris Omnia
when multiple hostapd variants have been built.
