### PR TITLE
tlvf: remove kMinimumLength from BaseClass

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
@@ -75,7 +75,7 @@ size_t tlvVsClientAssociationEvent::get_initial_size()
 
 bool tlvVsClientAssociationEvent::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -128,7 +128,7 @@ size_t tlvVsClientAssociationControlRequest::get_initial_size()
 
 bool tlvVsClientAssociationControlRequest::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -49,7 +49,7 @@ size_t cACTION_APMANAGER_4ADDR_STA_JOINED::get_initial_size()
 
 bool cACTION_APMANAGER_4ADDR_STA_JOINED::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -97,7 +97,7 @@ size_t cACTION_APMANAGER_JOINED_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_JOINED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -149,7 +149,7 @@ size_t cACTION_APMANAGER_ENABLE_APS_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_ENABLE_APS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -190,7 +190,7 @@ size_t cACTION_APMANAGER_ENABLE_APS_RESPONSE::get_initial_size()
 
 bool cACTION_APMANAGER_ENABLE_APS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -222,7 +222,7 @@ size_t cACTION_APMANAGER_INIT_DONE_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_INIT_DONE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -258,7 +258,7 @@ size_t cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::get_ini
 
 bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -296,7 +296,7 @@ size_t cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::get_in
 
 bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -333,7 +333,7 @@ size_t cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -376,7 +376,7 @@ size_t cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -411,7 +411,7 @@ size_t cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -441,7 +441,7 @@ size_t cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUES
 
 bool cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -477,7 +477,7 @@ size_t cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::get_initial_size(
 
 bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -516,7 +516,7 @@ size_t cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -555,7 +555,7 @@ size_t cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -594,7 +594,7 @@ size_t cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -633,7 +633,7 @@ size_t cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -685,7 +685,7 @@ size_t cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -730,7 +730,7 @@ size_t cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::get_initial_size
 
 bool cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -769,7 +769,7 @@ size_t cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::get_initial_
 
 bool cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -808,7 +808,7 @@ size_t cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -847,7 +847,7 @@ size_t cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -886,7 +886,7 @@ size_t cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -925,7 +925,7 @@ size_t cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -964,7 +964,7 @@ size_t cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1003,7 +1003,7 @@ size_t cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1059,7 +1059,7 @@ size_t cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1104,7 +1104,7 @@ size_t cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1143,7 +1143,7 @@ size_t cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1188,7 +1188,7 @@ size_t cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1230,7 +1230,7 @@ size_t cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1269,7 +1269,7 @@ size_t cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1308,7 +1308,7 @@ size_t cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1352,7 +1352,7 @@ size_t cACTION_APMANAGER_ACK::get_initial_size()
 
 bool cACTION_APMANAGER_ACK::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1393,7 +1393,7 @@ size_t cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1432,7 +1432,7 @@ size_t cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::get_initial_size()
 
 bool cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1471,7 +1471,7 @@ size_t cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_si
 
 bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1510,7 +1510,7 @@ size_t cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::get_initial_size()
 
 bool cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1549,7 +1549,7 @@ size_t cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::get_initial_size()
 
 bool cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1588,7 +1588,7 @@ size_t cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::get_initial_size
 
 bool cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1627,7 +1627,7 @@ size_t cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::get_initial_size
 
 bool cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1660,7 +1660,7 @@ size_t cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::get_initial_size()
 
 bool cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -113,7 +113,7 @@ size_t cACTION_BACKHAUL_REGISTER_REQUEST::get_initial_size()
 
 bool cACTION_BACKHAUL_REGISTER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -162,7 +162,7 @@ size_t cACTION_BACKHAUL_REGISTER_RESPONSE::get_initial_size()
 
 bool cACTION_BACKHAUL_REGISTER_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -194,7 +194,7 @@ size_t cACTION_BACKHAUL_BUSY_NOTIFICATION::get_initial_size()
 
 bool cACTION_BACKHAUL_BUSY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -435,7 +435,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
 
 bool cACTION_BACKHAUL_ENABLE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -507,7 +507,7 @@ size_t cACTION_BACKHAUL_CONNECTED_NOTIFICATION::get_initial_size()
 
 bool cACTION_BACKHAUL_CONNECTED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -545,7 +545,7 @@ size_t cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::get_initial_size()
 
 bool cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -593,7 +593,7 @@ size_t cACTION_BACKHAUL_ENABLE_APS_REQUEST::get_initial_size()
 
 bool cACTION_BACKHAUL_ENABLE_APS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -635,7 +635,7 @@ size_t cACTION_BACKHAUL_ROAM_REQUEST::get_initial_size()
 
 bool cACTION_BACKHAUL_ROAM_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -673,7 +673,7 @@ size_t cACTION_BACKHAUL_ROAM_RESPONSE::get_initial_size()
 
 bool cACTION_BACKHAUL_ROAM_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -705,7 +705,7 @@ size_t cACTION_BACKHAUL_RESET::get_initial_size()
 
 bool cACTION_BACKHAUL_RESET::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -741,7 +741,7 @@ size_t cACTION_BACKHAUL_4ADDR_CONNECTED::get_initial_size()
 
 bool cACTION_BACKHAUL_4ADDR_CONNECTED::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -780,7 +780,7 @@ size_t cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::get_initial_size()
 
 bool cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -819,7 +819,7 @@ size_t cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::get_initial_siz
 
 bool cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -857,7 +857,7 @@ size_t cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::get_initial_size()
 
 bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -896,7 +896,7 @@ size_t cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::get_initial_size()
 
 bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -935,7 +935,7 @@ size_t cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_siz
 
 bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -37,7 +37,7 @@ size_t cACTION_BML_PING_REQUEST::get_initial_size()
 
 bool cACTION_BML_PING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -67,7 +67,7 @@ size_t cACTION_BML_PING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_PING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -97,7 +97,7 @@ size_t cACTION_BML_NW_MAP_REQUEST::get_initial_size()
 
 bool cACTION_BML_NW_MAP_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -190,7 +190,7 @@ size_t cACTION_BML_NW_MAP_RESPONSE::get_initial_size()
 
 bool cACTION_BML_NW_MAP_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -293,7 +293,7 @@ size_t cACTION_BML_NW_MAP_UPDATE::get_initial_size()
 
 bool cACTION_BML_NW_MAP_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -396,7 +396,7 @@ size_t cACTION_BML_STATS_UPDATE::get_initial_size()
 
 bool cACTION_BML_STATS_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -493,7 +493,7 @@ size_t cACTION_BML_EVENTS_UPDATE::get_initial_size()
 
 bool cACTION_BML_EVENTS_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -531,7 +531,7 @@ size_t cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::get_initial_size()
 
 bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -561,7 +561,7 @@ size_t cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::get_initial_size()
 
 bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -591,7 +591,7 @@ size_t cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::get_initial_size()
 
 bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -621,7 +621,7 @@ size_t cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::get_initial_size()
 
 bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -651,7 +651,7 @@ size_t cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -681,7 +681,7 @@ size_t cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -711,7 +711,7 @@ size_t cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::get_initial_size()
 
 bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -741,7 +741,7 @@ size_t cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::get_initial_size()
 
 bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -771,7 +771,7 @@ size_t cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::get_initial_size()
 
 bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -801,7 +801,7 @@ size_t cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::get_initial_size()
 
 bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -831,7 +831,7 @@ size_t cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::get_initial_size()
 
 bool cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -861,7 +861,7 @@ size_t cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::get_initial_size()
 
 bool cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -891,7 +891,7 @@ size_t cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::get_initial_size()
 
 bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -921,7 +921,7 @@ size_t cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::get_initial_size()
 
 bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -956,7 +956,7 @@ size_t cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -993,7 +993,7 @@ size_t cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1030,7 +1030,7 @@ size_t cACTION_BML_SET_CLIENT_ROAMING_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_CLIENT_ROAMING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1062,7 +1062,7 @@ size_t cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1092,7 +1092,7 @@ size_t cACTION_BML_GET_CLIENT_ROAMING_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_CLIENT_ROAMING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1127,7 +1127,7 @@ size_t cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1164,7 +1164,7 @@ size_t cACTION_BML_SET_DFS_REENTRY_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_DFS_REENTRY_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1196,7 +1196,7 @@ size_t cACTION_BML_SET_DFS_REENTRY_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_DFS_REENTRY_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1226,7 +1226,7 @@ size_t cACTION_BML_GET_DFS_REENTRY_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_DFS_REENTRY_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1261,7 +1261,7 @@ size_t cACTION_BML_GET_DFS_REENTRY_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_DFS_REENTRY_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1298,7 +1298,7 @@ size_t cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::get_initia
 
 bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1330,7 +1330,7 @@ size_t cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::get_initi
 
 bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1360,7 +1360,7 @@ size_t cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::get_initia
 
 bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1395,7 +1395,7 @@ size_t cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::get_initi
 
 bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1432,7 +1432,7 @@ size_t cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1464,7 +1464,7 @@ size_t cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1494,7 +1494,7 @@ size_t cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1529,7 +1529,7 @@ size_t cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1566,7 +1566,7 @@ size_t cACTION_BML_SET_IRE_ROAMING_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_IRE_ROAMING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1598,7 +1598,7 @@ size_t cACTION_BML_SET_IRE_ROAMING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_IRE_ROAMING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1628,7 +1628,7 @@ size_t cACTION_BML_GET_IRE_ROAMING_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_IRE_ROAMING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1663,7 +1663,7 @@ size_t cACTION_BML_GET_IRE_ROAMING_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_IRE_ROAMING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1700,7 +1700,7 @@ size_t cACTION_BML_SET_LOAD_BALANCER_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_LOAD_BALANCER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1732,7 +1732,7 @@ size_t cACTION_BML_SET_LOAD_BALANCER_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_LOAD_BALANCER_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1762,7 +1762,7 @@ size_t cACTION_BML_GET_LOAD_BALANCER_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_LOAD_BALANCER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1797,7 +1797,7 @@ size_t cACTION_BML_GET_LOAD_BALANCER_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_LOAD_BALANCER_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1834,7 +1834,7 @@ size_t cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1866,7 +1866,7 @@ size_t cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1896,7 +1896,7 @@ size_t cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1931,7 +1931,7 @@ size_t cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1969,7 +1969,7 @@ size_t cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::get_initial_size()
 
 bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2002,7 +2002,7 @@ size_t cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::get_initial_size()
 
 bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2038,7 +2038,7 @@ size_t cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::get_initial_size()
 
 bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2077,7 +2077,7 @@ size_t cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::get_initial_size()
 
 bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2115,7 +2115,7 @@ size_t cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2154,7 +2154,7 @@ size_t cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2192,7 +2192,7 @@ size_t cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2231,7 +2231,7 @@ size_t cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2269,7 +2269,7 @@ size_t cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2301,7 +2301,7 @@ size_t cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2331,7 +2331,7 @@ size_t cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2366,7 +2366,7 @@ size_t cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2451,7 +2451,7 @@ size_t cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::get_initial_size()
 
 bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2496,7 +2496,7 @@ size_t cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::get_initial_size()
 
 bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2581,7 +2581,7 @@ size_t cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::get_initial_size()
 
 bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2626,7 +2626,7 @@ size_t cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::get_initial_size()
 
 bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2681,7 +2681,7 @@ size_t cACTION_BML_STEERING_SET_GROUP_REQUEST::get_initial_size()
 
 bool cACTION_BML_STEERING_SET_GROUP_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2727,7 +2727,7 @@ size_t cACTION_BML_STEERING_SET_GROUP_RESPONSE::get_initial_size()
 
 bool cACTION_BML_STEERING_SET_GROUP_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2788,7 +2788,7 @@ size_t cACTION_BML_STEERING_CLIENT_SET_REQUEST::get_initial_size()
 
 bool cACTION_BML_STEERING_CLIENT_SET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2837,7 +2837,7 @@ size_t cACTION_BML_STEERING_CLIENT_SET_RESPONSE::get_initial_size()
 
 bool cACTION_BML_STEERING_CLIENT_SET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2874,7 +2874,7 @@ size_t cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::get_initial_size(
 
 bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2912,7 +2912,7 @@ size_t cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::get_initial_size
 
 bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2973,7 +2973,7 @@ size_t cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 
 bool cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3021,7 +3021,7 @@ size_t cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::get_initial_size()
 
 bool cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3071,7 +3071,7 @@ size_t cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::get_initial_size()
 
 bool cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3115,7 +3115,7 @@ size_t cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::get_initial_size()
 
 bool cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3204,7 +3204,7 @@ size_t cACTION_BML_STEERING_EVENTS_UPDATE::get_initial_size()
 
 bool cACTION_BML_STEERING_EVENTS_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3248,7 +3248,7 @@ size_t cACTION_BML_TRIGGER_TOPOLOGY_QUERY::get_initial_size()
 
 bool cACTION_BML_TRIGGER_TOPOLOGY_QUERY::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3293,7 +3293,7 @@ size_t cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::get_initial_size()
 
 bool cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -42,7 +42,7 @@ size_t cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::get_initial_size()
 
 bool cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -79,7 +79,7 @@ size_t cACTION_CLI_ENABLE_LOAD_BALANCER::get_initial_size()
 
 bool cACTION_CLI_ENABLE_LOAD_BALANCER::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -116,7 +116,7 @@ size_t cACTION_CLI_ENABLE_DEBUG::get_initial_size()
 
 bool cACTION_CLI_ENABLE_DEBUG::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -154,7 +154,7 @@ size_t cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::get_initial_size()
 
 bool cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -196,7 +196,7 @@ size_t cACTION_CLI_RESPONSE_INT::get_initial_size()
 
 bool cACTION_CLI_RESPONSE_INT::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -287,7 +287,7 @@ size_t cACTION_CLI_RESPONSE_STR::get_initial_size()
 
 bool cACTION_CLI_RESPONSE_STR::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -343,7 +343,7 @@ size_t cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::get_initial_size()
 
 bool cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -388,7 +388,7 @@ size_t cACTION_CLI_OPTIMAL_PATH_TASK::get_initial_size()
 
 bool cACTION_CLI_OPTIMAL_PATH_TASK::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -427,7 +427,7 @@ size_t cACTION_CLI_LOAD_BALANCER_TASK::get_initial_size()
 
 bool cACTION_CLI_LOAD_BALANCER_TASK::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -460,7 +460,7 @@ size_t cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::get_initial_size()
 
 bool cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -496,7 +496,7 @@ size_t cACTION_CLI_DUMP_NODE_INFO::get_initial_size()
 
 bool cACTION_CLI_DUMP_NODE_INFO::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -547,7 +547,7 @@ size_t cACTION_CLI_PING_SLAVE_REQUEST::get_initial_size()
 
 bool cACTION_CLI_PING_SLAVE_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -596,7 +596,7 @@ size_t cACTION_CLI_PING_ALL_SLAVES_REQUEST::get_initial_size()
 
 bool cACTION_CLI_PING_ALL_SLAVES_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -636,7 +636,7 @@ size_t cACTION_CLI_BACKHAUL_SCAN_RESULTS::get_initial_size()
 
 bool cACTION_CLI_BACKHAUL_SCAN_RESULTS::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -681,7 +681,7 @@ size_t cACTION_CLI_BACKHAUL_ROAM_REQUEST::get_initial_size()
 
 bool cACTION_CLI_BACKHAUL_ROAM_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -729,7 +729,7 @@ size_t cACTION_CLI_CLIENT_ALLOW_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_ALLOW_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -777,7 +777,7 @@ size_t cACTION_CLI_CLIENT_DISALLOW_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_DISALLOW_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -831,7 +831,7 @@ size_t cACTION_CLI_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_DISCONNECT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -886,7 +886,7 @@ size_t cACTION_CLI_CLIENT_BSS_STEER_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_BSS_STEER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -936,7 +936,7 @@ size_t cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -989,7 +989,7 @@ size_t cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1087,7 +1087,7 @@ size_t cACTION_CLI_CLIENT_BEACON_11K_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_BEACON_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1163,7 +1163,7 @@ size_t cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::get_initial_size()
 
 bool cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1216,7 +1216,7 @@ size_t cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::get_initial_size()
 
 bool cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1274,7 +1274,7 @@ size_t cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::get_initial_size()
 
 bool cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1331,7 +1331,7 @@ size_t cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::get_initial_size()
 
 bool cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1375,7 +1375,7 @@ size_t cACTION_CLI_HOSTAP_STATS_MEASUREMENT::get_initial_size()
 
 bool cACTION_CLI_HOSTAP_STATS_MEASUREMENT::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -116,7 +116,7 @@ size_t cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -212,7 +212,7 @@ size_t cACTION_CONTROL_SLAVE_JOINED_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -280,7 +280,7 @@ size_t cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -331,7 +331,7 @@ size_t cACTION_CONTROL_SON_CONFIG_UPDATE::get_initial_size()
 
 bool cACTION_CONTROL_SON_CONFIG_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -416,7 +416,7 @@ size_t cACTION_CONTROL_CONTROLLER_PING_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -505,7 +505,7 @@ size_t cACTION_CONTROL_CONTROLLER_PING_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -594,7 +594,7 @@ size_t cACTION_CONTROL_AGENT_PING_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_AGENT_PING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -683,7 +683,7 @@ size_t cACTION_CONTROL_AGENT_PING_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_AGENT_PING_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -726,7 +726,7 @@ size_t cACTION_CONTROL_ARP_QUERY_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_ARP_QUERY_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -765,7 +765,7 @@ size_t cACTION_CONTROL_ARP_QUERY_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_ARP_QUERY_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -809,7 +809,7 @@ size_t cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -850,7 +850,7 @@ size_t cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -883,7 +883,7 @@ size_t cACTION_CONTROL_BACKHAUL_RESET::get_initial_size()
 
 bool cACTION_CONTROL_BACKHAUL_RESET::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -919,7 +919,7 @@ size_t cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -958,7 +958,7 @@ size_t cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::get_initial_size()
 
 bool cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -997,7 +997,7 @@ size_t cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1036,7 +1036,7 @@ size_t cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1075,7 +1075,7 @@ size_t cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1127,7 +1127,7 @@ size_t cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1172,7 +1172,7 @@ size_t cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1211,7 +1211,7 @@ size_t cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::get_initial_si
 
 bool cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1250,7 +1250,7 @@ size_t cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::get_initi
 
 bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1288,7 +1288,7 @@ size_t cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::get_init
 
 bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1326,7 +1326,7 @@ size_t cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1365,7 +1365,7 @@ size_t cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::get_initi
 
 bool cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1397,7 +1397,7 @@ size_t cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1433,7 +1433,7 @@ size_t cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1471,7 +1471,7 @@ size_t cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1556,7 +1556,7 @@ size_t cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1602,7 +1602,7 @@ size_t cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1641,7 +1641,7 @@ size_t cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1680,7 +1680,7 @@ size_t cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1719,7 +1719,7 @@ size_t cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1758,7 +1758,7 @@ size_t cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1796,7 +1796,7 @@ size_t cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1839,7 +1839,7 @@ size_t cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1880,7 +1880,7 @@ size_t cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1919,7 +1919,7 @@ size_t cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1958,7 +1958,7 @@ size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1997,7 +1997,7 @@ size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2036,7 +2036,7 @@ size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::get_initia
 
 bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2075,7 +2075,7 @@ size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_size
 
 bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2114,7 +2114,7 @@ size_t cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::get_initial_size
 
 bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2153,7 +2153,7 @@ size_t cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2192,7 +2192,7 @@ size_t cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2248,7 +2248,7 @@ size_t cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2293,7 +2293,7 @@ size_t cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2366,7 +2366,7 @@ size_t cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2411,7 +2411,7 @@ size_t cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2450,7 +2450,7 @@ size_t cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2489,7 +2489,7 @@ size_t cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2528,7 +2528,7 @@ size_t cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2567,7 +2567,7 @@ size_t cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2606,7 +2606,7 @@ size_t cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2645,7 +2645,7 @@ size_t cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2684,7 +2684,7 @@ size_t cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2723,7 +2723,7 @@ size_t cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2762,7 +2762,7 @@ size_t cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2801,7 +2801,7 @@ size_t cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2840,7 +2840,7 @@ size_t cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2879,7 +2879,7 @@ size_t cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2918,7 +2918,7 @@ size_t cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::get_initial_
 
 bool cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2957,7 +2957,7 @@ size_t cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -2996,7 +2996,7 @@ size_t cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -3035,7 +3035,7 @@ size_t cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::get_initial_size()
 
 bool cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
@@ -86,7 +86,7 @@ size_t cACTION_HEADER::get_initial_size()
 
 bool cACTION_HEADER::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -42,7 +42,7 @@ size_t cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -74,7 +74,7 @@ size_t cACTION_MONITOR_JOINED_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_JOINED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -110,7 +110,7 @@ size_t cACTION_MONITOR_SON_CONFIG_UPDATE::get_initial_size()
 
 bool cACTION_MONITOR_SON_CONFIG_UPDATE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -149,7 +149,7 @@ size_t cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::get_initial_size()
 
 bool cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -188,7 +188,7 @@ size_t cACTION_MONITOR_ERROR_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_ERROR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -220,7 +220,7 @@ size_t cACTION_MONITOR_ERROR_NOTIFICATION_ACK::get_initial_size()
 
 bool cACTION_MONITOR_ERROR_NOTIFICATION_ACK::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -250,7 +250,7 @@ size_t cACTION_MONITOR_HEARTBEAT_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_HEARTBEAT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -286,7 +286,7 @@ size_t cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -325,7 +325,7 @@ size_t cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -364,7 +364,7 @@ size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -414,7 +414,7 @@ size_t cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -458,7 +458,7 @@ size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::get_initial_size
 
 bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -497,7 +497,7 @@ size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -536,7 +536,7 @@ size_t cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -575,7 +575,7 @@ size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::get_initia
 
 bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -614,7 +614,7 @@ size_t cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::get_initial_size
 
 bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -653,7 +653,7 @@ size_t cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -692,7 +692,7 @@ size_t cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -730,7 +730,7 @@ size_t cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -772,7 +772,7 @@ size_t cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -859,7 +859,7 @@ size_t cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -905,7 +905,7 @@ size_t cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -944,7 +944,7 @@ size_t cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -983,7 +983,7 @@ size_t cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1022,7 +1022,7 @@ size_t cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1061,7 +1061,7 @@ size_t cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1100,7 +1100,7 @@ size_t cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1139,7 +1139,7 @@ size_t cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1178,7 +1178,7 @@ size_t cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1217,7 +1217,7 @@ size_t cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1256,7 +1256,7 @@ size_t cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1295,7 +1295,7 @@ size_t cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1334,7 +1334,7 @@ size_t cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::get_initial_size()
 
 bool cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1373,7 +1373,7 @@ size_t cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::get_initial_size()
 
 bool cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1412,7 +1412,7 @@ size_t cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::get_initial_
 
 bool cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1451,7 +1451,7 @@ size_t cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::get_initial_size()
 
 bool cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -42,7 +42,7 @@ size_t cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::get
 
 bool cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -102,7 +102,7 @@ size_t cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -153,7 +153,7 @@ size_t cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -197,7 +197,7 @@ size_t cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -236,7 +236,7 @@ size_t cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -320,7 +320,7 @@ size_t cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -369,7 +369,7 @@ size_t cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::get_initial_size()
 
 bool cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -408,7 +408,7 @@ size_t cACTION_PLATFORM_ARP_QUERY_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_ARP_QUERY_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -447,7 +447,7 @@ size_t cACTION_PLATFORM_ARP_QUERY_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_ARP_QUERY_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -480,7 +480,7 @@ size_t cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -516,7 +516,7 @@ size_t cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -555,7 +555,7 @@ size_t cACTION_PLATFORM_ONBOARD_SET_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_ONBOARD_SET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -616,7 +616,7 @@ size_t cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -654,7 +654,7 @@ size_t cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -704,7 +704,7 @@ size_t cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -742,7 +742,7 @@ size_t cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -784,7 +784,7 @@ size_t cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -819,7 +819,7 @@ size_t cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -861,7 +861,7 @@ size_t cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -896,7 +896,7 @@ size_t cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -931,7 +931,7 @@ size_t cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -969,7 +969,7 @@ size_t cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1008,7 +1008,7 @@ size_t cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1041,7 +1041,7 @@ size_t cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::get_initial_size()
 
 bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1083,7 +1083,7 @@ size_t cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::get_initial_size()
 
 bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1152,7 +1152,7 @@ size_t cACTION_PLATFORM_ERROR_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_ERROR_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1268,7 +1268,7 @@ size_t cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -1319,7 +1319,7 @@ size_t cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::get_initial_size()
 
 bool cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -212,7 +212,7 @@ size_t cConfigData::get_initial_size()
 
 bool cConfigData::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -367,7 +367,7 @@ size_t cWscAttrEncryptedSettings::get_initial_size()
 
 bool cWscAttrEncryptedSettings::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -485,7 +485,7 @@ size_t cWscVendorExtWfa::get_initial_size()
 
 bool cWscVendorExtWfa::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
@@ -70,7 +70,7 @@ size_t cCmduHeader::get_initial_size()
 
 bool cCmduHeader::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -96,7 +96,7 @@ size_t tlv1905NeighborDevice::get_initial_size()
 
 bool tlv1905NeighborDevice::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -54,7 +54,7 @@ size_t tlvAlMacAddressType::get_initial_size()
 
 bool tlvAlMacAddressType::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -53,7 +53,7 @@ size_t tlvAutoconfigFreqBand::get_initial_size()
 
 bool tlvAutoconfigFreqBand::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -120,7 +120,7 @@ size_t tlvDeviceBridgingCapability::get_initial_size()
 
 bool tlvDeviceBridgingCapability::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -229,7 +229,7 @@ size_t cMacList::get_initial_size()
 
 bool cMacList::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -102,7 +102,7 @@ size_t tlvDeviceInformation::get_initial_size()
 
 bool tlvDeviceInformation::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -48,7 +48,7 @@ size_t tlvEndOfMessage::get_initial_size()
 
 bool tlvEndOfMessage::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -64,7 +64,7 @@ size_t tlvLinkMetricQuery::get_initial_size()
 
 bool tlvLinkMetricQuery::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -53,7 +53,7 @@ size_t tlvLinkMetricResultCode::get_initial_size()
 
 bool tlvLinkMetricResultCode::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -54,7 +54,7 @@ size_t tlvMacAddress::get_initial_size()
 
 bool tlvMacAddress::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -96,7 +96,7 @@ size_t tlvNon1905neighborDeviceList::get_initial_size()
 
 bool tlvNon1905neighborDeviceList::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -96,7 +96,7 @@ size_t tlvPushButtonEventNotification::get_initial_size()
 
 bool tlvPushButtonEventNotification::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -72,7 +72,7 @@ size_t tlvPushButtonJoinNotification::get_initial_size()
 
 bool tlvPushButtonJoinNotification::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -102,7 +102,7 @@ size_t tlvReceiverLinkMetric::get_initial_size()
 
 bool tlvReceiverLinkMetric::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -53,7 +53,7 @@ size_t tlvSearchedRole::get_initial_size()
 
 bool tlvSearchedRole::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -53,7 +53,7 @@ size_t tlvSupportedFreqBand::get_initial_size()
 
 bool tlvSupportedFreqBand::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -53,7 +53,7 @@ size_t tlvSupportedRole::get_initial_size()
 
 bool tlvSupportedRole::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -102,7 +102,7 @@ size_t tlvTransmitterLinkMetric::get_initial_size()
 
 bool tlvTransmitterLinkMetric::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
@@ -83,7 +83,7 @@ size_t tlvUnknown::get_initial_size()
 
 bool tlvUnknown::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -54,7 +54,7 @@ size_t tlvVendorSpecific::get_initial_size()
 
 bool tlvVendorSpecific::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -591,7 +591,7 @@ size_t tlvWscM1::get_initial_size()
 
 bool tlvWscM1::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -609,7 +609,7 @@ size_t tlvWscM2::get_initial_size()
 
 bool tlvWscM2::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -456,7 +456,7 @@ size_t tlvTestVarList::get_initial_size()
 
 bool tlvTestVarList::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -701,7 +701,7 @@ size_t cInner::get_initial_size()
 
 bool cInner::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
@@ -54,7 +54,7 @@ size_t tlvApCapability::get_initial_size()
 
 bool tlvApCapability::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
@@ -106,7 +106,7 @@ size_t tlvApMetric::get_initial_size()
 
 bool tlvApMetric::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
@@ -96,7 +96,7 @@ size_t tlvApMetricQuery::get_initial_size()
 
 bool tlvApMetricQuery::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -131,7 +131,7 @@ size_t tlvApRadioBasicCapabilities::get_initial_size()
 
 bool tlvApRadioBasicCapabilities::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -250,7 +250,7 @@ size_t cOperatingClassesInfo::get_initial_size()
 
 bool cOperatingClassesInfo::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -54,7 +54,7 @@ size_t tlvApRadioIdentifier::get_initial_size()
 
 bool tlvApRadioIdentifier::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -126,7 +126,7 @@ size_t tlvChannelPreference::get_initial_size()
 
 bool tlvChannelPreference::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -244,7 +244,7 @@ size_t cPreferenceOperatingClasses::get_initial_size()
 
 bool cPreferenceOperatingClasses::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
@@ -59,7 +59,7 @@ size_t tlvChannelSelectionResponse::get_initial_size()
 
 bool tlvChannelSelectionResponse::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
@@ -113,7 +113,7 @@ size_t tlvClientAssociationControlRequest::get_initial_size()
 
 bool tlvClientAssociationControlRequest::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
@@ -65,7 +65,7 @@ size_t tlvClientAssociationEvent::get_initial_size()
 
 bool tlvClientAssociationEvent::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -88,7 +88,7 @@ size_t tlvHigherLayerData::get_initial_size()
 
 bool tlvHigherLayerData::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -108,7 +108,7 @@ size_t tlvOperatingChannelReport::get_initial_size()
 
 bool tlvOperatingChannelReport::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -126,7 +126,7 @@ size_t tlvRadioOperationRestriction::get_initial_size()
 
 bool tlvRadioOperationRestriction::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
@@ -244,7 +244,7 @@ size_t cRestrictedOperatingClasses::get_initial_size()
 
 bool cRestrictedOperatingClasses::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -90,7 +90,7 @@ size_t tlvSearchedService::get_initial_size()
 
 bool tlvSearchedService::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
@@ -71,7 +71,7 @@ size_t tlvSteeringBTMReport::get_initial_size()
 
 bool tlvSteeringBTMReport::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
@@ -170,7 +170,7 @@ size_t tlvSteeringRequest::get_initial_size()
 
 bool tlvSteeringRequest::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -90,7 +90,7 @@ size_t tlvSupportedService::get_initial_size()
 
 bool tlvSupportedService::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
@@ -59,7 +59,7 @@ size_t tlvTransmitPowerLimit::get_initial_size()
 
 bool tlvTransmitPowerLimit::init()
 {
-    if (getBuffRemainingBytes() < kMinimumLength) {
+    if (getBuffRemainingBytes() < get_initial_size()) {
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -38,7 +38,6 @@ protected:
     const bool m_parse__;
     const bool m_swap__;
     bool m_init_succeeded = false;
-    static const size_t kMinimumLength = 3; // tlv header length
 };
 
 #endif //_BaseClass_H_

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -355,7 +355,6 @@ class TlvF:
         self.MEMBER_LOCK_ORDER_COUNTER = "lock_order_counter"
         self.MEMBER_BUFF = "buff"
         self.MEMBER_BUFF_PTR = "buff_ptr"
-        self.MEMBER_CONST_MINIMUM_LENGTH = "kMinimumLength"
 
         self.src_path = os.path.abspath(src_path)
         self.yaml_root_path = os.path.abspath(yaml_path)
@@ -1505,7 +1504,7 @@ class TlvF:
 
         self.insertLineCpp(insert_name, insert_marker, "bool %s::init()" % (name))
         self.insertLineCpp(insert_name, insert_marker, "{")
-        self.insertLineCpp(insert_name, insert_marker, "%sif (getBuffRemainingBytes() < %s) {" % (self.getIndentation(1), self.MEMBER_CONST_MINIMUM_LENGTH))
+        self.insertLineCpp(insert_name, insert_marker, "%sif (getBuffRemainingBytes() < get_initial_size()) {" % (self.getIndentation(1)))
         self.insertLineCpp(insert_name, insert_marker, '%sTLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";' %  self.getIndentation(2) )
         self.insertLineCpp(insert_name, insert_marker, "%sreturn false;" % self.getIndentation(2))
         self.insertLineCpp(insert_name, insert_marker, "%s}" % self.getIndentation(1) )


### PR DESCRIPTION
kMinimumLength is 3, and is used to verify that each TLV has at least 3
bytes - 1 byte type, 2 bytes length.
TLVF generates a check for this in the init() function of each class,
even if it is not a TLV class, which verifies that there is "enough"
room in the buffer.
This check is wrong for non TLV classes which may not contain even a
single parameter (many of the VS classes for example), and is wrong also
for TLV classes since it only verifies there is enough room for the TLV
header.
It is even more silly to use it since we have a better API to use -
get_initial_size(), which takes to account not only the TLV header size
but also each class members.

Therefore, delete kMinimumLength and use get_initial_size() instead for
all init() functions.

Since this change is big, a followup commit will produce all the
autogenerated files.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>