### PR TITLE
Feature/tlvf print error on init failure

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
@@ -80,22 +80,43 @@ bool tlvVsClientAssociationEvent::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     m_capabilities = (beerocks::message::sRadioCapabilities*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sRadioCapabilities))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sRadioCapabilities))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sRadioCapabilities) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_capabilities->struct_init(); }
     m_disconnect_reason = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_disconnect_source = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_disconnect_type = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -54,10 +54,16 @@ bool cACTION_APMANAGER_4ADDR_STA_JOINED::init()
         return false;
     }
     m_src_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_src_mac->struct_init(); }
     m_dst_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_dst_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -102,10 +108,16 @@ bool cACTION_APMANAGER_JOINED_NOTIFICATION::init()
         return false;
     }
     m_params = (sNodeHostap*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeHostap) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -154,11 +166,20 @@ bool cACTION_APMANAGER_ENABLE_APS_REQUEST::init()
         return false;
     }
     m_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_bandwidth = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_center_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -195,7 +216,10 @@ bool cACTION_APMANAGER_ENABLE_APS_RESPONSE::init()
         return false;
     }
     m_success = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -263,7 +287,10 @@ bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
         return false;
     }
     m_params = (sApSetRestrictedFailsafe*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApSetRestrictedFailsafe))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApSetRestrictedFailsafe))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApSetRestrictedFailsafe) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -301,7 +328,10 @@ bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
         return false;
     }
     m_success = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -338,7 +368,10 @@ bool cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -381,9 +414,15 @@ bool cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     m_vap_info = (sVapInfo*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVapInfo))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVapInfo))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVapInfo) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_vap_info->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -482,7 +521,10 @@ bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
         return false;
     }
     m_params = (sVapsList*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVapsList))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVapsList))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVapsList) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -521,7 +563,10 @@ bool cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -560,7 +605,10 @@ bool cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -599,7 +647,10 @@ bool cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -638,7 +689,10 @@ bool cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -690,10 +744,16 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_supported_channels_list = (sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWifiChannel)*(beerocks::message::SUPPORTED_CHANNELS_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+        return false;
+    }
     m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
@@ -735,7 +795,10 @@ bool cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsCacCompleted*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sDfsCacCompleted))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sDfsCacCompleted))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sDfsCacCompleted) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -774,7 +837,10 @@ bool cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsChannelAvailable*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sDfsChannelAvailable))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sDfsChannelAvailable))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sDfsChannelAvailable) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -813,7 +879,10 @@ bool cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -852,7 +921,10 @@ bool cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -891,7 +963,10 @@ bool cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborSetParams11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNeighborSetParams11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNeighborSetParams11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNeighborSetParams11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -930,7 +1005,10 @@ bool cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborRemoveParams11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNeighborRemoveParams11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNeighborRemoveParams11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNeighborRemoveParams11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -969,7 +1047,10 @@ bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::init()
         return false;
     }
     m_params = (sClientAssociationParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientAssociationParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sClientAssociationParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientAssociationParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1008,7 +1089,10 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::init()
         return false;
     }
     m_params = (sClientDisconnectionParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectionParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectionParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientDisconnectionParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1064,14 +1148,26 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     m_type = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_reason = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1109,7 +1205,10 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     m_params = (sClientDisconnectResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientDisconnectResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1154,10 +1253,16 @@ bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1202,10 +1307,16 @@ bool cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1244,7 +1355,10 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurementRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1283,7 +1397,10 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurement) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1322,7 +1439,10 @@ bool cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1366,9 +1486,15 @@ bool cACTION_APMANAGER_ACK::init()
         return false;
     }
     m_reason = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_sta_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_sta_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1407,7 +1533,10 @@ bool cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::init()
         return false;
     }
     m_params = (sNodeBssSteerRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeBssSteerRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1446,7 +1575,10 @@ bool cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::init()
         return false;
     }
     m_params = (sNodeBssSteerResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeBssSteerResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeBssSteerResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1485,7 +1617,10 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1524,7 +1659,10 @@ bool cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_params = (sSteeringClientSetRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientSetRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1563,7 +1701,10 @@ bool cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringClientSetResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientSetResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1602,7 +1743,10 @@ bool cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvProbeReq*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvProbeReq))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvProbeReq))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvProbeReq) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1641,7 +1785,10 @@ bool cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvAuthFail*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvAuthFail))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvAuthFail))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvAuthFail) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -118,19 +118,37 @@ bool cACTION_BACKHAUL_REGISTER_REQUEST::init()
         return false;
     }
     m_sta_iface = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_sta_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_hostap_iface = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_hostap_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_local_master = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_local_gw = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_sta_iface_filter_low = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_onboarding = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -167,7 +185,10 @@ bool cACTION_BACKHAUL_REGISTER_RESPONSE::init()
         return false;
     }
     m_is_backhaul_manager = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -440,41 +461,83 @@ bool cACTION_BACKHAUL_ENABLE::init()
         return false;
     }
     m_bridge_iface = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_bridge_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_iface_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_iface_mac->struct_init(); }
     m_iface_is_5ghz = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_wire_iface = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_wire_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_sta_iface = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_sta_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_ap_iface = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_ap_iface_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_ssid = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_SSID_MAX_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::WIFI_SSID_MAX_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::WIFI_SSID_MAX_LENGTH) << ") Failed!";
+        return false;
+    }
     m_ssid_idx__  = beerocks::message::WIFI_SSID_MAX_LENGTH;
     m_pass = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::WIFI_PASS_MAX_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::WIFI_PASS_MAX_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::WIFI_PASS_MAX_LENGTH) << ") Failed!";
+        return false;
+    }
     m_pass_idx__  = beerocks::message::WIFI_PASS_MAX_LENGTH;
     m_security_type = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_preferred_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_preferred_bssid->struct_init(); }
     m_wire_iface_type = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_wireless_iface_type = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_mem_only_psk = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_backhaul_preferred_radio_band = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -512,7 +575,10 @@ bool cACTION_BACKHAUL_CONNECTED_NOTIFICATION::init()
         return false;
     }
     m_params = (sBackhaulParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBackhaulParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBackhaulParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -550,7 +616,10 @@ bool cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::init()
         return false;
     }
     m_stopped = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -598,11 +667,20 @@ bool cACTION_BACKHAUL_ENABLE_APS_REQUEST::init()
         return false;
     }
     m_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_bandwidth = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_center_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -640,7 +718,10 @@ bool cACTION_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     m_params = (sBackhaulRoam*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBackhaulRoam))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRoam))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBackhaulRoam) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -678,7 +759,10 @@ bool cACTION_BACKHAUL_ROAM_RESPONSE::init()
         return false;
     }
     m_connected = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -746,7 +830,10 @@ bool cACTION_BACKHAUL_4ADDR_CONNECTED::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -785,7 +872,10 @@ bool cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
         return false;
     }
     m_params = (sBackhaulRssi*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBackhaulRssi))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRssi))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBackhaulRssi) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -824,7 +914,10 @@ bool cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
         return false;
     }
     m_attempts = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -862,7 +955,10 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurementRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -901,7 +997,10 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurement) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -940,7 +1039,10 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -170,7 +170,10 @@ bool cACTION_BML_NW_MAP_RESPONSE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -195,15 +198,24 @@ bool cACTION_BML_NW_MAP_RESPONSE::init()
         return false;
     }
     m_node_num = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -273,7 +285,10 @@ bool cACTION_BML_NW_MAP_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -298,15 +313,24 @@ bool cACTION_BML_NW_MAP_UPDATE::init()
         return false;
     }
     m_node_num = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -376,7 +400,10 @@ bool cACTION_BML_STATS_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -401,15 +428,24 @@ bool cACTION_BML_STATS_UPDATE::init()
         return false;
     }
     m_num_of_stats_bulks = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -475,7 +511,10 @@ bool cACTION_BML_EVENTS_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -499,12 +538,18 @@ bool cACTION_BML_EVENTS_UPDATE::init()
     }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -961,7 +1006,10 @@ bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -998,7 +1046,10 @@ bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1035,7 +1086,10 @@ bool cACTION_BML_SET_CLIENT_ROAMING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1132,7 +1186,10 @@ bool cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1169,7 +1226,10 @@ bool cACTION_BML_SET_DFS_REENTRY_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1266,7 +1326,10 @@ bool cACTION_BML_GET_DFS_REENTRY_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1303,7 +1366,10 @@ bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1400,7 +1466,10 @@ bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1437,7 +1506,10 @@ bool cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1534,7 +1606,10 @@ bool cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1571,7 +1646,10 @@ bool cACTION_BML_SET_IRE_ROAMING_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1668,7 +1746,10 @@ bool cACTION_BML_GET_IRE_ROAMING_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1705,7 +1786,10 @@ bool cACTION_BML_SET_LOAD_BALANCER_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1802,7 +1886,10 @@ bool cACTION_BML_GET_LOAD_BALANCER_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1839,7 +1926,10 @@ bool cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1936,7 +2026,10 @@ bool cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1974,7 +2067,10 @@ bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sLoggingLevelChange) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2043,7 +2139,10 @@ bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::init()
         return false;
     }
     m_params = (sWifiCredentials*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWifiCredentials) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2082,7 +2181,10 @@ bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2120,7 +2222,10 @@ bool cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::init()
         return false;
     }
     m_params = (sRestrictedChannels*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sRestrictedChannels) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2159,7 +2264,10 @@ bool cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2197,7 +2305,10 @@ bool cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::init()
         return false;
     }
     m_params = (sRestrictedChannels*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sRestrictedChannels) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2236,7 +2347,10 @@ bool cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::init()
         return false;
     }
     m_params = (sRestrictedChannels*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sRestrictedChannels))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sRestrictedChannels) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2274,7 +2388,10 @@ bool cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2371,7 +2488,10 @@ bool cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::init()
         return false;
     }
     m_isEnable = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2426,7 +2546,10 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::alloc_vap_list(size_t count) 
     }
     m_vap_list_idx__ += count;
     *m_vap_list_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { 
         for (size_t i = m_vap_list_idx__ - count; i < m_vap_list_idx__; i++) { m_vap_list[i].struct_init(); }
     }
@@ -2456,14 +2579,23 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_vap_list_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vap_list_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_vap_list = (sConfigVapInfo*)m_buff_ptr__;
     uint8_t vap_list_size = *m_vap_list_size;
     m_vap_list_idx__ = vap_list_size;
