### PR TITLE
test_flows.sh: correct string comparison in [ ... ]

### DIFF
--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -484,7 +484,7 @@ main() {
 
     if [ $error -gt 0 ]; then
         err "$error / $count tests failed"
-        if [ "$VERBOSE" == "true" ]; then
+        if [ "$VERBOSE" = "true" ]; then
             for dockerimage in gateway repeater1 repeater2; do
                 info "*** Dumping logs from $dockerimage ***"
                 docker exec $dockerimage sh -c '


### PR DESCRIPTION
Posix shell test uses '=' for string comparison, not '=='.