### PR TITLE
Bugfix - Client Steering EasyMesh Messages

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -682,9 +682,12 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST failed";
             return false;
         }
+
         std::string sta_mac = network_utils::mac_to_string(request->mac());
-        LOG(DEBUG) << "CLIENT_DISALLOW, mac = " << sta_mac;
-        ap_wlan_hal->sta_deny(sta_mac);
+        std::string bssid   = network_utils::mac_to_string(request->bssid());
+        LOG(DEBUG) << "CLIENT_DISALLOW: mac = " << sta_mac << ", bssid = " << bssid;
+
+        ap_wlan_hal->sta_deny(sta_mac, bssid);
         break;
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_ALLOW_REQUEST: {
@@ -693,11 +696,12 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_ALLOW_REQUEST failed";
             return false;
         }
-        std::string sta_mac = network_utils::mac_to_string(request->mac());
-        LOG(DEBUG) << "CLIENT_ALLOW, mac = " << sta_mac
-                   << ", ip = " << network_utils::ipv4_to_string(request->ipv4());
 
-        ap_wlan_hal->sta_allow(sta_mac);
+        std::string sta_mac = network_utils::mac_to_string(request->mac());
+        std::string bssid   = network_utils::mac_to_string(request->bssid());
+        LOG(DEBUG) << "CLIENT_ALLOW: mac = " << sta_mac << ", bssid = " << bssid;
+
+        ap_wlan_hal->sta_allow(sta_mac, bssid);
         break;
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST: {
@@ -802,9 +806,9 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         std::string target_bssid  = network_utils::mac_to_string(request->params().target.bssid);
         uint8_t disassoc_imminent = request->params().disassoc_imminent;
 
-        LOG(DEBUG) << " CLIENT_BSS_STEER (802.11v) for sta_mac = " << sta_mac
+        LOG(DEBUG) << "CLIENT_BSS_STEER (802.11v) for sta_mac = " << sta_mac
                    << " to bssid = " << target_bssid
-                   << " channel =" << int(request->params().target.channel);
+                   << " channel = " << int(request->params().target.channel);
         ap_wlan_hal->sta_bss_steer(sta_mac, target_bssid, request->params().target.channel,
                                    (disassoc_imminent) ? request->params().disassoc_timer_ms : 0,
                                    (disassoc_imminent) ? bss_steer_imminent_valid_int

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4034,8 +4034,6 @@ bool slave_thread::handle_multi_ap_policy_config_request(Socket *sd,
 
 bool slave_thread::handle_client_association_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
-    //TODO - this is a stub handler for the purpose of controller certification testing,
-    //       will be implemented later on agent certification
     const auto mid = cmdu_rx.getMessageId();
     LOG(DEBUG) << "Received CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE, mid=" << std::dec
                << int(mid);
@@ -4046,14 +4044,9 @@ bool slave_thread::handle_client_association_request(Socket *sd, ieee1905_1::Cmd
         LOG(ERROR) << "addClass wfa_map::tlvClientAssociationControlRequest failed";
         return false;
     }
-    auto sta_mac = std::get<1>(association_control_request_tlv->sta_list(0));
 
-    //Add VS tlv
-    auto vs_tlv =
-        message_com::add_vs_tlv<beerocks_message::tlvVsClientAssociationControlRequest>(cmdu_tx);
-    if (!vs_tlv) {
-        LOG(ERROR) << "add_vs_tlv tlvVsClientAssociationControlRequest failed";
-    }
+    const auto &bssid   = association_control_request_tlv->bssid_to_block_client();
+    const auto &sta_mac = std::get<1>(association_control_request_tlv->sta_list(0));
 
     auto block = association_control_request_tlv->association_control();
     if (block == wfa_map::tlvClientAssociationControlRequest::UNBLOCK) {
@@ -4063,10 +4056,9 @@ bool slave_thread::handle_client_association_request(Socket *sd, ieee1905_1::Cmd
             LOG(ERROR) << "Failed building ACTION_APMANAGER_CLIENT_ALLOW_REQUEST message!";
             return false;
         }
-        if (vs_tlv) {
-            request_out->ipv4() = vs_tlv->ipv4();
-        }
-        request_out->mac() = sta_mac;
+
+        request_out->mac()   = sta_mac;
+        request_out->bssid() = bssid;
     } else if (block == wfa_map::tlvClientAssociationControlRequest::BLOCK) {
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST>(cmdu_tx, mid);
@@ -4074,14 +4066,18 @@ bool slave_thread::handle_client_association_request(Socket *sd, ieee1905_1::Cmd
             LOG(ERROR) << "Failed building ACTION_APMANAGER_CLIENT_DISALLOW_REQUEST message!";
             return false;
         }
-        request_out->mac() = sta_mac;
+
+        request_out->mac()   = sta_mac;
+        request_out->bssid() = bssid;
     }
+
     message_com::send_cmdu(ap_manager_socket, cmdu_tx);
 
     if (!cmdu_tx.create(mid, ieee1905_1::eMessageType::ACK_MESSAGE)) {
         LOG(ERROR) << "cmdu creation of type ACK_MESSAGE, has failed";
         return false;
     }
+
     LOG(DEBUG) << "sending ACK message back to controller";
     return send_cmdu_to_controller(cmdu_tx);
 }

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -130,15 +130,16 @@ bool ap_wlan_hal_dummy::set_start_disabled(bool enable, int vap_id) { return tru
 
 bool ap_wlan_hal_dummy::set_channel(int chan, int bw, int center_channel) { return true; }
 
-bool ap_wlan_hal_dummy::sta_allow(const std::string &mac)
+bool ap_wlan_hal_dummy::sta_allow(const std::string &mac, const std::string &bssid)
 {
-    LOG(DEBUG) << "Got client allow request for " << mac;
+    LOG(DEBUG) << "Got client allow request for " << mac << " on bssid " << bssid;
     return true;
 }
 
-bool ap_wlan_hal_dummy::sta_deny(const std::string &mac)
+bool ap_wlan_hal_dummy::sta_deny(const std::string &mac, const std::string &bssid)
 {
-    LOG(DEBUG) << "Got client disallow request for " << mac << " reject_sta: 33";
+    LOG(DEBUG) << "Got client disallow request for " << mac << " on bssid " << bssid
+               << " reject_sta: 33";
     return true;
 }
 

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
@@ -37,8 +37,8 @@ public:
     virtual bool disable() override;
     virtual bool set_start_disabled(bool enable, int vap_id = beerocks::IFACE_RADIO_ID) override;
     virtual bool set_channel(int chan, int bw = 0, int center_channel = 0) override;
-    virtual bool sta_allow(const std::string &mac) override;
-    virtual bool sta_deny(const std::string &mac) override;
+    virtual bool sta_allow(const std::string &mac, const std::string &bssid) override;
+    virtual bool sta_deny(const std::string &mac, const std::string &bssid) override;
     virtual bool sta_disassoc(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_deauth(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_bss_steer(const std::string &mac, const std::string &bssid, int chan,

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -534,31 +534,43 @@ bool ap_wlan_hal_dwpal::set_channel(int chan, int bw, int center_channel)
     return true;
 }
 
-bool ap_wlan_hal_dwpal::sta_allow(const std::string &mac)
+bool ap_wlan_hal_dwpal::sta_allow(const std::string &mac, const std::string &bssid)
 {
-    // Build command string
-    std::string cmd = "STA_ALLOW " + mac;
+    // Check if the requested BSSID is part of this radio
+    for (const auto &vap : m_radio_info.available_vaps) {
+        if (vap.second.mac == bssid) {
+            // Send the command
+            std::string cmd = "STA_ALLOW " + mac;
+            if (!dwpal_send_cmd(cmd, vap.first)) {
+                LOG(ERROR) << "sta_allow() failed!";
+                return false;
+            }
 
-    // Send command
-    if (!dwpal_send_cmd(cmd)) {
-        LOG(ERROR) << "sta_allow() failed!";
-        return false;
+            return true;
+        }
     }
 
+    // If the requested BSSID is not part of this radio, return silently
     return true;
 }
 
-bool ap_wlan_hal_dwpal::sta_deny(const std::string &mac)
+bool ap_wlan_hal_dwpal::sta_deny(const std::string &mac, const std::string &bssid)
 {
-    // Build command string
-    std::string cmd = "DENY_MAC " + mac + " reject_sta=33";
+    // Check if the requested BSSID is part of this radio
+    for (const auto &vap : m_radio_info.available_vaps) {
+        if (vap.second.mac == bssid) {
+            // Send the command
+            std::string cmd = "DENY_MAC " + mac + " reject_sta=33";
+            if (!dwpal_send_cmd(cmd, vap.first)) {
+                LOG(ERROR) << "sta_allow() failed!";
+                return false;
+            }
 
-    // Send command
-    if (!dwpal_send_cmd(cmd)) {
-        LOG(ERROR) << "sta_deny() failed!";
-        return false;
+            return true;
+        }
     }
 
+    // If the requested BSSID is not part of this radio, return silently
     return true;
 }
 

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
@@ -37,8 +37,8 @@ public:
     virtual bool disable() override;
     virtual bool set_start_disabled(bool enable, int vap_id = beerocks::IFACE_RADIO_ID) override;
     virtual bool set_channel(int chan, int bw = 0, int center_channel = 0) override;
-    virtual bool sta_allow(const std::string &mac) override;
-    virtual bool sta_deny(const std::string &mac) override;
+    virtual bool sta_allow(const std::string &mac, const std::string &bssid) override;
+    virtual bool sta_deny(const std::string &mac, const std::string &bssid) override;
     virtual bool sta_disassoc(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_deauth(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_bss_steer(const std::string &mac, const std::string &bssid, int chan,

--- a/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
@@ -104,19 +104,21 @@ public:
      * Allow the station with the given MAC address to connect.
      *
      * @param [in] mac The MAC address of the station.
+     * @param [in] bssid The BSSID to which the operation is applicable.
      *
      * @return true on success or false on error.
      */
-    virtual bool sta_allow(const std::string &mac) = 0;
+    virtual bool sta_allow(const std::string &mac, const std::string &bssid) = 0;
 
     /*!
      * Deny the station with the given MAC address from connecting to the AP.
      *
      * @param [in] mac The MAC address of the station.        
+     * @param [in] bssid The BSSID to which the operation is applicable.
      * 
      * @return true on success or false on error.
      */
-    virtual bool sta_deny(const std::string &mac) = 0;
+    virtual bool sta_deny(const std::string &mac, const std::string &bssid) = 0;
 
     /*!
      * Disassociate the station with the given MAC address.

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -136,9 +136,9 @@ bool ap_wlan_hal_nl80211::set_channel(int chan, int bw, int center_channel)
     return true;
 }
 
-bool ap_wlan_hal_nl80211::sta_allow(const std::string &mac)
+bool ap_wlan_hal_nl80211::sta_allow(const std::string &mac, const std::string &bssid)
 {
-    LOG(TRACE) << __func__ << " mac: " << mac;
+    LOG(TRACE) << __func__ << " mac: " << mac << ", bssid: " << bssid;
 
     // Build command string
     // We use the DENY_ACL list only
@@ -153,9 +153,9 @@ bool ap_wlan_hal_nl80211::sta_allow(const std::string &mac)
     return true;
 }
 
-bool ap_wlan_hal_nl80211::sta_deny(const std::string &mac)
+bool ap_wlan_hal_nl80211::sta_deny(const std::string &mac, const std::string &bssid)
 {
-    LOG(TRACE) << __func__ << " mac: " << mac;
+    LOG(TRACE) << __func__ << " mac: " << mac << ", bssid: " << bssid;
 
     // Build command string
     // We use the DENY_ACL list only

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
@@ -37,8 +37,8 @@ public:
     virtual bool disable() override;
     virtual bool set_start_disabled(bool enable, int vap_id = beerocks::IFACE_RADIO_ID) override;
     virtual bool set_channel(int chan, int bw, int center_channel) override;
-    virtual bool sta_allow(const std::string &mac) override;
-    virtual bool sta_deny(const std::string &mac) override;
+    virtual bool sta_allow(const std::string &mac, const std::string &bssid) override;
+    virtual bool sta_deny(const std::string &mac, const std::string &bssid) override;
     virtual bool sta_disassoc(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_deauth(int8_t vap_id, const std::string &mac, uint32_t reason = 0) override;
     virtual bool sta_bss_steer(const std::string &mac, const std::string &bssid, int chan,

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_1905_vs.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_1905_vs.h
@@ -61,26 +61,6 @@ class tlvVsClientAssociationEvent : public BaseClass
         uint8_t* m_disconnect_type = nullptr;
 };
 
-class tlvVsClientAssociationControlRequest : public BaseClass
-{
-    public:
-        tlvVsClientAssociationControlRequest(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvVsClientAssociationControlRequest(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
-        ~tlvVsClientAssociationControlRequest();
-
-        static eActionOp_1905_VS get_action_op(){
-            return (eActionOp_1905_VS)(ACTION_TLV_VENDOR_SPECIFIC);
-        }
-        beerocks::net::sIpv4Addr& ipv4();
-        void class_swap();
-        static size_t get_initial_size();
-
-    private:
-        bool init();
-        eActionOp_1905_VS* m_action_op = nullptr;
-        beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
-};
-
 }; // close namespace: beerocks_message
 
 #endif //_BEEROCKS/TLVF_BEEROCKS_MESSAGE_1905_VS_H_

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -590,6 +590,7 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_DISALLOW_REQUEST);
         }
         sMacAddr& mac();
+        sMacAddr& bssid();
         void class_swap();
         static size_t get_initial_size();
 
@@ -597,6 +598,7 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
         sMacAddr* m_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
 };
 
 class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
@@ -610,7 +612,7 @@ class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_ALLOW_REQUEST);
         }
         sMacAddr& mac();
-        beerocks::net::sIpv4Addr& ipv4();
+        sMacAddr& bssid();
         void class_swap();
         static size_t get_initial_size();
 
@@ -618,7 +620,7 @@ class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
         sMacAddr* m_mac = nullptr;
-        beerocks::net::sIpv4Addr* m_ipv4 = nullptr;
+        sMacAddr* m_bssid = nullptr;
 };
 
 class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
@@ -100,43 +100,4 @@ bool tlvVsClientAssociationEvent::init()
     return true;
 }
 
-tlvVsClientAssociationControlRequest::tlvVsClientAssociationControlRequest(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
-    m_init_succeeded = init();
-}
-tlvVsClientAssociationControlRequest::tlvVsClientAssociationControlRequest(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
-    m_init_succeeded = init();
-}
-tlvVsClientAssociationControlRequest::~tlvVsClientAssociationControlRequest() {
-}
-beerocks::net::sIpv4Addr& tlvVsClientAssociationControlRequest::ipv4() {
-    return (beerocks::net::sIpv4Addr&)(*m_ipv4);
-}
-
-void tlvVsClientAssociationControlRequest::class_swap()
-{
-    m_ipv4->struct_swap();
-}
-
-size_t tlvVsClientAssociationControlRequest::get_initial_size()
-{
-    size_t class_size = 0;
-    class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
-    return class_size;
-}
-
-bool tlvVsClientAssociationControlRequest::init()
-{
-    if (getBuffRemainingBytes() < get_initial_size()) {
-        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
-        return false;
-    }
-    m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
-    if (!m_parse__) { m_ipv4->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
-    return true;
-}
-
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1129,15 +1129,21 @@ sMacAddr& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::mac() {
     return (sMacAddr&)(*m_mac);
 }
 
+sMacAddr& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
 void cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::class_swap()
 {
     m_mac->struct_swap();
+    m_bssid->struct_swap();
 }
 
 size_t cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // bssid
     return class_size;
 }
 
@@ -1150,6 +1156,9 @@ bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
     m_mac = (sMacAddr*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!m_parse__) { m_bssid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1168,21 +1177,21 @@ sMacAddr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::mac() {
     return (sMacAddr&)(*m_mac);
 }
 
-beerocks::net::sIpv4Addr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::ipv4() {
-    return (beerocks::net::sIpv4Addr&)(*m_ipv4);
+sMacAddr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::bssid() {
+    return (sMacAddr&)(*m_bssid);
 }
 
 void cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::class_swap()
 {
     m_mac->struct_swap();
-    m_ipv4->struct_swap();
+    m_bssid->struct_swap();
 }
 
 size_t cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sMacAddr); // mac
-    class_size += sizeof(beerocks::net::sIpv4Addr); // ipv4
+    class_size += sizeof(sMacAddr); // bssid
     return class_size;
 }
 
@@ -1195,9 +1204,9 @@ bool cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::init()
     m_mac = (sMacAddr*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
     if (!m_parse__) { m_mac->struct_init(); }
-    m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
-    if (!m_parse__) { m_ipv4->struct_init(); }
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!m_parse__) { m_bssid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_1905_vs.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_1905_vs.yaml
@@ -35,8 +35,3 @@ tlvVsClientAssociationEvent:
   disconnect_type: 
     _type: uint8_t
     _comment: relevant only on disconnect event
-
-
-tlvVsClientAssociationControlRequest:
-  _type: class
-  ipv4: beerocks::net::sIpv4Addr 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -133,11 +133,12 @@ cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE:
 cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST:
   _type: class
   mac: sMacAddr
+  bssid: sMacAddr
 
 cACTION_APMANAGER_CLIENT_ALLOW_REQUEST:
   _type: class
   mac: sMacAddr
-  ipv4: beerocks::net::sIpv4Addr
+  bssid: sMacAddr
 
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
   _type: class

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -283,7 +283,6 @@ void son_management::handle_cli_message(Socket *sd,
         std::string hostap_mac = network_utils::mac_to_string(cli_request->hostap_mac());
         LOG(DEBUG) << "CLI client allow request for " << client_mac << " to " << hostap_mac;
 
-        auto current_ap_mac   = database.get_node_parent(client_mac);
         Socket *hostap_mac_sd = database.get_node_socket(hostap_mac);
         if (!cmdu_tx.create(0,
                             ieee1905_1::eMessageType::CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE)) {
@@ -301,7 +300,7 @@ void son_management::handle_cli_message(Socket *sd,
         }
 
         association_control_request_tlv->bssid_to_block_client() =
-            network_utils::mac_from_string(current_ap_mac);
+            network_utils::mac_from_string(hostap_mac);
         association_control_request_tlv->association_control() =
             wfa_map::tlvClientAssociationControlRequest::UNBLOCK;
         //TODO: Get real validity_period_sec
@@ -309,16 +308,6 @@ void son_management::handle_cli_message(Socket *sd,
         association_control_request_tlv->alloc_sta_list();
         auto sta_list         = association_control_request_tlv->sta_list(0);
         std::get<1>(sta_list) = network_utils::mac_from_string(client_mac);
-
-        auto vs_tlv =
-            message_com::add_vs_tlv<beerocks_message::tlvVsClientAssociationControlRequest>(
-                cmdu_tx);
-        if (!vs_tlv) {
-            LOG(ERROR) << "add_vs_tlv tlvVsClientAssociationControlRequest failed";
-            isOK = false;
-            break;
-        }
-        vs_tlv->ipv4() = network_utils::ipv4_from_string(database.get_node_ipv4(client_mac));
 
         const auto parent_radio = database.get_node_parent_radio(hostap_mac);
         son_actions::send_cmdu_to_agent(hostap_mac_sd, cmdu_tx, parent_radio);
@@ -377,7 +366,6 @@ void son_management::handle_cli_message(Socket *sd,
         LOG(DEBUG) << "CLI client disallow request for " << client_mac << " to " << hostap_mac;
 
         Socket *hostap_mac_sd = database.get_node_socket(hostap_mac);
-        auto current_ap_mac   = database.get_node_parent(client_mac);
         if (!cmdu_tx.create(0,
                             ieee1905_1::eMessageType::CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE)) {
             LOG(ERROR)
@@ -395,7 +383,7 @@ void son_management::handle_cli_message(Socket *sd,
         }
 
         association_control_request_tlv->bssid_to_block_client() =
-            network_utils::mac_from_string(current_ap_mac);
+            network_utils::mac_from_string(hostap_mac);
         association_control_request_tlv->association_control() =
             wfa_map::tlvClientAssociationControlRequest::BLOCK;
         //TODO: Get real validity_period_sec


### PR DESCRIPTION
This PR fixes the client steering logic after switching to EasyMesh messages.
Current implementation sends incorrect values and missing local agent BSSID filtering.
This caused the target agent to add the steering station into it's DENY list which completely broke the mechanism.