-    if (!buffPtrIncrementSafe(sizeof(sConfigVapInfo)*(vap_list_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sConfigVapInfo) * (vap_list_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sConfigVapInfo) * (vap_list_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2501,7 +2633,10 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2556,7 +2691,10 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::alloc_vap_list(size_t count)
     }
     m_vap_list_idx__ += count;
     *m_vap_list_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { 
         for (size_t i = m_vap_list_idx__ - count; i < m_vap_list_idx__; i++) { m_vap_list[i].struct_init(); }
     }
@@ -2586,14 +2724,23 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_vap_list_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vap_list_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_vap_list = (sConfigVapInfo*)m_buff_ptr__;
     uint8_t vap_list_size = *m_vap_list_size;
     m_vap_list_idx__ = vap_list_size;
-    if (!buffPtrIncrementSafe(sizeof(sConfigVapInfo)*(vap_list_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sConfigVapInfo) * (vap_list_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sConfigVapInfo) * (vap_list_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2631,7 +2778,10 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::init()
         return false;
     }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2686,15 +2836,27 @@ bool cACTION_BML_STEERING_SET_GROUP_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_cfg_2 = (sSteeringApConfig*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringApConfig))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringApConfig))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringApConfig) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cfg_2->struct_init(); }
     m_cfg_5 = (sSteeringApConfig*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringApConfig))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringApConfig))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringApConfig) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cfg_5->struct_init(); }
     m_remove = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2732,7 +2894,10 @@ bool cACTION_BML_STEERING_SET_GROUP_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2793,18 +2958,33 @@ bool cACTION_BML_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_config = (sSteeringClientConfig*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientConfig))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientConfig))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientConfig) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_config->struct_init(); }
     m_remove = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2842,7 +3022,10 @@ bool cACTION_BML_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2879,7 +3062,10 @@ bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::init()
         return false;
     }
     m_unregister = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2917,7 +3103,10 @@ bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2978,17 +3167,32 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_type = (eDisconnectType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eDisconnectType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eDisconnectType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eDisconnectType) << ") Failed!";
+        return false;
+    }
     m_reason = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3026,7 +3230,10 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3076,12 +3283,21 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::init()
         return false;
     }
     m_steeringGroupIndex = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -3120,7 +3336,10 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::init()
         return false;
     }
     m_error_code = (int32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3186,7 +3405,10 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -3210,12 +3432,18 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::init()
     }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -3253,7 +3481,10 @@ bool cACTION_BML_TRIGGER_TOPOLOGY_QUERY::init()
         return false;
     }
     m_al_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_al_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -3298,10 +3529,16 @@ bool cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::init()
         return false;
     }
     m_al_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_al_mac->struct_init(); }
     m_ruid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ruid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -47,7 +47,10 @@ bool cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::init()
         return false;
     }
     m_isEnable = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -84,7 +87,10 @@ bool cACTION_CLI_ENABLE_LOAD_BALANCER::init()
         return false;
     }
     m_isEnable = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -121,7 +127,10 @@ bool cACTION_CLI_ENABLE_DEBUG::init()
         return false;
     }
     m_isEnable = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -159,7 +168,10 @@ bool cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::init()
         return false;
     }
     m_attempts = (int32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -201,9 +213,15 @@ bool cACTION_CLI_RESPONSE_INT::init()
         return false;
     }
     m_isOK = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_currentValue = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -269,7 +287,10 @@ bool cACTION_CLI_RESPONSE_STR::alloc_buffer(size_t count) {
     }
     m_buffer_idx__ += count;
     *m_buffer_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -293,12 +314,18 @@ bool cACTION_CLI_RESPONSE_STR::init()
     }
     m_buffer_size = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_buffer_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
     if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
-    if (!buffPtrIncrementSafe(sizeof(char)*(buffer_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -348,14 +375,23 @@ bool cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_center_frequency = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_center_frequency = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -393,7 +429,10 @@ bool cACTION_CLI_OPTIMAL_PATH_TASK::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -432,7 +471,10 @@ bool cACTION_CLI_LOAD_BALANCER_TASK::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ap_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -501,7 +543,10 @@ bool cACTION_CLI_DUMP_NODE_INFO::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -552,12 +597,21 @@ bool cACTION_CLI_PING_SLAVE_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_num_of_req = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_size = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -601,9 +655,15 @@ bool cACTION_CLI_PING_ALL_SLAVES_REQUEST::init()
         return false;
     }
     m_num_of_req = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_size = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -641,7 +701,10 @@ bool cACTION_CLI_BACKHAUL_SCAN_RESULTS::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -686,10 +749,16 @@ bool cACTION_CLI_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     m_slave_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_slave_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -734,10 +803,16 @@ bool cACTION_CLI_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -782,10 +857,16 @@ bool cACTION_CLI_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -836,12 +917,21 @@ bool cACTION_CLI_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_type = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_reason = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -891,13 +981,22 @@ bool cACTION_CLI_CLIENT_BSS_STEER_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_disassoc_timer_ms = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -941,10 +1040,16 @@ bool cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -994,13 +1099,22 @@ bool cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1092,28 +1206,58 @@ bool cACTION_CLI_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_ssid = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(beerocks::message::WIFI_SSID_MAX_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (beerocks::message::WIFI_SSID_MAX_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (beerocks::message::WIFI_SSID_MAX_LENGTH) << ") Failed!";
+        return false;
+    }
     m_ssid_idx__  = beerocks::message::WIFI_SSID_MAX_LENGTH;
     m_use_optional_ssid = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_measurement_mode = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_duration = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_rand_ival = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_repeats = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_op_class = (int16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1168,16 +1312,28 @@ bool cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     m_hostap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_peer_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_peer_mac->struct_init(); }
     m_group_identity = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1221,10 +1377,16 @@ bool cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1279,15 +1441,27 @@ bool cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ap_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1336,13 +1510,22 @@ bool cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ap_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1380,7 +1563,10 @@ bool cACTION_CLI_HOSTAP_STATS_MEASUREMENT::init()
         return false;
     }
     m_ap_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ap_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -121,32 +121,62 @@ bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::init()
         return false;
     }
     m_slave_version = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::VERSION_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::VERSION_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::VERSION_LENGTH) << ") Failed!";
+        return false;
+    }
     m_slave_version_idx__  = beerocks::message::VERSION_LENGTH;
     m_platform_settings = (sPlatformSettings*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sPlatformSettings) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_platform_settings->struct_init(); }
     m_wlan_settings = (sWlanSettings*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWlanSettings) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
     m_backhaul_params = (sBackhaulParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBackhaulParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBackhaulParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_backhaul_params->struct_init(); }
     m_hostap = (sNodeHostap*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeHostap) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap->struct_init(); }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_low_pass_filter_on = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_enable_repeater_mode = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_radio_identifier = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_radio_identifier->struct_init(); }
     m_is_slave_reconf = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -217,12 +247,21 @@ bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::init()
         return false;
     }
     m_master_version = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::VERSION_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::VERSION_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::VERSION_LENGTH) << ") Failed!";
+        return false;
+    }
     m_master_version_idx__  = beerocks::message::VERSION_LENGTH;
     m_err_code = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_config = (sSonConfig*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSonConfig) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_config->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -285,19 +324,34 @@ bool cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::init()
         return false;
     }
     m_backhaul_iface_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_backhaul_iface_mac->struct_init(); }
     m_backhaul_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::net::sIpv4Addr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_backhaul_ipv4->struct_init(); }
     m_bridge_iface_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bridge_iface_mac->struct_init(); }
     m_bridge_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::net::sIpv4Addr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bridge_ipv4->struct_init(); }
     m_hostap = (sNodeHostap*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeHostap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeHostap) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_hostap->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -336,7 +390,10 @@ bool cACTION_CONTROL_SON_CONFIG_UPDATE::init()
         return false;
     }
     m_config = (sSonConfig*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSonConfig) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_config->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -394,7 +451,10 @@ bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -421,11 +481,20 @@ bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_seq = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_size = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_data = (uint8_t*)m_buff_ptr__;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -483,7 +552,10 @@ bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -510,11 +582,20 @@ bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_seq = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_size = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_data = (uint8_t*)m_buff_ptr__;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -572,7 +653,10 @@ bool cACTION_CONTROL_AGENT_PING_REQUEST::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -599,11 +683,20 @@ bool cACTION_CONTROL_AGENT_PING_REQUEST::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_seq = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_size = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_data = (uint8_t*)m_buff_ptr__;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -661,7 +754,10 @@ bool cACTION_CONTROL_AGENT_PING_RESPONSE::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -688,11 +784,20 @@ bool cACTION_CONTROL_AGENT_PING_RESPONSE::init()
         return false;
     }
     m_total = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_seq = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_size = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_data = (uint8_t*)m_buff_ptr__;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -731,7 +836,10 @@ bool cACTION_CONTROL_ARP_QUERY_REQUEST::init()
         return false;
     }
     m_params = (sArpQuery*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sArpQuery))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sArpQuery))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sArpQuery) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -770,7 +878,10 @@ bool cACTION_CONTROL_ARP_QUERY_RESPONSE::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sArpMonitorData) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -814,10 +925,16 @@ bool cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         return false;
     }
     m_bridge_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bridge_mac->struct_init(); }
     m_operational = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -855,7 +972,10 @@ bool cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
         return false;
     }
     m_params = (sBackhaulRssi*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBackhaulRssi))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRssi))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBackhaulRssi) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -924,7 +1044,10 @@ bool cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     m_params = (sBackhaulRoam*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBackhaulRoam))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBackhaulRoam))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBackhaulRoam) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -963,7 +1086,10 @@ bool cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sLoggingLevelChange) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1002,7 +1128,10 @@ bool cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1041,7 +1170,10 @@ bool cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1080,7 +1212,10 @@ bool cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1132,10 +1267,16 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_supported_channels = (sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWifiChannel)*(beerocks::message::SUPPORTED_CHANNELS_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+        return false;
+    }
     m_supported_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
@@ -1177,7 +1318,10 @@ bool cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsCacCompleted*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sDfsCacCompleted))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sDfsCacCompleted))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sDfsCacCompleted) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1216,7 +1360,10 @@ bool cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
         return false;
     }
     m_params = (sDfsChannelAvailable*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sDfsChannelAvailable))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sDfsChannelAvailable))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sDfsChannelAvailable) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1255,7 +1402,10 @@ bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
         return false;
     }
     m_params = (sApSetRestrictedFailsafe*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApSetRestrictedFailsafe))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApSetRestrictedFailsafe))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApSetRestrictedFailsafe) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1293,7 +1443,10 @@ bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
         return false;
     }
     m_success = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1331,7 +1484,10 @@ bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1370,7 +1526,10 @@ bool cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
         return false;
     }
     m_attempts = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1438,7 +1597,10 @@ bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         return false;
     }
     m_cs_params = (sApChannelSwitch*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApChannelSwitch))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApChannelSwitch) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_cs_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1476,7 +1638,10 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_sync = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1531,7 +1696,10 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
     }
     m_sta_stats_idx__ += count;
     *m_sta_stats_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { 
         for (size_t i = m_sta_stats_idx__ - count; i < m_sta_stats_idx__; i++) { m_sta_stats[i].struct_init(); }
     }
