### PR TITLE
Feature/implement agent topology response

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1770,7 +1770,12 @@ bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cm
         return false;
     }
 
-    if (!tlvSupportedService->alloc_supported_service_list()) {
+    size_t number_of_supported_services = 1;
+    if (local_master) {
+        number_of_supported_services++;
+    }
+
+    if (!tlvSupportedService->alloc_supported_service_list(number_of_supported_services)) {
         LOG(ERROR) << "alloc_supported_service_list failed";
         return false;
     }
@@ -1782,7 +1787,18 @@ bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cm
     }
 
     std::get<1>(supportedServiceTuple) =
-        wfa_map::tlvSupportedService::eSupportedService::MULTI_AP_CONTROLLER;
+        wfa_map::tlvSupportedService::eSupportedService::MULTI_AP_AGENT;
+
+    if (local_master) {
+        auto supportedServiceTuple = tlvSupportedService->supported_service_list(1);
+        if (!std::get<0>(supportedServiceTuple)) {
+            LOG(ERROR) << "Failed accessing supported_service_list";
+            return false;
+        }
+
+        std::get<1>(supportedServiceTuple) =
+            wfa_map::tlvSupportedService::eSupportedService::MULTI_AP_CONTROLLER;
+    }
 
     // TODO: the Operational BSS and Associated Clients TLVs are temporary dummies.
     // later to be updated by real platfrom data from bpl

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -30,6 +30,8 @@
 #include <tlvf/ieee_1905_1/tlvSearchedRole.h>
 #include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
 #include <tlvf/ieee_1905_1/tlvSupportedRole.h>
+#include <tlvf/wfa_map/tlvApOperationalBSS.h>
+#include <tlvf/wfa_map/tlvAssociatedClients.h>
 #include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvSearchedService.h>
 #include <tlvf/wfa_map/tlvSupportedService.h>
@@ -1730,7 +1732,7 @@ bool backhaul_manager::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
         return false;
     }
     case ieee1905_1::eMessageType::TOPOLOGY_QUERY_MESSAGE: {
-        return handle_1905_discovery_query(cmdu_rx);
+        return handle_1905_discovery_query(cmdu_rx, src_mac);
         //LOG(INFO) << "I got the Topology Query message!";
     }
     case ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE: {
@@ -1750,13 +1752,75 @@ bool backhaul_manager::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
  * @return true on success
  * @return false on failure
  */
-bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx)
+bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                                   const std::string &src_mac)
 {
     const auto mid = cmdu_rx.getMessageId();
     LOG(DEBUG) << "Received TOPOLOGY_QUERY_MESSAGE , mid=" << std::dec << int(mid);
-    //TODO - this should be part of the discovery agent, will be done as part of
-    //       agent certification
-    return true;
+    auto cmdu_tx_header = cmdu_tx.create(mid, ieee1905_1::eMessageType::TOPOLOGY_RESPONSE_MESSAGE);
+    if (!cmdu_tx_header) {
+        LOG(ERROR) << "Failed creating topology discovery response header! mid=" << std::hex
+                   << (int)mid;
+        return false;
+    }
+
+    auto tlvSupportedService = cmdu_tx.addClass<wfa_map::tlvSupportedService>();
+    if (!tlvSupportedService) {
+        LOG(ERROR) << "addClass wfa_map::tlvSupportedService failed, mid=" << std::hex << (int)mid;
+        return false;
+    }
+
+    if (!tlvSupportedService->alloc_supported_service_list()) {
+        LOG(ERROR) << "alloc_supported_service_list failed";
+        return false;
+    }
+
+    auto supportedServiceTuple = tlvSupportedService->supported_service_list(0);
+    if (!std::get<0>(supportedServiceTuple)) {
+        LOG(ERROR) << "Failed accessing supported_service_list";
+        return false;
+    }
+
+    std::get<1>(supportedServiceTuple) =
+        wfa_map::tlvSupportedService::eSupportedService::MULTI_AP_CONTROLLER;
+
+    // TODO: the Operational BSS and Associated Clients TLVs are temporary dummies.
+    // later to be updated by real platfrom data from bpl
+    auto tlvApOperationalBSS = cmdu_tx.addClass<wfa_map::tlvApOperationalBSS>();
+    if (!tlvApOperationalBSS) {
+        LOG(ERROR) << "addClass wfa_map::tlvApOperationalBSS failed, mid=" << std::hex << (int)mid;
+        return false;
+    }
+    //add dummy data
+    auto radio_list     = tlvApOperationalBSS->create_radio_list();
+    auto radio_bss_list = radio_list->create_radio_bss_list();
+    radio_bss_list->set_ssid("wlan_0");
+    radio_list->add_radio_bss_list(radio_bss_list);
+    radio_bss_list = radio_list->create_radio_bss_list();
+    radio_bss_list->set_ssid("wlan_2");
+    radio_list->add_radio_bss_list(radio_bss_list);
+    tlvApOperationalBSS->add_radio_list(radio_list);
+
+    auto tlvAssociatedClients = cmdu_tx.addClass<wfa_map::tlvAssociatedClients>();
+    if (!tlvAssociatedClients) {
+        LOG(ERROR) << "addClass wfa_map::tlvAssociatedClients failed, mid=" << std::hex << (int)mid;
+        return false;
+    }
+    auto bss_list   = tlvAssociatedClients->create_bss_list();
+    auto client_1   = bss_list->create_clients_associated_list();
+    client_1->mac() = network_utils::mac_from_string("aa:bb:cc:dd:ee:ff");
+    client_1->time_since_last_association_sec() = 5;
+    bss_list->add_clients_associated_list(client_1);
+    auto client_2   = bss_list->create_clients_associated_list();
+    client_2->mac() = network_utils::mac_from_string("00:11:22:33:44:55");
+    client_2->time_since_last_association_sec() = 1;
+    bss_list->add_clients_associated_list(client_2);
+    tlvAssociatedClients->add_bss_list(bss_list);
+
+    bss_list->bssid() = network_utils::mac_from_string("ab:cd:ef:01:23:45");
+
+    LOG(DEBUG) << "Sending topology response message, mid: " << std::hex << (int)mid;
+    return send_cmdu_to_bus(cmdu_tx, src_mac, bridge_info.mac);
 }
 
 bool backhaul_manager::handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageRx &cmdu_rx,

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -77,7 +77,8 @@ private:
     // 1905 messages handlers
     bool handle_1905_autoconfiguration_response(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                 const std::string &src_mac);
