### PR TITLE
tools: docker: add agent gdb configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -141,6 +141,25 @@
             ]
         },
         {
+            "name": "(gdb) Launch beerocks_agent",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/../build/install/bin/beerocks_agent",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "(gdb) Launch tlv_test",
             "type": "cppdbg",
             "request": "launch",


### PR DESCRIPTION
Add agent GDB configuration to vscode's launch.json which can be
used to debug the agent from the vscode UI.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>