@@ -1561,15 +1729,24 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_ap_stats = (sApStatsParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApStatsParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ap_stats->struct_init(); }
     m_sta_stats_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_sta_stats_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_sta_stats = (sStaStatsParams*)m_buff_ptr__;
     uint8_t sta_stats_size = *m_sta_stats_size;
     m_sta_stats_idx__ = sta_stats_size;
-    if (!buffPtrIncrementSafe(sizeof(sStaStatsParams)*(sta_stats_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStaStatsParams) * (sta_stats_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaStatsParams) * (sta_stats_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1607,7 +1784,10 @@ bool cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sApLoadNotificationParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApLoadNotificationParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApLoadNotificationParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApLoadNotificationParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1646,7 +1826,10 @@ bool cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborSetParams11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNeighborSetParams11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNeighborSetParams11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNeighborSetParams11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1685,7 +1868,10 @@ bool cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     m_params = (sNeighborRemoveParams11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNeighborRemoveParams11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNeighborRemoveParams11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNeighborRemoveParams11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1724,7 +1910,10 @@ bool cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sApActivityNotificationParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApActivityNotificationParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApActivityNotificationParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApActivityNotificationParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1763,7 +1952,10 @@ bool cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
         return false;
     }
     m_params = (sVapsList*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVapsList))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVapsList))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVapsList) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1801,7 +1993,10 @@ bool cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1844,9 +2039,15 @@ bool cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     m_vap_info = (sVapInfo*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVapInfo))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVapInfo))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVapInfo) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_vap_info->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1885,7 +2086,10 @@ bool cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::init()
         return false;
     }
     m_params = (sClientMonitoringParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientMonitoringParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sClientMonitoringParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientMonitoringParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1924,7 +2128,10 @@ bool cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1963,7 +2170,10 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurementRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2002,7 +2212,10 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurement) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2041,7 +2254,10 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2080,7 +2296,10 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2119,7 +2338,10 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurement) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2158,7 +2380,10 @@ bool cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2197,7 +2422,10 @@ bool cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2253,14 +2481,26 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     m_type = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_reason = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -2298,7 +2538,10 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     m_params = (sClientDisconnectResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sClientDisconnectResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientDisconnectResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2371,13 +2614,22 @@ bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::net::sIpv4Addr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ipv4->struct_init(); }
     m_name = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::NODE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::NODE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::NODE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_name_idx__  = beerocks::message::NODE_NAME_LENGTH;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2416,7 +2668,10 @@ bool cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sArpMonitorData) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2455,7 +2710,10 @@ bool cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     m_params = (sBeaconRequest11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBeaconRequest11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBeaconRequest11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBeaconRequest11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2494,7 +2752,10 @@ bool cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::init()
         return false;
     }
     m_params = (sBeaconResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBeaconResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBeaconResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBeaconResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2533,7 +2794,10 @@ bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     m_params = (sStaChannelLoadRequest11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadRequest11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadRequest11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaChannelLoadRequest11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2572,7 +2836,10 @@ bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStaChannelLoadResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaChannelLoadResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2611,7 +2878,10 @@ bool cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     m_params = (sStatisticsRequest11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStatisticsRequest11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsRequest11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStatisticsRequest11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2650,7 +2920,10 @@ bool cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStatisticsResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStatisticsResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStatisticsResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2689,7 +2962,10 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2728,7 +3004,10 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sLinkMeasurementsResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sLinkMeasurementsResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sLinkMeasurementsResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sLinkMeasurementsResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2767,7 +3046,10 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::init()
         return false;
     }
     m_params = (sSteeringSetGroupRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringSetGroupRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2806,7 +3088,10 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringSetGroupResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringSetGroupResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2845,7 +3130,10 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_params = (sSteeringClientSetRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientSetRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2884,7 +3172,10 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringClientSetResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientSetResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2923,7 +3214,10 @@ bool cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvActivity*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvActivity))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvActivity))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvActivity) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -2962,7 +3256,10 @@ bool cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvSnrXing*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvSnrXing))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvSnrXing))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvSnrXing) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -3001,7 +3298,10 @@ bool cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvProbeReq*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvProbeReq))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvProbeReq))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvProbeReq) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -3040,7 +3340,10 @@ bool cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvAuthFail*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvAuthFail))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvAuthFail))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvAuthFail) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
@@ -92,28 +92,55 @@ bool cACTION_HEADER::init()
     }
     m_magic = (uint32_t*)m_buff_ptr__;
     if (!m_parse__) *m_magic = beerocks::message::MESSAGE_MAGIC;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_version = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_version = beerocks::message::MESSAGE_VERSION;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_action = (eAction*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eAction))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eAction))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eAction) << ") Failed!";
+        return false;
+    }
     m_action_op = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_direction = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_direction = 0x1;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_radio_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_radio_mac->struct_init(); }
     m_last = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_last = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_id = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -47,7 +47,10 @@ bool cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         return false;
     }
     m_vap_id = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -115,7 +118,10 @@ bool cACTION_MONITOR_SON_CONFIG_UPDATE::init()
         return false;
     }
     m_config = (sSonConfig*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSonConfig))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSonConfig) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_config->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -154,7 +160,10 @@ bool cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sLoggingLevelChange) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -193,7 +202,10 @@ bool cACTION_MONITOR_ERROR_NOTIFICATION::init()
         return false;
     }
     m_error_code = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -291,7 +303,10 @@ bool cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::init()
         return false;
     }
     m_params = (sClientMonitoringParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientMonitoringParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sClientMonitoringParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientMonitoringParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -330,7 +345,10 @@ bool cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -369,7 +387,10 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_params = (sNodeRssiMeasurementRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurementRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurementRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -419,13 +440,22 @@ bool cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::net::sIpv4Addr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ipv4->struct_init(); }
     m_channel = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -463,7 +493,10 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurement) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -502,7 +535,10 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_params = (sNodeRssiMeasurement*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sNodeRssiMeasurement))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sNodeRssiMeasurement) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -541,7 +577,10 @@ bool cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -580,7 +619,10 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -619,7 +661,10 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -658,7 +703,10 @@ bool cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -697,7 +745,10 @@ bool cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sApActivityNotificationParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApActivityNotificationParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApActivityNotificationParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApActivityNotificationParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -735,7 +786,10 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
         return false;
     }
     m_sync = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -777,9 +831,15 @@ bool cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::init()
         return false;
     }
     m_new_tx_state = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     m_new_hostap_enabled_state = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -834,7 +894,10 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
     }
     m_sta_stats_idx__ += count;
     *m_sta_stats_size += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { 
         for (size_t i = m_sta_stats_idx__ - count; i < m_sta_stats_idx__; i++) { m_sta_stats[i].struct_init(); }
     }
@@ -864,15 +927,24 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         return false;
     }
     m_ap_stats = (sApStatsParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApStatsParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ap_stats->struct_init(); }
     m_sta_stats_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_sta_stats_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_sta_stats = (sStaStatsParams*)m_buff_ptr__;
     uint8_t sta_stats_size = *m_sta_stats_size;
     m_sta_stats_idx__ = sta_stats_size;
-    if (!buffPtrIncrementSafe(sizeof(sStaStatsParams)*(sta_stats_size))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStaStatsParams) * (sta_stats_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaStatsParams) * (sta_stats_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -910,7 +982,10 @@ bool cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     m_params = (sApLoadNotificationParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApLoadNotificationParams))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sApLoadNotificationParams))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApLoadNotificationParams) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -949,7 +1024,10 @@ bool cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     m_params = (sBeaconRequest11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBeaconRequest11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBeaconRequest11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBeaconRequest11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -988,7 +1066,10 @@ bool cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::init()
         return false;
     }
     m_params = (sBeaconResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sBeaconResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sBeaconResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sBeaconResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1027,7 +1108,10 @@ bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     m_params = (sStaChannelLoadRequest11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadRequest11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadRequest11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaChannelLoadRequest11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1066,7 +1150,10 @@ bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStaChannelLoadResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStaChannelLoadResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaChannelLoadResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1105,7 +1192,10 @@ bool cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     m_params = (sStatisticsRequest11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStatisticsRequest11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsRequest11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStatisticsRequest11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1144,7 +1234,10 @@ bool cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sStatisticsResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sStatisticsResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sStatisticsResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStatisticsResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1183,7 +1276,10 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1222,7 +1318,10 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
         return false;
     }
     m_params = (sLinkMeasurementsResponse11k*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sLinkMeasurementsResponse11k))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sLinkMeasurementsResponse11k))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sLinkMeasurementsResponse11k) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1261,7 +1360,10 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::init()
         return false;
     }
     m_params = (sSteeringSetGroupRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringSetGroupRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1300,7 +1402,10 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringSetGroupResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringSetGroupResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringSetGroupResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1339,7 +1444,10 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     m_params = (sSteeringClientSetRequest*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetRequest))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientSetRequest) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1378,7 +1486,10 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     m_params = (sSteeringClientSetResponse*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringClientSetResponse))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringClientSetResponse) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1417,7 +1528,10 @@ bool cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvActivity*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvActivity))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvActivity))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvActivity) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1456,7 +1570,10 @@ bool cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
         return false;
     }
     m_params = (sSteeringEvSnrXing*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sSteeringEvSnrXing))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sSteeringEvSnrXing))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sSteeringEvSnrXing) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -47,7 +47,10 @@ bool cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::init(
         return false;
     }
     m_is_backhaul_manager = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -107,7 +110,10 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -158,13 +164,22 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::init()
         return false;
     }
     m_platform_settings = (sPlatformSettings*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sPlatformSettings) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_platform_settings->struct_init(); }
     m_wlan_settings = (sWlanSettings*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWlanSettings) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
     m_valid = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -202,7 +217,10 @@ bool cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sArpMonitorData) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -241,7 +259,10 @@ bool cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::init()
         return false;
     }
     m_wlan_settings = (sWlanSettings*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWlanSettings) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -325,17 +346,32 @@ bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_dhcp_op = (eDHCPOp*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eDHCPOp))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eDHCPOp))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eDHCPOp) << ") Failed!";