-    bool handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                     const std::string &src_mac);
     bool handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                const std::string &src_mac);
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApOperationalBSS.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApOperationalBSS.h
@@ -1,0 +1,119 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVAPOPERATIONALBSS_H_
+#define _TLVF_WFA_MAP_TLVAPOPERATIONALBSS_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include <tuple>
+#include <vector>
+#include "tlvf/common/sMacAddr.h"
+#include <tlvf/tlvfutils.h>
+
+namespace wfa_map {
+
+class cRadioInfo;
+class cRadioBssInfo;
+
+class tlvApOperationalBSS : public BaseClass
+{
+    public:
+        tlvApOperationalBSS(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApOperationalBSS(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvApOperationalBSS();
+
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        uint8_t& radio_list_length();
+        std::tuple<bool, cRadioInfo&> radio_list(size_t idx);
+        std::shared_ptr<cRadioInfo> create_radio_list();
+        bool add_radio_list(std::shared_ptr<cRadioInfo> ptr);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_radio_list_length = nullptr;
+        cRadioInfo* m_radio_list = nullptr;
+        size_t m_radio_list_idx__ = 0;
+        std::vector<std::shared_ptr<cRadioInfo>> m_radio_list_vector;
+        bool m_lock_allocation__ = false;
+        int m_lock_order_counter__ = 0;
+};
+
+class cRadioInfo : public BaseClass
+{
+    public:
+        cRadioInfo(uint8_t* buff, size_t buff_len, bool parse = false);
+        cRadioInfo(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cRadioInfo();
+
+        sMacAddr& radio_uid();
+        uint8_t& radio_bss_list_length();
+        std::tuple<bool, cRadioBssInfo&> radio_bss_list(size_t idx);
+        std::shared_ptr<cRadioBssInfo> create_radio_bss_list();
+        bool add_radio_bss_list(std::shared_ptr<cRadioBssInfo> ptr);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        sMacAddr* m_radio_uid = nullptr;
+        uint8_t* m_radio_bss_list_length = nullptr;
+        cRadioBssInfo* m_radio_bss_list = nullptr;
+        size_t m_radio_bss_list_idx__ = 0;
+        std::vector<std::shared_ptr<cRadioBssInfo>> m_radio_bss_list_vector;
+        bool m_lock_allocation__ = false;
+        int m_lock_order_counter__ = 0;
+};
+
+class cRadioBssInfo : public BaseClass
+{
+    public:
+        cRadioBssInfo(uint8_t* buff, size_t buff_len, bool parse = false);
+        cRadioBssInfo(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cRadioBssInfo();
+
+        sMacAddr& radio_bssid();
+        uint8_t& ssid_length();
+        std::string ssid_str();
+        char* ssid(size_t length = 0);
+        bool set_ssid(const std::string& str);
+        bool set_ssid(const char buffer[], size_t size);
+        bool alloc_ssid(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        sMacAddr* m_radio_bssid = nullptr;
+        uint8_t* m_ssid_length = nullptr;
+        char* m_ssid = nullptr;
+        size_t m_ssid_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVAPOPERATIONALBSS_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvAssociatedClients.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvAssociatedClients.h
@@ -1,0 +1,110 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVASSOCIATEDCLIENTS_H_
+#define _TLVF_WFA_MAP_TLVASSOCIATEDCLIENTS_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include <tuple>
+#include <vector>
+#include "tlvf/common/sMacAddr.h"
+
+namespace wfa_map {
+
+class cBssInfo;
+class cClientInfo;
+
+class tlvAssociatedClients : public BaseClass
+{
+    public:
+        tlvAssociatedClients(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvAssociatedClients(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvAssociatedClients();
+
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        uint8_t& bss_list_length();
+        std::tuple<bool, cBssInfo&> bss_list(size_t idx);
+        std::shared_ptr<cBssInfo> create_bss_list();
+        bool add_bss_list(std::shared_ptr<cBssInfo> ptr);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_bss_list_length = nullptr;
+        cBssInfo* m_bss_list = nullptr;
+        size_t m_bss_list_idx__ = 0;
+        std::vector<std::shared_ptr<cBssInfo>> m_bss_list_vector;
+        bool m_lock_allocation__ = false;
+        int m_lock_order_counter__ = 0;
+};
+
+class cBssInfo : public BaseClass
+{
+    public:
+        cBssInfo(uint8_t* buff, size_t buff_len, bool parse = false);
+        cBssInfo(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cBssInfo();
+
+        sMacAddr& bssid();
+        uint16_t& clients_associated_list_length();
+        std::tuple<bool, cClientInfo&> clients_associated_list(size_t idx);
+        std::shared_ptr<cClientInfo> create_clients_associated_list();
+        bool add_clients_associated_list(std::shared_ptr<cClientInfo> ptr);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        sMacAddr* m_bssid = nullptr;
+        uint16_t* m_clients_associated_list_length = nullptr;
+        cClientInfo* m_clients_associated_list = nullptr;
+        size_t m_clients_associated_list_idx__ = 0;
+        std::vector<std::shared_ptr<cClientInfo>> m_clients_associated_list_vector;
+        bool m_lock_allocation__ = false;
+        int m_lock_order_counter__ = 0;
+};
+
+class cClientInfo : public BaseClass
+{
+    public:
+        cClientInfo(uint8_t* buff, size_t buff_len, bool parse = false);
+        cClientInfo(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cClientInfo();
+
+        sMacAddr& mac();
+        uint16_t& time_since_last_association_sec();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        sMacAddr* m_mac = nullptr;
+        uint16_t* m_time_since_last_association_sec = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVASSOCIATEDCLIENTS_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApOperationalBSS.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApOperationalBSS.cpp
@@ -1,0 +1,508 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvApOperationalBSS.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvApOperationalBSS::tlvApOperationalBSS(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvApOperationalBSS::tlvApOperationalBSS(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvApOperationalBSS::~tlvApOperationalBSS() {
+}
+const eTlvTypeMap& tlvApOperationalBSS::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvApOperationalBSS::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t& tlvApOperationalBSS::radio_list_length() {
+    return (uint8_t&)(*m_radio_list_length);
+}
+
+std::tuple<bool, cRadioInfo&> tlvApOperationalBSS::radio_list(size_t idx) {
+    bool ret_success = ( (m_radio_list_idx__ > 0) && (m_radio_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, *(m_radio_list_vector[ret_idx]));
+}
+
+std::shared_ptr<cRadioInfo> tlvApOperationalBSS::create_radio_list() {
+    if (m_lock_order_counter__ > 0) {
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list radio_list, abort!";
+        return nullptr;
+    }
+    size_t len = cRadioInfo::get_initial_size();
+    if (m_lock_allocation__ || getBuffRemainingBytes() < len) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return nullptr;
+    }
+    m_lock_order_counter__ = 0;
+    m_lock_allocation__ = true;
+    uint8_t *src = (uint8_t *)m_radio_list;
+    if (m_radio_list_idx__ > 0) {
+        src = (uint8_t *)m_radio_list_vector[m_radio_list_idx__ - 1]->getBuffPtr();
+    }
+    if (!m_parse__) {
+        uint8_t *dst = src + len;
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    return std::make_shared<cRadioInfo>(src, getBuffRemainingBytes(src), m_parse__);
+}
+
+bool tlvApOperationalBSS::add_radio_list(std::shared_ptr<cRadioInfo> ptr) {
+    if (ptr == nullptr) {
+        TLVF_LOG(ERROR) << "Received entry is nullptr";
+        return false;
+    }
+    if (m_lock_allocation__ == false) {
+        TLVF_LOG(ERROR) << "No call to create_radio_list was called before add_radio_list";
+        return false;
+    }
+    uint8_t *src = (uint8_t *)m_radio_list;
+    if (m_radio_list_idx__ > 0) {
+        src = (uint8_t *)m_radio_list_vector[m_radio_list_idx__ - 1]->getBuffPtr();
+    }
+    if (ptr->getStartBuffPtr() != src) {
+        TLVF_LOG(ERROR) << "Received entry pointer is different than expected (expecting the same pointer returned from add method)";
+        return false;
+    }
+    if (ptr->getLen() > getBuffRemainingBytes(ptr->getStartBuffPtr())) {;
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return false;
+    }
+    m_radio_list_idx__++;
+    if (!m_parse__) { (*m_radio_list_length)++; }
+    size_t len = ptr->getLen();
+    m_radio_list_vector.push_back(ptr);
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(!m_parse__ && m_length){ (*m_length) += len; }
+    m_lock_allocation__ = false;
+    return true;
+}
+
+void tlvApOperationalBSS::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    for (size_t i = 0; i < (size_t)*m_radio_list_length; i++){
+        std::get<1>(radio_list(i)).class_swap();
+    }
+}
+
+bool tlvApOperationalBSS::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvApOperationalBSS::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint8_t); // radio_list_length
+    return class_size;
+}
+
+bool tlvApOperationalBSS::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_OPERATIONAL_BSS;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_radio_list_length = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_radio_list_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_radio_list = (cRadioInfo*)m_buff_ptr__;
+    uint8_t radio_list_length = *m_radio_list_length;
+    m_radio_list_idx__ = 0;
+    for (size_t i = 0; i < radio_list_length; i++) {
+        auto radio_list = create_radio_list();
+        if (!radio_list) {
+            TLVF_LOG(ERROR) << "create_radio_list() failed";
+            return false;
+        }
+        if (!add_radio_list(radio_list)) {
+            TLVF_LOG(ERROR) << "add_radio_list() failed";
+            return false;
+        }
+        // swap back since radio_list will be swapped as part of the whole class swap
+        radio_list->class_swap();
+    }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_OPERATIONAL_BSS) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_OPERATIONAL_BSS) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+cRadioInfo::cRadioInfo(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cRadioInfo::cRadioInfo(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cRadioInfo::~cRadioInfo() {
+}
+sMacAddr& cRadioInfo::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
+}
+
+uint8_t& cRadioInfo::radio_bss_list_length() {
+    return (uint8_t&)(*m_radio_bss_list_length);
+}
+
+std::tuple<bool, cRadioBssInfo&> cRadioInfo::radio_bss_list(size_t idx) {
+    bool ret_success = ( (m_radio_bss_list_idx__ > 0) && (m_radio_bss_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, *(m_radio_bss_list_vector[ret_idx]));
+}
+
+std::shared_ptr<cRadioBssInfo> cRadioInfo::create_radio_bss_list() {
+    if (m_lock_order_counter__ > 0) {
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list radio_bss_list, abort!";
+        return nullptr;
+    }
+    size_t len = cRadioBssInfo::get_initial_size();
+    if (m_lock_allocation__ || getBuffRemainingBytes() < len) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return nullptr;
+    }
+    m_lock_order_counter__ = 0;
+    m_lock_allocation__ = true;
+    uint8_t *src = (uint8_t *)m_radio_bss_list;
+    if (m_radio_bss_list_idx__ > 0) {
+        src = (uint8_t *)m_radio_bss_list_vector[m_radio_bss_list_idx__ - 1]->getBuffPtr();
+    }
+    if (!m_parse__) {
+        uint8_t *dst = src + len;
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    return std::make_shared<cRadioBssInfo>(src, getBuffRemainingBytes(src), m_parse__);
+}
+
+bool cRadioInfo::add_radio_bss_list(std::shared_ptr<cRadioBssInfo> ptr) {
+    if (ptr == nullptr) {
+        TLVF_LOG(ERROR) << "Received entry is nullptr";
+        return false;
+    }
+    if (m_lock_allocation__ == false) {
+        TLVF_LOG(ERROR) << "No call to create_radio_bss_list was called before add_radio_bss_list";
+        return false;
+    }
+    uint8_t *src = (uint8_t *)m_radio_bss_list;
+    if (m_radio_bss_list_idx__ > 0) {
+        src = (uint8_t *)m_radio_bss_list_vector[m_radio_bss_list_idx__ - 1]->getBuffPtr();
+    }
+    if (ptr->getStartBuffPtr() != src) {
+        TLVF_LOG(ERROR) << "Received entry pointer is different than expected (expecting the same pointer returned from add method)";
+        return false;
+    }
+    if (ptr->getLen() > getBuffRemainingBytes(ptr->getStartBuffPtr())) {;
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return false;
+    }
+    m_radio_bss_list_idx__++;
+    if (!m_parse__) { (*m_radio_bss_list_length)++; }
+    size_t len = ptr->getLen();
+    m_radio_bss_list_vector.push_back(ptr);
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    m_lock_allocation__ = false;
+    return true;
+}
+
+void cRadioInfo::class_swap()
+{
+    m_radio_uid->struct_swap();
+    for (size_t i = 0; i < (size_t)*m_radio_bss_list_length; i++){
+        std::get<1>(radio_bss_list(i)).class_swap();
+    }
+}
+
+bool cRadioInfo::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cRadioInfo::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(sMacAddr); // radio_uid
+    class_size += sizeof(uint8_t); // radio_bss_list_length
+    return class_size;
+}
+
+bool cRadioInfo::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { m_radio_uid->struct_init(); }
+    m_radio_bss_list_length = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_radio_bss_list_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    m_radio_bss_list = (cRadioBssInfo*)m_buff_ptr__;
+    uint8_t radio_bss_list_length = *m_radio_bss_list_length;
+    m_radio_bss_list_idx__ = 0;
+    for (size_t i = 0; i < radio_bss_list_length; i++) {
+        auto radio_bss_list = create_radio_bss_list();
+        if (!radio_bss_list) {
+            TLVF_LOG(ERROR) << "create_radio_bss_list() failed";
+            return false;
+        }
+        if (!add_radio_bss_list(radio_bss_list)) {
+            TLVF_LOG(ERROR) << "add_radio_bss_list() failed";
+            return false;
+        }
+        // swap back since radio_bss_list will be swapped as part of the whole class swap
+        radio_bss_list->class_swap();
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cRadioBssInfo::cRadioBssInfo(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cRadioBssInfo::cRadioBssInfo(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cRadioBssInfo::~cRadioBssInfo() {
+}
+sMacAddr& cRadioBssInfo::radio_bssid() {
+    return (sMacAddr&)(*m_radio_bssid);
+}
+
+uint8_t& cRadioBssInfo::ssid_length() {
+    return (uint8_t&)(*m_ssid_length);
+}
+
+std::string cRadioBssInfo::ssid_str() {
+    char *ssid_ = ssid();
+    if (!ssid_) { return std::string(); }
+    return std::string(ssid_, m_ssid_idx__);
+}
+
+char* cRadioBssInfo::ssid(size_t length) {
+    if( (m_ssid_idx__ <= 0) || (m_ssid_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "ssid length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_ssid);
+}
+
+bool cRadioBssInfo::set_ssid(const std::string& str) { return set_ssid(str.c_str(), str.size()); }
+bool cRadioBssInfo::set_ssid(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_ssid received an empty string.";
+        return false;
+    }
+    if (!alloc_ssid(size)) { return false; }
+    std::copy(str, str + size, m_ssid);
+    return true;
+}
+bool cRadioBssInfo::alloc_ssid(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list ssid, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_ssid[*m_ssid_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_ssid_idx__ += count;
+    *m_ssid_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    return true;
+}
+
+void cRadioBssInfo::class_swap()
+{
+    m_radio_bssid->struct_swap();
+}
+
+bool cRadioBssInfo::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cRadioBssInfo::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(sMacAddr); // radio_bssid
+    class_size += sizeof(uint8_t); // ssid_length
+    return class_size;
+}
+
+bool cRadioBssInfo::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_radio_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { m_radio_bssid->struct_init(); }
+    m_ssid_length = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    m_ssid = (char*)m_buff_ptr__;
+    uint8_t ssid_length = *m_ssid_length;
+    m_ssid_idx__ = ssid_length;
+    if (!buffPtrIncrementSafe(sizeof(char) * (ssid_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (ssid_length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvAssociatedClients.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvAssociatedClients.cpp
@@ -1,0 +1,450 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvAssociatedClients.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvAssociatedClients::tlvAssociatedClients(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvAssociatedClients::tlvAssociatedClients(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvAssociatedClients::~tlvAssociatedClients() {
+}
+const eTlvTypeMap& tlvAssociatedClients::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvAssociatedClients::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t& tlvAssociatedClients::bss_list_length() {
+    return (uint8_t&)(*m_bss_list_length);
+}
+
+std::tuple<bool, cBssInfo&> tlvAssociatedClients::bss_list(size_t idx) {
+    bool ret_success = ( (m_bss_list_idx__ > 0) && (m_bss_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, *(m_bss_list_vector[ret_idx]));
+}
+
+std::shared_ptr<cBssInfo> tlvAssociatedClients::create_bss_list() {
+    if (m_lock_order_counter__ > 0) {
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list bss_list, abort!";
+        return nullptr;
+    }
+    size_t len = cBssInfo::get_initial_size();
+    if (m_lock_allocation__ || getBuffRemainingBytes() < len) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return nullptr;
+    }
+    m_lock_order_counter__ = 0;
+    m_lock_allocation__ = true;
+    uint8_t *src = (uint8_t *)m_bss_list;
+    if (m_bss_list_idx__ > 0) {
+        src = (uint8_t *)m_bss_list_vector[m_bss_list_idx__ - 1]->getBuffPtr();
+    }
+    if (!m_parse__) {
+        uint8_t *dst = src + len;
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    return std::make_shared<cBssInfo>(src, getBuffRemainingBytes(src), m_parse__);
+}
+
+bool tlvAssociatedClients::add_bss_list(std::shared_ptr<cBssInfo> ptr) {
+    if (ptr == nullptr) {
+        TLVF_LOG(ERROR) << "Received entry is nullptr";
+        return false;
+    }
+    if (m_lock_allocation__ == false) {
+        TLVF_LOG(ERROR) << "No call to create_bss_list was called before add_bss_list";
+        return false;
+    }
+    uint8_t *src = (uint8_t *)m_bss_list;
+    if (m_bss_list_idx__ > 0) {
+        src = (uint8_t *)m_bss_list_vector[m_bss_list_idx__ - 1]->getBuffPtr();
+    }
+    if (ptr->getStartBuffPtr() != src) {
+        TLVF_LOG(ERROR) << "Received entry pointer is different than expected (expecting the same pointer returned from add method)";
+        return false;
+    }
+    if (ptr->getLen() > getBuffRemainingBytes(ptr->getStartBuffPtr())) {;
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return false;
+    }
+    m_bss_list_idx__++;
+    if (!m_parse__) { (*m_bss_list_length)++; }
+    size_t len = ptr->getLen();
+    m_bss_list_vector.push_back(ptr);
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(!m_parse__ && m_length){ (*m_length) += len; }
+    m_lock_allocation__ = false;
+    return true;
+}
+
+void tlvAssociatedClients::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    for (size_t i = 0; i < (size_t)*m_bss_list_length; i++){
+        std::get<1>(bss_list(i)).class_swap();
+    }
+}
+
+bool tlvAssociatedClients::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvAssociatedClients::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint8_t); // bss_list_length
+    return class_size;
+}
+
+bool tlvAssociatedClients::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_ASSOCIATED_CLIENTS;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_bss_list_length = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_bss_list_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_bss_list = (cBssInfo*)m_buff_ptr__;
+    uint8_t bss_list_length = *m_bss_list_length;
+    m_bss_list_idx__ = 0;
+    for (size_t i = 0; i < bss_list_length; i++) {
+        auto bss_list = create_bss_list();
+        if (!bss_list) {
+            TLVF_LOG(ERROR) << "create_bss_list() failed";
+            return false;
+        }
+        if (!add_bss_list(bss_list)) {
+            TLVF_LOG(ERROR) << "add_bss_list() failed";
+            return false;
+        }
+        // swap back since bss_list will be swapped as part of the whole class swap
+        bss_list->class_swap();
+    }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_ASSOCIATED_CLIENTS) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_ASSOCIATED_CLIENTS) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+cBssInfo::cBssInfo(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cBssInfo::cBssInfo(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cBssInfo::~cBssInfo() {
+}
+sMacAddr& cBssInfo::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
+uint16_t& cBssInfo::clients_associated_list_length() {
+    return (uint16_t&)(*m_clients_associated_list_length);
+}
+
+std::tuple<bool, cClientInfo&> cBssInfo::clients_associated_list(size_t idx) {
+    bool ret_success = ( (m_clients_associated_list_idx__ > 0) && (m_clients_associated_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, *(m_clients_associated_list_vector[ret_idx]));
+}
+
+std::shared_ptr<cClientInfo> cBssInfo::create_clients_associated_list() {
+    if (m_lock_order_counter__ > 0) {
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list clients_associated_list, abort!";
+        return nullptr;
+    }
+    size_t len = cClientInfo::get_initial_size();
+    if (m_lock_allocation__ || getBuffRemainingBytes() < len) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return nullptr;
+    }
+    m_lock_order_counter__ = 0;
+    m_lock_allocation__ = true;
+    uint8_t *src = (uint8_t *)m_clients_associated_list;
+    if (m_clients_associated_list_idx__ > 0) {
+        src = (uint8_t *)m_clients_associated_list_vector[m_clients_associated_list_idx__ - 1]->getBuffPtr();
+    }
+    if (!m_parse__) {
+        uint8_t *dst = src + len;
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    return std::make_shared<cClientInfo>(src, getBuffRemainingBytes(src), m_parse__);
+}
+
+bool cBssInfo::add_clients_associated_list(std::shared_ptr<cClientInfo> ptr) {
+    if (ptr == nullptr) {
+        TLVF_LOG(ERROR) << "Received entry is nullptr";
+        return false;
+    }
+    if (m_lock_allocation__ == false) {
+        TLVF_LOG(ERROR) << "No call to create_clients_associated_list was called before add_clients_associated_list";
+        return false;
+    }
+    uint8_t *src = (uint8_t *)m_clients_associated_list;
+    if (m_clients_associated_list_idx__ > 0) {
+        src = (uint8_t *)m_clients_associated_list_vector[m_clients_associated_list_idx__ - 1]->getBuffPtr();
+    }
+    if (ptr->getStartBuffPtr() != src) {
+        TLVF_LOG(ERROR) << "Received entry pointer is different than expected (expecting the same pointer returned from add method)";
+        return false;
+    }
+    if (ptr->getLen() > getBuffRemainingBytes(ptr->getStartBuffPtr())) {;
+        TLVF_LOG(ERROR) << "Not enough available space on buffer";
+        return false;
+    }
+    m_clients_associated_list_idx__++;
+    if (!m_parse__) { (*m_clients_associated_list_length)++; }
+    size_t len = ptr->getLen();
+    m_clients_associated_list_vector.push_back(ptr);
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    m_lock_allocation__ = false;
+    return true;
+}
+
+void cBssInfo::class_swap()
+{
+    m_bssid->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_clients_associated_list_length));
+    for (size_t i = 0; i < (size_t)*m_clients_associated_list_length; i++){
+        std::get<1>(clients_associated_list(i)).class_swap();
+    }
+}
+
+bool cBssInfo::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cBssInfo::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(uint16_t); // clients_associated_list_length
+    return class_size;
+}
+
+bool cBssInfo::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { m_bssid->struct_init(); }
+    m_clients_associated_list_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_clients_associated_list_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_clients_associated_list = (cClientInfo*)m_buff_ptr__;
+    uint16_t clients_associated_list_length = *m_clients_associated_list_length;
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&clients_associated_list_length)); }
+    m_clients_associated_list_idx__ = 0;
+    for (size_t i = 0; i < clients_associated_list_length; i++) {
+        auto clients_associated_list = create_clients_associated_list();
+        if (!clients_associated_list) {
+            TLVF_LOG(ERROR) << "create_clients_associated_list() failed";
+            return false;
+        }
+        if (!add_clients_associated_list(clients_associated_list)) {
+            TLVF_LOG(ERROR) << "add_clients_associated_list() failed";
+            return false;
+        }
+        // swap back since clients_associated_list will be swapped as part of the whole class swap
+        clients_associated_list->class_swap();
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cClientInfo::cClientInfo(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cClientInfo::cClientInfo(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cClientInfo::~cClientInfo() {
+}
+sMacAddr& cClientInfo::mac() {
+    return (sMacAddr&)(*m_mac);
+}
+
+uint16_t& cClientInfo::time_since_last_association_sec() {
+    return (uint16_t&)(*m_time_since_last_association_sec);
+}
+
+void cClientInfo::class_swap()
+{
+    m_mac->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_time_since_last_association_sec));
+}
+
+bool cClientInfo::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cClientInfo::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(sMacAddr); // mac
+    class_size += sizeof(uint16_t); // time_since_last_association_sec
+    return class_size;
+}
+
+bool cClientInfo::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { m_mac->struct_init(); }
+    m_time_since_last_association_sec = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -12,6 +12,8 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvApCapability.yaml",
   "tlvf/wfa_map/tlvChannelPreference.yaml",
   "tlvf/wfa_map/tlvSupportedService.yaml",
+  "tlvf/wfa_map/tlvApOperationalBSS.yaml",
+  "tlvf/wfa_map/tlvAssociatedClients.yaml",
   "tlvf/wfa_map/tlvSearchedService.yaml",
   "tlvf/wfa_map/tlvApRadioBasicCapabilities.yaml",
   "tlvf/wfa_map/tlvApRadioIdentifier.yaml",

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApOperationalBSS.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApOperationalBSS.yaml
@@ -13,23 +13,23 @@ tlvApOperationalBSS:
     _type: uint8_t
     _length_var: True
   radio_list:
-    _type: sRadioInfo
+    _type: cRadioInfo
     _length: [ radio_list_length ]
 
-sRadioInfo:
-  _type: struct
+cRadioInfo:
+  _type: class
   radio_uid: sMacAddr
   radio_bss_list_length:
     _type: uint8_t
     _length_var: True
   radio_bss_list:
-    _type: sRadioBssInfo
+    _type: cRadioBssInfo
     _length: [ radio_bss_list_length ]
 
-sRadioBssInfo:
-  _type: struct
+cRadioBssInfo:
+  _type: class
   radio_bssid: sMacAddr
   ssid_length: uint8_t
   ssid:
-    _type: uint8_t
-    _length: []
+    _type: char
+    _length: [ssid_length]

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvAssociatedClients.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvAssociatedClients.yaml
@@ -13,21 +13,21 @@ tlvAssociatedClients:
     _type: uint8_t
     _length_var: True
   bss_list:
-    _type: sBssInfo
+    _type: cBssInfo
     _length: [ bss_list_length ]
 
-sBssInfo:
-  _type: struct
+cBssInfo:
+  _type: class
   bssid: sMacAddr
   clients_associated_list_length:
     _type: uint16_t
     _length_var: True
   clients_associated_list:
-    _type: sClientInfo
+    _type: cClientInfo
     _length: [ clients_associated_list_length ]
 
-sClientInfo:
-  _type: struct
+cClientInfo:
+  _type: class
   mac: sMacAddr
   time_since_last_association_sec: uint16_t
 


### PR DESCRIPTION
## Overview

The last step of test 4.2.1 in the MAUT EasyMesh certification test plan is the Topology Response sent by the MAUT to the controller, this change implements the flow, i.e. sending a topology response message to the controller upon receiving a topology query from it.
Currently the message's contents are mainly filled with dummy data, to be updated later by real platform data.

## Changes

- Update TLVf to generate __AP Operational BSS__ and __Associated Clients__ TLVs
- Add topology _query_ __RX__ handling
- Add topology _reponse_ __TX__ creation
- Send the topology response to bus

## Required future changes and related changes
- Adding real platform data to the response message
- Adding agent test flows, as the current flows are controller-based.