+        return false;
+    }
     m_op = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_mac->struct_init(); }
     m_ipv4 = (beerocks::net::sIpv4Addr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(beerocks::net::sIpv4Addr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::net::sIpv4Addr) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_ipv4->struct_init(); }
     m_hostname = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::NODE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::NODE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::NODE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_hostname_idx__  = beerocks::message::NODE_NAME_LENGTH;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -374,7 +410,10 @@ bool cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     m_params = (sLoggingLevelChange*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sLoggingLevelChange))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sLoggingLevelChange) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -413,7 +452,10 @@ bool cACTION_PLATFORM_ARP_QUERY_REQUEST::init()
         return false;
     }
     m_params = (sArpQuery*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sArpQuery))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sArpQuery))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sArpQuery) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -452,7 +494,10 @@ bool cACTION_PLATFORM_ARP_QUERY_RESPONSE::init()
         return false;
     }
     m_params = (sArpMonitorData*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sArpMonitorData))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sArpMonitorData) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -521,7 +566,10 @@ bool cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::init()
         return false;
     }
     m_params = (sOnboarding*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sOnboarding))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sOnboarding))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sOnboarding) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -560,7 +608,10 @@ bool cACTION_PLATFORM_ONBOARD_SET_REQUEST::init()
         return false;
     }
     m_params = (sOnboarding*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sOnboarding))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sOnboarding))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sOnboarding) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -621,7 +672,10 @@ bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::init()
         return false;
     }
     m_iface_name = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -659,7 +713,10 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::init()
         return false;
     }
     m_vap_id = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -709,13 +766,22 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::init()
         return false;
     }
     m_front_params = (sWifiCredentials*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWifiCredentials) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_front_params->struct_init(); }
     m_back_params = (sWifiCredentials*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWifiCredentials) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_back_params->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -789,10 +855,16 @@ bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::init()
         return false;
     }
     m_params = (sAdminCredentials*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sAdminCredentials))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sAdminCredentials))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sAdminCredentials) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -866,10 +938,16 @@ bool cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::init()
         return false;
     }
     m_params = (sDeviceInfo*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sDeviceInfo))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sDeviceInfo))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sDeviceInfo) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_params->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -936,7 +1014,10 @@ bool cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::init()
         return false;
     }
     m_local_master = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -974,7 +1055,10 @@ bool cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVersions) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_versions->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1013,7 +1097,10 @@ bool cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVersions) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_versions->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1088,10 +1175,16 @@ bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::init()
         return false;
     }
     m_versions = (sVersions*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVersions))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVersions))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVersions) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_versions->struct_init(); }
     m_result = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1157,9 +1250,15 @@ bool cACTION_PLATFORM_ERROR_NOTIFICATION::init()
         return false;
     }
     m_code = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     m_data = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(256))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (256))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (256) << ") Failed!";
+        return false;
+    }
     m_data_idx__  = 256;
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -1273,21 +1372,42 @@ bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::init()
         return false;
     }
     m_iface_name_ap = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_iface_name_ap_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_iface_name_bh = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(beerocks::message::IFACE_NAME_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (beerocks::message::IFACE_NAME_LENGTH) << ") Failed!";
+        return false;
+    }
     m_iface_name_bh_idx__  = beerocks::message::IFACE_NAME_LENGTH;
     m_status_ap = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_status_bh = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_status_bh_wired = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_is_bh_manager = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_status_operational = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }
@@ -1324,7 +1444,10 @@ bool cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         return false;
     }
     m_operational = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -95,7 +95,10 @@ bool cConfigData::alloc_ssid(size_t count) {
     m_multiap_attr = (sWscAttrVendorExtMultiAp *)((uint8_t *)(m_multiap_attr) + len);
     m_ssid_idx__ += count;
     *m_ssid_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -172,7 +175,10 @@ bool cConfigData::alloc_network_key(size_t count) {
     m_multiap_attr = (sWscAttrVendorExtMultiAp *)((uint8_t *)(m_multiap_attr) + len);
     m_network_key_idx__ += count;
     *m_network_key_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -218,37 +224,67 @@ bool cConfigData::init()
     }
     m_ssid_type = (eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_ssid_type = ATTR_SSID;
-    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
     m_ssid_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_ssid_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_ssid = (char*)m_buff_ptr__;
     uint16_t ssid_length = *m_ssid_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&ssid_length)); }
     m_ssid_idx__ = ssid_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(ssid_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (ssid_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (ssid_length) << ") Failed!";
+        return false;
+    }
     m_authentication_type_attr = (sWscAttrAuthenticationType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWscAttrAuthenticationType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrAuthenticationType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWscAttrAuthenticationType) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_authentication_type_attr->struct_init(); }
     m_encryption_type_attr = (sWscAttrEncryptionType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWscAttrEncryptionType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrEncryptionType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWscAttrEncryptionType) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_encryption_type_attr->struct_init(); }
     m_network_key_type = (eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_network_key_type = ATTR_NETWORK_KEY;
-    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
     m_network_key_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_network_key_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_network_key = (char*)m_buff_ptr__;
     uint16_t network_key_length = *m_network_key_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&network_key_length)); }
     m_network_key_idx__ = network_key_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(network_key_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (network_key_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (network_key_length) << ") Failed!";
+        return false;
+    }
     m_bssid_attr = (sWscAttrBssid*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWscAttrBssid))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrBssid))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWscAttrBssid) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_bssid_attr->struct_init(); }
     m_multiap_attr = (sWscAttrVendorExtMultiAp*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWscAttrVendorExtMultiAp))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sWscAttrVendorExtMultiAp))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWscAttrVendorExtMultiAp) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_multiap_attr->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
@@ -345,7 +381,10 @@ bool cWscAttrEncryptedSettings::alloc_encrypted_settings(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_encrypted_settings_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -373,12 +412,21 @@ bool cWscAttrEncryptedSettings::init()
     }
     m_type = (eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_type = eWscAttributes::ATTR_ENCR_SETTINGS;
-    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_iv = (char*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(char)*(WSC_ENCRYPTED_SETTINGS_IV_LENGTH))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (WSC_ENCRYPTED_SETTINGS_IV_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (WSC_ENCRYPTED_SETTINGS_IV_LENGTH) << ") Failed!";
+        return false;
+    }
     m_iv_idx__  = WSC_ENCRYPTED_SETTINGS_IV_LENGTH;
     if (!m_parse__) {
         if (m_length) { (*m_length) += (sizeof(char) * WSC_ENCRYPTED_SETTINGS_IV_LENGTH); }
@@ -389,7 +437,10 @@ bool cWscAttrEncryptedSettings::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_encrypted_settings_idx__ = len/sizeof(char);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
@@ -461,7 +512,10 @@ bool cWscVendorExtWfa::alloc_vs_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_vs_data_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -491,21 +545,36 @@ bool cWscVendorExtWfa::init()
     }
     m_type = (eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_type = ATTR_VENDOR_EXTENSION;
-    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_vendor_id_0 = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vendor_id_0 = WSC_VENDOR_ID_WFA_1;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_vendor_id_1 = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vendor_id_1 = WSC_VENDOR_ID_WFA_2;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_vendor_id_2 = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_vendor_id_2 = WSC_VENDOR_ID_WFA_3;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_vs_data = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -513,7 +582,10 @@ bool cWscVendorExtWfa::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_vs_data_idx__ = len/sizeof(uint8_t);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
@@ -76,20 +76,38 @@ bool cCmduHeader::init()
     }
     m_message_version = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_message_version = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_reserved = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_reserved = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_message_type = (eMessageType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eMessageType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eMessageType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eMessageType) << ") Failed!";
+        return false;
+    }
     m_message_id = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_message_id = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_fragment_id = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_fragment_id = 0x0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_flags = (sFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFlags) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_flags->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -68,7 +68,10 @@ bool tlv1905NeighborDevice::alloc_mac_al_1905_device(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_mac_al_1905_device_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_mac_al_1905_device_idx__ - count; i < m_mac_al_1905_device_idx__; i++) { m_mac_al_1905_device[i].struct_init(); }
@@ -102,12 +105,21 @@ bool tlv1905NeighborDevice::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_1905_NEIGHBOR_DEVICE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_mac_local_iface = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_local_iface->struct_init(); }
     m_mac_al_1905_device = (sMacAl1905Device*)m_buff_ptr__;
@@ -116,7 +128,10 @@ bool tlv1905NeighborDevice::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_mac_al_1905_device_idx__ = len/sizeof(sMacAl1905Device);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -60,12 +60,21 @@ bool tlvAlMacAddressType::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AL_MAC_ADDRESS_TYPE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -59,12 +59,21 @@ bool tlvAutoconfigFreqBand::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_AUTOCONFIG_FREQ_BAND;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_value = (eValue*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eValue))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eValue) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -95,7 +95,10 @@ bool tlvDeviceBridgingCapability::add_bridging_tuples_list(std::shared_ptr<cMacL
     if (!m_parse__) { (*m_bridging_tuples_list_length)++; }
     size_t len = ptr->getLen();
     m_bridging_tuples_list_vector.push_back(ptr);
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -126,13 +129,22 @@ bool tlvDeviceBridgingCapability::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_bridging_tuples_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_bridging_tuples_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_bridging_tuples_list = (cMacList*)m_buff_ptr__;
     uint8_t bridging_tuples_list_length = *m_bridging_tuples_list_length;
@@ -206,7 +218,10 @@ bool cMacList::alloc_mac_list(size_t count) {
     }
     m_mac_list_idx__ += count;
     *m_mac_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { 
         for (size_t i = m_mac_list_idx__ - count; i < m_mac_list_idx__; i++) { m_mac_list[i].struct_init(); }
     }
@@ -235,11 +250,17 @@ bool cMacList::init()
     }
     m_mac_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_mac_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_mac_list = (sMacAddr*)m_buff_ptr__;
     uint8_t mac_list_length = *m_mac_list_length;
     m_mac_list_idx__ = mac_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(mac_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr) * (mac_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (mac_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -73,7 +73,10 @@ bool tlvDeviceInformation::alloc_info(size_t count) {
     }
     m_info_idx__ += count;
     *m_info_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_info_idx__ - count; i < m_info_idx__; i++) { m_info[i].struct_init(); }
@@ -108,22 +111,37 @@ bool tlvDeviceInformation::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_DEVICE_INFORMATION;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
     m_info_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_info_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_info = (sInfo*)m_buff_ptr__;
     uint8_t info_length = *m_info_length;
     m_info_idx__ = info_length;
-    if (!buffPtrIncrementSafe(sizeof(sInfo)*(info_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sInfo) * (info_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sInfo) * (info_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_DEVICE_INFORMATION) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -54,10 +54,16 @@ bool tlvEndOfMessage::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_END_OF_MESSAGE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_END_OF_MESSAGE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -70,19 +70,34 @@ bool tlvLinkMetricQuery::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_QUERY;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_neighbor_type = (eNeighborType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eNeighborType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eNeighborType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eNeighborType) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eNeighborType); }
     m_mac_al_1905_device = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_al_1905_device->struct_init(); }
     m_link_metrics = (eLinkMetricsType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eLinkMetricsType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eLinkMetricsType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eLinkMetricsType) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eLinkMetricsType); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -59,12 +59,21 @@ bool tlvLinkMetricResultCode::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_LINK_METRIC_RESULT_CODE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_value = (eValue*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eValue))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eValue) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -60,12 +60,21 @@ bool tlvMacAddress::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_MAC_ADDRESS;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -68,7 +68,10 @@ bool tlvNon1905neighborDeviceList::alloc_mac_non_1905_device(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_mac_non_1905_device_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_mac_non_1905_device_idx__ - count; i < m_mac_non_1905_device_idx__; i++) { m_mac_non_1905_device[i].struct_init(); }
@@ -102,12 +105,21 @@ bool tlvNon1905neighborDeviceList::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_mac_local_iface = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac_local_iface->struct_init(); }
     m_mac_non_1905_device = (sMacAddr*)m_buff_ptr__;
@@ -116,7 +128,10 @@ bool tlvNon1905neighborDeviceList::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_mac_non_1905_device_idx__ = len/sizeof(sMacAddr);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -69,7 +69,10 @@ bool tlvPushButtonEventNotification::alloc_media_type_list(size_t count) {
     }
     m_media_type_list_idx__ += count;
     *m_media_type_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_media_type_list_idx__ - count; i < m_media_type_list_idx__; i++) { m_media_type_list[i].struct_init(); }
@@ -102,18 +105,30 @@ bool tlvPushButtonEventNotification::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_media_type_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_media_type_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_media_type_list = (sMediaType*)m_buff_ptr__;
     uint8_t media_type_list_length = *m_media_type_list_length;
     m_media_type_list_idx__ = media_type_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sMediaType)*(media_type_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMediaType) * (media_type_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMediaType) * (media_type_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -78,23 +78,41 @@ bool tlvPushButtonJoinNotification::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_al_mac_notification_src = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_al_mac_notification_src->struct_init(); }
     m_mid_of_the_notification = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_transmitter_iface_mac_of_new_device_joined = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_transmitter_iface_mac_of_new_device_joined->struct_init(); }
     m_iface_mac_of_new_device_joined = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_iface_mac_of_new_device_joined->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -72,7 +72,10 @@ bool tlvReceiverLinkMetric::alloc_interface_pair_info(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_interface_pair_info_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_interface_pair_info_idx__ - count; i < m_interface_pair_info_idx__; i++) { m_interface_pair_info[i].struct_init(); }
@@ -108,16 +111,28 @@ bool tlvReceiverLinkMetric::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_RECEIVER_LINK_METRIC;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_reporter_al_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_reporter_al_mac->struct_init(); }
     m_neighbor_al_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_neighbor_al_mac->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
@@ -126,7 +141,10 @@ bool tlvReceiverLinkMetric::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_interface_pair_info_idx__ = len/sizeof(sInterfacePairInfo);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -59,12 +59,21 @@ bool tlvSearchedRole::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SEARCHED_ROLE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_value = (eValue*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eValue))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eValue) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -59,12 +59,21 @@ bool tlvSupportedFreqBand::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_FREQ_BAND;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_value = (eValue*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eValue))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eValue) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -59,12 +59,21 @@ bool tlvSupportedRole::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_SUPPORTED_ROLE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_value = (eValue*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eValue))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eValue))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eValue) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -72,7 +72,10 @@ bool tlvTransmitterLinkMetric::alloc_interface_pair_info(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_interface_pair_info_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_interface_pair_info_idx__ - count; i < m_interface_pair_info_idx__; i++) { m_interface_pair_info[i].struct_init(); }
@@ -108,16 +111,28 @@ bool tlvTransmitterLinkMetric::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_TRANSMITTER_LINK_METRIC;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_reporter_al_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_reporter_al_mac->struct_init(); }
     m_neighbor_al_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_neighbor_al_mac->struct_init(); }
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
@@ -126,7 +141,10 @@ bool tlvTransmitterLinkMetric::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_interface_pair_info_idx__ = len/sizeof(sInterfacePairInfo);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
@@ -63,7 +63,10 @@ bool tlvUnknown::alloc_data(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_data_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -88,17 +91,26 @@ bool tlvUnknown::init()
         return false;
     }
     m_type = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_data = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_data_idx__ = len/sizeof(uint8_t);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -60,12 +60,21 @@ bool tlvVendorSpecific::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_VENDOR_SPECIFIC;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0x3;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_vendor_oui = (sVendorOUI*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sVendorOUI))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sVendorOUI))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVendorOUI) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_vendor_oui->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -151,7 +151,10 @@ bool tlvWscM1::alloc_manufacturer(size_t count) {
     m_vendor_ext = (WSC::cWscVendorExtWfa *)((uint8_t *)(m_vendor_ext) + len);
     m_manufacturer_idx__ += count;
     *m_manufacturer_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -227,7 +230,10 @@ bool tlvWscM1::alloc_model_name(size_t count) {
     m_vendor_ext = (WSC::cWscVendorExtWfa *)((uint8_t *)(m_vendor_ext) + len);
     m_model_name_idx__ += count;
     *m_model_name_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -300,7 +306,10 @@ bool tlvWscM1::alloc_model_number(size_t count) {
     m_vendor_ext = (WSC::cWscVendorExtWfa *)((uint8_t *)(m_vendor_ext) + len);
     m_model_number_idx__ += count;
     *m_model_number_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -370,7 +379,10 @@ bool tlvWscM1::alloc_serial_number(size_t count) {
     m_vendor_ext = (WSC::cWscVendorExtWfa *)((uint8_t *)(m_vendor_ext) + len);
     m_serial_number_idx__ += count;
     *m_serial_number_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -440,7 +452,10 @@ bool tlvWscM1::alloc_device_name(size_t count) {
     m_vendor_ext = (WSC::cWscVendorExtWfa *)((uint8_t *)(m_vendor_ext) + len);
     m_device_name_idx__ += count;
     *m_device_name_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -515,7 +530,10 @@ bool tlvWscM1::add_vendor_ext(std::shared_ptr<WSC::cWscVendorExtWfa> ptr) {
     m_vendor_ext_init = true;
     size_t len = ptr->getLen();
     m_vendor_ext_ptr = ptr;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -597,141 +615,243 @@ bool tlvWscM1::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_version_attr = (WSC::sWscAttrVersion*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrVersion) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion); }
     if (!m_parse__) { m_version_attr->struct_init(); }
     m_message_type_attr = (WSC::sWscAttrMessageType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMessageType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMessageType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrMessageType) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMessageType); }
     if (!m_parse__) { m_message_type_attr->struct_init(); }
     m_uuid_e_attr = (WSC::sWscAttrUuidE*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrUuidE))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrUuidE))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrUuidE) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrUuidE); }
     if (!m_parse__) { m_uuid_e_attr->struct_init(); }
     m_mac_attr = (WSC::sWscAttrMac*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMac))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMac))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrMac) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMac); }
     if (!m_parse__) { m_mac_attr->struct_init(); }
     m_enrolee_nonce_attr = (WSC::sWscAttrEnroleeNonce*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEnroleeNonce) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnroleeNonce); }
     if (!m_parse__) { m_enrolee_nonce_attr->struct_init(); }
     m_public_key_attr = (WSC::sWscAttrPublicKey*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrPublicKey) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPublicKey); }
     if (!m_parse__) { m_public_key_attr->struct_init(); }
     m_authentication_type_flags_attr = (WSC::sWscAttrAuthenticationTypeFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticationTypeFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticationTypeFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrAuthenticationTypeFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticationTypeFlags); }
     if (!m_parse__) { m_authentication_type_flags_attr->struct_init(); }
     m_encryption_type_flags_attr = (WSC::sWscAttrEncryptionTypeFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEncryptionTypeFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEncryptionTypeFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEncryptionTypeFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEncryptionTypeFlags); }
     if (!m_parse__) { m_encryption_type_flags_attr->struct_init(); }
     m_connection_type_flags_attr = (WSC::sWscAttrConnectionTypeFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConnectionTypeFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConnectionTypeFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrConnectionTypeFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConnectionTypeFlags); }
     if (!m_parse__) { m_connection_type_flags_attr->struct_init(); }
     m_configuration_methods_attr = (WSC::sWscAttrConfigurationMethods*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationMethods))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationMethods))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrConfigurationMethods) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationMethods); }
     if (!m_parse__) { m_configuration_methods_attr->struct_init(); }
     m_wsc_state_attr = (WSC::sWscAttrWscState*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrWscState))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrWscState))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrWscState) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrWscState); }
     if (!m_parse__) { m_wsc_state_attr->struct_init(); }
     m_manufacturer_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_type = WSC::ATTR_MANUFACTURER;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_manufacturer_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(manufacturer_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (manufacturer_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (manufacturer_length) << ") Failed!";
+        return false;
+    }
     m_model_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_type = WSC::ATTR_MODEL_NAME;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(model_name_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (model_name_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_name_length) << ") Failed!";
+        return false;
+    }
     m_model_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_type = WSC::ATTR_MODEL_NUMBER;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(model_number_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (model_number_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_number_length) << ") Failed!";
+        return false;
+    }
     m_serial_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_type = WSC::ATTR_SERIAL_NUMBER;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_serial_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(serial_number_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (serial_number_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (serial_number_length) << ") Failed!";
+        return false;
+    }
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrPrimaryDeviceType) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPrimaryDeviceType); }
     if (!m_parse__) { m_primary_device_type_attr->struct_init(); }
     m_device_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_device_name_type = WSC::ATTR_DEV_NAME;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_device_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_device_name_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_device_name = (char*)m_buff_ptr__;
     uint16_t device_name_length = *m_device_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
     m_device_name_idx__ = device_name_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(device_name_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (device_name_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (device_name_length) << ") Failed!";
+        return false;
+    }
     m_rf_bands_attr = (WSC::sWscAttrRfBands*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrRfBands) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRfBands); }
     if (!m_parse__) { m_rf_bands_attr->struct_init(); }
     m_association_state_attr = (WSC::sWscAttrAssociationState*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAssociationState))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAssociationState))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrAssociationState) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAssociationState); }
     if (!m_parse__) { m_association_state_attr->struct_init(); }
     m_device_password_id_attr = (WSC::sWscAttrDevicePasswordID*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrDevicePasswordID))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrDevicePasswordID))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrDevicePasswordID) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrDevicePasswordID); }
     if (!m_parse__) { m_device_password_id_attr->struct_init(); }
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationError))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationError))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrConfigurationError) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationError); }
     if (!m_parse__) { m_configuration_error_attr->struct_init(); }
     m_os_version_attr = (WSC::sWscAttrOsVersion*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrOsVersion))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrOsVersion))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrOsVersion) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrOsVersion); }
     if (!m_parse__) { m_os_version_attr->struct_init(); }
     m_vendor_ext = (WSC::cWscVendorExtWfa*)m_buff_ptr__;

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -149,7 +149,10 @@ bool tlvWscM2::alloc_manufacturer(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_manufacturer_idx__ += count;
     *m_manufacturer_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -227,7 +230,10 @@ bool tlvWscM2::alloc_model_name(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_model_name_idx__ += count;
     *m_model_name_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -302,7 +308,10 @@ bool tlvWscM2::alloc_model_number(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_model_number_idx__ += count;
     *m_model_number_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -374,7 +383,10 @@ bool tlvWscM2::alloc_serial_number(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_serial_number_idx__ += count;
     *m_serial_number_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -446,7 +458,10 @@ bool tlvWscM2::alloc_device_name(size_t count) {
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
     m_device_name_idx__ += count;
     *m_device_name_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -527,7 +542,10 @@ bool tlvWscM2::add_encrypted_settings(std::shared_ptr<WSC::cWscAttrEncryptedSett
     size_t len = ptr->getLen();
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len - ptr->get_initial_size());
     m_encrypted_settings_ptr = ptr;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -615,141 +633,243 @@ bool tlvWscM2::init()
     }
     m_type = (eTlvType*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvType::TLV_WSC;
-    if (!buffPtrIncrementSafe(sizeof(eTlvType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_version_attr = (WSC::sWscAttrVersion*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrVersion) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion); }
     if (!m_parse__) { m_version_attr->struct_init(); }
     m_message_type_attr = (WSC::sWscAttrMessageType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMessageType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrMessageType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrMessageType) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMessageType); }
     if (!m_parse__) { m_message_type_attr->struct_init(); }
     m_enrolee_nonce_attr = (WSC::sWscAttrEnroleeNonce*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEnroleeNonce) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnroleeNonce); }
     if (!m_parse__) { m_enrolee_nonce_attr->struct_init(); }
     m_registrar_nonce_attr = (WSC::sWscAttrRegistrarNonce*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRegistrarNonce))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRegistrarNonce))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrRegistrarNonce) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRegistrarNonce); }
     if (!m_parse__) { m_registrar_nonce_attr->struct_init(); }
     m_uuid_r_attr = (WSC::sWscAttrUuidR*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrUuidR))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrUuidR))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrUuidR) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrUuidR); }
     if (!m_parse__) { m_uuid_r_attr->struct_init(); }
     m_public_key_attr = (WSC::sWscAttrPublicKey*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrPublicKey) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPublicKey); }
     if (!m_parse__) { m_public_key_attr->struct_init(); }
     m_authentication_type_flags_attr = (WSC::sWscAttrAuthenticationTypeFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticationTypeFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticationTypeFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrAuthenticationTypeFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticationTypeFlags); }
     if (!m_parse__) { m_authentication_type_flags_attr->struct_init(); }
     m_encryption_type_flags_attr = (WSC::sWscAttrEncryptionTypeFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEncryptionTypeFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEncryptionTypeFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEncryptionTypeFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEncryptionTypeFlags); }
     if (!m_parse__) { m_encryption_type_flags_attr->struct_init(); }
     m_connection_type_flags_attr = (WSC::sWscAttrConnectionTypeFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConnectionTypeFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConnectionTypeFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrConnectionTypeFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConnectionTypeFlags); }
     if (!m_parse__) { m_connection_type_flags_attr->struct_init(); }
     m_configuration_methods_attr = (WSC::sWscAttrConfigurationMethods*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationMethods))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationMethods))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrConfigurationMethods) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationMethods); }
     if (!m_parse__) { m_configuration_methods_attr->struct_init(); }
     m_manufacturer_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_type = WSC::ATTR_MANUFACTURER;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_manufacturer_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_manufacturer_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(manufacturer_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (manufacturer_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (manufacturer_length) << ") Failed!";
+        return false;
+    }
     m_model_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_type = WSC::ATTR_MODEL_NAME;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_name_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(model_name_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (model_name_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_name_length) << ") Failed!";
+        return false;
+    }
     m_model_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_type = WSC::ATTR_MODEL_NUMBER;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_model_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_model_number_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(model_number_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (model_number_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_number_length) << ") Failed!";
+        return false;
+    }
     m_serial_number_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_type = WSC::ATTR_SERIAL_NUMBER;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_serial_number_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_serial_number_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(serial_number_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (serial_number_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (serial_number_length) << ") Failed!";
+        return false;
+    }
     m_primary_device_type_attr = (WSC::sWscAttrPrimaryDeviceType*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPrimaryDeviceType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrPrimaryDeviceType) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrPrimaryDeviceType); }
     if (!m_parse__) { m_primary_device_type_attr->struct_init(); }
     m_device_name_type = (WSC::eWscAttributes*)m_buff_ptr__;
     if (!m_parse__) *m_device_name_type = WSC::ATTR_DEV_NAME;
-    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::eWscAttributes) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::eWscAttributes); }
     m_device_name_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_device_name_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_device_name = (char*)m_buff_ptr__;
     uint16_t device_name_length = *m_device_name_length;
     if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
     m_device_name_idx__ = device_name_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(device_name_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (device_name_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (device_name_length) << ") Failed!";
+        return false;
+    }
     m_rf_bands_attr = (WSC::sWscAttrRfBands*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRfBands))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrRfBands) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrRfBands); }
     if (!m_parse__) { m_rf_bands_attr->struct_init(); }
     m_association_state_attr = (WSC::sWscAttrAssociationState*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAssociationState))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAssociationState))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrAssociationState) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAssociationState); }
     if (!m_parse__) { m_association_state_attr->struct_init(); }
     m_configuration_error_attr = (WSC::sWscAttrConfigurationError*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationError))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrConfigurationError))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrConfigurationError) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrConfigurationError); }
     if (!m_parse__) { m_configuration_error_attr->struct_init(); }
     m_device_password_id_attr = (WSC::sWscAttrDevicePasswordID*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrDevicePasswordID))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrDevicePasswordID))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrDevicePasswordID) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrDevicePasswordID); }
     if (!m_parse__) { m_device_password_id_attr->struct_init(); }
     m_os_version_attr = (WSC::sWscAttrOsVersion*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrOsVersion))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrOsVersion))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrOsVersion) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrOsVersion); }
     if (!m_parse__) { m_os_version_attr->struct_init(); }
     m_version2_attr = (WSC::sWscAttrVersion2*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion2))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrVersion2))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrVersion2) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrVersion2); }
     if (!m_parse__) { m_version2_attr->struct_init(); }
     m_encrypted_settings = (WSC::cWscAttrEncryptedSettings*)m_buff_ptr__;
@@ -767,7 +887,10 @@ bool tlvWscM2::init()
         encrypted_settings->class_swap();
     }
     m_authenticator = (WSC::sWscAttrAuthenticator*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticator))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrAuthenticator))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrAuthenticator) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticator); }
     if (!m_parse__) { m_authenticator->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -78,7 +78,10 @@ bool tlvTestVarList::alloc_simple_list(size_t count) {
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
     m_simple_list_idx__ += count;
     *m_simple_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -148,7 +151,10 @@ bool tlvTestVarList::alloc_test_string(size_t count) {
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
     m_test_string_idx__ += count;
     *m_test_string_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -223,7 +229,10 @@ bool tlvTestVarList::add_complex_list(std::shared_ptr<cInner> ptr) {
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len - ptr->get_initial_size());
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len - ptr->get_initial_size());
     m_complex_list_vector.push_back(ptr);
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -289,7 +298,10 @@ bool tlvTestVarList::add_var1(std::shared_ptr<cInner> ptr) {
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len - ptr->get_initial_size());
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len - ptr->get_initial_size());
     m_var1_ptr = ptr;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -341,7 +353,10 @@ bool tlvTestVarList::add_var3(std::shared_ptr<cInner> ptr) {
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len - ptr->get_initial_size());
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len - ptr->get_initial_size());
     m_var3_ptr = ptr;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -417,7 +432,10 @@ bool tlvTestVarList::add_unknown_length_list(std::shared_ptr<cInner> ptr) {
     m_unknown_length_list_idx__++;
     size_t len = ptr->getLen();
     m_unknown_length_list_vector.push_back(ptr);
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -462,29 +480,53 @@ bool tlvTestVarList::init()
     }
     m_type = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_type = 0xff;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_var0 = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_simple_list_length = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_simple_list = (uint16_t*)m_buff_ptr__;
     uint8_t simple_list_length = *m_simple_list_length;
     m_simple_list_idx__ = simple_list_length;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t)*(simple_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t) * (simple_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) * (simple_list_length) << ") Failed!";
+        return false;
+    }
     m_test_string_length = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_test_string = (char*)m_buff_ptr__;
     uint8_t test_string_length = *m_test_string_length;
     m_test_string_idx__ = test_string_length;
-    if (!buffPtrIncrementSafe(sizeof(char)*(test_string_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(char) * (test_string_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (test_string_length) << ") Failed!";
+        return false;
+    }
     m_complex_list_length = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_complex_list = (cInner*)m_buff_ptr__;
     uint8_t complex_list_length = *m_complex_list_length;
@@ -531,7 +573,10 @@ bool tlvTestVarList::init()
         var3->class_swap();
     }
     m_var2 = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint32_t); }
     m_unknown_length_list = (cInner*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -622,7 +667,10 @@ bool cInner::alloc_list(size_t count) {
     m_unknown_length_list_inner = (char *)((uint8_t *)(m_unknown_length_list_inner) + len);
     m_list_idx__ += count;
     *m_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -677,7 +725,10 @@ bool cInner::alloc_unknown_length_list_inner(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_unknown_length_list_inner_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -707,19 +758,34 @@ bool cInner::init()
     }
     m_type = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_type = 0x1;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_list_length = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_list = (uint8_t*)m_buff_ptr__;
     uint8_t list_length = *m_list_length;
     m_list_idx__ = list_length;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (list_length) << ") Failed!";
+        return false;
+    }
     m_var1 = (uint32_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint32_t); }
     m_unknown_length_list_inner = (char*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -727,7 +793,10 @@ bool cInner::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_unknown_length_list_inner_idx__ = len/sizeof(char);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
@@ -60,12 +60,21 @@ bool tlvApCapability::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_CAPABILITY;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_value = (sValue*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sValue))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sValue))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sValue) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sValue); }
     if (!m_parse__) { m_value->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
@@ -79,7 +79,10 @@ bool tlvApMetric::alloc_estimated_service_info_field(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_estimated_service_info_field_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -112,22 +115,40 @@ bool tlvApMetric::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_METRIC;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_channel_utilization = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_number_of_stas_currently_associated = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_estimated_service_parameters = (sEstimatedService*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sEstimatedService))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sEstimatedService))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sEstimatedService) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sEstimatedService); }
     if (!m_parse__) { m_estimated_service_parameters->struct_init(); }
     m_estimated_service_info_field = (uint8_t*)m_buff_ptr__;
@@ -136,7 +157,10 @@ bool tlvApMetric::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_estimated_service_info_field_idx__ = len/sizeof(uint8_t);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
@@ -69,7 +69,10 @@ bool tlvApMetricQuery::alloc_bssid_list(size_t count) {
     }
     m_bssid_list_idx__ += count;
     *m_bssid_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_bssid_list_idx__ - count; i < m_bssid_list_idx__; i++) { m_bssid_list[i].struct_init(); }
@@ -102,18 +105,30 @@ bool tlvApMetricQuery::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_METRIC_QUERY;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_bssid_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_bssid_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_bssid_list = (sMacAddr*)m_buff_ptr__;
     uint8_t bssid_list_length = *m_bssid_list_length;
     m_bssid_list_idx__ = bssid_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(bssid_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr) * (bssid_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (bssid_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_METRIC_QUERY) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -103,7 +103,10 @@ bool tlvApRadioBasicCapabilities::add_operating_classes_info_list(std::shared_pt
     if (!m_parse__) { (*m_operating_classes_info_list_length)++; }
     size_t len = ptr->getLen();
     m_operating_classes_info_list_vector.push_back(ptr);
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -137,20 +140,35 @@ bool tlvApRadioBasicCapabilities::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_maximum_number_of_bsss_supported = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_info_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_info_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_info_list = (cOperatingClassesInfo*)m_buff_ptr__;
     uint8_t operating_classes_info_list_length = *m_operating_classes_info_list_length;
@@ -231,7 +249,10 @@ bool cOperatingClassesInfo::alloc_statically_non_operable_channels_list(size_t c
     }
     m_statically_non_operable_channels_list_idx__ += count;
     *m_statically_non_operable_channels_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -255,16 +276,28 @@ bool cOperatingClassesInfo::init()
         return false;
     }
     m_operating_class = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_maximum_transmit_power_dbm = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_statically_non_operable_channels_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_statically_non_operable_channels_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_statically_non_operable_channels_list = (uint8_t*)m_buff_ptr__;
     uint8_t statically_non_operable_channels_list_length = *m_statically_non_operable_channels_list_length;
     m_statically_non_operable_channels_list_idx__ = statically_non_operable_channels_list_length;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(statically_non_operable_channels_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (statically_non_operable_channels_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (statically_non_operable_channels_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -60,12 +60,21 @@ bool tlvApRadioIdentifier::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -99,7 +99,10 @@ bool tlvChannelPreference::add_operating_classes_list(std::shared_ptr<cPreferenc
     if (!m_parse__) { (*m_operating_classes_list_length)++; }
     size_t len = ptr->getLen();
     m_operating_classes_list_vector.push_back(ptr);
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -132,17 +135,29 @@ bool tlvChannelPreference::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_PREFERENCE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_list = (cPreferenceOperatingClasses*)m_buff_ptr__;
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
@@ -220,7 +235,10 @@ bool cPreferenceOperatingClasses::alloc_channel_list(size_t count) {
     m_flags = (sFlags *)((uint8_t *)(m_flags) + len);
     m_channel_list_idx__ += count;
     *m_channel_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     return true;
 }
 
@@ -249,16 +267,28 @@ bool cPreferenceOperatingClasses::init()
         return false;
     }
     m_operating_class = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_channel_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_channel_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_channel_list = (uint8_t*)m_buff_ptr__;
     uint8_t channel_list_length = *m_channel_list_length;
     m_channel_list_idx__ = channel_list_length;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t)*(channel_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (channel_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (channel_list_length) << ") Failed!";
+        return false;
+    }
     m_flags = (sFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFlags) << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { m_flags->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
@@ -65,16 +65,28 @@ bool tlvChannelSelectionResponse::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_response_code = (eResponseCode*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eResponseCode))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eResponseCode))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eResponseCode) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eResponseCode); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
@@ -81,7 +81,10 @@ bool tlvClientAssociationControlRequest::alloc_sta_list(size_t count) {
     }
     m_sta_list_idx__ += count;
     *m_sta_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_sta_list_idx__ - count; i < m_sta_list_idx__; i++) { m_sta_list[i].struct_init(); }
@@ -119,28 +122,49 @@ bool tlvClientAssociationControlRequest::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CLIENT_ASSOCIATION_CONTROL_REQUEST;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_bssid_to_block_client = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid_to_block_client->struct_init(); }
     m_association_control = (eAssociationControl*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eAssociationControl))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eAssociationControl))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eAssociationControl) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eAssociationControl); }
     m_validity_period_sec = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_sta_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_sta_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_sta_list = (sMacAddr*)m_buff_ptr__;
     uint8_t sta_list_length = *m_sta_list_length;
     m_sta_list_idx__ = sta_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(sta_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr) * (sta_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (sta_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_CLIENT_ASSOCIATION_CONTROL_REQUEST) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
@@ -71,20 +71,35 @@ bool tlvClientAssociationEvent::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_CLIENT_ASSOCIATION_EVENT;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_client_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_client_mac->struct_init(); }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_association_event = (eAssociationEvent*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eAssociationEvent))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eAssociationEvent))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eAssociationEvent) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eAssociationEvent); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -67,7 +67,10 @@ bool tlvHigherLayerData::alloc_payload(size_t count) {
         std::copy_n(src, move_length, dst);
     }
     m_payload_idx__ += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -94,12 +97,21 @@ bool tlvHigherLayerData::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_HIGHER_LAYER_DATA;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_protocol = (eProtocol*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(eProtocol))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eProtocol))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eProtocol) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eProtocol); }
     m_payload = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
@@ -107,7 +119,10 @@ bool tlvHigherLayerData::init()
         if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_payload_idx__ = len/sizeof(uint8_t);
-        if (!buffPtrIncrementSafe(len)) { return false; }
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
     }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -74,7 +74,10 @@ bool tlvOperatingChannelReport::alloc_operating_classes_list(size_t count) {
     m_current_transmit_power = (int8_t *)((uint8_t *)(m_current_transmit_power) + len);
     m_operating_classes_list_idx__ += count;
     *m_operating_classes_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_operating_classes_list_idx__ - count; i < m_operating_classes_list_idx__; i++) { m_operating_classes_list[i].struct_init(); }
@@ -114,24 +117,42 @@ bool tlvOperatingChannelReport::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_list = (sOperatingClasses*)m_buff_ptr__;
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
     m_operating_classes_list_idx__ = operating_classes_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sOperatingClasses)*(operating_classes_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sOperatingClasses) * (operating_classes_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sOperatingClasses) * (operating_classes_list_length) << ") Failed!";
+        return false;
+    }
     m_current_transmit_power = (int8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(int8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(int8_t); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -99,7 +99,10 @@ bool tlvRadioOperationRestriction::add_operating_classes_list(std::shared_ptr<cR
     if (!m_parse__) { (*m_operating_classes_list_length)++; }
     size_t len = ptr->getLen();
     m_operating_classes_list_vector.push_back(ptr);
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(!m_parse__ && m_length){ (*m_length) += len; }
     m_lock_allocation__ = false;
     return true;
@@ -132,17 +135,29 @@ bool tlvRadioOperationRestriction::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_operating_classes_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_operating_classes_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_operating_classes_list = (cRestrictedOperatingClasses*)m_buff_ptr__;
     uint8_t operating_classes_list_length = *m_operating_classes_list_length;
@@ -220,7 +235,10 @@ bool cRestrictedOperatingClasses::alloc_channel_list(size_t count) {
     }
     m_channel_list_idx__ += count;
     *m_channel_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if (!m_parse__) { 
         for (size_t i = m_channel_list_idx__ - count; i < m_channel_list_idx__; i++) { m_channel_list[i].struct_init(); }
     }
@@ -249,14 +267,23 @@ bool cRestrictedOperatingClasses::init()
         return false;
     }
     m_operating_class = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_channel_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_channel_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     m_channel_list = (sChannelInfo*)m_buff_ptr__;
     uint8_t channel_list_length = *m_channel_list_length;
     m_channel_list_idx__ = channel_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sChannelInfo)*(channel_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sChannelInfo) * (channel_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sChannelInfo) * (channel_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     return true;
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -69,7 +69,10 @@ bool tlvSearchedService::alloc_searched_service_list(size_t count) {
     }
     m_searched_service_list_idx__ += count;
     *m_searched_service_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -96,18 +99,30 @@ bool tlvSearchedService::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SEARCHED_SERVICE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_searched_service_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_searched_service_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_searched_service_list = (eSearchedService*)m_buff_ptr__;
     uint8_t searched_service_list_length = *m_searched_service_list_length;
     m_searched_service_list_idx__ = searched_service_list_length;
-    if (!buffPtrIncrementSafe(sizeof(eSearchedService)*(searched_service_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eSearchedService) * (searched_service_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eSearchedService) * (searched_service_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
@@ -77,23 +77,41 @@ bool tlvSteeringBTMReport::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_STEERING_BTM_REPORT;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_sta_mac = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_sta_mac->struct_init(); }
     m_btm_status_code = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_target_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_target_bssid->struct_init(); }
     if (m_parse__ && m_swap__) { class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
@@ -87,7 +87,10 @@ bool tlvSteeringRequest::alloc_sta_list(size_t count) {
     m_target_bssid_list = (sTargetBssidInfo *)((uint8_t *)(m_target_bssid_list) + len);
     m_sta_list_idx__ += count;
     *m_sta_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_sta_list_idx__ - count; i < m_sta_list_idx__; i++) { m_sta_list[i].struct_init(); }
@@ -131,7 +134,10 @@ bool tlvSteeringRequest::alloc_target_bssid_list(size_t count) {
     }
     m_target_bssid_list_idx__ += count;
     *m_target_bssid_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     if (!m_parse__) { 
         for (size_t i = m_target_bssid_list_idx__ - count; i < m_target_bssid_list_idx__; i++) { m_target_bssid_list[i].struct_init(); }
@@ -176,39 +182,69 @@ bool tlvSteeringRequest::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_STEERING_REQUEST;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_bssid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_bssid->struct_init(); }
     m_request_flags = (sRequestFlags*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sRequestFlags))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sRequestFlags))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sRequestFlags) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sRequestFlags); }
     if (!m_parse__) { m_request_flags->struct_init(); }
     m_steering_opportunity_window_sec = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_btm_disassociation_timer_ms = (uint16_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_sta_list_length = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_sta_list = (sMacAddr*)m_buff_ptr__;
     uint8_t sta_list_length = *m_sta_list_length;
     m_sta_list_idx__ = sta_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr)*(sta_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr) * (sta_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (sta_list_length) << ") Failed!";
+        return false;
+    }
     m_target_bssid_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_target_bssid_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_target_bssid_list = (sTargetBssidInfo*)m_buff_ptr__;
     uint8_t target_bssid_list_length = *m_target_bssid_list_length;
     m_target_bssid_list_idx__ = target_bssid_list_length;
-    if (!buffPtrIncrementSafe(sizeof(sTargetBssidInfo)*(target_bssid_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sTargetBssidInfo) * (target_bssid_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sTargetBssidInfo) * (target_bssid_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_STEERING_REQUEST) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -69,7 +69,10 @@ bool tlvSupportedService::alloc_supported_service_list(size_t count) {
     }
     m_supported_service_list_idx__ += count;
     *m_supported_service_list_length += count;
-    if (!buffPtrIncrementSafe(len)) { return false; }
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
     if(m_length){ (*m_length) += len; }
     return true;
 }
@@ -96,18 +99,30 @@ bool tlvSupportedService::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_SUPPORTED_SERVICE;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_supported_service_list_length = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_supported_service_list_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_supported_service_list = (eSupportedService*)m_buff_ptr__;
     uint8_t supported_service_list_length = *m_supported_service_list_length;
     m_supported_service_list_idx__ = supported_service_list_length;
-    if (!buffPtrIncrementSafe(sizeof(eSupportedService)*(supported_service_list_length))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eSupportedService) * (supported_service_list_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eSupportedService) * (supported_service_list_length) << ") Failed!";
+        return false;
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
@@ -65,16 +65,28 @@ bool tlvTransmitPowerLimit::init()
     }
     m_type = (eTlvTypeMap*)m_buff_ptr__;
     if (!m_parse__) *m_type = eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT;
-    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
     m_length = (uint16_t*)m_buff_ptr__;
     if (!m_parse__) *m_length = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint16_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     m_radio_uid = (sMacAddr*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
     m_transmit_power_limit_dbm = (uint8_t*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(uint8_t))) { return false; }
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     if (m_parse__ && m_swap__) { class_swap(); }
     if (m_parse__) {

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -771,7 +771,10 @@ class TlvF:
                         lines_cpp.append("if (!m_%s__) *m_%s = %s;" % ( self.MEMBER_PARSE, param_name, param_val_const) )
                     elif param_val != None: lines_cpp.append("if (!m_%s__) *m_%s = %s;" % ( self.MEMBER_PARSE, param_name, param_val) )
                     elif param_length_var: lines_cpp.append("if (!m_%s__) *m_%s = 0;" % ( self.MEMBER_PARSE, param_name) )
-                    lines_cpp.append("%sif (!buffPtrIncrementSafe(sizeof(%s))) { return false; }" % (self.getIndentation(0), param_type) )
+                    lines_cpp.append("%sif (!buffPtrIncrementSafe(sizeof(%s))) {" % (self.getIndentation(0), param_type) )
+                    lines_cpp.append("%sLOG(ERROR) << \"buffPtrIncrementSafe(\" << std::dec << sizeof(%s) << \") Failed!\";" % (self.getIndentation(1), param_type))
+                    lines_cpp.append("%sreturn false;" %(self.getIndentation(1)))
+                    lines_cpp.append("%s}" %(self.getIndentation(0)))
 
                     if obj_meta.is_tlv_class and param_name != MetaData.TLV_TYPE_TYPE and param_name != MetaData.TLV_TYPE_LENGTH:
                         lines_cpp.append( "if(m_length && !m_%s__){ (*m_length) += sizeof(%s); }" % ( self.MEMBER_PARSE, param_type) )
@@ -868,7 +871,10 @@ class TlvF:
                     lines_cpp.append("%s}" %(self.getIndentation(1)))
                 else:
                     lines_cpp.append("%sm_%s_idx__ = len/sizeof(%s);" % (self.getIndentation(1), param_name, param_type))
-                    lines_cpp.append("%sif (!buffPtrIncrementSafe(len)) { return false; }" % (self.getIndentation(1)))
+                    lines_cpp.append("%sif (!buffPtrIncrementSafe(len)) {" % (self.getIndentation(1)) )
+                    lines_cpp.append("%sLOG(ERROR) << \"buffPtrIncrementSafe(\" << std::dec << len << \") Failed!\";" % (self.getIndentation(2)))
+                    lines_cpp.append("%sreturn false;" %(self.getIndentation(2)))
+                    lines_cpp.append("%s}" %(self.getIndentation(1)))
                 lines_cpp.append("}")
             if is_var_len or is_dynamic_len:
                 param_meta.list_index = obj_meta.list_index
@@ -897,9 +903,15 @@ class TlvF:
                     lines_cpp.append("}")
                 else:
                     lines_cpp.append("m_%s_idx__ = %s;" % (param_name, param_length))
-                    lines_cpp.append("%sif (!buffPtrIncrementSafe(sizeof(%s)*(%s))) { return false; }" % (self.getIndentation(0), param_type,param_length) )
+                    lines_cpp.append("%sif (!buffPtrIncrementSafe(sizeof(%s) * (%s))) {" % (self.getIndentation(0), param_type, param_length))
+                    lines_cpp.append("%sLOG(ERROR) << \"buffPtrIncrementSafe(\" << std::dec << sizeof(%s) * (%s) << \") Failed!\";" % (self.getIndentation(1), param_type,param_length))
+                    lines_cpp.append("%sreturn false;" %(self.getIndentation(1)))
+                    lines_cpp.append("%s}" %(self.getIndentation(0)))
             if is_int_len or is_const_len:
-                lines_cpp.append("%sif (!buffPtrIncrementSafe(sizeof(%s)*(%s))) { return false; }" % (self.getIndentation(0), param_type,param_length) )
+                lines_cpp.append("%sif (!buffPtrIncrementSafe(sizeof(%s) * (%s))) {" % (self.getIndentation(0), param_type, param_length))
+                lines_cpp.append("%sLOG(ERROR) << \"buffPtrIncrementSafe(\" << std::dec << sizeof(%s) * (%s) << \") Failed!\";" % (self.getIndentation(1), param_type,param_length))
+                lines_cpp.append("%sreturn false;" %(self.getIndentation(1)))
+                lines_cpp.append("%s}" %(self.getIndentation(0)))
                 lines_cpp.append("m_%s_idx__  = %s;" % (param_name, param_length))
                 if obj_meta.is_tlv_class or TypeInfo(param_type).type == TypeInfo.STRUCT:
                     lines_cpp.append("if (!m_parse__) {")
@@ -1123,7 +1135,10 @@ class TlvF:
                 lines_cpp.append( "%sm_%s_vector.push_back(ptr);" % (self.getIndentation(1), param_name ))
             else:
                 lines_cpp.append( "%sm_%s_ptr = ptr;" % (self.getIndentation(1), param_name ))
-            lines_cpp.append("%sif (!buffPtrIncrementSafe(len)) { return false; }" % (self.getIndentation(1)) )
+            lines_cpp.append("%sif (!buffPtrIncrementSafe(len)) {" % (self.getIndentation(1)) )
+            lines_cpp.append("%sLOG(ERROR) << \"buffPtrIncrementSafe(\" << std::dec << len << \") Failed!\";" % (self.getIndentation(2)))
+            lines_cpp.append("%sreturn false;" %(self.getIndentation(2)))
+            lines_cpp.append("%s}" %(self.getIndentation(1)))
             if obj_meta.is_tlv_class:
                 lines_cpp.append( "%sif(!m_parse__ && m_length){ (*m_length) += len; }" % (self.getIndentation(1)))
             lines_cpp.append( "%sm_%s__ = false;" % (self.getIndentation(1), self.MEMBER_LOCK_ALLOCATION))
@@ -1156,7 +1171,10 @@ class TlvF:
             lines_cpp.append( "%sm_%s_idx__ += count;" % (self.getIndentation(1), param_name) )
             if is_var_len:
                 lines_cpp.append( "%s*m_%s += count;" % (self.getIndentation(1), param_length) )
-            lines_cpp.append("%sif (!buffPtrIncrementSafe(len)) { return false; }" % (self.getIndentation(1)))
+            lines_cpp.append("%sif (!buffPtrIncrementSafe(len)) {" % (self.getIndentation(1)) )
+            lines_cpp.append("%sLOG(ERROR) << \"buffPtrIncrementSafe(\" << std::dec << len << \") Failed!\";" % (self.getIndentation(2)))
+            lines_cpp.append("%sreturn false;" %(self.getIndentation(2)))
+            lines_cpp.append("%s}" %(self.getIndentation(1)))
             if obj_meta.is_tlv_class:
                 lines_cpp.append( "%sif(m_length){ (*m_length) += len; }" % (self.getIndentation(1)))
             if TypeInfo(param_type).type == TypeInfo.STRUCT:


### PR DESCRIPTION
Till now, whenever buffPtrIncrementSafe() failed, it returned "silently"
without logging the failure so it was rather difficult to find out where
the error is.

Since this is autogenerated code, it is easy to add explicit error log
to all these cases - so add them in tlvf.py.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>