### PR TITLE
tlvf: CmduMessageTx ->TlvList refactor

### DIFF
--- a/agent/src/beerocks/monitor/monitor_stats.cpp
+++ b/agent/src/beerocks/monitor/monitor_stats.cpp
@@ -128,7 +128,7 @@ void monitor_stats::process()
             return;
         }
 
-        auto beerocks_header = message_com::get_vs_class_header(cmdu_tx);
+        auto beerocks_header = message_com::get_beerocks_header(cmdu_tx);
         if (!beerocks_header) {
             LOG(ERROR) << "Failed getting beerocks_header!";
             return;
@@ -181,7 +181,7 @@ void monitor_stats::process()
             sta_stats_msg.rx_rssi           = sta_stats.rx_rssi_curr;
         }
 
-        beerocks_header->id() = requests_list.front();
+        beerocks_header->actionhdr()->id() = requests_list.front();
         requests_list.pop_front();
         message_com::send_cmdu(slave_socket, cmdu_tx);
     }

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -614,7 +614,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_MONITOR_SON_CONFIG_UPDATE: {
         LOG(TRACE) << "received ACTION_MONITOR_SON_CONFIG_UPDATE";
-        auto update = cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_SON_CONFIG_UPDATE>();
+        auto update =
+            beerocks_header->addClass<beerocks_message::cACTION_MONITOR_SON_CONFIG_UPDATE>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_SON_CONFIG_UPDATE failed";
             return false;
@@ -642,7 +643,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST: {
         // LOG(TRACE) << "received ACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST"; // floods the log
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST failed";
             return false;
@@ -656,7 +658,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL: {
         LOG(TRACE) << "received ACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL failed";
             return false;
@@ -673,7 +676,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_MONITOR_CLIENT_START_MONITORING_REQUEST: {
         LOG(TRACE) << "received ACTION_MONITOR_CLIENT_START_MONITORING_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST failed";
             return false;
@@ -716,7 +720,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST: {
 
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST failed";
             send_steering_return_status(
@@ -782,7 +787,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 
         LOG(TRACE) << "received ACTION_MONITOR_STEERING_CLIENT_SET_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST failed";
             send_steering_return_status(
@@ -840,7 +846,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST: {
         LOG(TRACE) << "received ACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST failed";
             return false;
@@ -855,8 +862,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         LOG(TRACE) << "received ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST";
 
         auto request =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;
@@ -909,7 +916,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_MONITOR_CLIENT_BEACON_11K_REQUEST: {
         LOG(TRACE) << "received ACTION_MONITOR_CLIENT_BEACON_11K_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST failed";
             return false;
@@ -963,7 +971,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST failed";
             return false;
@@ -1000,7 +1009,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST failed";
             return false;
@@ -1082,8 +1092,8 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST: {
         auto request =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST failed";
             return false;

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -436,7 +436,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         LOG(TRACE) << "ACTION_APMANAGER_ENABLE_APS_REQUEST";
 
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_ENABLE_APS_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_ENABLE_APS_REQUEST>();
         if (!notification) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_ENABLE_APS_REQUEST failed";
             return false;
@@ -498,7 +498,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST: {
 
-        auto request = cmdu_rx.addClass<
+        auto request = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass "
@@ -557,7 +557,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START failed";
             return false;
@@ -619,7 +620,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE: {
         auto update =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE failed";
             return false;
@@ -631,7 +633,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE: {
         auto update =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE failed";
             return false;
@@ -643,7 +646,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST failed";
             send_steering_return_status(
@@ -671,7 +675,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_DISALLOW_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST failed";
             return false;
@@ -685,7 +690,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         break;
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_ALLOW_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_ALLOW_REQUEST failed";
             return false;
@@ -718,9 +724,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         break;
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST: {
-        auto request =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
+        auto request = beerocks_header->addClass<
+            beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;
@@ -788,7 +793,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST failed";
             return false;
@@ -830,7 +836,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST>();
         if (!request) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST failed";
             return false;
@@ -865,8 +872,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION: {
         auto update =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION failed";
             return false;
@@ -878,7 +885,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     }
     case beerocks_message::ACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST failed";
             send_steering_return_status(

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1374,7 +1374,8 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
     // Handle messages
     switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_BACKHAUL_REGISTER_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_REGISTER_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_BACKHAUL_REGISTER_REQUEST>();
         if (!request) {
             LOG(ERROR) << "addClass cACTION_BACKHAUL_REGISTER_REQUEST failed";
             return false;
@@ -1405,7 +1406,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
 
     case beerocks_message::ACTION_BACKHAUL_ENABLE: {
 
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_ENABLE>();
+        auto request = beerocks_header->addClass<beerocks_message::cACTION_BACKHAUL_ENABLE>();
         if (!request) {
             LOG(ERROR) << "addClass cACTION_BACKHAUL_ENABLE failed";
             return false;
@@ -1484,7 +1485,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         break;
     }
     case beerocks_message::ACTION_BACKHAUL_ROAM_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_ROAM_REQUEST>();
+        auto request = beerocks_header->addClass<beerocks_message::cACTION_BACKHAUL_ROAM_REQUEST>();
         if (!request) {
             LOG(ERROR) << "addClass ACTION_BACKHAUL_ROAM_REQUEST failed";
             return false;
@@ -1510,7 +1511,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
     case beerocks_message::ACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST: {
         LOG(DEBUG) << "ACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST received from iface "
                    << soc->sta_iface;
-        auto request_in = cmdu_rx.addClass<
+        auto request_in = beerocks_header->addClass<
             beerocks_message::cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST>();
         if (!request_in) {
             LOG(ERROR)
@@ -1529,8 +1530,8 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         LOG(DEBUG) << "ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST";
 
         auto request =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
         if (!request) {
             LOG(ERROR) << "addClass cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -731,7 +731,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST: {
         LOG(TRACE) << "ACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST failed";
             return false;
@@ -792,7 +793,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL: {
         LOG(TRACE) << "ACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL failed";
             return false;
@@ -805,7 +807,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_ARP_QUERY_REQUEST: {
         LOG(TRACE) << "ACTION_PLATFORM_ARP_QUERY_REQUEST";
 
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_ARP_QUERY_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ARP_QUERY_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_ARP_QUERY_REQUEST failed";
             return false;
@@ -898,7 +901,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     } break;
     case beerocks_message::ACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION: {
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION failed";
             return false;
@@ -917,8 +921,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     } break;
     case beerocks_message::ACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION: {
         auto notification =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION failed";
             return false;
@@ -929,8 +933,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION: {
 
         auto notification =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION failed";
             return false;
@@ -1051,7 +1055,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST: {
         // Request message
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST failed";
             break;
@@ -1136,7 +1141,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_ONBOARD_SET_REQUEST: {
         LOG(TRACE) << "ACTION_PLATFORM_ONBOARD_SET_REQUEST";
         // Request message
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_ONBOARD_SET_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ONBOARD_SET_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_ONBOARD_SET_REQUEST failed";
             break;
@@ -1153,7 +1159,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         LOG(TRACE) << "ACTION_PLATFORM_WPS_ONBOARDING_REQUEST";
 
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_WPS_ONBOARDING_REQUEST failed";
             break;
@@ -1218,7 +1224,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     } break;
 
     case beerocks_message::ACTION_PLATFORM_ERROR_NOTIFICATION: {
-        auto error = cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_ERROR_NOTIFICATION>();
+        auto error =
+            beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ERROR_NOTIFICATION>();
         if (error == nullptr) {
             LOG(ERROR) << "addClass failed";
             break;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2211,7 +2211,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE: {
         LOG(TRACE) << "received ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE";
         auto response =
-            beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE>();
         if (!response) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE failed";
             return false;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -352,19 +352,19 @@ bool slave_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 
         switch (beerocks_header->action()) {
         case beerocks_message::ACTION_CONTROL: {
-            return handle_cmdu_control_message(sd, beerocks_header, cmdu_rx);
+            return handle_cmdu_control_message(sd, beerocks_header);
         } break;
         case beerocks_message::ACTION_BACKHAUL: {
-            return handle_cmdu_backhaul_manager_message(sd, beerocks_header, cmdu_rx);
+            return handle_cmdu_backhaul_manager_message(sd, beerocks_header);
         } break;
         case beerocks_message::ACTION_PLATFORM: {
-            return handle_cmdu_platform_manager_message(sd, beerocks_header, cmdu_rx);
+            return handle_cmdu_platform_manager_message(sd, beerocks_header);
         } break;
         case beerocks_message::ACTION_APMANAGER: {
-            return handle_cmdu_ap_manager_message(sd, beerocks_header, cmdu_rx);
+            return handle_cmdu_ap_manager_message(sd, beerocks_header);
         } break;
         case beerocks_message::ACTION_MONITOR: {
-            return handle_cmdu_monitor_message(sd, beerocks_header, cmdu_rx);
+            return handle_cmdu_monitor_message(sd, beerocks_header);
         } break;
         default: {
             LOG(ERROR) << "Unknown message, action: " << int(beerocks_header->action());
@@ -440,19 +440,18 @@ bool slave_thread::handle_cmdu_control_ieee1905_1_message(Socket *sd,
     return true;
 }
 
-bool slave_thread::handle_cmdu_control_message(
-    Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-    ieee1905_1::CmduMessageRx &cmdu_rx)
+bool slave_thread::handle_cmdu_control_message(Socket *sd,
+                                               std::shared_ptr<beerocks_header> beerocks_header)
 {
     // LOG(DEBUG) << "handle_cmdu_control_message(), INTEL_VS: action=" + std::to_string(beerocks_header->action()) + ", action_op=" + std::to_string(beerocks_header->action_op());
     // LOG(DEBUG) << "received radio_mac=" << network_utils::mac_to_string(beerocks_header->radio_mac()) << ", local radio_mac=" << network_utils::mac_to_string(hostap_params.iface_mac);
 
     // to me or not to me, this is the question...
-    if (beerocks_header->radio_mac() != hostap_params.iface_mac) {
+    if (beerocks_header->actionhdr()->radio_mac() != hostap_params.iface_mac) {
         return true;
     }
 
-    if (beerocks_header->direction() == beerocks::BEEROCKS_DIRECTION_CONTROLLER) {
+    if (beerocks_header->actionhdr()->direction() == beerocks::BEEROCKS_DIRECTION_CONTROLLER) {
         return true;
     }
 
@@ -475,7 +474,8 @@ bool slave_thread::handle_cmdu_control_message(
     switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_CONTROL_ARP_QUERY_REQUEST: {
         LOG(TRACE) << "ACTION_CONTROL_ARP_QUERY_REQUEST";
-        auto request_in = cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_ARP_QUERY_REQUEST>();
+        auto request_in =
+            beerocks_header->addClass<beerocks_message::cACTION_CONTROL_ARP_QUERY_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_ARP_QUERY_REQUEST failed";
             return false;
@@ -494,7 +494,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_SON_CONFIG_UPDATE: {
         LOG(DEBUG) << "received ACTION_CONTROL_SON_CONFIG_UPDATE";
-        auto update = cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_SON_CONFIG_UPDATE>();
+        auto update =
+            beerocks_header->addClass<beerocks_message::cACTION_CONTROL_SON_CONFIG_UPDATE>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_SON_CONFIG_UPDATE failed";
             return false;
@@ -506,7 +507,7 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST: {
         LOG(DEBUG) << "received ACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST";
 
-        auto request_in = cmdu_rx.addClass<
+        auto request_in = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR)
@@ -530,7 +531,8 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START: {
         LOG(DEBUG) << "received ACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START";
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START failed";
             return false;
@@ -552,7 +554,8 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_CLIENT_START_MONITORING_REQUEST: {
         LOG(DEBUG) << "received ACTION_CONTROL_CLIENT_START_MONITORING_REQUEST";
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_START_MONITORING_REQUEST failed";
             return false;
@@ -594,7 +597,8 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST: {
         LOG(DEBUG) << "received ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST";
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST failed";
             return false;
@@ -621,8 +625,8 @@ bool slave_thread::handle_cmdu_control_message(
         LOG(DEBUG) << "received ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST";
 
         auto request_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;
@@ -682,7 +686,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_DISCONNECT_REQUEST: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_DISCONNECT_REQUEST failed";
             return false;
@@ -707,7 +712,7 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_CONTROLLER_PING_REQUEST: {
         LOG(DEBUG) << "received ACTION_CONTROL_CONTROLLER_PING_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CONTROLLER_PING_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_CONTROL_CONTROLLER_PING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_CONTROLLER_PING_REQUEST failed";
             return false;
@@ -735,7 +740,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_AGENT_PING_RESPONSE: {
         LOG(DEBUG) << "received ACTION_CONTROL_AGENT_PING_RESPONSE";
-        auto response = cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_AGENT_PING_RESPONSE>();
+        auto response =
+            beerocks_header->addClass<beerocks_message::cACTION_CONTROL_AGENT_PING_RESPONSE>();
         if (response == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_AGENT_PING_RESPONSE failed";
             return false;
@@ -764,7 +770,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL failed";
             return false;
@@ -803,7 +810,8 @@ bool slave_thread::handle_cmdu_control_message(
         LOG(TRACE) << "received ACTION_CONTROL_BACKHAUL_ROAM_REQUEST";
         if (is_backhaul_manager && backhaul_params.backhaul_is_wireless) {
             auto request_in =
-                cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST>();
             if (request_in == nullptr) {
                 LOG(ERROR) << "addClass cACTION_CONTROL_BACKHAUL_ROAM_REQUEST failed";
                 return false;
@@ -838,9 +846,8 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST: {
         if (monitor_socket) {
             // LOG(TRACE) << "received ACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST"; // floods the log
-            auto request_in =
-                cmdu_rx
-                    .addClass<beerocks_message::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST>();
+            auto request_in = beerocks_header->addClass<
+                beerocks_message::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST>();
             if (request_in == nullptr) {
                 LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST failed";
                 return false;
@@ -860,7 +867,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST failed";
             return false;
@@ -880,8 +888,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST: {
         auto request_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST failed";
             return false;
@@ -901,7 +909,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST failed";
             return false;
@@ -928,7 +937,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST failed";
             return false;
@@ -948,7 +958,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST failed";
             return false;
@@ -968,8 +979,8 @@ bool slave_thread::handle_cmdu_control_message(
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST: {
         auto request_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST failed";
             return false;
@@ -990,7 +1001,7 @@ bool slave_thread::handle_cmdu_control_message(
     }
 
     case beerocks_message::ACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST: {
-        auto request_in = cmdu_rx.addClass<
+        auto request_in = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST>();
         if (request_in == nullptr) {
             LOG(ERROR)
@@ -1024,7 +1035,8 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST: {
         LOG(TRACE) << "ACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST";
         auto update =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass failed";
             return false;
@@ -1060,7 +1072,8 @@ bool slave_thread::handle_cmdu_control_message(
     case beerocks_message::ACTION_CONTROL_STEERING_CLIENT_SET_REQUEST: {
         LOG(TRACE) << "ACTION_CONTROL_STEERING_CLIENT_SET_REQUEST";
         auto update =
-            cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST>();
         if (update == nullptr) {
             LOG(ERROR) << "addClass failed";
             return false;
@@ -1132,8 +1145,7 @@ bool slave_thread::handle_cmdu_control_message(
 }
 
 bool slave_thread::handle_cmdu_backhaul_manager_message(
-    Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-    ieee1905_1::CmduMessageRx &cmdu_rx)
+    Socket *sd, std::shared_ptr<beerocks_header> beerocks_header)
 {
     if (backhaul_manager_socket == nullptr) {
         LOG(ERROR) << "backhaul_socket == nullptr";
@@ -1149,7 +1161,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
         LOG(DEBUG) << "ACTION_BACKHAUL_REGISTER_RESPONSE";
         if (slave_state == STATE_WAIT_FOR_BACKHAUL_MANAGER_REGISTER_RESPONSE) {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_REGISTER_RESPONSE>();
+                beerocks_header->addClass<beerocks_message::cACTION_BACKHAUL_REGISTER_RESPONSE>();
             if (!response) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
@@ -1164,7 +1176,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
 
     case beerocks_message::ACTION_BACKHAUL_ENABLE_APS_REQUEST: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_ENABLE_APS_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_BACKHAUL_ENABLE_APS_REQUEST>();
         if (!notification_in) {
             LOG(ERROR) << "Failed building cACTION_BACKHAUL_ENABLE_APS_REQUEST message!";
             return false;
@@ -1192,7 +1204,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
     case beerocks_message::ACTION_BACKHAUL_CONNECTED_NOTIFICATION: {
 
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_CONNECTED_NOTIFICATION>();
+            beerocks_header->addClass<beerocks_message::cACTION_BACKHAUL_CONNECTED_NOTIFICATION>();
         if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
@@ -1295,7 +1307,8 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
         LOG(DEBUG) << "ACTION_BACKHAUL_DISCONNECTED_NOTIFICATION";
 
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION>();
         if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
@@ -1319,9 +1332,8 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
     case beerocks_message::ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE: {
         LOG(DEBUG) << "ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE";
 
-        auto response_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
+        auto response_in = beerocks_header->addClass<
+            beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
         if (!response_in) {
             LOG(ERROR)
                 << "Failed building ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE message!";
@@ -1350,7 +1362,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
     }
     case beerocks_message::ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE: {
         LOG(DEBUG) << "ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE";
-        auto response_in = cmdu_rx.addClass<
+        auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>();
         if (!response_in) {
             LOG(ERROR) << "Failed building ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE "
@@ -1375,7 +1387,8 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
     case beerocks_message::ACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION: {
         LOG(DEBUG) << "ACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION";
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION>();
         if (!notification_in) {
             LOG(ERROR) << "Failed building ACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION message!";
             return false;
@@ -1422,8 +1435,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
 }
 
 bool slave_thread::handle_cmdu_platform_manager_message(
-    Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-    ieee1905_1::CmduMessageRx &cmdu_rx)
+    Socket *sd, std::shared_ptr<beerocks_header> beerocks_header)
 {
     if (platform_manager_socket != sd) {
         LOG(ERROR) << "Unknown socket, ACTION_PLATFORM_MANAGER action_op: "
@@ -1436,7 +1448,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         LOG(TRACE) << "ACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE";
         if (slave_state == STATE_WAIT_FOR_PLATFORM_MANAGER_REGISTER_RESPONSE) {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE failed";
                 return false;
@@ -1472,7 +1485,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         // LOG(TRACE) << "ACTION_PLATFORM_ARP_MONITOR_NOTIFICATION";
         if (master_socket) {
             auto notification_in =
-                cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION>();
             if (notification_in == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION failed";
                 return false;
@@ -1494,7 +1508,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         LOG(TRACE) << "ACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION";
 
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION failed";
             return false;
@@ -1509,7 +1524,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
     }
     case beerocks_message::ACTION_PLATFORM_OPERATIONAL_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_OPERATIONAL_NOTIFICATION failed";
             return false;
@@ -1534,7 +1550,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
     }
     case beerocks_message::ACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION: {
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION failed";
             return false;
@@ -1577,7 +1594,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         LOG(TRACE) << "ACTION_PLATFORM_ARP_QUERY_RESPONSE";
         if (master_socket) {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_ARP_QUERY_RESPONSE>();
+                beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ARP_QUERY_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ARP_QUERY_RESPONSE failed";
                 return false;
@@ -1607,9 +1624,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
     return true;
 }
 
-bool slave_thread::handle_cmdu_ap_manager_message(
-    Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-    ieee1905_1::CmduMessageRx &cmdu_rx)
+bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
+                                                  std::shared_ptr<beerocks_header> beerocks_header)
 {
     if (ap_manager_socket == nullptr) {
         if (beerocks_header->action_op() !=
@@ -1644,7 +1660,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     case beerocks_message::ACTION_APMANAGER_JOINED_NOTIFICATION: {
         LOG(INFO) << "received ACTION_APMANAGER_JOINED_NOTIFICATION";
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_JOINED_NOTIFICATION>();
+            beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_JOINED_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_JOINED_NOTIFICATION failed";
             return false;
@@ -1660,7 +1676,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE: {
-        auto response_in = cmdu_rx.addClass<
+        auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass "
@@ -1684,7 +1700,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION: {
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION failed";
             return false;
@@ -1716,7 +1733,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         configuration_in_progress = false;
         LOG(INFO) << "received ACTION_APMANAGER_ENABLE_APS_RESPONSE";
 
-        auto response = cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_ENABLE_APS_RESPONSE>();
+        auto response =
+            beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_ENABLE_APS_RESPONSE>();
         if (!response) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_ENABLE_APS_RESPONSE failed";
             return false;
@@ -1736,7 +1754,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION failed";
             return false;
@@ -1757,7 +1776,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION failed";
@@ -1780,7 +1799,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     case beerocks_message::ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION: {
         LOG(INFO) << "ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION";
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION failed";
             return false;
@@ -1804,7 +1824,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         LOG(INFO) << "ACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION";
 
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION failed";
             return false;
@@ -1832,7 +1853,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     case beerocks_message::ACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION: {
         LOG(INFO) << "received ACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION";
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION failed";
             return false;
@@ -1849,7 +1871,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE: {
-        auto response_in = cmdu_rx.addClass<
+        auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE failed";
@@ -1877,8 +1899,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION failed";
             return false;
@@ -1945,7 +1967,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_ACK: {
-        auto response_in = cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_ACK>();
+        auto response_in = beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_ACK>();
         if (!response_in) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE failed";
             return false;
@@ -1965,7 +1987,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE: {
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE failed";
             return false;
@@ -1991,7 +2014,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE: {
-        auto response_in = cmdu_rx.addClass<
+        auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR)
@@ -2013,7 +2036,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass sACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION failed";
@@ -2033,7 +2056,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR)
@@ -2054,7 +2077,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION>();
         if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION failed";
             return false;
@@ -2102,7 +2126,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
         break;
     }
     case beerocks_message::ACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION failed";
@@ -2123,7 +2147,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
 
     case beerocks_message::ACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass "
@@ -2146,7 +2170,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE failed";
             return false;
@@ -2165,7 +2190,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     }
     case beerocks_message::ACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE failed";
             return false;
@@ -2268,9 +2294,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(
     return true;
 }
 
-bool slave_thread::handle_cmdu_monitor_message(
-    Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-    ieee1905_1::CmduMessageRx &cmdu_rx)
+bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
+                                               std::shared_ptr<beerocks_header> beerocks_header)
 {
     if (monitor_socket == nullptr) {
         if (beerocks_header->action_op() != beerocks_message::ACTION_MONITOR_JOINED_NOTIFICATION) {
@@ -2307,7 +2332,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION: {
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION failed";
             return false;
@@ -2326,8 +2352,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_STATUS_CHANGED_NOTIFICATION failed";
             return false;
@@ -2357,8 +2383,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE: {
         auto response_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE failed";
             break;
@@ -2383,7 +2409,7 @@ bool slave_thread::handle_cmdu_monitor_message(
         break;
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR)
@@ -2414,7 +2440,8 @@ bool slave_thread::handle_cmdu_monitor_message(
         // LOG(DEBUG) << "Received ACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE"; // the print is flooding the log
 
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE failed";
             return false;
@@ -2447,9 +2474,8 @@ bool slave_thread::handle_cmdu_monitor_message(
         break;
     }
     case beerocks_message::ACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION: {
-        auto notification_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION>();
+        auto notification_in = beerocks_header->addClass<
+            beerocks_message::cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION>();
         if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION failed";
             return false;
@@ -2467,7 +2493,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION failed";
             break;
@@ -2486,7 +2513,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     case beerocks_message::ACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE: {
         LOG(TRACE) << "ACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE id=" << int(beerocks_header->id());
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE failed";
             break;
@@ -2504,7 +2532,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE: {
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE failed";
             break;
@@ -2523,7 +2552,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE: {
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE failed";
             break;
@@ -2540,7 +2570,7 @@ bool slave_thread::handle_cmdu_monitor_message(
         break;
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE: {
-        auto response_in = cmdu_rx.addClass<
+        auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE failed";
@@ -2561,7 +2591,7 @@ bool slave_thread::handle_cmdu_monitor_message(
     case beerocks_message::ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE: {
         LOG(INFO) << "ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE: action_op: "
                   << int(beerocks_header->action_op());
-        auto response_in = cmdu_rx.addClass<
+        auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE failed";
@@ -2581,7 +2611,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION: {
         auto response_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION>();
         if (response_in == nullptr) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION failed";
             break;
@@ -2600,7 +2631,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION failed";
             return false;
@@ -2618,7 +2650,7 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_ERROR_NOTIFICATION: {
         auto notification =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_ERROR_NOTIFICATION>();
+            beerocks_header->addClass<beerocks_message::cACTION_MONITOR_ERROR_NOTIFICATION>();
         if (notification == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_ERROR_NOTIFICATION failed";
             return false;
@@ -2659,7 +2691,7 @@ bool slave_thread::handle_cmdu_monitor_message(
         break;
     }
     case beerocks_message::ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION failed";
@@ -2677,7 +2709,7 @@ bool slave_thread::handle_cmdu_monitor_message(
         break;
     }
     case beerocks_message::ACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION: {
-        auto notification_in = cmdu_rx.addClass<
+        auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR)
@@ -2697,9 +2729,8 @@ bool slave_thread::handle_cmdu_monitor_message(
         break;
     }
     case beerocks_message::ACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION: {
-        auto notification_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION>();
+        auto notification_in = beerocks_header->addClass<
+            beerocks_message::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION failed";
             return false;
@@ -2718,8 +2749,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE: {
         auto notification_in =
-            cmdu_rx
-                .addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE failed";
             return false;
@@ -2738,7 +2769,8 @@ bool slave_thread::handle_cmdu_monitor_message(
     }
     case beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE: {
         auto notification_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE>();
         if (notification_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE failed";
             return false;
@@ -3968,7 +4000,7 @@ bool slave_thread::parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessage
     }
 
     auto joined_response =
-        cmdu_rx.addClass<beerocks_message::cACTION_CONTROL_SLAVE_JOINED_RESPONSE>();
+        beerocks_header->addClass<beerocks_message::cACTION_CONTROL_SLAVE_JOINED_RESPONSE>();
     if (joined_response == nullptr) {
         LOG(ERROR) << "addClass cACTION_CONTROL_SLAVE_JOINED_RESPONSE failed";
         return false;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2211,7 +2211,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE: {
         LOG(TRACE) << "received ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE";
         auto response =
-            cmdu_rx.addClass<beerocks_message::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE>();
+            beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE>();
         if (!response) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE failed";
             return false;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3720,7 +3720,7 @@ bool slave_thread::autoconfig_wsc_parse_m2_encrypted_settings(
     // cConfigData constructor, but then parsing will fail since the length
     // will be calculated wrong. TLVF does not support parsing network byte order
     // without full swap, so keep this workaround for now (another future TLVF V2 feature)
-    WSC::cConfigData config_data(decrypted, datalen, true, true);
+    WSC::cConfigData config_data(decrypted, datalen, true);
 
     // get length of config_data for KWA authentication
     size_t len = config_data.getLen();

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3566,14 +3566,14 @@ bool slave_thread::send_cmdu_to_controller(ieee1905_1::CmduMessageTx &cmdu_tx)
     }
 
     if (cmdu_tx.getMessageType() == ieee1905_1::eMessageType::VENDOR_SPECIFIC_MESSAGE) {
-        auto beerocks_header = message_com::get_vs_class_header(cmdu_tx);
+        auto beerocks_header = message_com::get_beerocks_header(cmdu_tx);
         if (!beerocks_header) {
             LOG(ERROR) << "Failed getting beerocks_header!";
             return false;
         }
 
-        beerocks_header->radio_mac() = hostap_params.iface_mac;
-        beerocks_header->direction() = beerocks::BEEROCKS_DIRECTION_CONTROLLER;
+        beerocks_header->actionhdr()->radio_mac() = hostap_params.iface_mac;
+        beerocks_header->actionhdr()->direction() = beerocks::BEEROCKS_DIRECTION_CONTROLLER;
     }
     return message_com::send_cmdu(master_socket, cmdu_tx, backhaul_params.controller_bridge_mac,
                                   backhaul_params.bridge_mac);

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -15,7 +15,7 @@
 #include <bcl/beerocks_logging.h>
 #include <bcl/beerocks_socket_thread.h>
 
-#include <beerocks/tlvf/beerocks_message_header.h>
+#include <beerocks/tlvf/beerocks_header.h>
 
 #include <mapf/common/encryption.h>
 #include <tlvf/ieee_1905_1/tlvWscM1.h>
@@ -118,23 +118,16 @@ protected:
     virtual std::string print_cmdu_types(const beerocks::message::sUdsHeader *cmdu_header) override;
 
 private:
-    bool
-    handle_cmdu_control_message(Socket *sd,
-                                std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-                                ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_control_message(Socket *sd,
+                                     std::shared_ptr<beerocks::beerocks_header> beerocks_header);
     bool handle_cmdu_backhaul_manager_message(
-        Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-        ieee1905_1::CmduMessageRx &cmdu_rx);
+        Socket *sd, std::shared_ptr<beerocks::beerocks_header> beerocks_header);
     bool handle_cmdu_platform_manager_message(
-        Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-        ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool handle_cmdu_ap_manager_message(
-        Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-        ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool
-    handle_cmdu_monitor_message(Socket *sd,
-                                std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-                                ieee1905_1::CmduMessageRx &cmdu_rx);
+        Socket *sd, std::shared_ptr<beerocks::beerocks_header> beerocks_header);
+    bool handle_cmdu_ap_manager_message(Socket *sd,
+                                        std::shared_ptr<beerocks::beerocks_header> beerocks_header);
+    bool handle_cmdu_monitor_message(Socket *sd,
+                                     std::shared_ptr<beerocks::beerocks_header> beerocks_header);
     bool handle_cmdu_control_ieee1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 
     void process_keep_alive();

--- a/common/beerocks/bcl/include/bcl/beerocks_message_structs.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_message_structs.h
@@ -20,7 +20,6 @@ typedef struct {
     uint8_t dst_bridge_mac[net::MAC_ADDR_LEN] = {};
     uint8_t src_bridge_mac[net::MAC_ADDR_LEN] = {};
     uint16_t length                           = 0;
-    uint8_t swap_needed                       = 0;
 } __attribute__((packed)) sUdsHeader;
 
 //////////////////// tlvf includes /////////////////////////////

--- a/common/beerocks/bcl/include/bcl/beerocks_ucc_listener.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_ucc_listener.h
@@ -107,13 +107,13 @@ private:
 
 class tlvPrefilledData : public BaseClass {
 public:
-    tlvPrefilledData(uint8_t *buff, size_t buff_len, bool parse = false, bool swap_needed = false)
-        : BaseClass(buff, buff_len, parse, swap_needed)
+    tlvPrefilledData(uint8_t *buff, size_t buff_len, bool parse = false)
+        : BaseClass(buff, buff_len, parse)
     {
         m_init_succeeded = true;
     };
-    tlvPrefilledData(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false)
-        : BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed)
+    tlvPrefilledData(std::shared_ptr<BaseClass> base, bool parse = false)
+        : BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse)
     {
         m_init_succeeded = true;
     };

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -209,8 +209,7 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
             if (tlv_vendor_specific.vendor_oui() ==
                 ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL) {
                 // assuming that the magic is the first data on the beerocks header
-                auto beerocks_magic = *(
-                    uint32_t *)((uint8_t *)tlv + ieee1905_1::tlvVendorSpecific::get_initial_size());
+                auto beerocks_magic = *(uint32_t *)(tlv_vendor_specific.payload());
                 if (uds_header->swap_needed) {
                     swap_32(beerocks_magic);
                 }

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -23,8 +23,9 @@ using namespace beerocks;
 
 socket_thread::socket_thread(const std::string &unix_socket_path_)
     : thread_base(), cmdu_tx(TX_BUFFER_UDS, TX_BUFFER_UDS_SIZE),
-      unix_socket_path(unix_socket_path_), server_socket(nullptr),
-      server_max_connections(DEFAULT_MAX_SOCKET_CONNECTIONS)
+      unix_socket_path(unix_socket_path_), cmdu_rx(rx_buffer + sizeof(message::sUdsHeader),
+                                                   sizeof(rx_buffer) - sizeof(message::sUdsHeader)),
+      server_socket(nullptr), server_max_connections(DEFAULT_MAX_SOCKET_CONNECTIONS)
 {
     memset(TX_BUFFER_UDS, 0, TX_BUFFER_UDS_SIZE);
     set_select_timeout(500);
@@ -162,8 +163,7 @@ bool socket_thread::handle_cmdu_message_uds(Socket *sd)
         return false;
     }
 
-    if (!cmdu_rx.parse(rx_buffer + sizeof(message::sUdsHeader), uds_header->length,
-                       uds_header->swap_needed)) {
+    if (!cmdu_rx.parse(uds_header->swap_needed)) {
         THREAD_LOG(ERROR) << "parsing cmdu failure, rx_buffer" << std::hex << rx_buffer << std::dec
                           << ", uds_header->length=" << int(uds_header->length)
                           << ", uds_header->swap_needed=" << int(uds_header->swap_needed);

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -194,7 +194,7 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
         swap_16(length);
         if (static_cast<ieee1905_1::eTlvType>(type) == ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC) {
             auto tlv_vendor_specific = ieee1905_1::tlvVendorSpecific(
-                (uint8_t *)tlv, length + sizeof(ieee1905_1::TlvHeader), true, true);
+                (uint8_t *)tlv, length + sizeof(ieee1905_1::TlvHeader), true);
             if (!tlv_vendor_specific.isInitialized()) {
                 LOG(ERROR) << "tlvVendorSpecific init() failure";
                 ret = false;

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -17,11 +17,6 @@
 
 using namespace beerocks;
 
-typedef struct sTlvHeader {
-    uint8_t type;
-    uint16_t length;
-} __attribute__((packed)) sTlvHeader;
-
 #define DEFAULT_MAX_SOCKET_CONNECTIONS 10
 #define TX_BUFFER_UDS (tx_buffer + sizeof(beerocks::message::sUdsHeader))
 #define TX_BUFFER_UDS_SIZE (sizeof(tx_buffer) - sizeof(beerocks::message::sUdsHeader))
@@ -185,10 +180,10 @@ bool socket_thread::handle_cmdu_message_uds(Socket *sd)
 // FIXME - WLANRTSYS-6360 - should be moved to transport
 bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
 {
-    sTlvHeader *tlv =
-        reinterpret_cast<sTlvHeader *>((uint8_t *)uds_header + sizeof(message::sUdsHeader) +
-                                       ieee1905_1::cCmduHeader::get_initial_size());
-    sTlvHeader *first_tlv = tlv;
+    ieee1905_1::TlvHeader *tlv = reinterpret_cast<ieee1905_1::TlvHeader *>(
+        (uint8_t *)uds_header + sizeof(message::sUdsHeader) +
+        ieee1905_1::cCmduHeader::get_initial_size());
+    ieee1905_1::TlvHeader *first_tlv = tlv;
 
     bool ret = true;
 
@@ -203,7 +198,8 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
 
         if (static_cast<ieee1905_1::eTlvType>(type) == ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC) {
             auto tlv_vendor_specific = ieee1905_1::tlvVendorSpecific(
-                (uint8_t *)tlv, length + sizeof(sTlvHeader), true, uds_header->swap_needed);
+                (uint8_t *)tlv, length + sizeof(ieee1905_1::TlvHeader), true,
+                uds_header->swap_needed);
             if (!tlv_vendor_specific.isInitialized()) {
                 LOG(ERROR) << "tlvVendorSpecific init() failure";
                 ret = false;
@@ -241,7 +237,7 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
         }
 
         // set the next tlv
-        tlv    = (sTlvHeader *)((uint8_t *)tlv + sizeof(sTlvHeader) + length);
+        tlv    = (ieee1905_1::TlvHeader *)((uint8_t *)tlv + sizeof(ieee1905_1::TlvHeader) + length);
         type   = tlv->type;
         length = tlv->length;
 

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -163,10 +163,9 @@ bool socket_thread::handle_cmdu_message_uds(Socket *sd)
         return false;
     }
 
-    if (!cmdu_rx.parse(uds_header->swap_needed)) {
+    if (!cmdu_rx.parse()) {
         THREAD_LOG(ERROR) << "parsing cmdu failure, rx_buffer" << std::hex << rx_buffer << std::dec
-                          << ", uds_header->length=" << int(uds_header->length)
-                          << ", uds_header->swap_needed=" << int(uds_header->swap_needed);
+                          << ", uds_header->length=" << int(uds_header->length);
         return false;
     }
 
@@ -192,14 +191,10 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
 
     do {
 
-        if (uds_header->swap_needed) {
-            swap_16(length);
-        }
-
+        swap_16(length);
         if (static_cast<ieee1905_1::eTlvType>(type) == ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC) {
             auto tlv_vendor_specific = ieee1905_1::tlvVendorSpecific(
-                (uint8_t *)tlv, length + sizeof(ieee1905_1::TlvHeader), true,
-                uds_header->swap_needed);
+                (uint8_t *)tlv, length + sizeof(ieee1905_1::TlvHeader), true, true);
             if (!tlv_vendor_specific.isInitialized()) {
                 LOG(ERROR) << "tlvVendorSpecific init() failure";
                 ret = false;
@@ -210,9 +205,7 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
                 ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL) {
                 // assuming that the magic is the first data on the beerocks header
                 auto beerocks_magic = *(uint32_t *)(tlv_vendor_specific.payload());
-                if (uds_header->swap_needed) {
-                    swap_32(beerocks_magic);
-                }
+                swap_32(beerocks_magic);
 
                 if (beerocks_magic != message::MESSAGE_MAGIC) {
                     THREAD_LOG(WARNING) << "mismatch magic " << std::hex << int(beerocks_magic)
@@ -225,10 +218,8 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
                 THREAD_LOG(INFO) << "Not an Intel vendor specific message!";
             }
 
-            if (uds_header->swap_needed) {
-                // cancel the swap we did
-                tlv_vendor_specific.class_swap();
-            }
+            // cancel the swap we did
+            tlv_vendor_specific.class_swap();
         } else if (static_cast<ieee1905_1::eTlvType>(type) ==
                        ieee1905_1::eTlvType::TLV_END_OF_MESSAGE &&
                    length == 0) {

--- a/common/beerocks/btl/btl.cpp
+++ b/common/beerocks/btl/btl.cpp
@@ -44,7 +44,7 @@ bool transport_socket_thread::send_cmdu_to_bus(ieee1905_1::CmduMessageTx &cmdu_t
                                                const std::string &dst_mac,
                                                const std::string &src_mac)
 {
-    if (!cmdu_tx.finalize(true)) {
+    if (!cmdu_tx.finalize()) {
         THREAD_LOG(ERROR) << "finalize failed";
         return false;
     }

--- a/common/beerocks/btl/btl_local_bus.cpp
+++ b/common/beerocks/btl/btl_local_bus.cpp
@@ -213,8 +213,7 @@ bool transport_socket_thread::handle_cmdu_message_bus()
         return false;
     }
 
-    if (!cmdu_rx.parse(rx_buffer + sizeof(message::sUdsHeader), uds_header->length,
-                       uds_header->swap_needed)) {
+    if (!cmdu_rx.parse(uds_header->swap_needed)) {
         THREAD_LOG(ERROR) << "parsing cmdu failure, rx_buffer" << std::hex << rx_buffer << std::dec
                           << ", uds_header->length=" << int(uds_header->length)
                           << ", uds_header->swap_needed=" << int(uds_header->swap_needed);

--- a/common/beerocks/btl/btl_local_bus.cpp
+++ b/common/beerocks/btl/btl_local_bus.cpp
@@ -205,18 +205,16 @@ bool transport_socket_thread::handle_cmdu_message_bus()
                 uds_header->src_bridge_mac);
     std::copy_n((uint8_t *)cmdu_rx_msg->metadata()->dst, sizeof(mapf::CmduRxMessage::Metadata::dst),
                 uds_header->dst_bridge_mac);
-    uds_header->length      = cmdu_rx_msg->metadata()->length;
-    uds_header->swap_needed = true;
+    uds_header->length = cmdu_rx_msg->metadata()->length;
 
     if (!verify_cmdu(uds_header)) {
         THREAD_LOG(ERROR) << "Failed verifying cmdu header";
         return false;
     }
 
-    if (!cmdu_rx.parse(uds_header->swap_needed)) {
+    if (!cmdu_rx.parse()) {
         THREAD_LOG(ERROR) << "parsing cmdu failure, rx_buffer" << std::hex << rx_buffer << std::dec
-                          << ", uds_header->length=" << int(uds_header->length)
-                          << ", uds_header->swap_needed=" << int(uds_header->swap_needed);
+                          << ", uds_header->length=" << int(uds_header->length);
         return false;
     }
 

--- a/common/beerocks/btl/btl_uds.cpp
+++ b/common/beerocks/btl/btl_uds.cpp
@@ -115,8 +115,7 @@ bool transport_socket_thread::bus_send(ieee1905_1::CmduMessage &cmdu, const std:
         THREAD_LOG(ERROR) << "uds_header=nullptr";
         return false;
     }
-    uds_header->length      = length;
-    uds_header->swap_needed = true;
+    uds_header->length = length;
     net::network_utils::mac_from_string(uds_header->src_bridge_mac, src_mac);
     net::network_utils::mac_from_string(uds_header->dst_bridge_mac, dst_mac);
     return message_com::send_data(bus, cmdu.getMessageBuff() - sizeof(message::sUdsHeader),

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_1905_vs.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_1905_vs.h
@@ -28,8 +28,8 @@ namespace beerocks_message {
 class tlvVsClientAssociationEvent : public BaseClass
 {
     public:
-        tlvVsClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvVsClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvVsClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvVsClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvVsClientAssociationEvent();
 
         static eActionOp_1905_VS get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -30,8 +30,8 @@ namespace beerocks_message {
 class cACTION_APMANAGER_4ADDR_STA_JOINED : public BaseClass
 {
     public:
-        cACTION_APMANAGER_4ADDR_STA_JOINED(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_4ADDR_STA_JOINED(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_4ADDR_STA_JOINED(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_4ADDR_STA_JOINED(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_4ADDR_STA_JOINED();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -52,8 +52,8 @@ class cACTION_APMANAGER_4ADDR_STA_JOINED : public BaseClass
 class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_JOINED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -74,8 +74,8 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_ENABLE_APS_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_ENABLE_APS_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -98,8 +98,8 @@ class cACTION_APMANAGER_ENABLE_APS_REQUEST : public BaseClass
 class cACTION_APMANAGER_ENABLE_APS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_ENABLE_APS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_ENABLE_APS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_ENABLE_APS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_ENABLE_APS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_ENABLE_APS_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -118,8 +118,8 @@ class cACTION_APMANAGER_ENABLE_APS_RESPONSE : public BaseClass
 class cACTION_APMANAGER_INIT_DONE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_INIT_DONE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_INIT_DONE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_INIT_DONE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_INIT_DONE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_INIT_DONE_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -136,8 +136,8 @@ class cACTION_APMANAGER_INIT_DONE_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -156,8 +156,8 @@ class cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST : public 
 class cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -176,8 +176,8 @@ class cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE : public
 class cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -196,8 +196,8 @@ class cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -218,8 +218,8 @@ class cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -236,8 +236,8 @@ class cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST : public BaseClass
 class cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -254,8 +254,8 @@ class cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST
 class cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -274,8 +274,8 @@ class cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -294,8 +294,8 @@ class cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START : public BaseClass
 class cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -314,8 +314,8 @@ class cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -334,8 +334,8 @@ class cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -354,8 +354,8 @@ class cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -378,8 +378,8 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -398,8 +398,8 @@ class cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -418,8 +418,8 @@ class cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION : public BaseC
 class cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -438,8 +438,8 @@ class cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE : public BaseClass
 class cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -458,8 +458,8 @@ class cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE : public BaseClass
 class cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -478,8 +478,8 @@ class cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
 class cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -498,8 +498,8 @@ class cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
 class cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -518,8 +518,8 @@ class cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -538,8 +538,8 @@ class cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -564,8 +564,8 @@ class cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST : public BaseClass
 class cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -584,8 +584,8 @@ class cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE : public BaseClass
 class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -606,8 +606,8 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
 class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_ALLOW_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -628,8 +628,8 @@ class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass
 class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -648,8 +648,8 @@ class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -668,8 +668,8 @@ class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 class cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -688,8 +688,8 @@ class cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_ACK : public BaseClass
 {
     public:
-        cACTION_APMANAGER_ACK(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_ACK(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_ACK(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_ACK(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_ACK();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -710,8 +710,8 @@ class cACTION_APMANAGER_ACK : public BaseClass
 class cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -730,8 +730,8 @@ class cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST : public BaseClass
 class cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -750,8 +750,8 @@ class cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE : public BaseClass
 class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -770,8 +770,8 @@ class cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseCla
 class cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -790,8 +790,8 @@ class cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST : public BaseClass
 class cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -810,8 +810,8 @@ class cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 class cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -830,8 +830,8 @@ class cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -850,8 +850,8 @@ class cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -878,8 +878,8 @@ class cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST : public BaseClass
 class cACTION_APMANAGER_HEARTBEAT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_HEARTBEAT_NOTIFICATION();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -896,8 +896,8 @@ class cACTION_APMANAGER_HEARTBEAT_NOTIFICATION : public BaseClass
 class cACTION_APMANAGER_READ_ACS_REPORT_REQUEST : public BaseClass
 {
     public:
-        cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_READ_ACS_REPORT_REQUEST();
 
         static eActionOp_APMANAGER get_action_op(){
@@ -914,8 +914,8 @@ class cACTION_APMANAGER_READ_ACS_REPORT_REQUEST : public BaseClass
 class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE();
 
         static eActionOp_APMANAGER get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -29,8 +29,8 @@ namespace beerocks_message {
 class cACTION_BACKHAUL_REGISTER_REQUEST : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_REGISTER_REQUEST();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -68,8 +68,8 @@ class cACTION_BACKHAUL_REGISTER_REQUEST : public BaseClass
 class cACTION_BACKHAUL_REGISTER_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_REGISTER_RESPONSE();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -88,8 +88,8 @@ class cACTION_BACKHAUL_REGISTER_RESPONSE : public BaseClass
 class cACTION_BACKHAUL_BUSY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_BUSY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_BUSY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_BUSY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_BUSY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_BUSY_NOTIFICATION();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -106,8 +106,8 @@ class cACTION_BACKHAUL_BUSY_NOTIFICATION : public BaseClass
 class cACTION_BACKHAUL_ENABLE : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_ENABLE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_ENABLE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_ENABLE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_ENABLE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_ENABLE();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -171,8 +171,8 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
 class cACTION_BACKHAUL_CONNECTED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_CONNECTED_NOTIFICATION();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -191,8 +191,8 @@ class cACTION_BACKHAUL_CONNECTED_NOTIFICATION : public BaseClass
 class cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -211,8 +211,8 @@ class cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION : public BaseClass
 class cACTION_BACKHAUL_ENABLE_APS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_ENABLE_APS_REQUEST();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -235,8 +235,8 @@ class cACTION_BACKHAUL_ENABLE_APS_REQUEST : public BaseClass
 class cACTION_BACKHAUL_ROAM_REQUEST : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_ROAM_REQUEST();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -255,8 +255,8 @@ class cACTION_BACKHAUL_ROAM_REQUEST : public BaseClass
 class cACTION_BACKHAUL_ROAM_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_ROAM_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_ROAM_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_ROAM_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_ROAM_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_ROAM_RESPONSE();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -275,8 +275,8 @@ class cACTION_BACKHAUL_ROAM_RESPONSE : public BaseClass
 class cACTION_BACKHAUL_RESET : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_RESET();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -293,8 +293,8 @@ class cACTION_BACKHAUL_RESET : public BaseClass
 class cACTION_BACKHAUL_4ADDR_CONNECTED : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_4ADDR_CONNECTED(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_4ADDR_CONNECTED(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_4ADDR_CONNECTED(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_4ADDR_CONNECTED(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_4ADDR_CONNECTED();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -313,8 +313,8 @@ class cACTION_BACKHAUL_4ADDR_CONNECTED : public BaseClass
 class cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -333,8 +333,8 @@ class cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION : public BaseClass
 class cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -353,8 +353,8 @@ class cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST : public BaseClas
 class cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -373,8 +373,8 @@ class cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 class cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE();
 
         static eActionOp_BACKHAUL get_action_op(){
@@ -393,8 +393,8 @@ class cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 class cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE();
 
         static eActionOp_BACKHAUL get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -29,8 +29,8 @@ namespace beerocks_message {
 class cACTION_BML_PING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_PING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -47,8 +47,8 @@ class cACTION_BML_PING_REQUEST : public BaseClass
 class cACTION_BML_PING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_PING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -65,8 +65,8 @@ class cACTION_BML_PING_RESPONSE : public BaseClass
 class cACTION_BML_NW_MAP_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_NW_MAP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_NW_MAP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_NW_MAP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_NW_MAP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_NW_MAP_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -83,8 +83,8 @@ class cACTION_BML_NW_MAP_REQUEST : public BaseClass
 class cACTION_BML_NW_MAP_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_NW_MAP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_NW_MAP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_NW_MAP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_NW_MAP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_NW_MAP_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -113,8 +113,8 @@ class cACTION_BML_NW_MAP_RESPONSE : public BaseClass
 class cACTION_BML_NW_MAP_UPDATE : public BaseClass
 {
     public:
-        cACTION_BML_NW_MAP_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_NW_MAP_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_NW_MAP_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_NW_MAP_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_NW_MAP_UPDATE();
 
         static eActionOp_BML get_action_op(){
@@ -143,8 +143,8 @@ class cACTION_BML_NW_MAP_UPDATE : public BaseClass
 class cACTION_BML_STATS_UPDATE : public BaseClass
 {
     public:
-        cACTION_BML_STATS_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STATS_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STATS_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STATS_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STATS_UPDATE();
 
         static eActionOp_BML get_action_op(){
@@ -173,8 +173,8 @@ class cACTION_BML_STATS_UPDATE : public BaseClass
 class cACTION_BML_EVENTS_UPDATE : public BaseClass
 {
     public:
-        cACTION_BML_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_EVENTS_UPDATE();
 
         static eActionOp_BML get_action_op(){
@@ -201,8 +201,8 @@ class cACTION_BML_EVENTS_UPDATE : public BaseClass
 class cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -219,8 +219,8 @@ class cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST : public BaseClass
 class cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -237,8 +237,8 @@ class cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE : public BaseClass
 class cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -255,8 +255,8 @@ class cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST : public BaseClass
 class cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -273,8 +273,8 @@ class cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE : public BaseClass
 class cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -291,8 +291,8 @@ class cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE : public BaseClass
 class cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -309,8 +309,8 @@ class cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST : public BaseClass
 class cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -327,8 +327,8 @@ class cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST : public BaseClass
 class cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -345,8 +345,8 @@ class cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE : public BaseClass
 class cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -363,8 +363,8 @@ class cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST : public BaseClass
 class cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -381,8 +381,8 @@ class cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE : public BaseClass
 class cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -399,8 +399,8 @@ class cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST : public BaseClass
 class cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -417,8 +417,8 @@ class cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE : public BaseClass
 class cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -435,8 +435,8 @@ class cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST : public BaseClass
 class cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -453,8 +453,8 @@ class cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE : public BaseClass
 class cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -473,8 +473,8 @@ class cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST : public BaseClass
 class cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -493,8 +493,8 @@ class cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE : public BaseClass
 class cACTION_BML_SET_CLIENT_ROAMING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CLIENT_ROAMING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -513,8 +513,8 @@ class cACTION_BML_SET_CLIENT_ROAMING_REQUEST : public BaseClass
 class cACTION_BML_SET_CLIENT_ROAMING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CLIENT_ROAMING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -531,8 +531,8 @@ class cACTION_BML_SET_CLIENT_ROAMING_RESPONSE : public BaseClass
 class cACTION_BML_GET_CLIENT_ROAMING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CLIENT_ROAMING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -549,8 +549,8 @@ class cACTION_BML_GET_CLIENT_ROAMING_REQUEST : public BaseClass
 class cACTION_BML_GET_CLIENT_ROAMING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CLIENT_ROAMING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -569,8 +569,8 @@ class cACTION_BML_GET_CLIENT_ROAMING_RESPONSE : public BaseClass
 class cACTION_BML_SET_DFS_REENTRY_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_DFS_REENTRY_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -589,8 +589,8 @@ class cACTION_BML_SET_DFS_REENTRY_REQUEST : public BaseClass
 class cACTION_BML_SET_DFS_REENTRY_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_DFS_REENTRY_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -607,8 +607,8 @@ class cACTION_BML_SET_DFS_REENTRY_RESPONSE : public BaseClass
 class cACTION_BML_GET_DFS_REENTRY_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_DFS_REENTRY_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -625,8 +625,8 @@ class cACTION_BML_GET_DFS_REENTRY_REQUEST : public BaseClass
 class cACTION_BML_GET_DFS_REENTRY_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_DFS_REENTRY_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -645,8 +645,8 @@ class cACTION_BML_GET_DFS_REENTRY_RESPONSE : public BaseClass
 class cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -665,8 +665,8 @@ class cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST : public Bas
 class cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -683,8 +683,8 @@ class cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE : public Ba
 class cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -701,8 +701,8 @@ class cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST : public Bas
 class cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -721,8 +721,8 @@ class cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE : public Ba
 class cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -741,8 +741,8 @@ class cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST : public BaseClass
 class cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -759,8 +759,8 @@ class cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE : public BaseClass
 class cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -777,8 +777,8 @@ class cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST : public BaseClass
 class cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -797,8 +797,8 @@ class cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE : public BaseClass
 class cACTION_BML_SET_IRE_ROAMING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_IRE_ROAMING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -817,8 +817,8 @@ class cACTION_BML_SET_IRE_ROAMING_REQUEST : public BaseClass
 class cACTION_BML_SET_IRE_ROAMING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_IRE_ROAMING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -835,8 +835,8 @@ class cACTION_BML_SET_IRE_ROAMING_RESPONSE : public BaseClass
 class cACTION_BML_GET_IRE_ROAMING_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_IRE_ROAMING_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -853,8 +853,8 @@ class cACTION_BML_GET_IRE_ROAMING_REQUEST : public BaseClass
 class cACTION_BML_GET_IRE_ROAMING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_IRE_ROAMING_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -873,8 +873,8 @@ class cACTION_BML_GET_IRE_ROAMING_RESPONSE : public BaseClass
 class cACTION_BML_SET_LOAD_BALANCER_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_LOAD_BALANCER_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -893,8 +893,8 @@ class cACTION_BML_SET_LOAD_BALANCER_REQUEST : public BaseClass
 class cACTION_BML_SET_LOAD_BALANCER_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_LOAD_BALANCER_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -911,8 +911,8 @@ class cACTION_BML_SET_LOAD_BALANCER_RESPONSE : public BaseClass
 class cACTION_BML_GET_LOAD_BALANCER_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_LOAD_BALANCER_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -929,8 +929,8 @@ class cACTION_BML_GET_LOAD_BALANCER_REQUEST : public BaseClass
 class cACTION_BML_GET_LOAD_BALANCER_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_LOAD_BALANCER_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -949,8 +949,8 @@ class cACTION_BML_GET_LOAD_BALANCER_RESPONSE : public BaseClass
 class cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -969,8 +969,8 @@ class cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST : public BaseClass
 class cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -987,8 +987,8 @@ class cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE : public BaseClass
 class cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1005,8 +1005,8 @@ class cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST : public BaseClass
 class cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1025,8 +1025,8 @@ class cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE : public BaseClass
 class cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1045,8 +1045,8 @@ class cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST : public BaseClass
 class cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1063,8 +1063,8 @@ class cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE : public BaseClass
 class cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1083,8 +1083,8 @@ class cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST : public BaseClass
 class cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1103,8 +1103,8 @@ class cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE : public BaseClass
 class cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1123,8 +1123,8 @@ class cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST : public BaseClass
 class cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1143,8 +1143,8 @@ class cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE : public BaseClass
 class cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1163,8 +1163,8 @@ class cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST : public BaseClass
 class cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1183,8 +1183,8 @@ class cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE : public BaseClass
 class cACTION_BML_SET_CERTIFICATION_MODE_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CERTIFICATION_MODE_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1203,8 +1203,8 @@ class cACTION_BML_SET_CERTIFICATION_MODE_REQUEST : public BaseClass
 class cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1221,8 +1221,8 @@ class cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE : public BaseClass
 class cACTION_BML_GET_CERTIFICATION_MODE_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CERTIFICATION_MODE_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1239,8 +1239,8 @@ class cACTION_BML_GET_CERTIFICATION_MODE_REQUEST : public BaseClass
 class cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1259,8 +1259,8 @@ class cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE : public BaseClass
 class cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1286,8 +1286,8 @@ class cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST : public BaseClass
 class cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1306,8 +1306,8 @@ class cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE : public BaseClass
 class cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1333,8 +1333,8 @@ class cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE : public BaseClass
 class cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1353,8 +1353,8 @@ class cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST : public BaseClass
 class cACTION_BML_STEERING_SET_GROUP_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_SET_GROUP_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1379,8 +1379,8 @@ class cACTION_BML_STEERING_SET_GROUP_REQUEST : public BaseClass
 class cACTION_BML_STEERING_SET_GROUP_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_SET_GROUP_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1399,8 +1399,8 @@ class cACTION_BML_STEERING_SET_GROUP_RESPONSE : public BaseClass
 class cACTION_BML_STEERING_CLIENT_SET_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_CLIENT_SET_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1427,8 +1427,8 @@ class cACTION_BML_STEERING_CLIENT_SET_REQUEST : public BaseClass
 class cACTION_BML_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_CLIENT_SET_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1447,8 +1447,8 @@ class cACTION_BML_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 class cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1467,8 +1467,8 @@ class cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST : public BaseClass
 class cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1487,8 +1487,8 @@ class cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE : public BaseClass
 class cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1515,8 +1515,8 @@ class cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST : public BaseClass
 class cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1535,8 +1535,8 @@ class cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE : public BaseClass
 class cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST();
 
         static eActionOp_BML get_action_op(){
@@ -1559,8 +1559,8 @@ class cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST : public BaseClass
 class cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE();
 
         static eActionOp_BML get_action_op(){
@@ -1579,8 +1579,8 @@ class cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE : public BaseClass
 class cACTION_BML_STEERING_EVENTS_UPDATE : public BaseClass
 {
     public:
-        cACTION_BML_STEERING_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_STEERING_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_STEERING_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_STEERING_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_STEERING_EVENTS_UPDATE();
 
         static eActionOp_BML get_action_op(){
@@ -1607,8 +1607,8 @@ class cACTION_BML_STEERING_EVENTS_UPDATE : public BaseClass
 class cACTION_BML_TRIGGER_TOPOLOGY_QUERY : public BaseClass
 {
     public:
-        cACTION_BML_TRIGGER_TOPOLOGY_QUERY(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_TRIGGER_TOPOLOGY_QUERY(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_TRIGGER_TOPOLOGY_QUERY(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_TRIGGER_TOPOLOGY_QUERY(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_TRIGGER_TOPOLOGY_QUERY();
 
         static eActionOp_BML get_action_op(){
@@ -1627,8 +1627,8 @@ class cACTION_BML_TRIGGER_TOPOLOGY_QUERY : public BaseClass
 class cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST : public BaseClass
 {
     public:
-        cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST();
 
         static eActionOp_BML get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_cli.h
@@ -30,8 +30,8 @@ namespace beerocks_message {
 class cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS : public BaseClass
 {
     public:
-        cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS();
 
         static eActionOp_CLI get_action_op(){
@@ -50,8 +50,8 @@ class cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS : public BaseClass
 class cACTION_CLI_ENABLE_LOAD_BALANCER : public BaseClass
 {
     public:
-        cACTION_CLI_ENABLE_LOAD_BALANCER(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_ENABLE_LOAD_BALANCER(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_ENABLE_LOAD_BALANCER(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_ENABLE_LOAD_BALANCER(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_ENABLE_LOAD_BALANCER();
 
         static eActionOp_CLI get_action_op(){
@@ -70,8 +70,8 @@ class cACTION_CLI_ENABLE_LOAD_BALANCER : public BaseClass
 class cACTION_CLI_ENABLE_DEBUG : public BaseClass
 {
     public:
-        cACTION_CLI_ENABLE_DEBUG(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_ENABLE_DEBUG(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_ENABLE_DEBUG(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_ENABLE_DEBUG(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_ENABLE_DEBUG();
 
         static eActionOp_CLI get_action_op(){
@@ -90,8 +90,8 @@ class cACTION_CLI_ENABLE_DEBUG : public BaseClass
 class cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS : public BaseClass
 {
     public:
-        cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS();
 
         static eActionOp_CLI get_action_op(){
@@ -110,8 +110,8 @@ class cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS : public BaseClass
 class cACTION_CLI_RESPONSE_INT : public BaseClass
 {
     public:
-        cACTION_CLI_RESPONSE_INT(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_RESPONSE_INT(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_RESPONSE_INT(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_RESPONSE_INT(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_RESPONSE_INT();
 
         static eActionOp_CLI get_action_op(){
@@ -132,8 +132,8 @@ class cACTION_CLI_RESPONSE_INT : public BaseClass
 class cACTION_CLI_RESPONSE_STR : public BaseClass
 {
     public:
-        cACTION_CLI_RESPONSE_STR(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_RESPONSE_STR(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_RESPONSE_STR(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_RESPONSE_STR(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_RESPONSE_STR();
 
         static eActionOp_CLI get_action_op(){
@@ -160,8 +160,8 @@ class cACTION_CLI_RESPONSE_STR : public BaseClass
 class cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT : public BaseClass
 {
     public:
-        cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT();
 
         static eActionOp_CLI get_action_op(){
@@ -184,8 +184,8 @@ class cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT : public BaseClass
 class cACTION_CLI_OPTIMAL_PATH_TASK : public BaseClass
 {
     public:
-        cACTION_CLI_OPTIMAL_PATH_TASK(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_OPTIMAL_PATH_TASK(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_OPTIMAL_PATH_TASK(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_OPTIMAL_PATH_TASK(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_OPTIMAL_PATH_TASK();
 
         static eActionOp_CLI get_action_op(){
@@ -204,8 +204,8 @@ class cACTION_CLI_OPTIMAL_PATH_TASK : public BaseClass
 class cACTION_CLI_LOAD_BALANCER_TASK : public BaseClass
 {
     public:
-        cACTION_CLI_LOAD_BALANCER_TASK(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_LOAD_BALANCER_TASK(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_LOAD_BALANCER_TASK(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_LOAD_BALANCER_TASK(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_LOAD_BALANCER_TASK();
 
         static eActionOp_CLI get_action_op(){
@@ -224,8 +224,8 @@ class cACTION_CLI_LOAD_BALANCER_TASK : public BaseClass
 class cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK : public BaseClass
 {
     public:
-        cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK();
 
         static eActionOp_CLI get_action_op(){
@@ -242,8 +242,8 @@ class cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK : public BaseClass
 class cACTION_CLI_DUMP_NODE_INFO : public BaseClass
 {
     public:
-        cACTION_CLI_DUMP_NODE_INFO(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_DUMP_NODE_INFO(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_DUMP_NODE_INFO(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_DUMP_NODE_INFO(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_DUMP_NODE_INFO();
 
         static eActionOp_CLI get_action_op(){
@@ -262,8 +262,8 @@ class cACTION_CLI_DUMP_NODE_INFO : public BaseClass
 class cACTION_CLI_PING_SLAVE_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_PING_SLAVE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_PING_SLAVE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_PING_SLAVE_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_PING_SLAVE_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_PING_SLAVE_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -286,8 +286,8 @@ class cACTION_CLI_PING_SLAVE_REQUEST : public BaseClass
 class cACTION_CLI_PING_ALL_SLAVES_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_PING_ALL_SLAVES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_PING_ALL_SLAVES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_PING_ALL_SLAVES_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_PING_ALL_SLAVES_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_PING_ALL_SLAVES_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -308,8 +308,8 @@ class cACTION_CLI_PING_ALL_SLAVES_REQUEST : public BaseClass
 class cACTION_CLI_BACKHAUL_SCAN_RESULTS : public BaseClass
 {
     public:
-        cACTION_CLI_BACKHAUL_SCAN_RESULTS(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_BACKHAUL_SCAN_RESULTS(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_BACKHAUL_SCAN_RESULTS(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_BACKHAUL_SCAN_RESULTS(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_BACKHAUL_SCAN_RESULTS();
 
         static eActionOp_CLI get_action_op(){
@@ -328,8 +328,8 @@ class cACTION_CLI_BACKHAUL_SCAN_RESULTS : public BaseClass
 class cACTION_CLI_BACKHAUL_ROAM_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_BACKHAUL_ROAM_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -350,8 +350,8 @@ class cACTION_CLI_BACKHAUL_ROAM_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_ALLOW_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_ALLOW_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -372,8 +372,8 @@ class cACTION_CLI_CLIENT_ALLOW_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_DISALLOW_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_DISALLOW_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -394,8 +394,8 @@ class cACTION_CLI_CLIENT_DISALLOW_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_DISCONNECT_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_DISCONNECT_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -418,8 +418,8 @@ class cACTION_CLI_CLIENT_DISCONNECT_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_BSS_STEER_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_BSS_STEER_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -442,8 +442,8 @@ class cACTION_CLI_CLIENT_BSS_STEER_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -464,8 +464,8 @@ class cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -488,8 +488,8 @@ class cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_BEACON_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_BEACON_11K_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -528,8 +528,8 @@ class cACTION_CLI_CLIENT_BEACON_11K_REQUEST : public BaseClass
 class cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -554,8 +554,8 @@ class cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
 class cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -576,8 +576,8 @@ class cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST : public BaseClass
 class cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -602,8 +602,8 @@ class cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
 class cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST();
 
         static eActionOp_CLI get_action_op(){
@@ -626,8 +626,8 @@ class cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
 class cACTION_CLI_HOSTAP_STATS_MEASUREMENT : public BaseClass
 {
     public:
-        cACTION_CLI_HOSTAP_STATS_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CLI_HOSTAP_STATS_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CLI_HOSTAP_STATS_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CLI_HOSTAP_STATS_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CLI_HOSTAP_STATS_MEASUREMENT();
 
         static eActionOp_CLI get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -29,8 +29,8 @@ namespace beerocks_message {
 class cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -72,8 +72,8 @@ class cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_SLAVE_JOINED_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_SLAVE_JOINED_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_SLAVE_JOINED_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_SLAVE_JOINED_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_SLAVE_JOINED_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_SLAVE_JOINED_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -101,8 +101,8 @@ class cACTION_CONTROL_SLAVE_JOINED_RESPONSE : public BaseClass
 class cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -129,8 +129,8 @@ class cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_SON_CONFIG_UPDATE : public BaseClass
 {
     public:
-        cACTION_CONTROL_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_SON_CONFIG_UPDATE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -149,8 +149,8 @@ class cACTION_CONTROL_SON_CONFIG_UPDATE : public BaseClass
 class cACTION_CONTROL_CONTROLLER_PING_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CONTROLLER_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CONTROLLER_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CONTROLLER_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CONTROLLER_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CONTROLLER_PING_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -179,8 +179,8 @@ class cACTION_CONTROL_CONTROLLER_PING_REQUEST : public BaseClass
 class cACTION_CONTROL_CONTROLLER_PING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CONTROLLER_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CONTROLLER_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CONTROLLER_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CONTROLLER_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CONTROLLER_PING_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -209,8 +209,8 @@ class cACTION_CONTROL_CONTROLLER_PING_RESPONSE : public BaseClass
 class cACTION_CONTROL_AGENT_PING_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_AGENT_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_AGENT_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_AGENT_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_AGENT_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_AGENT_PING_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -239,8 +239,8 @@ class cACTION_CONTROL_AGENT_PING_REQUEST : public BaseClass
 class cACTION_CONTROL_AGENT_PING_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_AGENT_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_AGENT_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_AGENT_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_AGENT_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_AGENT_PING_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -269,8 +269,8 @@ class cACTION_CONTROL_AGENT_PING_RESPONSE : public BaseClass
 class cACTION_CONTROL_ARP_QUERY_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_ARP_QUERY_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -289,8 +289,8 @@ class cACTION_CONTROL_ARP_QUERY_REQUEST : public BaseClass
 class cACTION_CONTROL_ARP_QUERY_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_ARP_QUERY_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -309,8 +309,8 @@ class cACTION_CONTROL_ARP_QUERY_RESPONSE : public BaseClass
 class cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -331,8 +331,8 @@ class cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -351,8 +351,8 @@ class cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_BACKHAUL_RESET : public BaseClass
 {
     public:
-        cACTION_CONTROL_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_BACKHAUL_RESET();
 
         static eActionOp_CONTROL get_action_op(){
@@ -369,8 +369,8 @@ class cACTION_CONTROL_BACKHAUL_RESET : public BaseClass
 class cACTION_CONTROL_BACKHAUL_ROAM_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_BACKHAUL_ROAM_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -389,8 +389,8 @@ class cACTION_CONTROL_BACKHAUL_ROAM_REQUEST : public BaseClass
 class cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL : public BaseClass
 {
     public:
-        cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL();
 
         static eActionOp_CONTROL get_action_op(){
@@ -409,8 +409,8 @@ class cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL : public BaseClass
 class cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -429,8 +429,8 @@ class cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -449,8 +449,8 @@ class cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -469,8 +469,8 @@ class cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -493,8 +493,8 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -513,8 +513,8 @@ class cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -533,8 +533,8 @@ class cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION : public BaseCla
 class cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -553,8 +553,8 @@ class cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST : public Ba
 class cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -573,8 +573,8 @@ class cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE : public B
 class cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START();
 
         static eActionOp_CONTROL get_action_op(){
@@ -593,8 +593,8 @@ class cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START : public BaseClass
 class cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -613,8 +613,8 @@ class cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST : public Ba
 class cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER();
 
         static eActionOp_CONTROL get_action_op(){
@@ -631,8 +631,8 @@ class cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER : public BaseClass
 class cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -651,8 +651,8 @@ class cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST : public BaseClass
 class cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -671,8 +671,8 @@ class cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST : public BaseClass
 class cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -698,8 +698,8 @@ class cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
 class cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -718,8 +718,8 @@ class cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -738,8 +738,8 @@ class cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST : public BaseClass
 class cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -758,8 +758,8 @@ class cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST : public BaseClass
 class cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -778,8 +778,8 @@ class cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -798,8 +798,8 @@ class cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -818,8 +818,8 @@ class cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -840,8 +840,8 @@ class cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -860,8 +860,8 @@ class cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -880,8 +880,8 @@ class cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -900,8 +900,8 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -920,8 +920,8 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -940,8 +940,8 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public Bas
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -960,8 +960,8 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
 class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -980,8 +980,8 @@ class cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1000,8 +1000,8 @@ class cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1020,8 +1020,8 @@ class cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1046,8 +1046,8 @@ class cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1066,8 +1066,8 @@ class cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE : public BaseClass
 class cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1095,8 +1095,8 @@ class cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1115,8 +1115,8 @@ class cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1135,8 +1135,8 @@ class cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1155,8 +1155,8 @@ class cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE : public BaseClass
 class cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1175,8 +1175,8 @@ class cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1195,8 +1195,8 @@ class cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE : public BaseClass
 class cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1215,8 +1215,8 @@ class cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1235,8 +1235,8 @@ class cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE : public BaseClass
 class cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1255,8 +1255,8 @@ class cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
 class cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1275,8 +1275,8 @@ class cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE : public BaseClass
 class cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1295,8 +1295,8 @@ class cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST : public BaseClass
 class cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1315,8 +1315,8 @@ class cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE : public BaseClass
 class cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1335,8 +1335,8 @@ class cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST : public BaseClass
 class cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1355,8 +1355,8 @@ class cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 class cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1375,8 +1375,8 @@ class cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION : public BaseC
 class cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1395,8 +1395,8 @@ class cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){
@@ -1415,8 +1415,8 @@ class cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION : public BaseClass
 class cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION();
 
         static eActionOp_CONTROL get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_header.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_header.h
@@ -28,8 +28,8 @@ namespace beerocks_message {
 class cACTION_HEADER : public BaseClass
 {
     public:
-        cACTION_HEADER(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_HEADER(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_HEADER(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_HEADER(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_HEADER();
 
         const uint32_t& magic();

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_monitor.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_monitor.h
@@ -28,8 +28,8 @@ namespace beerocks_message {
 class cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -48,8 +48,8 @@ class cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_JOINED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_JOINED_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -66,8 +66,8 @@ class cACTION_MONITOR_JOINED_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_SON_CONFIG_UPDATE : public BaseClass
 {
     public:
-        cACTION_MONITOR_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_SON_CONFIG_UPDATE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -86,8 +86,8 @@ class cACTION_MONITOR_SON_CONFIG_UPDATE : public BaseClass
 class cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL : public BaseClass
 {
     public:
-        cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL();
 
         static eActionOp_MONITOR get_action_op(){
@@ -106,8 +106,8 @@ class cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL : public BaseClass
 class cACTION_MONITOR_ERROR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_ERROR_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -126,8 +126,8 @@ class cACTION_MONITOR_ERROR_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_ERROR_NOTIFICATION_ACK : public BaseClass
 {
     public:
-        cACTION_MONITOR_ERROR_NOTIFICATION_ACK(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_ERROR_NOTIFICATION_ACK(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_ERROR_NOTIFICATION_ACK(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_ERROR_NOTIFICATION_ACK(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_ERROR_NOTIFICATION_ACK();
 
         static eActionOp_MONITOR get_action_op(){
@@ -144,8 +144,8 @@ class cACTION_MONITOR_ERROR_NOTIFICATION_ACK : public BaseClass
 class cACTION_MONITOR_HEARTBEAT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HEARTBEAT_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -162,8 +162,8 @@ class cACTION_MONITOR_HEARTBEAT_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -182,8 +182,8 @@ class cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -202,8 +202,8 @@ class cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -222,8 +222,8 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -246,8 +246,8 @@ class cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -266,8 +266,8 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -286,8 +286,8 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE : public BaseClass
 class cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -306,8 +306,8 @@ class cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -326,8 +326,8 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION : public Bas
 class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -346,8 +346,8 @@ class cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE : public BaseClass
 class cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -366,8 +366,8 @@ class cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -386,8 +386,8 @@ class cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -406,8 +406,8 @@ class cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST : public BaseClass
 class cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -428,8 +428,8 @@ class cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -455,8 +455,8 @@ class cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
 class cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -475,8 +475,8 @@ class cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION : public BaseClass
 class cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -495,8 +495,8 @@ class cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -515,8 +515,8 @@ class cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE : public BaseClass
 class cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -535,8 +535,8 @@ class cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -555,8 +555,8 @@ class cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE : public BaseClass
 class cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -575,8 +575,8 @@ class cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -595,8 +595,8 @@ class cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE : public BaseClass
 class cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -615,8 +615,8 @@ class cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST : public BaseClass
 class cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -635,8 +635,8 @@ class cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE : public BaseClass
 class cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -655,8 +655,8 @@ class cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST : public BaseClass
 class cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -675,8 +675,8 @@ class cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE : public BaseClass
 class cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST : public BaseClass
 {
     public:
-        cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST();
 
         static eActionOp_MONITOR get_action_op(){
@@ -695,8 +695,8 @@ class cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST : public BaseClass
 class cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE();
 
         static eActionOp_MONITOR get_action_op(){
@@ -715,8 +715,8 @@ class cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE : public BaseClass
 class cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){
@@ -735,8 +735,8 @@ class cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION : public BaseC
 class cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION();
 
         static eActionOp_MONITOR get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_platform.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_platform.h
@@ -29,8 +29,8 @@ namespace beerocks_message {
 class cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -49,8 +49,8 @@ class cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION : pub
 class cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -74,8 +74,8 @@ class cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST : public BaseClass
 class cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -98,8 +98,8 @@ class cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE : public BaseClass
 class cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -118,8 +118,8 @@ class cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -138,8 +138,8 @@ class cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -171,8 +171,8 @@ class cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL : public BaseClass
 {
     public:
-        cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -191,8 +191,8 @@ class cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL : public BaseClass
 class cACTION_PLATFORM_ARP_QUERY_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ARP_QUERY_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -211,8 +211,8 @@ class cACTION_PLATFORM_ARP_QUERY_REQUEST : public BaseClass
 class cACTION_PLATFORM_ARP_QUERY_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ARP_QUERY_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -231,8 +231,8 @@ class cACTION_PLATFORM_ARP_QUERY_RESPONSE : public BaseClass
 class cACTION_PLATFORM_ONBOARD_QUERY_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ONBOARD_QUERY_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -249,8 +249,8 @@ class cACTION_PLATFORM_ONBOARD_QUERY_REQUEST : public BaseClass
 class cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -269,8 +269,8 @@ class cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE : public BaseClass
 class cACTION_PLATFORM_ONBOARD_SET_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ONBOARD_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ONBOARD_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ONBOARD_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ONBOARD_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ONBOARD_SET_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -289,8 +289,8 @@ class cACTION_PLATFORM_ONBOARD_SET_REQUEST : public BaseClass
 class cACTION_PLATFORM_WPS_ONBOARDING_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_WPS_ONBOARDING_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -314,8 +314,8 @@ class cACTION_PLATFORM_WPS_ONBOARDING_REQUEST : public BaseClass
 class cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -334,8 +334,8 @@ class cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST : public BaseClass
 class cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -358,8 +358,8 @@ class cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE : public BaseClass
 class cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -376,8 +376,8 @@ class cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST : public BaseClass
 class cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -398,8 +398,8 @@ class cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE : public BaseClass
 class cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -416,8 +416,8 @@ class cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST : public BaseClass
 class cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -438,8 +438,8 @@ class cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE : public BaseClass
 class cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -456,8 +456,8 @@ class cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST : public BaseClass
 class cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -476,8 +476,8 @@ class cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE : public BaseClass
 class cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -496,8 +496,8 @@ class cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -516,8 +516,8 @@ class cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST : public BaseClass
 {
     public:
-        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -534,8 +534,8 @@ class cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST : public BaseClass
 class cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE : public BaseClass
 {
     public:
-        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -556,8 +556,8 @@ class cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE : public BaseClass
 class cACTION_PLATFORM_ERROR_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_ERROR_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -583,8 +583,8 @@ class cACTION_PLATFORM_ERROR_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){
@@ -624,8 +624,8 @@ class cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION : public BaseClass
 class cACTION_PLATFORM_OPERATIONAL_NOTIFICATION : public BaseClass
 {
     public:
-        cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse = false);
+        cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cACTION_PLATFORM_OPERATIONAL_NOTIFICATION();
 
         static eActionOp_PLATFORM get_action_op(){

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-tlvVsClientAssociationEvent::tlvVsClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvVsClientAssociationEvent::tlvVsClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvVsClientAssociationEvent::tlvVsClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvVsClientAssociationEvent::tlvVsClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvVsClientAssociationEvent::~tlvVsClientAssociationEvent() {
@@ -117,7 +117,7 @@ bool tlvVsClientAssociationEvent::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_APMANAGER_4ADDR_STA_JOINED::cACTION_APMANAGER_4ADDR_STA_JOINED(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_4ADDR_STA_JOINED::cACTION_APMANAGER_4ADDR_STA_JOINED(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_4ADDR_STA_JOINED::cACTION_APMANAGER_4ADDR_STA_JOINED(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_4ADDR_STA_JOINED::cACTION_APMANAGER_4ADDR_STA_JOINED(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_4ADDR_STA_JOINED::~cACTION_APMANAGER_4ADDR_STA_JOINED() {
@@ -65,16 +65,16 @@ bool cACTION_APMANAGER_4ADDR_STA_JOINED::init()
         return false;
     }
     if (!m_parse__) { m_dst_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_JOINED_NOTIFICATION::cACTION_APMANAGER_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_JOINED_NOTIFICATION::cACTION_APMANAGER_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_JOINED_NOTIFICATION::cACTION_APMANAGER_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_JOINED_NOTIFICATION::cACTION_APMANAGER_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_JOINED_NOTIFICATION::~cACTION_APMANAGER_JOINED_NOTIFICATION() {
@@ -119,16 +119,16 @@ bool cACTION_APMANAGER_JOINED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_ENABLE_APS_REQUEST::cACTION_APMANAGER_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_ENABLE_APS_REQUEST::cACTION_APMANAGER_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_ENABLE_APS_REQUEST::cACTION_APMANAGER_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_ENABLE_APS_REQUEST::cACTION_APMANAGER_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_ENABLE_APS_REQUEST::~cACTION_APMANAGER_ENABLE_APS_REQUEST() {
@@ -180,16 +180,16 @@ bool cACTION_APMANAGER_ENABLE_APS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_ENABLE_APS_RESPONSE::cACTION_APMANAGER_ENABLE_APS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_ENABLE_APS_RESPONSE::cACTION_APMANAGER_ENABLE_APS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_ENABLE_APS_RESPONSE::cACTION_APMANAGER_ENABLE_APS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_ENABLE_APS_RESPONSE::cACTION_APMANAGER_ENABLE_APS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_ENABLE_APS_RESPONSE::~cACTION_APMANAGER_ENABLE_APS_RESPONSE() {
@@ -220,16 +220,16 @@ bool cACTION_APMANAGER_ENABLE_APS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_INIT_DONE_NOTIFICATION::cACTION_APMANAGER_INIT_DONE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_INIT_DONE_NOTIFICATION::cACTION_APMANAGER_INIT_DONE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_INIT_DONE_NOTIFICATION::cACTION_APMANAGER_INIT_DONE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_INIT_DONE_NOTIFICATION::cACTION_APMANAGER_INIT_DONE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_INIT_DONE_NOTIFICATION::~cACTION_APMANAGER_INIT_DONE_NOTIFICATION() {
@@ -250,16 +250,16 @@ bool cACTION_APMANAGER_INIT_DONE_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::~cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST() {
@@ -292,16 +292,16 @@ bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::~cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE() {
@@ -332,16 +332,16 @@ bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION() {
@@ -372,16 +372,16 @@ bool cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION() {
@@ -424,16 +424,16 @@ bool cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_vap_info->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::~cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST() {
@@ -454,16 +454,16 @@ bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::~cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST() {
@@ -484,16 +484,16 @@ bool cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST:
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION() {
@@ -526,16 +526,16 @@ bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::~cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START() {
@@ -568,16 +568,16 @@ bool cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION() {
@@ -610,16 +610,16 @@ bool cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION() {
@@ -652,16 +652,16 @@ bool cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION() {
@@ -694,16 +694,16 @@ bool cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION() {
@@ -758,16 +758,16 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION() {
@@ -800,16 +800,16 @@ bool cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::~cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION() {
@@ -842,16 +842,16 @@ bool cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::~cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE() {
@@ -884,16 +884,16 @@ bool cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::~cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE() {
@@ -926,16 +926,16 @@ bool cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::~cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST() {
@@ -968,16 +968,16 @@ bool cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::~cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST() {
@@ -1010,16 +1010,16 @@ bool cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::~cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION() {
@@ -1052,16 +1052,16 @@ bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::~cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION() {
@@ -1094,16 +1094,16 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::~cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST() {
@@ -1168,16 +1168,16 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::~cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE() {
@@ -1210,16 +1210,16 @@ bool cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::~cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST() {
@@ -1264,16 +1264,16 @@ bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_bssid->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::~cACTION_APMANAGER_CLIENT_ALLOW_REQUEST() {
@@ -1318,16 +1318,16 @@ bool cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_bssid->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST() {
@@ -1360,16 +1360,16 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE() {
@@ -1402,16 +1402,16 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::~cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION() {
@@ -1444,16 +1444,16 @@ bool cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_ACK::cACTION_APMANAGER_ACK(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_ACK::cACTION_APMANAGER_ACK(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_ACK::cACTION_APMANAGER_ACK(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_ACK::cACTION_APMANAGER_ACK(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_ACK::~cACTION_APMANAGER_ACK() {
@@ -1496,16 +1496,16 @@ bool cACTION_APMANAGER_ACK::init()
         return false;
     }
     if (!m_parse__) { m_sta_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::~cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST() {
@@ -1538,16 +1538,16 @@ bool cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::~cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE() {
@@ -1580,16 +1580,16 @@ bool cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
@@ -1622,16 +1622,16 @@ bool cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::~cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST() {
@@ -1664,16 +1664,16 @@ bool cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::~cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE() {
@@ -1706,16 +1706,16 @@ bool cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::~cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION() {
@@ -1748,16 +1748,16 @@ bool cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::~cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION() {
@@ -1790,16 +1790,16 @@ bool cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::~cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST() {
@@ -1838,7 +1838,7 @@ std::shared_ptr<WSC::cConfigData> cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQU
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<WSC::cConfigData>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<WSC::cConfigData>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::add_wifi_credentials(std::shared_ptr<WSC::cConfigData> ptr) {
@@ -1916,16 +1916,16 @@ bool cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::init()
         // swap back since wifi_credentials will be swapped as part of the whole class swap
         wifi_credentials->class_swap();
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::cACTION_APMANAGER_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::~cACTION_APMANAGER_HEARTBEAT_NOTIFICATION() {
@@ -1946,16 +1946,16 @@ bool cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::cACTION_APMANAGER_READ_ACS_REPORT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::~cACTION_APMANAGER_READ_ACS_REPORT_REQUEST() {
@@ -1976,16 +1976,16 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::~cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE() {
@@ -2028,7 +2028,7 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::init()
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_BACKHAUL_REGISTER_REQUEST::cACTION_BACKHAUL_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_REGISTER_REQUEST::cACTION_BACKHAUL_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_REGISTER_REQUEST::cACTION_BACKHAUL_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_REGISTER_REQUEST::cACTION_BACKHAUL_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_REGISTER_REQUEST::~cACTION_BACKHAUL_REGISTER_REQUEST() {
@@ -149,16 +149,16 @@ bool cACTION_BACKHAUL_REGISTER_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_REGISTER_RESPONSE::cACTION_BACKHAUL_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_REGISTER_RESPONSE::cACTION_BACKHAUL_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_REGISTER_RESPONSE::cACTION_BACKHAUL_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_REGISTER_RESPONSE::cACTION_BACKHAUL_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_REGISTER_RESPONSE::~cACTION_BACKHAUL_REGISTER_RESPONSE() {
@@ -189,16 +189,16 @@ bool cACTION_BACKHAUL_REGISTER_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_BUSY_NOTIFICATION::cACTION_BACKHAUL_BUSY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_BUSY_NOTIFICATION::cACTION_BACKHAUL_BUSY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_BUSY_NOTIFICATION::cACTION_BACKHAUL_BUSY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_BUSY_NOTIFICATION::cACTION_BACKHAUL_BUSY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_BUSY_NOTIFICATION::~cACTION_BACKHAUL_BUSY_NOTIFICATION() {
@@ -219,16 +219,16 @@ bool cACTION_BACKHAUL_BUSY_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_ENABLE::cACTION_BACKHAUL_ENABLE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_ENABLE::cACTION_BACKHAUL_ENABLE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_ENABLE::cACTION_BACKHAUL_ENABLE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_ENABLE::cACTION_BACKHAUL_ENABLE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_ENABLE::~cACTION_BACKHAUL_ENABLE() {
@@ -504,16 +504,16 @@ bool cACTION_BACKHAUL_ENABLE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_CONNECTED_NOTIFICATION::cACTION_BACKHAUL_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_CONNECTED_NOTIFICATION::cACTION_BACKHAUL_CONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_CONNECTED_NOTIFICATION::cACTION_BACKHAUL_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_CONNECTED_NOTIFICATION::cACTION_BACKHAUL_CONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_CONNECTED_NOTIFICATION::~cACTION_BACKHAUL_CONNECTED_NOTIFICATION() {
@@ -546,16 +546,16 @@ bool cACTION_BACKHAUL_CONNECTED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::~cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION() {
@@ -586,16 +586,16 @@ bool cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_ENABLE_APS_REQUEST::cACTION_BACKHAUL_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_ENABLE_APS_REQUEST::cACTION_BACKHAUL_ENABLE_APS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_ENABLE_APS_REQUEST::cACTION_BACKHAUL_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_ENABLE_APS_REQUEST::cACTION_BACKHAUL_ENABLE_APS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_ENABLE_APS_REQUEST::~cACTION_BACKHAUL_ENABLE_APS_REQUEST() {
@@ -647,16 +647,16 @@ bool cACTION_BACKHAUL_ENABLE_APS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_ROAM_REQUEST::cACTION_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_ROAM_REQUEST::cACTION_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_ROAM_REQUEST::cACTION_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_ROAM_REQUEST::cACTION_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_ROAM_REQUEST::~cACTION_BACKHAUL_ROAM_REQUEST() {
@@ -689,16 +689,16 @@ bool cACTION_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_ROAM_RESPONSE::cACTION_BACKHAUL_ROAM_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_ROAM_RESPONSE::cACTION_BACKHAUL_ROAM_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_ROAM_RESPONSE::cACTION_BACKHAUL_ROAM_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_ROAM_RESPONSE::cACTION_BACKHAUL_ROAM_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_ROAM_RESPONSE::~cACTION_BACKHAUL_ROAM_RESPONSE() {
@@ -729,16 +729,16 @@ bool cACTION_BACKHAUL_ROAM_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_RESET::cACTION_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_RESET::cACTION_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_RESET::cACTION_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_RESET::cACTION_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_RESET::~cACTION_BACKHAUL_RESET() {
@@ -759,16 +759,16 @@ bool cACTION_BACKHAUL_RESET::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_4ADDR_CONNECTED::cACTION_BACKHAUL_4ADDR_CONNECTED(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_4ADDR_CONNECTED::cACTION_BACKHAUL_4ADDR_CONNECTED(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_4ADDR_CONNECTED::cACTION_BACKHAUL_4ADDR_CONNECTED(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_4ADDR_CONNECTED::cACTION_BACKHAUL_4ADDR_CONNECTED(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_4ADDR_CONNECTED::~cACTION_BACKHAUL_4ADDR_CONNECTED() {
@@ -801,16 +801,16 @@ bool cACTION_BACKHAUL_4ADDR_CONNECTED::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::~cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION() {
@@ -843,16 +843,16 @@ bool cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::~cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST() {
@@ -884,16 +884,16 @@ bool cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST() {
@@ -926,16 +926,16 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE() {
@@ -968,16 +968,16 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
@@ -1010,7 +1010,7 @@ bool cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_BML_PING_REQUEST::cACTION_BML_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_PING_REQUEST::cACTION_BML_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_PING_REQUEST::cACTION_BML_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_PING_REQUEST::cACTION_BML_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_PING_REQUEST::~cACTION_BML_PING_REQUEST() {
@@ -41,16 +41,16 @@ bool cACTION_BML_PING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_PING_RESPONSE::cACTION_BML_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_PING_RESPONSE::cACTION_BML_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_PING_RESPONSE::cACTION_BML_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_PING_RESPONSE::cACTION_BML_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_PING_RESPONSE::~cACTION_BML_PING_RESPONSE() {
@@ -71,16 +71,16 @@ bool cACTION_BML_PING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_NW_MAP_REQUEST::cACTION_BML_NW_MAP_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_NW_MAP_REQUEST::cACTION_BML_NW_MAP_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_NW_MAP_REQUEST::cACTION_BML_NW_MAP_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_NW_MAP_REQUEST::cACTION_BML_NW_MAP_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_NW_MAP_REQUEST::~cACTION_BML_NW_MAP_REQUEST() {
@@ -101,16 +101,16 @@ bool cACTION_BML_NW_MAP_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_NW_MAP_RESPONSE::cACTION_BML_NW_MAP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_NW_MAP_RESPONSE::cACTION_BML_NW_MAP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_NW_MAP_RESPONSE::cACTION_BML_NW_MAP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_NW_MAP_RESPONSE::cACTION_BML_NW_MAP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_NW_MAP_RESPONSE::~cACTION_BML_NW_MAP_RESPONSE() {
@@ -210,22 +210,22 @@ bool cACTION_BML_NW_MAP_RESPONSE::init()
     }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
+    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_NW_MAP_UPDATE::cACTION_BML_NW_MAP_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_NW_MAP_UPDATE::cACTION_BML_NW_MAP_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_NW_MAP_UPDATE::cACTION_BML_NW_MAP_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_NW_MAP_UPDATE::cACTION_BML_NW_MAP_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_NW_MAP_UPDATE::~cACTION_BML_NW_MAP_UPDATE() {
@@ -325,22 +325,22 @@ bool cACTION_BML_NW_MAP_UPDATE::init()
     }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
+    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STATS_UPDATE::cACTION_BML_STATS_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STATS_UPDATE::cACTION_BML_STATS_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STATS_UPDATE::cACTION_BML_STATS_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STATS_UPDATE::cACTION_BML_STATS_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STATS_UPDATE::~cACTION_BML_STATS_UPDATE() {
@@ -440,22 +440,22 @@ bool cACTION_BML_STATS_UPDATE::init()
     }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
+    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_EVENTS_UPDATE::cACTION_BML_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_EVENTS_UPDATE::cACTION_BML_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_EVENTS_UPDATE::cACTION_BML_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_EVENTS_UPDATE::cACTION_BML_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_EVENTS_UPDATE::~cACTION_BML_EVENTS_UPDATE() {
@@ -544,22 +544,22 @@ bool cACTION_BML_EVENTS_UPDATE::init()
     }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
+    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::~cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST() {
@@ -580,16 +580,16 @@ bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::~cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE() {
@@ -610,16 +610,16 @@ bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::~cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST() {
@@ -640,16 +640,16 @@ bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::~cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE() {
@@ -670,16 +670,16 @@ bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::~cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE() {
@@ -700,16 +700,16 @@ bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::~cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST() {
@@ -730,16 +730,16 @@ bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::~cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST() {
@@ -760,16 +760,16 @@ bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::~cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE() {
@@ -790,16 +790,16 @@ bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::~cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST() {
@@ -820,16 +820,16 @@ bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::~cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE() {
@@ -850,16 +850,16 @@ bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::~cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST() {
@@ -880,16 +880,16 @@ bool cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::~cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE() {
@@ -910,16 +910,16 @@ bool cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::~cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST() {
@@ -940,16 +940,16 @@ bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::~cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE() {
@@ -970,16 +970,16 @@ bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::~cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST() {
@@ -1010,16 +1010,16 @@ bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::~cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE() {
@@ -1050,16 +1050,16 @@ bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CLIENT_ROAMING_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CLIENT_ROAMING_REQUEST::~cACTION_BML_SET_CLIENT_ROAMING_REQUEST() {
@@ -1090,16 +1090,16 @@ bool cACTION_BML_SET_CLIENT_ROAMING_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::~cACTION_BML_SET_CLIENT_ROAMING_RESPONSE() {
@@ -1120,16 +1120,16 @@ bool cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CLIENT_ROAMING_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CLIENT_ROAMING_REQUEST::~cACTION_BML_GET_CLIENT_ROAMING_REQUEST() {
@@ -1150,16 +1150,16 @@ bool cACTION_BML_GET_CLIENT_ROAMING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::~cACTION_BML_GET_CLIENT_ROAMING_RESPONSE() {
@@ -1190,16 +1190,16 @@ bool cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_DFS_REENTRY_REQUEST::cACTION_BML_SET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_DFS_REENTRY_REQUEST::cACTION_BML_SET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_DFS_REENTRY_REQUEST::cACTION_BML_SET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_DFS_REENTRY_REQUEST::cACTION_BML_SET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_DFS_REENTRY_REQUEST::~cACTION_BML_SET_DFS_REENTRY_REQUEST() {
@@ -1230,16 +1230,16 @@ bool cACTION_BML_SET_DFS_REENTRY_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_DFS_REENTRY_RESPONSE::cACTION_BML_SET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_DFS_REENTRY_RESPONSE::cACTION_BML_SET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_DFS_REENTRY_RESPONSE::cACTION_BML_SET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_DFS_REENTRY_RESPONSE::cACTION_BML_SET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_DFS_REENTRY_RESPONSE::~cACTION_BML_SET_DFS_REENTRY_RESPONSE() {
@@ -1260,16 +1260,16 @@ bool cACTION_BML_SET_DFS_REENTRY_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_DFS_REENTRY_REQUEST::cACTION_BML_GET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_DFS_REENTRY_REQUEST::cACTION_BML_GET_DFS_REENTRY_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_DFS_REENTRY_REQUEST::cACTION_BML_GET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_DFS_REENTRY_REQUEST::cACTION_BML_GET_DFS_REENTRY_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_DFS_REENTRY_REQUEST::~cACTION_BML_GET_DFS_REENTRY_REQUEST() {
@@ -1290,16 +1290,16 @@ bool cACTION_BML_GET_DFS_REENTRY_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_DFS_REENTRY_RESPONSE::cACTION_BML_GET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_DFS_REENTRY_RESPONSE::cACTION_BML_GET_DFS_REENTRY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_DFS_REENTRY_RESPONSE::cACTION_BML_GET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_DFS_REENTRY_RESPONSE::cACTION_BML_GET_DFS_REENTRY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_DFS_REENTRY_RESPONSE::~cACTION_BML_GET_DFS_REENTRY_RESPONSE() {
@@ -1330,16 +1330,16 @@ bool cACTION_BML_GET_DFS_REENTRY_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::~cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST() {
@@ -1370,16 +1370,16 @@ bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::~cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE() {
@@ -1400,16 +1400,16 @@ bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::~cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST() {
@@ -1430,16 +1430,16 @@ bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::~cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE() {
@@ -1470,16 +1470,16 @@ bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::~cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST() {
@@ -1510,16 +1510,16 @@ bool cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::~cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE() {
@@ -1540,16 +1540,16 @@ bool cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::~cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST() {
@@ -1570,16 +1570,16 @@ bool cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::~cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE() {
@@ -1610,16 +1610,16 @@ bool cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_IRE_ROAMING_REQUEST::cACTION_BML_SET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_IRE_ROAMING_REQUEST::cACTION_BML_SET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_IRE_ROAMING_REQUEST::cACTION_BML_SET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_IRE_ROAMING_REQUEST::cACTION_BML_SET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_IRE_ROAMING_REQUEST::~cACTION_BML_SET_IRE_ROAMING_REQUEST() {
@@ -1650,16 +1650,16 @@ bool cACTION_BML_SET_IRE_ROAMING_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_IRE_ROAMING_RESPONSE::cACTION_BML_SET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_IRE_ROAMING_RESPONSE::cACTION_BML_SET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_IRE_ROAMING_RESPONSE::cACTION_BML_SET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_IRE_ROAMING_RESPONSE::cACTION_BML_SET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_IRE_ROAMING_RESPONSE::~cACTION_BML_SET_IRE_ROAMING_RESPONSE() {
@@ -1680,16 +1680,16 @@ bool cACTION_BML_SET_IRE_ROAMING_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_IRE_ROAMING_REQUEST::cACTION_BML_GET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_IRE_ROAMING_REQUEST::cACTION_BML_GET_IRE_ROAMING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_IRE_ROAMING_REQUEST::cACTION_BML_GET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_IRE_ROAMING_REQUEST::cACTION_BML_GET_IRE_ROAMING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_IRE_ROAMING_REQUEST::~cACTION_BML_GET_IRE_ROAMING_REQUEST() {
@@ -1710,16 +1710,16 @@ bool cACTION_BML_GET_IRE_ROAMING_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_IRE_ROAMING_RESPONSE::cACTION_BML_GET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_IRE_ROAMING_RESPONSE::cACTION_BML_GET_IRE_ROAMING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_IRE_ROAMING_RESPONSE::cACTION_BML_GET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_IRE_ROAMING_RESPONSE::cACTION_BML_GET_IRE_ROAMING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_IRE_ROAMING_RESPONSE::~cACTION_BML_GET_IRE_ROAMING_RESPONSE() {
@@ -1750,16 +1750,16 @@ bool cACTION_BML_GET_IRE_ROAMING_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_LOAD_BALANCER_REQUEST::cACTION_BML_SET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_LOAD_BALANCER_REQUEST::cACTION_BML_SET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_LOAD_BALANCER_REQUEST::cACTION_BML_SET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_LOAD_BALANCER_REQUEST::cACTION_BML_SET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_LOAD_BALANCER_REQUEST::~cACTION_BML_SET_LOAD_BALANCER_REQUEST() {
@@ -1790,16 +1790,16 @@ bool cACTION_BML_SET_LOAD_BALANCER_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_LOAD_BALANCER_RESPONSE::cACTION_BML_SET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_LOAD_BALANCER_RESPONSE::cACTION_BML_SET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_LOAD_BALANCER_RESPONSE::cACTION_BML_SET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_LOAD_BALANCER_RESPONSE::cACTION_BML_SET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_LOAD_BALANCER_RESPONSE::~cACTION_BML_SET_LOAD_BALANCER_RESPONSE() {
@@ -1820,16 +1820,16 @@ bool cACTION_BML_SET_LOAD_BALANCER_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_LOAD_BALANCER_REQUEST::cACTION_BML_GET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_LOAD_BALANCER_REQUEST::cACTION_BML_GET_LOAD_BALANCER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_LOAD_BALANCER_REQUEST::cACTION_BML_GET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_LOAD_BALANCER_REQUEST::cACTION_BML_GET_LOAD_BALANCER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_LOAD_BALANCER_REQUEST::~cACTION_BML_GET_LOAD_BALANCER_REQUEST() {
@@ -1850,16 +1850,16 @@ bool cACTION_BML_GET_LOAD_BALANCER_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_LOAD_BALANCER_RESPONSE::cACTION_BML_GET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_LOAD_BALANCER_RESPONSE::cACTION_BML_GET_LOAD_BALANCER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_LOAD_BALANCER_RESPONSE::cACTION_BML_GET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_LOAD_BALANCER_RESPONSE::cACTION_BML_GET_LOAD_BALANCER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_LOAD_BALANCER_RESPONSE::~cACTION_BML_GET_LOAD_BALANCER_RESPONSE() {
@@ -1890,16 +1890,16 @@ bool cACTION_BML_GET_LOAD_BALANCER_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::~cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST() {
@@ -1930,16 +1930,16 @@ bool cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::~cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE() {
@@ -1960,16 +1960,16 @@ bool cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::~cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST() {
@@ -1990,16 +1990,16 @@ bool cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::~cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE() {
@@ -2030,16 +2030,16 @@ bool cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::~cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST() {
@@ -2072,16 +2072,16 @@ bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::~cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE() {
@@ -2102,16 +2102,16 @@ bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::~cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST() {
@@ -2144,16 +2144,16 @@ bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::~cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE() {
@@ -2185,16 +2185,16 @@ bool cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::~cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST() {
@@ -2227,16 +2227,16 @@ bool cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::~cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE() {
@@ -2268,16 +2268,16 @@ bool cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::~cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST() {
@@ -2310,16 +2310,16 @@ bool cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::~cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE() {
@@ -2352,16 +2352,16 @@ bool cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::~cACTION_BML_SET_CERTIFICATION_MODE_REQUEST() {
@@ -2392,16 +2392,16 @@ bool cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::~cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE() {
@@ -2422,16 +2422,16 @@ bool cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::cACTION_BML_GET_CERTIFICATION_MODE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::~cACTION_BML_GET_CERTIFICATION_MODE_REQUEST() {
@@ -2452,16 +2452,16 @@ bool cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::~cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE() {
@@ -2492,16 +2492,16 @@ bool cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::~cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST() {
@@ -2596,16 +2596,16 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sConfigVapInfo) * (vap_list_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::~cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE() {
@@ -2637,16 +2637,16 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::~cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE() {
@@ -2741,16 +2741,16 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sConfigVapInfo) * (vap_list_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::~cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST() {
@@ -2782,16 +2782,16 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_SET_GROUP_REQUEST::cACTION_BML_STEERING_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_SET_GROUP_REQUEST::cACTION_BML_STEERING_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_SET_GROUP_REQUEST::cACTION_BML_STEERING_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_SET_GROUP_REQUEST::cACTION_BML_STEERING_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_SET_GROUP_REQUEST::~cACTION_BML_STEERING_SET_GROUP_REQUEST() {
@@ -2857,16 +2857,16 @@ bool cACTION_BML_STEERING_SET_GROUP_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_SET_GROUP_RESPONSE::cACTION_BML_STEERING_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_SET_GROUP_RESPONSE::cACTION_BML_STEERING_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_SET_GROUP_RESPONSE::cACTION_BML_STEERING_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_SET_GROUP_RESPONSE::cACTION_BML_STEERING_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_SET_GROUP_RESPONSE::~cACTION_BML_STEERING_SET_GROUP_RESPONSE() {
@@ -2898,16 +2898,16 @@ bool cACTION_BML_STEERING_SET_GROUP_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_CLIENT_SET_REQUEST::cACTION_BML_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_CLIENT_SET_REQUEST::cACTION_BML_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_CLIENT_SET_REQUEST::cACTION_BML_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_CLIENT_SET_REQUEST::cACTION_BML_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_CLIENT_SET_REQUEST::~cACTION_BML_STEERING_CLIENT_SET_REQUEST() {
@@ -2985,16 +2985,16 @@ bool cACTION_BML_STEERING_CLIENT_SET_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_CLIENT_SET_RESPONSE::cACTION_BML_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_CLIENT_SET_RESPONSE::cACTION_BML_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_CLIENT_SET_RESPONSE::cACTION_BML_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_CLIENT_SET_RESPONSE::cACTION_BML_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_CLIENT_SET_RESPONSE::~cACTION_BML_STEERING_CLIENT_SET_RESPONSE() {
@@ -3026,16 +3026,16 @@ bool cACTION_BML_STEERING_CLIENT_SET_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::~cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST() {
@@ -3066,16 +3066,16 @@ bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::~cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE() {
@@ -3107,16 +3107,16 @@ bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::~cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST() {
@@ -3193,16 +3193,16 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::~cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE() {
@@ -3234,16 +3234,16 @@ bool cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::~cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST() {
@@ -3299,16 +3299,16 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_client_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::~cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE() {
@@ -3340,16 +3340,16 @@ bool cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_STEERING_EVENTS_UPDATE::cACTION_BML_STEERING_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_STEERING_EVENTS_UPDATE::cACTION_BML_STEERING_EVENTS_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_STEERING_EVENTS_UPDATE::cACTION_BML_STEERING_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_STEERING_EVENTS_UPDATE::cACTION_BML_STEERING_EVENTS_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_STEERING_EVENTS_UPDATE::~cACTION_BML_STEERING_EVENTS_UPDATE() {
@@ -3438,22 +3438,22 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::init()
     }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
+    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_TRIGGER_TOPOLOGY_QUERY::cACTION_BML_TRIGGER_TOPOLOGY_QUERY(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_TRIGGER_TOPOLOGY_QUERY::cACTION_BML_TRIGGER_TOPOLOGY_QUERY(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_TRIGGER_TOPOLOGY_QUERY::cACTION_BML_TRIGGER_TOPOLOGY_QUERY(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_TRIGGER_TOPOLOGY_QUERY::cACTION_BML_TRIGGER_TOPOLOGY_QUERY(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_TRIGGER_TOPOLOGY_QUERY::~cACTION_BML_TRIGGER_TOPOLOGY_QUERY() {
@@ -3486,16 +3486,16 @@ bool cACTION_BML_TRIGGER_TOPOLOGY_QUERY::init()
         return false;
     }
     if (!m_parse__) { m_al_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::~cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST() {
@@ -3540,7 +3540,7 @@ bool cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_ruid->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::~cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS() {
@@ -51,16 +51,16 @@ bool cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_ENABLE_LOAD_BALANCER::cACTION_CLI_ENABLE_LOAD_BALANCER(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_ENABLE_LOAD_BALANCER::cACTION_CLI_ENABLE_LOAD_BALANCER(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_ENABLE_LOAD_BALANCER::cACTION_CLI_ENABLE_LOAD_BALANCER(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_ENABLE_LOAD_BALANCER::cACTION_CLI_ENABLE_LOAD_BALANCER(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_ENABLE_LOAD_BALANCER::~cACTION_CLI_ENABLE_LOAD_BALANCER() {
@@ -91,16 +91,16 @@ bool cACTION_CLI_ENABLE_LOAD_BALANCER::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_ENABLE_DEBUG::cACTION_CLI_ENABLE_DEBUG(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_ENABLE_DEBUG::cACTION_CLI_ENABLE_DEBUG(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_ENABLE_DEBUG::cACTION_CLI_ENABLE_DEBUG(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_ENABLE_DEBUG::cACTION_CLI_ENABLE_DEBUG(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_ENABLE_DEBUG::~cACTION_CLI_ENABLE_DEBUG() {
@@ -131,16 +131,16 @@ bool cACTION_CLI_ENABLE_DEBUG::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::~cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS() {
@@ -172,16 +172,16 @@ bool cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_RESPONSE_INT::cACTION_CLI_RESPONSE_INT(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_RESPONSE_INT::cACTION_CLI_RESPONSE_INT(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_RESPONSE_INT::cACTION_CLI_RESPONSE_INT(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_RESPONSE_INT::cACTION_CLI_RESPONSE_INT(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_RESPONSE_INT::~cACTION_CLI_RESPONSE_INT() {
@@ -222,16 +222,16 @@ bool cACTION_CLI_RESPONSE_INT::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_RESPONSE_STR::cACTION_CLI_RESPONSE_STR(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_RESPONSE_STR::cACTION_CLI_RESPONSE_STR(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_RESPONSE_STR::cACTION_CLI_RESPONSE_STR(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_RESPONSE_STR::cACTION_CLI_RESPONSE_STR(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_RESPONSE_STR::~cACTION_CLI_RESPONSE_STR() {
@@ -320,22 +320,22 @@ bool cACTION_CLI_RESPONSE_STR::init()
     }
     m_buffer = (char*)m_buff_ptr__;
     uint32_t buffer_size = *m_buffer_size;
-    if (m_parse__ && m_swap__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
+    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&buffer_size)); }
     m_buffer_idx__ = buffer_size;
     if (!buffPtrIncrementSafe(sizeof(char) * (buffer_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (buffer_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::~cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT() {
@@ -392,16 +392,16 @@ bool cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_OPTIMAL_PATH_TASK::cACTION_CLI_OPTIMAL_PATH_TASK(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_OPTIMAL_PATH_TASK::cACTION_CLI_OPTIMAL_PATH_TASK(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_OPTIMAL_PATH_TASK::cACTION_CLI_OPTIMAL_PATH_TASK(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_OPTIMAL_PATH_TASK::cACTION_CLI_OPTIMAL_PATH_TASK(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_OPTIMAL_PATH_TASK::~cACTION_CLI_OPTIMAL_PATH_TASK() {
@@ -434,16 +434,16 @@ bool cACTION_CLI_OPTIMAL_PATH_TASK::init()
         return false;
     }
     if (!m_parse__) { m_client_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_LOAD_BALANCER_TASK::cACTION_CLI_LOAD_BALANCER_TASK(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_LOAD_BALANCER_TASK::cACTION_CLI_LOAD_BALANCER_TASK(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_LOAD_BALANCER_TASK::cACTION_CLI_LOAD_BALANCER_TASK(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_LOAD_BALANCER_TASK::cACTION_CLI_LOAD_BALANCER_TASK(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_LOAD_BALANCER_TASK::~cACTION_CLI_LOAD_BALANCER_TASK() {
@@ -476,16 +476,16 @@ bool cACTION_CLI_LOAD_BALANCER_TASK::init()
         return false;
     }
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::~cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK() {
@@ -506,16 +506,16 @@ bool cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_DUMP_NODE_INFO::cACTION_CLI_DUMP_NODE_INFO(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_DUMP_NODE_INFO::cACTION_CLI_DUMP_NODE_INFO(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_DUMP_NODE_INFO::cACTION_CLI_DUMP_NODE_INFO(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_DUMP_NODE_INFO::cACTION_CLI_DUMP_NODE_INFO(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_DUMP_NODE_INFO::~cACTION_CLI_DUMP_NODE_INFO() {
@@ -548,16 +548,16 @@ bool cACTION_CLI_DUMP_NODE_INFO::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_PING_SLAVE_REQUEST::cACTION_CLI_PING_SLAVE_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_PING_SLAVE_REQUEST::cACTION_CLI_PING_SLAVE_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_PING_SLAVE_REQUEST::cACTION_CLI_PING_SLAVE_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_PING_SLAVE_REQUEST::cACTION_CLI_PING_SLAVE_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_PING_SLAVE_REQUEST::~cACTION_CLI_PING_SLAVE_REQUEST() {
@@ -612,16 +612,16 @@ bool cACTION_CLI_PING_SLAVE_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_PING_ALL_SLAVES_REQUEST::cACTION_CLI_PING_ALL_SLAVES_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_PING_ALL_SLAVES_REQUEST::cACTION_CLI_PING_ALL_SLAVES_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_PING_ALL_SLAVES_REQUEST::cACTION_CLI_PING_ALL_SLAVES_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_PING_ALL_SLAVES_REQUEST::cACTION_CLI_PING_ALL_SLAVES_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_PING_ALL_SLAVES_REQUEST::~cACTION_CLI_PING_ALL_SLAVES_REQUEST() {
@@ -664,16 +664,16 @@ bool cACTION_CLI_PING_ALL_SLAVES_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_BACKHAUL_SCAN_RESULTS::cACTION_CLI_BACKHAUL_SCAN_RESULTS(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_BACKHAUL_SCAN_RESULTS::cACTION_CLI_BACKHAUL_SCAN_RESULTS(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_BACKHAUL_SCAN_RESULTS::cACTION_CLI_BACKHAUL_SCAN_RESULTS(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_BACKHAUL_SCAN_RESULTS::cACTION_CLI_BACKHAUL_SCAN_RESULTS(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_BACKHAUL_SCAN_RESULTS::~cACTION_CLI_BACKHAUL_SCAN_RESULTS() {
@@ -706,16 +706,16 @@ bool cACTION_CLI_BACKHAUL_SCAN_RESULTS::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_BACKHAUL_ROAM_REQUEST::cACTION_CLI_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_BACKHAUL_ROAM_REQUEST::cACTION_CLI_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_BACKHAUL_ROAM_REQUEST::cACTION_CLI_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_BACKHAUL_ROAM_REQUEST::cACTION_CLI_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_BACKHAUL_ROAM_REQUEST::~cACTION_CLI_BACKHAUL_ROAM_REQUEST() {
@@ -760,16 +760,16 @@ bool cACTION_CLI_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_bssid->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_ALLOW_REQUEST::cACTION_CLI_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_ALLOW_REQUEST::cACTION_CLI_CLIENT_ALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_ALLOW_REQUEST::cACTION_CLI_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_ALLOW_REQUEST::cACTION_CLI_CLIENT_ALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_ALLOW_REQUEST::~cACTION_CLI_CLIENT_ALLOW_REQUEST() {
@@ -814,16 +814,16 @@ bool cACTION_CLI_CLIENT_ALLOW_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_DISALLOW_REQUEST::cACTION_CLI_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_DISALLOW_REQUEST::cACTION_CLI_CLIENT_DISALLOW_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_DISALLOW_REQUEST::cACTION_CLI_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_DISALLOW_REQUEST::cACTION_CLI_CLIENT_DISALLOW_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_DISALLOW_REQUEST::~cACTION_CLI_CLIENT_DISALLOW_REQUEST() {
@@ -868,16 +868,16 @@ bool cACTION_CLI_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_hostap_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_DISCONNECT_REQUEST::cACTION_CLI_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_DISCONNECT_REQUEST::cACTION_CLI_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_DISCONNECT_REQUEST::cACTION_CLI_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_DISCONNECT_REQUEST::cACTION_CLI_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_DISCONNECT_REQUEST::~cACTION_CLI_CLIENT_DISCONNECT_REQUEST() {
@@ -932,16 +932,16 @@ bool cACTION_CLI_CLIENT_DISCONNECT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_BSS_STEER_REQUEST::cACTION_CLI_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_BSS_STEER_REQUEST::cACTION_CLI_CLIENT_BSS_STEER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_BSS_STEER_REQUEST::cACTION_CLI_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_BSS_STEER_REQUEST::cACTION_CLI_CLIENT_BSS_STEER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_BSS_STEER_REQUEST::~cACTION_CLI_CLIENT_BSS_STEER_REQUEST() {
@@ -997,16 +997,16 @@ bool cACTION_CLI_CLIENT_BSS_STEER_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::~cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST() {
@@ -1051,16 +1051,16 @@ bool cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_client_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::~cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST() {
@@ -1115,16 +1115,16 @@ bool cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_BEACON_11K_REQUEST::cACTION_CLI_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_BEACON_11K_REQUEST::cACTION_CLI_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_BEACON_11K_REQUEST::cACTION_CLI_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_BEACON_11K_REQUEST::cACTION_CLI_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_BEACON_11K_REQUEST::~cACTION_CLI_CLIENT_BEACON_11K_REQUEST() {
@@ -1258,16 +1258,16 @@ bool cACTION_CLI_CLIENT_BEACON_11K_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int16_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::~cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST() {
@@ -1334,16 +1334,16 @@ bool cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::~cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST() {
@@ -1388,16 +1388,16 @@ bool cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::~cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST() {
@@ -1462,16 +1462,16 @@ bool cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::~cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST() {
@@ -1526,16 +1526,16 @@ bool cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CLI_HOSTAP_STATS_MEASUREMENT::cACTION_CLI_HOSTAP_STATS_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CLI_HOSTAP_STATS_MEASUREMENT::cACTION_CLI_HOSTAP_STATS_MEASUREMENT(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CLI_HOSTAP_STATS_MEASUREMENT::cACTION_CLI_HOSTAP_STATS_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CLI_HOSTAP_STATS_MEASUREMENT::cACTION_CLI_HOSTAP_STATS_MEASUREMENT(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CLI_HOSTAP_STATS_MEASUREMENT::~cACTION_CLI_HOSTAP_STATS_MEASUREMENT() {
@@ -1568,7 +1568,7 @@ bool cACTION_CLI_HOSTAP_STATS_MEASUREMENT::init()
         return false;
     }
     if (!m_parse__) { m_ap_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::~cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION() {
@@ -177,16 +177,16 @@ bool cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_SLAVE_JOINED_RESPONSE::cACTION_CONTROL_SLAVE_JOINED_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_SLAVE_JOINED_RESPONSE::cACTION_CONTROL_SLAVE_JOINED_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_SLAVE_JOINED_RESPONSE::cACTION_CONTROL_SLAVE_JOINED_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_SLAVE_JOINED_RESPONSE::cACTION_CONTROL_SLAVE_JOINED_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_SLAVE_JOINED_RESPONSE::~cACTION_CONTROL_SLAVE_JOINED_RESPONSE() {
@@ -263,16 +263,16 @@ bool cACTION_CONTROL_SLAVE_JOINED_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_config->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::~cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION() {
@@ -353,16 +353,16 @@ bool cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_hostap->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_SON_CONFIG_UPDATE::cACTION_CONTROL_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_SON_CONFIG_UPDATE::cACTION_CONTROL_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_SON_CONFIG_UPDATE::cACTION_CONTROL_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_SON_CONFIG_UPDATE::cACTION_CONTROL_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_SON_CONFIG_UPDATE::~cACTION_CONTROL_SON_CONFIG_UPDATE() {
@@ -395,16 +395,16 @@ bool cACTION_CONTROL_SON_CONFIG_UPDATE::init()
         return false;
     }
     if (!m_parse__) { m_config->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CONTROLLER_PING_REQUEST::cACTION_CONTROL_CONTROLLER_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CONTROLLER_PING_REQUEST::cACTION_CONTROL_CONTROLLER_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CONTROLLER_PING_REQUEST::cACTION_CONTROL_CONTROLLER_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CONTROLLER_PING_REQUEST::cACTION_CONTROL_CONTROLLER_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CONTROLLER_PING_REQUEST::~cACTION_CONTROL_CONTROLLER_PING_REQUEST() {
@@ -496,16 +496,16 @@ bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::init()
         return false;
     }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CONTROLLER_PING_RESPONSE::cACTION_CONTROL_CONTROLLER_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CONTROLLER_PING_RESPONSE::cACTION_CONTROL_CONTROLLER_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CONTROLLER_PING_RESPONSE::cACTION_CONTROL_CONTROLLER_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CONTROLLER_PING_RESPONSE::cACTION_CONTROL_CONTROLLER_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CONTROLLER_PING_RESPONSE::~cACTION_CONTROL_CONTROLLER_PING_RESPONSE() {
@@ -597,16 +597,16 @@ bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::init()
         return false;
     }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_AGENT_PING_REQUEST::cACTION_CONTROL_AGENT_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_AGENT_PING_REQUEST::cACTION_CONTROL_AGENT_PING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_AGENT_PING_REQUEST::cACTION_CONTROL_AGENT_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_AGENT_PING_REQUEST::cACTION_CONTROL_AGENT_PING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_AGENT_PING_REQUEST::~cACTION_CONTROL_AGENT_PING_REQUEST() {
@@ -698,16 +698,16 @@ bool cACTION_CONTROL_AGENT_PING_REQUEST::init()
         return false;
     }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_AGENT_PING_RESPONSE::cACTION_CONTROL_AGENT_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_AGENT_PING_RESPONSE::cACTION_CONTROL_AGENT_PING_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_AGENT_PING_RESPONSE::cACTION_CONTROL_AGENT_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_AGENT_PING_RESPONSE::cACTION_CONTROL_AGENT_PING_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_AGENT_PING_RESPONSE::~cACTION_CONTROL_AGENT_PING_RESPONSE() {
@@ -799,16 +799,16 @@ bool cACTION_CONTROL_AGENT_PING_RESPONSE::init()
         return false;
     }
     m_data = (uint8_t*)m_buff_ptr__;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_ARP_QUERY_REQUEST::cACTION_CONTROL_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_ARP_QUERY_REQUEST::cACTION_CONTROL_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_ARP_QUERY_REQUEST::cACTION_CONTROL_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_ARP_QUERY_REQUEST::cACTION_CONTROL_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_ARP_QUERY_REQUEST::~cACTION_CONTROL_ARP_QUERY_REQUEST() {
@@ -841,16 +841,16 @@ bool cACTION_CONTROL_ARP_QUERY_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_ARP_QUERY_RESPONSE::cACTION_CONTROL_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_ARP_QUERY_RESPONSE::cACTION_CONTROL_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_ARP_QUERY_RESPONSE::cACTION_CONTROL_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_ARP_QUERY_RESPONSE::cACTION_CONTROL_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_ARP_QUERY_RESPONSE::~cACTION_CONTROL_ARP_QUERY_RESPONSE() {
@@ -883,16 +883,16 @@ bool cACTION_CONTROL_ARP_QUERY_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::~cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION() {
@@ -935,16 +935,16 @@ bool cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::~cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION() {
@@ -977,16 +977,16 @@ bool cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_BACKHAUL_RESET::cACTION_CONTROL_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_BACKHAUL_RESET::cACTION_CONTROL_BACKHAUL_RESET(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_BACKHAUL_RESET::cACTION_CONTROL_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_BACKHAUL_RESET::cACTION_CONTROL_BACKHAUL_RESET(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_BACKHAUL_RESET::~cACTION_CONTROL_BACKHAUL_RESET() {
@@ -1007,16 +1007,16 @@ bool cACTION_CONTROL_BACKHAUL_RESET::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::~cACTION_CONTROL_BACKHAUL_ROAM_REQUEST() {
@@ -1049,16 +1049,16 @@ bool cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::~cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL() {
@@ -1091,16 +1091,16 @@ bool cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::~cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION() {
@@ -1133,16 +1133,16 @@ bool cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::~cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION() {
@@ -1175,16 +1175,16 @@ bool cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::~cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION() {
@@ -1217,16 +1217,16 @@ bool cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::~cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION() {
@@ -1281,16 +1281,16 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
     if (!m_parse__) {
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::~cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION() {
@@ -1323,16 +1323,16 @@ bool cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::~cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION() {
@@ -1365,16 +1365,16 @@ bool cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::~cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST() {
@@ -1407,16 +1407,16 @@ bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::~cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE() {
@@ -1447,16 +1447,16 @@ bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::~cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START() {
@@ -1489,16 +1489,16 @@ bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::~cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST() {
@@ -1530,16 +1530,16 @@ bool cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::~cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER() {
@@ -1560,16 +1560,16 @@ bool cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::~cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST() {
@@ -1602,16 +1602,16 @@ bool cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::~cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST() {
@@ -1642,16 +1642,16 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::~cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE() {
@@ -1747,16 +1747,16 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaStatsParams) * (sta_stats_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::~cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION() {
@@ -1789,16 +1789,16 @@ bool cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::~cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST() {
@@ -1831,16 +1831,16 @@ bool cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::~cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST() {
@@ -1873,16 +1873,16 @@ bool cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::~cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION() {
@@ -1915,16 +1915,16 @@ bool cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::~cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION() {
@@ -1957,16 +1957,16 @@ bool cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::~cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION() {
@@ -1997,16 +1997,16 @@ bool cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::~cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION() {
@@ -2049,16 +2049,16 @@ bool cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_vap_info->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::~cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST() {
@@ -2091,16 +2091,16 @@ bool cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::~cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST() {
@@ -2133,16 +2133,16 @@ bool cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST() {
@@ -2175,16 +2175,16 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE() {
@@ -2217,16 +2217,16 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION() {
@@ -2259,16 +2259,16 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
@@ -2301,16 +2301,16 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::~cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION() {
@@ -2343,16 +2343,16 @@ bool cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::~cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION() {
@@ -2385,16 +2385,16 @@ bool cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::~cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION() {
@@ -2427,16 +2427,16 @@ bool cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::~cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST() {
@@ -2501,16 +2501,16 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::~cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE() {
@@ -2543,16 +2543,16 @@ bool cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::~cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION() {
@@ -2631,16 +2631,16 @@ bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::init()
         return false;
     }
     m_name_idx__  = beerocks::message::NODE_NAME_LENGTH;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::~cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION() {
@@ -2673,16 +2673,16 @@ bool cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::~cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST() {
@@ -2715,16 +2715,16 @@ bool cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::~cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE() {
@@ -2757,16 +2757,16 @@ bool cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::~cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST() {
@@ -2799,16 +2799,16 @@ bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::~cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE() {
@@ -2841,16 +2841,16 @@ bool cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::~cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST() {
@@ -2883,16 +2883,16 @@ bool cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::~cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE() {
@@ -2925,16 +2925,16 @@ bool cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::~cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST() {
@@ -2967,16 +2967,16 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::~cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE() {
@@ -3009,16 +3009,16 @@ bool cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::~cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST() {
@@ -3051,16 +3051,16 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::~cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE() {
@@ -3093,16 +3093,16 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::~cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST() {
@@ -3135,16 +3135,16 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::~cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE() {
@@ -3177,16 +3177,16 @@ bool cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::~cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION() {
@@ -3219,16 +3219,16 @@ bool cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::~cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION() {
@@ -3261,16 +3261,16 @@ bool cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::~cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION() {
@@ -3303,16 +3303,16 @@ bool cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::~cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION() {
@@ -3345,7 +3345,7 @@ bool cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_HEADER::cACTION_HEADER(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_HEADER::cACTION_HEADER(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_HEADER::cACTION_HEADER(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_HEADER::cACTION_HEADER(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_HEADER::~cACTION_HEADER() {
@@ -141,7 +141,7 @@ bool cACTION_HEADER::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::~cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION() {
@@ -51,16 +51,16 @@ bool cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_JOINED_NOTIFICATION::cACTION_MONITOR_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_JOINED_NOTIFICATION::cACTION_MONITOR_JOINED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_JOINED_NOTIFICATION::cACTION_MONITOR_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_JOINED_NOTIFICATION::cACTION_MONITOR_JOINED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_JOINED_NOTIFICATION::~cACTION_MONITOR_JOINED_NOTIFICATION() {
@@ -81,16 +81,16 @@ bool cACTION_MONITOR_JOINED_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_SON_CONFIG_UPDATE::cACTION_MONITOR_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_SON_CONFIG_UPDATE::cACTION_MONITOR_SON_CONFIG_UPDATE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_SON_CONFIG_UPDATE::cACTION_MONITOR_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_SON_CONFIG_UPDATE::cACTION_MONITOR_SON_CONFIG_UPDATE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_SON_CONFIG_UPDATE::~cACTION_MONITOR_SON_CONFIG_UPDATE() {
@@ -123,16 +123,16 @@ bool cACTION_MONITOR_SON_CONFIG_UPDATE::init()
         return false;
     }
     if (!m_parse__) { m_config->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::~cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL() {
@@ -165,16 +165,16 @@ bool cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_ERROR_NOTIFICATION::cACTION_MONITOR_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_ERROR_NOTIFICATION::cACTION_MONITOR_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_ERROR_NOTIFICATION::cACTION_MONITOR_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_ERROR_NOTIFICATION::cACTION_MONITOR_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_ERROR_NOTIFICATION::~cACTION_MONITOR_ERROR_NOTIFICATION() {
@@ -206,16 +206,16 @@ bool cACTION_MONITOR_ERROR_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_ERROR_NOTIFICATION_ACK::cACTION_MONITOR_ERROR_NOTIFICATION_ACK(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_ERROR_NOTIFICATION_ACK::cACTION_MONITOR_ERROR_NOTIFICATION_ACK(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_ERROR_NOTIFICATION_ACK::cACTION_MONITOR_ERROR_NOTIFICATION_ACK(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_ERROR_NOTIFICATION_ACK::cACTION_MONITOR_ERROR_NOTIFICATION_ACK(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_ERROR_NOTIFICATION_ACK::~cACTION_MONITOR_ERROR_NOTIFICATION_ACK() {
@@ -236,16 +236,16 @@ bool cACTION_MONITOR_ERROR_NOTIFICATION_ACK::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_HEARTBEAT_NOTIFICATION::cACTION_MONITOR_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HEARTBEAT_NOTIFICATION::cACTION_MONITOR_HEARTBEAT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HEARTBEAT_NOTIFICATION::cACTION_MONITOR_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HEARTBEAT_NOTIFICATION::cACTION_MONITOR_HEARTBEAT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HEARTBEAT_NOTIFICATION::~cACTION_MONITOR_HEARTBEAT_NOTIFICATION() {
@@ -266,16 +266,16 @@ bool cACTION_MONITOR_HEARTBEAT_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::~cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST() {
@@ -308,16 +308,16 @@ bool cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::~cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST() {
@@ -350,16 +350,16 @@ bool cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST() {
@@ -392,16 +392,16 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::~cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST() {
@@ -456,16 +456,16 @@ bool cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION() {
@@ -498,16 +498,16 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE() {
@@ -540,16 +540,16 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::~cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION() {
@@ -582,16 +582,16 @@ bool cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION() {
@@ -624,16 +624,16 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::~cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE() {
@@ -666,16 +666,16 @@ bool cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::~cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION() {
@@ -708,16 +708,16 @@ bool cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::~cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION() {
@@ -750,16 +750,16 @@ bool cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::~cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST() {
@@ -790,16 +790,16 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::~cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION() {
@@ -840,16 +840,16 @@ bool cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::~cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE() {
@@ -945,16 +945,16 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sStaStatsParams) * (sta_stats_size) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::~cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION() {
@@ -987,16 +987,16 @@ bool cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::~cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST() {
@@ -1029,16 +1029,16 @@ bool cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::~cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE() {
@@ -1071,16 +1071,16 @@ bool cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::~cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST() {
@@ -1113,16 +1113,16 @@ bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::~cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE() {
@@ -1155,16 +1155,16 @@ bool cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::~cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST() {
@@ -1197,16 +1197,16 @@ bool cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::~cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE() {
@@ -1239,16 +1239,16 @@ bool cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::~cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST() {
@@ -1281,16 +1281,16 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::~cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE() {
@@ -1323,16 +1323,16 @@ bool cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::~cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST() {
@@ -1365,16 +1365,16 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::~cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE() {
@@ -1407,16 +1407,16 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::~cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST() {
@@ -1449,16 +1449,16 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::~cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE() {
@@ -1491,16 +1491,16 @@ bool cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::~cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION() {
@@ -1533,16 +1533,16 @@ bool cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::~cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION() {
@@ -1575,7 +1575,7 @@ bool cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -15,12 +15,12 @@
 
 using namespace beerocks_message;
 
-cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::~cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION() {
@@ -51,16 +51,16 @@ bool cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::init(
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::~cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST() {
@@ -115,16 +115,16 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::init()
         return false;
     }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::~cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE() {
@@ -180,16 +180,16 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::~cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION() {
@@ -222,16 +222,16 @@ bool cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::~cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION() {
@@ -264,16 +264,16 @@ bool cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_wlan_settings->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::~cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION() {
@@ -373,16 +373,16 @@ bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::init()
         return false;
     }
     m_hostname_idx__  = beerocks::message::NODE_NAME_LENGTH;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::~cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL() {
@@ -415,16 +415,16 @@ bool cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ARP_QUERY_REQUEST::cACTION_PLATFORM_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ARP_QUERY_REQUEST::cACTION_PLATFORM_ARP_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ARP_QUERY_REQUEST::cACTION_PLATFORM_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ARP_QUERY_REQUEST::cACTION_PLATFORM_ARP_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ARP_QUERY_REQUEST::~cACTION_PLATFORM_ARP_QUERY_REQUEST() {
@@ -457,16 +457,16 @@ bool cACTION_PLATFORM_ARP_QUERY_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ARP_QUERY_RESPONSE::cACTION_PLATFORM_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ARP_QUERY_RESPONSE::cACTION_PLATFORM_ARP_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ARP_QUERY_RESPONSE::cACTION_PLATFORM_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ARP_QUERY_RESPONSE::cACTION_PLATFORM_ARP_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ARP_QUERY_RESPONSE::~cACTION_PLATFORM_ARP_QUERY_RESPONSE() {
@@ -499,16 +499,16 @@ bool cACTION_PLATFORM_ARP_QUERY_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::~cACTION_PLATFORM_ONBOARD_QUERY_REQUEST() {
@@ -529,16 +529,16 @@ bool cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::~cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE() {
@@ -571,16 +571,16 @@ bool cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ONBOARD_SET_REQUEST::cACTION_PLATFORM_ONBOARD_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ONBOARD_SET_REQUEST::cACTION_PLATFORM_ONBOARD_SET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ONBOARD_SET_REQUEST::cACTION_PLATFORM_ONBOARD_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ONBOARD_SET_REQUEST::cACTION_PLATFORM_ONBOARD_SET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ONBOARD_SET_REQUEST::~cACTION_PLATFORM_ONBOARD_SET_REQUEST() {
@@ -613,16 +613,16 @@ bool cACTION_PLATFORM_ONBOARD_SET_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_params->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::~cACTION_PLATFORM_WPS_ONBOARDING_REQUEST() {
@@ -677,16 +677,16 @@ bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::init()
         return false;
     }
     m_iface_name_idx__  = beerocks::message::IFACE_NAME_LENGTH;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::~cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST() {
@@ -717,16 +717,16 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::~cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE() {
@@ -782,16 +782,16 @@ bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::~cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST() {
@@ -812,16 +812,16 @@ bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::~cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE() {
@@ -865,16 +865,16 @@ bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::~cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST() {
@@ -895,16 +895,16 @@ bool cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::~cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE() {
@@ -948,16 +948,16 @@ bool cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::~cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST() {
@@ -978,16 +978,16 @@ bool cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::~cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE() {
@@ -1018,16 +1018,16 @@ bool cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::~cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION() {
@@ -1060,16 +1060,16 @@ bool cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_versions->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::~cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION() {
@@ -1102,16 +1102,16 @@ bool cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_versions->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::~cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST() {
@@ -1132,16 +1132,16 @@ bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::~cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE() {
@@ -1185,16 +1185,16 @@ bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_ERROR_NOTIFICATION::cACTION_PLATFORM_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_ERROR_NOTIFICATION::cACTION_PLATFORM_ERROR_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_ERROR_NOTIFICATION::cACTION_PLATFORM_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_ERROR_NOTIFICATION::cACTION_PLATFORM_ERROR_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_ERROR_NOTIFICATION::~cACTION_PLATFORM_ERROR_NOTIFICATION() {
@@ -1260,16 +1260,16 @@ bool cACTION_PLATFORM_ERROR_NOTIFICATION::init()
         return false;
     }
     m_data_idx__  = 256;
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::~cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION() {
@@ -1408,16 +1408,16 @@ bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::~cACTION_PLATFORM_OPERATIONAL_NOTIFICATION() {
@@ -1448,7 +1448,7 @@ bool cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
@@ -31,8 +31,10 @@ namespace beerocks {
 class beerocks_header : public ieee1905_1::TlvList {
 public:
     beerocks_header() = delete;
-    beerocks_header(uint8_t *buff, size_t buff_len, bool parse, bool swap) :
-        TlvList(buff, buff_len, parse, swap) {}
+    beerocks_header(uint8_t *buff, size_t buff_len, bool parse, bool swap)
+        : TlvList(buff, buff_len, parse, swap)
+    {
+    }
     std::shared_ptr<beerocks_message::cACTION_HEADER> actionhdr()
     {
         return getClass<beerocks_message::cACTION_HEADER>();
@@ -41,26 +43,20 @@ public:
     {
         return actionhdr() ? actionhdr()->action() : beerocks_message::ACTION_NONE;
     }
-    uint8_t action_op()
-    {
-        return actionhdr() ? actionhdr()->action_op() : 0;
-    };
-    uint16_t id()
-    {
-        return actionhdr() ? actionhdr()->id() : 0;
-    }
+    uint8_t action_op() { return actionhdr() ? actionhdr()->action_op() : 0; };
+    uint16_t id() { return actionhdr() ? actionhdr()->id() : 0; }
     virtual bool finalize(bool swap_needed) override
     {
         if (m_finalized)
             return true;
-        
-        for (auto &it: m_class_vector){
-            if(!(it->isPostInitSucceeded())){
+
+        for (auto &it : m_class_vector) {
+            if (!(it->isPostInitSucceeded())) {
                 TLVF_LOG(ERROR) << "TLV post init failed";
                 return false;
             }
         }
-                
+
         if (swap_needed)
             swap();
 

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
@@ -31,10 +31,7 @@ namespace beerocks {
 class beerocks_header : public ieee1905_1::TlvList {
 public:
     beerocks_header() = delete;
-    beerocks_header(uint8_t *buff, size_t buff_len, bool parse, bool swap)
-        : TlvList(buff, buff_len, parse, swap)
-    {
-    }
+    beerocks_header(uint8_t *buff, size_t buff_len, bool parse) : TlvList(buff, buff_len, parse) {}
     std::shared_ptr<beerocks_message::cACTION_HEADER> actionhdr()
     {
         return getClass<beerocks_message::cACTION_HEADER>();
@@ -45,7 +42,7 @@ public:
     }
     uint8_t action_op() { return actionhdr() ? actionhdr()->action_op() : 0; };
     uint16_t id() { return actionhdr() ? actionhdr()->id() : 0; }
-    virtual bool finalize(bool swap_needed) override
+    virtual bool finalize() override
     {
         if (m_finalized)
             return true;
@@ -57,8 +54,7 @@ public:
             }
         }
 
-        if (swap_needed)
-            swap();
+        swap();
 
         m_finalized = true;
         return true;

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019 Tomer Eliyahu (Intel Corporation)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_BEEROCKS_HEADER_H_
+#define _TLVF_BEEROCKS_HEADER_H_
+
+#include <beerocks/tlvf/beerocks_message_header.h>
+#include <tlvf/TlvList.h>
+#include <tlvf/tlvflogging.h>
+
+namespace beerocks {
+
+/**
+ * @brief beerocks_header
+ *
+ * Each vendor specific message used for internal and external communication
+ * between the different components in prplMesh, via UDS or the BTL, includes
+ * an action header and the actual message data.
+ * These stored in the vendor specific TLV payload as a separate TLVlist.
+ *
+ * Note that this is not really a "header", a more appropriate name would be
+ * beerocks_actions - but since the name beerocks_header is widely used, we keep
+ * it for backward comparability. Same goes to all the getter functions.
+ *
+ */
+class beerocks_header : public ieee1905_1::TlvList {
+public:
+    beerocks_header() = delete;
+    beerocks_header(uint8_t *buff, size_t buff_len, bool parse, bool swap) :
+        TlvList(buff, buff_len, parse, swap) {}
+    std::shared_ptr<beerocks_message::cACTION_HEADER> actionhdr()
+    {
+        return getClass<beerocks_message::cACTION_HEADER>();
+    }
+    beerocks_message::eAction action()
+    {
+        return actionhdr() ? actionhdr()->action() : beerocks_message::ACTION_NONE;
+    }
+    uint8_t action_op()
+    {
+        return actionhdr() ? actionhdr()->action_op() : 0;
+    };
+    uint16_t id()
+    {
+        return actionhdr() ? actionhdr()->id() : 0;
+    }
+    virtual bool finalize(bool swap_needed) override
+    {
+        if (m_finalized)
+            return true;
+        
+        for (auto &it: m_class_vector){
+            if(!(it->isPostInitSucceeded())){
+                TLVF_LOG(ERROR) << "TLV post init failed";
+                return false;
+            }
+        }
+                
+        if (swap_needed)
+            swap();
+
+        m_finalized = true;
+        return true;
+    }
+};
+
+} // namespace beerocks
+
+#endif // _TLVF_BEEROCKS_HEADER_H_

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -50,10 +50,10 @@ public:
     static std::shared_ptr<beerocks_header>
     parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx);
 
-    static std::shared_ptr<beerocks_header>
-    get_beerocks_header(ieee1905_1::CmduMessage &cmdu)
+    static std::shared_ptr<beerocks_header> get_beerocks_header(ieee1905_1::CmduMessage &cmdu)
     {
-        return cmdu.tlvs.getInnerTlvList<beerocks_header>(ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC);
+        return cmdu.tlvs.getInnerTlvList<beerocks_header>(
+            ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC);
     }
 
     template <class T>
@@ -61,23 +61,26 @@ public:
     {
         auto vs_tlv = cmdu_tx.getClass<ieee1905_1::tlvVendorSpecific>();
         if (!vs_tlv) {
-            std::cout << "beerocks_message.h[ " << __LINE__ << "]: " << __FUNCTION__ << " failed!" << std::endl;
+            std::cout << "beerocks_message.h[ " << __LINE__ << "]: " << __FUNCTION__ << " failed!"
+                      << std::endl;
             return false;
         }
         // Allocate maximum allowed length for the payload, so it can accommodate variable length
         // data inside the internal TLV list.
         // On finalize(), the buffer is shrunk back to its real size.
         size_t payload_length;
-        const size_t max_vs_tlv_length = cmdu_tx.max_tlv_length() - ieee1905_1::tlvVendorSpecific::get_initial_size();
+        const size_t max_vs_tlv_length =
+            cmdu_tx.max_tlv_length() - ieee1905_1::tlvVendorSpecific::get_initial_size();
         payload_length = std::min(vs_tlv->getBuffRemainingBytes() -
-                                    ieee1905_1::tlvEndOfMessage::get_initial_size(),
-                                    max_vs_tlv_length);
+                                      ieee1905_1::tlvEndOfMessage::get_initial_size(),
+                                  max_vs_tlv_length);
         if (!vs_tlv->alloc_payload(payload_length)) {
-            std::cout << "beerocks_message.h[ " << __LINE__ << "]: " << __FUNCTION__ << " failed!" << std::endl;
+            std::cout << "beerocks_message.h[ " << __LINE__ << "]: " << __FUNCTION__ << " failed!"
+                      << std::endl;
             return false;
         }
-        std::shared_ptr<beerocks_header> hdr = std::make_shared<beerocks_header>(vs_tlv->payload(),
-                                                            vs_tlv->payload_length(), false, false);
+        std::shared_ptr<beerocks_header> hdr = std::make_shared<beerocks_header>(
+            vs_tlv->payload(), vs_tlv->payload_length(), false, false);
         if (!hdr)
             return false;
         if (!hdr->addClass<beerocks_message::cACTION_HEADER>())
@@ -86,7 +89,7 @@ public:
             return false;
 
         beerocks_message::eAction action = beerocks_message::eAction::ACTION_NONE;
-        auto action_op = hdr->getClass<T>()->get_action_op();
+        auto action_op                   = hdr->getClass<T>()->get_action_op();
         if (typeid(action_op) == typeid(beerocks_message::eActionOp_1905_VS))
             action = beerocks_message::eAction::ACTION_1905_VS;
         else if (typeid(action_op) == typeid(beerocks_message::eActionOp_CONTROL))
@@ -105,7 +108,8 @@ public:
             action = beerocks_message::eAction::ACTION_BML;
 
         if (action == beerocks_message::eAction::ACTION_NONE) {
-            std::cout << "beerocks_message.h[ " << __LINE__ << "]: " << __FUNCTION__ << " failed!" << std::endl;
+            std::cout << "beerocks_message.h[ " << __LINE__ << "]: " << __FUNCTION__ << " failed!"
+                      << std::endl;
             return false;
         }
 
@@ -133,7 +137,8 @@ public:
      * @return std::shared_ptr<T> to the created operation class
      */
     template <class T>
-    static std::shared_ptr<T> create_jumbo_vs_message(ieee1905_1::CmduMessageTx &cmdu_tx, uint16_t id = 0)
+    static std::shared_ptr<T> create_jumbo_vs_message(ieee1905_1::CmduMessageTx &cmdu_tx,
+                                                      uint16_t id = 0)
     {
         auto max_tlv_length = cmdu_tx.max_tlv_length();
 

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -145,7 +145,7 @@ public:
         cmdu_tx.set_max_tlv_length(cmdu_tx.tlvs.getMessageBuffLength() -
                                    ieee1905_1::CmduMessage::kCmduHeaderLength -
                                    ieee1905_1::tlvEndOfMessage::get_initial_size());
-        auto ret = create_vs_message(cmdu_tx, id);
+        auto ret = create_vs_message<T>(cmdu_tx, id);
         cmdu_tx.set_max_tlv_length(max_tlv_length);
 
         return ret;

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -47,7 +47,7 @@ public:
     static bool
     intel_oui(std::shared_ptr<ieee1905_1::tlvVendorSpecific> tlv_vendor_specific_header);
 
-    static std::shared_ptr<beerocks_message::cACTION_HEADER>
+    static std::shared_ptr<beerocks_header>
     parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx);
 
     template <class T> static std::shared_ptr<T> get_vs_class(ieee1905_1::CmduMessage &cmdu)

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -79,8 +79,8 @@ public:
                       << std::endl;
             return false;
         }
-        std::shared_ptr<beerocks_header> hdr = std::make_shared<beerocks_header>(
-            vs_tlv->payload(), vs_tlv->payload_length(), false, false);
+        std::shared_ptr<beerocks_header> hdr =
+            std::make_shared<beerocks_header>(vs_tlv->payload(), vs_tlv->payload_length(), false);
         if (!hdr)
             return false;
         if (!hdr->addClass<beerocks_message::cACTION_HEADER>())

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -55,12 +55,6 @@ public:
         return std::dynamic_pointer_cast<T>(cmdu.getClass(2));
     }
 
-    static std::shared_ptr<beerocks_message::cACTION_HEADER>
-    get_vs_class_header(ieee1905_1::CmduMessage &cmdu)
-    {
-        return std::dynamic_pointer_cast<beerocks_message::cACTION_HEADER>(cmdu.getClass(1));
-    }
-
     static std::shared_ptr<beerocks_header>
     get_beerocks_header(ieee1905_1::CmduMessage &cmdu)
     {

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -176,12 +176,7 @@ public:
         if (!beerocks_header)
             return nullptr;
 
-        // According to C++'03 Standard 14.2/4:
-        // When the name of a member template specialization appears after . or -> in a postfix-expression,
-        // or after nested-name-specifier in a qualified-id, and the postfix-expression or qualified-id
-        // explicitly depends on a template-parameter (14.6.2), the member template name must be prefixed by
-        // the keyword template. Otherwise the name is assumed to name a non-template.
-        return beerocks_header->template getClass<T>();
+        return beerocks_header->getClass<T>();
     }
 
     typedef struct sCmduInfo {

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -50,11 +50,6 @@ public:
     static std::shared_ptr<beerocks_header>
     parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx);
 
-    template <class T> static std::shared_ptr<T> get_vs_class(ieee1905_1::CmduMessage &cmdu)
-    {
-        return std::dynamic_pointer_cast<T>(cmdu.getClass(2));
-    }
-
     static std::shared_ptr<beerocks_header>
     get_beerocks_header(ieee1905_1::CmduMessage &cmdu)
     {

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -67,8 +67,8 @@ message_com::parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx)
     if (!intel_oui(tlv_header))
         return nullptr;
 
-    std::shared_ptr<beerocks_header> hdr = std::make_shared<beerocks_header>(tlv_header->payload(),
-                                                tlv_header->payload_length(), true, cmdu_rx.swap_needed());
+    std::shared_ptr<beerocks_header> hdr = std::make_shared<beerocks_header>(
+        tlv_header->payload(), tlv_header->payload_length(), true, cmdu_rx.swap_needed());
     if (!hdr)
         return nullptr;
     auto actionhdr = hdr->addClass<beerocks_message::cACTION_HEADER>();
@@ -81,7 +81,8 @@ message_com::parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx)
 std::string message_com::print_cmdu_types(const message::sUdsHeader *uds_header,
                                           sCmduInfo *cmdu_info)
 {
-    ieee1905_1::CmduMessageRx cmdu_rx((uint8_t *)uds_header + sizeof(message::sUdsHeader), uds_header->length);
+    ieee1905_1::CmduMessageRx cmdu_rx((uint8_t *)uds_header + sizeof(message::sUdsHeader),
+                                      uds_header->length);
 
     auto cmdu_header = cmdu_rx.parse(uds_header->swap_needed);
 
@@ -113,7 +114,8 @@ std::string message_com::print_cmdu_types(ieee1905_1::CmduMessageRx &cmdu_rx, sC
             LOG(ERROR) << "addClass<tlvVendorSpecific> failed!";
             return info;
         }
-        ieee1905_1::TlvList actions(tlv_header->payload(), tlv_header->payload_length(), true, true);
+        ieee1905_1::TlvList actions(tlv_header->payload(), tlv_header->payload_length(), true,
+                                    true);
         auto beerocks_header = actions.addClass<beerocks_message::cACTION_HEADER>();
         if (!beerocks_header) {
             LOG(ERROR) << "addClass<cACTION_HEADER> failed!";

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -66,7 +66,16 @@ message_com::parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx)
         return nullptr;
     if (!intel_oui(tlv_header))
         return nullptr;
-    return cmdu_rx.addClass<beerocks_message::cACTION_HEADER>();
+
+    std::shared_ptr<beerocks_header> hdr = std::make_shared<beerocks_header>(tlv_header->payload(),
+                                                tlv_header->payload_length(), true, cmdu_rx.swap_needed());
+    if (!hdr)
+        return nullptr;
+    auto actionhdr = hdr->addClass<beerocks_message::cACTION_HEADER>();
+    if (!actionhdr)
+        return nullptr;
+    cmdu_rx.tlvs.addInnerTlvList(ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC, hdr);
+    return hdr->getClass<beerocks_message::cACTION_HEADER>();
 }
 
 std::string message_com::print_cmdu_types(const message::sUdsHeader *uds_header,

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -55,7 +55,7 @@ bool message_com::intel_oui(
            ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL;
 }
 
-std::shared_ptr<beerocks_message::cACTION_HEADER>
+std::shared_ptr<beerocks_header>
 message_com::parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     if (!cmdu_rx.getMessageLength()) {
@@ -75,7 +75,7 @@ message_com::parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx)
     if (!actionhdr)
         return nullptr;
     cmdu_rx.tlvs.addInnerTlvList(ieee1905_1::eTlvType::TLV_VENDOR_SPECIFIC, hdr);
-    return hdr->getClass<beerocks_message::cACTION_HEADER>();
+    return hdr;
 }
 
 std::string message_com::print_cmdu_types(const message::sUdsHeader *uds_header,
@@ -113,7 +113,8 @@ std::string message_com::print_cmdu_types(ieee1905_1::CmduMessageRx &cmdu_rx, sC
             LOG(ERROR) << "addClass<tlvVendorSpecific> failed!";
             return info;
         }
-        auto beerocks_header = cmdu_rx.addClass<beerocks_message::cACTION_HEADER>();
+        ieee1905_1::TlvList actions(tlv_header->payload(), tlv_header->payload_length(), true, true);
+        auto beerocks_header = actions.addClass<beerocks_message::cACTION_HEADER>();
         if (!beerocks_header) {
             LOG(ERROR) << "addClass<cACTION_HEADER> failed!";
             return info;

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -72,10 +72,9 @@ message_com::parse_intel_vs_message(ieee1905_1::CmduMessageRx &cmdu_rx)
 std::string message_com::print_cmdu_types(const message::sUdsHeader *uds_header,
                                           sCmduInfo *cmdu_info)
 {
-    ieee1905_1::CmduMessageRx cmdu_rx;
+    ieee1905_1::CmduMessageRx cmdu_rx((uint8_t *)uds_header + sizeof(message::sUdsHeader), uds_header->length);
 
-    auto cmdu_header = cmdu_rx.parse((uint8_t *)uds_header + sizeof(message::sUdsHeader),
-                                     uds_header->length, uds_header->swap_needed);
+    auto cmdu_header = cmdu_rx.parse(uds_header->swap_needed);
 
     if (!cmdu_header) {
         LOG(ERROR) << "cmdu parse failed!";

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -148,9 +148,7 @@ bool message_com::send_cmdu(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
         return false;
     }
 
-    bool swap = !dst_mac.empty();
-
-    if (!cmdu_tx.finalize(swap)) {
+    if (!cmdu_tx.finalize(true)) {
         LOG(ERROR) << "finalize failed -> " << print_cmdu_types(uds_header);
         LOG(DEBUG) << "hex_dump(" + std::to_string(cmdu_tx.getMessageLength()) + "):" << std::endl
                    << utils::dump_buffer(
@@ -161,7 +159,7 @@ bool message_com::send_cmdu(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
 
     // update src & dst bridge mac on uds_header
     // swap is true if dst_mac is not empty so no need to verify it
-    if (swap) {
+    if (!dst_mac.empty()) {
         if (src_mac.empty()) {
             LOG(ERROR) << "src_mac is empty!";
             return false;
@@ -175,7 +173,7 @@ bool message_com::send_cmdu(Socket *sd, ieee1905_1::CmduMessageTx &cmdu_tx,
     }
 
     uds_header->length      = cmdu_tx.getMessageLength();
-    uds_header->swap_needed = swap;
+    uds_header->swap_needed = true;
 
     return send_data(sd, cmdu_tx.getMessageBuff() - sizeof(message::sUdsHeader),
                      uds_header->length + sizeof(message::sUdsHeader));

--- a/common/beerocks/tlvf/tlvf_conf.yaml
+++ b/common/beerocks/tlvf/tlvf_conf.yaml
@@ -6,13 +6,6 @@ include_yaml_path: {
 }
 
 # Relative to tlvf.py src_path variable
-include_source_path: {
-  "src/beerocks_message.cpp",
-  "include/beerocks/tlvf/beerocks_message.h",
-  "include/beerocks/tlvf/beerocks_header.h",
-}
-
-# Relative to tlvf.py src_path variable
 source_license_header: "intel/license.txt"
 
 debug:

--- a/common/beerocks/tlvf/tlvf_conf.yaml
+++ b/common/beerocks/tlvf/tlvf_conf.yaml
@@ -6,6 +6,13 @@ include_yaml_path: {
 }
 
 # Relative to tlvf.py src_path variable
+include_source_path: {
+  "src/beerocks_message.cpp",
+  "include/beerocks/tlvf/beerocks_message.h",
+  "include/beerocks/tlvf/beerocks_header.h",
+}
+
+# Relative to tlvf.py src_path variable
 source_license_header: "intel/license.txt"
 
 debug:

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -501,15 +501,14 @@ bool bml_internal::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         return false;
     }
 
-    if (process_cmdu_header(beerocks_header, cmdu_rx) != BML_RET_OK) {
+    if (process_cmdu_header(beerocks_header) != BML_RET_OK) {
         return false;
     }
 
     return true;
 }
 
-int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
-                                      ieee1905_1::CmduMessageRx &cmdu_rx)
+int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_header)
 {
 
     // BML messages
@@ -530,27 +529,30 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         // Network Map Response
         case beerocks_message::ACTION_BML_NW_MAP_RESPONSE: {
-            auto response = cmdu_rx.addClass<beerocks_message::cACTION_BML_NW_MAP_RESPONSE>();
+            auto response =
+                beerocks_header->addClass<beerocks_message::cACTION_BML_NW_MAP_RESPONSE>();
             uint32_t num_of_nodes = response->node_num();
             char *firstNode       = (num_of_nodes > 0) ? response->buffer(0) : nullptr;
 
             // Process the message
-            handle_nw_map_query_update(num_of_nodes, (int)beerocks_header->last(), firstNode, true);
+            handle_nw_map_query_update(num_of_nodes, (int)beerocks_header->actionhdr()->last(),
+                                       firstNode, true);
 
         } break;
         // Network map update
         case beerocks_message::ACTION_BML_NW_MAP_UPDATE: {
-            auto response         = cmdu_rx.addClass<beerocks_message::cACTION_BML_NW_MAP_UPDATE>();
+            auto response =
+                beerocks_header->addClass<beerocks_message::cACTION_BML_NW_MAP_UPDATE>();
             uint32_t num_of_nodes = response->node_num();
 
             auto firstNode = response->buffer(0);
             // Process the message
-            handle_nw_map_query_update(num_of_nodes, (int)beerocks_header->last(), firstNode,
-                                       false);
+            handle_nw_map_query_update(num_of_nodes, (int)beerocks_header->actionhdr()->last(),
+                                       firstNode, false);
         } break;
         // statistics update
         case beerocks_message::ACTION_BML_STATS_UPDATE: {
-            auto response         = cmdu_rx.addClass<beerocks_message::cACTION_BML_STATS_UPDATE>();
+            auto response = beerocks_header->addClass<beerocks_message::cACTION_BML_STATS_UPDATE>();
             uint32_t num_of_nodes = response->num_of_stats_bulks();
 
             auto firstNode = response->buffer(0);
@@ -559,7 +561,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         // event update
         case beerocks_message::ACTION_BML_EVENTS_UPDATE: {
-            auto response = cmdu_rx.addClass<beerocks_message::cACTION_BML_EVENTS_UPDATE>();
+            auto response =
+                beerocks_header->addClass<beerocks_message::cACTION_BML_EVENTS_UPDATE>();
             handle_event_update((uint8_t *)response->buffer(0));
         } break;
         case beerocks_message::ACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE: {
@@ -571,7 +574,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE>();
             if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -593,7 +597,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_CLIENT_ROAMING_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_CLIENT_ROAMING_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_CLIENT_ROAMING_RESPONSE>();
 
             // Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_CLIENT_ROAMING_REQUEST,
@@ -611,8 +616,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE: {
             auto response =
-                cmdu_rx
-                    .addClass<beerocks_message::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE>();
 
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST,
@@ -633,7 +638,7 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
             }
         } break;
         case beerocks_message::ACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE: {
-            auto response = cmdu_rx.addClass<
+            auto response = beerocks_header->addClass<
                 beerocks_message::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE>();
 
             //Signal any waiting threads
@@ -654,7 +659,7 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_IRE_ROAMING_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_IRE_ROAMING_RESPONSE>();
+                beerocks_header->addClass<beerocks_message::cACTION_BML_GET_IRE_ROAMING_RESPONSE>();
 
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_IRE_ROAMING_REQUEST,
@@ -672,7 +677,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_LOAD_BALANCER_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_LOAD_BALANCER_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_LOAD_BALANCER_RESPONSE>();
 
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_LOAD_BALANCER_REQUEST,
@@ -690,7 +696,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE>();
 
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_SERVICE_FAIRNESS_REQUEST,
@@ -708,7 +715,7 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_DFS_REENTRY_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_DFS_REENTRY_RESPONSE>();
+                beerocks_header->addClass<beerocks_message::cACTION_BML_GET_DFS_REENTRY_RESPONSE>();
 
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_DFS_REENTRY_REQUEST,
@@ -726,7 +733,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_CERTIFICATION_MODE_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE>();
 
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_GET_CERTIFICATION_MODE_REQUEST,
@@ -737,7 +745,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE>();
 
             // Signal any waiting threads
             if (m_prmWiFiCredentialsUpdate) {
@@ -757,7 +766,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE>();
             //Signal any waiting threads
             if (!wake_up(beerocks_message::ACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST,
                          (response->error_code() == 0))) {
@@ -767,7 +777,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE>();
             // Signal any waiting threads
             if (m_prmRestrictedChannelsGet) {
                 if (m_Restricted_channels != nullptr) {
@@ -784,7 +795,7 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
             LOG(TRACE) << "ACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE";
 
             if (m_prmSetVapListCreds) {
-                auto response = cmdu_rx.addClass<
+                auto response = beerocks_header->addClass<
                     beerocks_message::cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE>();
                 if (response == nullptr) {
                     LOG(ERROR) << "addClass cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE failed";
@@ -813,7 +824,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
             }
 
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -886,7 +898,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         // Onboard Query Response
         case beerocks_message::ACTION_PLATFORM_ONBOARD_QUERY_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -905,7 +918,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -924,8 +938,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE: {
             auto response =
-                cmdu_rx
-                    .addClass<beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -946,8 +960,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE: {
             auto response =
-                cmdu_rx
-                    .addClass<beerocks_message::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -968,7 +982,8 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
         } break;
         case beerocks_message::ACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -989,7 +1004,7 @@ int bml_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
             return BML_RET_OP_FAILED;
         } break;
         case beerocks_message::ACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE: {
-            auto response = cmdu_rx.addClass<
+            auto response = beerocks_header->addClass<
                 beerocks_message::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE>();
             if (response == nullptr) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE failed";

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -172,15 +172,13 @@ public:
     bool is_local_master() const { return (m_fLocal_Master); }
 
 protected:
-    typedef std::shared_ptr<beerocks_message::cACTION_HEADER> cmdu_vs_action_header_t;
     virtual bool init() override;
     virtual void on_thread_stop() override;
     virtual bool socket_disconnected(Socket *sd) override;
     virtual std::string print_cmdu_types(const beerocks::message::sUdsHeader *cmdu_header) override;
     bool wake_up(uint8_t action_opcode, int value);
     bool connect_to_master();
-    virtual int process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
-                                    ieee1905_1::CmduMessageRx &cmdu_rx);
+    virtual int process_cmdu_header(std::shared_ptr<beerocks::beerocks_header> beerocks_header);
 
     SocketClient *m_sockMaster = nullptr;
 

--- a/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.cpp
+++ b/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.cpp
@@ -374,8 +374,7 @@ bool bml_rdkb_internal::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     return (ret == BML_RET_OK);
 }
 
-int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
-                                           ieee1905_1::CmduMessageRx &cmdu_rx)
+int bml_rdkb_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_header)
 {
     auto action    = beerocks_header->action();
     auto action_op = beerocks_header->action_op();
@@ -386,7 +385,8 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
         // Process BML messages
         switch (action_op) {
         case beerocks_message::ACTION_BML_STEERING_EVENTS_UPDATE: {
-            auto response = cmdu_rx.addClass<beerocks_message::cACTION_BML_EVENTS_UPDATE>();
+            auto response =
+                beerocks_header->addClass<beerocks_message::cACTION_BML_EVENTS_UPDATE>();
             if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_EVENTS_UPDATE failed";
                 return BML_RET_OP_FAILED;
@@ -402,7 +402,8 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
         } break;
         case beerocks_message::ACTION_BML_STEERING_SET_GROUP_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_SET_GROUP_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_STEERING_SET_GROUP_RESPONSE>();
             if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_STEERING_SET_GROUP_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -419,7 +420,8 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
         } break;
         case beerocks_message::ACTION_BML_STEERING_CLIENT_SET_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_SET_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_SET_RESPONSE>();
             if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_STEERING_CLIENT_SET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -435,7 +437,7 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
             }
         } break;
         case beerocks_message::ACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE: {
-            auto response = cmdu_rx.addClass<
+            auto response = beerocks_header->addClass<
                 beerocks_message::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE>();
             if (!response) {
                 LOG(ERROR)
@@ -454,8 +456,8 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
         } break;
         case beerocks_message::ACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE: {
             auto response =
-                cmdu_rx
-                    .addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE>();
             if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -472,7 +474,8 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
         } break;
         case beerocks_message::ACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE: {
             auto response =
-                cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE>();
+                beerocks_header
+                    ->addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE>();
             if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE failed";
                 return BML_RET_OP_FAILED;
@@ -488,7 +491,7 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
             }
         } break;
         default: {
-            if ((ret = bml_internal::process_cmdu_header(beerocks_header, cmdu_rx)) != BML_RET_OK) {
+            if ((ret = bml_internal::process_cmdu_header(beerocks_header)) != BML_RET_OK) {
                 LOG(WARNING) << "unhandled extended cmdu header action bml type 0x" << std::hex
                              << action_op;
                 return ret;
@@ -496,7 +499,7 @@ int bml_rdkb_internal::process_cmdu_header(cmdu_vs_action_header_t beerocks_head
         }
         }
     } else {
-        if ((ret = bml_internal::process_cmdu_header(beerocks_header, cmdu_rx)) != BML_RET_OK) {
+        if ((ret = bml_internal::process_cmdu_header(beerocks_header)) != BML_RET_OK) {
             LOG(WARNING) << "unhandled extended cmdu header action type 0x" << std::hex << action;
             return ret;
         }

--- a/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.h
+++ b/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.h
@@ -90,8 +90,7 @@ public:
 
 protected:
     virtual bool handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx) override;
-    virtual int process_cmdu_header(cmdu_vs_action_header_t beerocks_header,
-                                    ieee1905_1::CmduMessageRx &cmdu_rx);
+    virtual int process_cmdu_header(std::shared_ptr<beerocks::beerocks_header> beerocks_header);
 
 private:
     bool handle_steering_event_update(uint8_t *data_buffer);

--- a/controller/src/beerocks/cli/beerocks_cli_socket.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_socket.cpp
@@ -231,7 +231,7 @@ bool cli_socket::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     switch (beerocks_header->action_op()) {
 
     case beerocks_message::ACTION_CLI_RESPONSE_STR: {
-        auto response = cmdu_rx.addClass<beerocks_message::cACTION_CLI_RESPONSE_STR>();
+        auto response = beerocks_header->addClass<beerocks_message::cACTION_CLI_RESPONSE_STR>();
         if (!response) {
             LOG(ERROR) << "addClass cACTION_CLI_RESPONSE_STR failed";
             return false;
@@ -248,7 +248,7 @@ bool cli_socket::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         break;
     }
     case beerocks_message::ACTION_CLI_RESPONSE_INT: {
-        auto notification = cmdu_rx.addClass<beerocks_message::cACTION_CLI_RESPONSE_INT>();
+        auto notification = beerocks_header->addClass<beerocks_message::cACTION_CLI_RESPONSE_INT>();
         if (!notification) {
             LOG(ERROR) << "addClass cACTION_CLI_RESPONSE_INT failed";
             return false;

--- a/controller/src/beerocks/master/db/network_map.cpp
+++ b/controller/src/beerocks/master/db/network_map.cpp
@@ -28,7 +28,8 @@ void network_map::send_bml_network_map_message(db &database, Socket *sd,
                                                ieee1905_1::CmduMessageTx &cmdu_tx, uint16_t id)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_NW_MAP_RESPONSE>(cmdu_tx, id);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_NW_MAP_RESPONSE>(cmdu_tx,
+                                                                                            id);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_NW_MAP_BRIDGE_RESPONSE message!";
         return;
@@ -106,9 +107,8 @@ void network_map::send_bml_network_map_message(db &database, Socket *sd,
                 message_com::send_cmdu(sd, cmdu_tx);
 
                 get_next_node = false;
-                response =
-                    message_com::create_vs_message<beerocks_message::cACTION_BML_NW_MAP_RESPONSE>(
-                        cmdu_tx, id);
+                response      = message_com::create_jumbo_vs_message<
+                    beerocks_message::cACTION_BML_NW_MAP_RESPONSE>(cmdu_tx, id);
                 beerocks_header                      = message_com::get_beerocks_header(cmdu_tx);
                 beerocks_header->actionhdr()->last() = 0;
                 num_of_nodes = response->node_num(); // prepare for next message
@@ -310,7 +310,7 @@ void network_map::send_bml_nodes_statistics_message_to_listeners(
     std::set<std::string> valid_hostaps)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_STATS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_STATS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -371,7 +371,8 @@ void network_map::send_bml_nodes_statistics_message_to_listeners(
 
             // prepare for next message
             response =
-                message_com::create_vs_message<beerocks_message::cACTION_BML_STATS_UPDATE>(cmdu_tx);
+                message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_STATS_UPDATE>(
+                    cmdu_tx);
 
             beerocks_header                      = message_com::get_beerocks_header(cmdu_tx);
             beerocks_header->actionhdr()->last() = 0;
@@ -465,7 +466,7 @@ void network_map::send_bml_bss_tm_req_message_to_listeners(db &database,
                                                            uint8_t disassoc_imminent)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -499,7 +500,7 @@ void network_map::send_bml_bh_roam_req_message_to_listeners(db &database,
                                                             std::string bssid, uint8_t channel)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -532,7 +533,7 @@ void network_map::send_bml_client_allow_req_message_to_listeners(
     std::string sta_mac, std::string hostap_mac, std::string ip)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -566,7 +567,7 @@ void network_map::send_bml_client_disallow_req_message_to_listeners(
     std::string sta_mac, std::string hostap_mac)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -600,7 +601,7 @@ void network_map::send_bml_acs_start_message_to_listeners(db &database,
                                                           std::string hostap_mac)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -634,7 +635,7 @@ void network_map::send_bml_csa_notification_message_to_listeners(
     uint16_t vht_center_frequency)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;
@@ -670,7 +671,7 @@ void network_map::send_bml_cac_status_changed_notification_message_to_listeners(
     std::string hostap_mac, uint8_t cac_completed)
 {
     auto response =
-        message_com::create_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
+        message_com::create_jumbo_vs_message<beerocks_message::cACTION_BML_EVENTS_UPDATE>(cmdu_tx);
     if (response == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_STATS_UPDATE message!";
         return;

--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -457,14 +457,14 @@ bool son_actions::send_cmdu_to_agent(const std::string &dest_mac,
                                      const std::string &radio_mac)
 {
     if (cmdu_tx.getMessageType() == ieee1905_1::eMessageType::VENDOR_SPECIFIC_MESSAGE) {
-        auto beerocks_header = message_com::get_vs_class_header(cmdu_tx);
+        auto beerocks_header = message_com::get_beerocks_header(cmdu_tx);
         if (!beerocks_header) {
             LOG(ERROR) << "Failed getting beerocks_header!";
             return false;
         }
 
-        beerocks_header->radio_mac() = network_utils::mac_from_string(radio_mac);
-        beerocks_header->direction() = beerocks::BEEROCKS_DIRECTION_AGENT;
+        beerocks_header->actionhdr()->radio_mac() = network_utils::mac_from_string(radio_mac);
+        beerocks_header->actionhdr()->direction() = beerocks::BEEROCKS_DIRECTION_AGENT;
     }
 
     auto master_thread_ctx = database.get_master_thread_ctx();

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -30,8 +30,7 @@ using namespace net;
 using namespace son;
 
 void son_management::handle_cli_message(Socket *sd,
-                                        std::shared_ptr<beerocks_message::cACTION_HEADER> header,
-                                        ieee1905_1::CmduMessageRx &cmdu_rx,
+                                        std::shared_ptr<beerocks_header> beerocks_header,
                                         ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
                                         task_pool &tasks)
 {
@@ -40,11 +39,12 @@ void son_management::handle_cli_message(Socket *sd,
 
     //LOG(DEBUG) << "NEW CLI action=" << int(header->action()) << " action_op=" << int(header->action_op());
 
-    switch (header->action_op()) {
+    switch (beerocks_header->action_op()) {
 
     case beerocks_message::ACTION_CLI_PING_SLAVE_REQUEST: {
         LOG(DEBUG) << "PING_SLAVE_REQUEST from CLI";
-        auto cli_request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_PING_SLAVE_REQUEST>();
+        auto cli_request =
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_PING_SLAVE_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_PING_SLAVE_REQUEST failed";
             isOK = false;
@@ -95,7 +95,7 @@ void son_management::handle_cli_message(Socket *sd,
     case beerocks_message::ACTION_CLI_PING_ALL_SLAVES_REQUEST: {
         LOG(DEBUG) << "PING_ALL_SLAVES_REQUEST from CLI";
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_PING_ALL_SLAVES_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_PING_ALL_SLAVES_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_PING_SLAVE_REQUEST failed";
             isOK = false;
@@ -147,7 +147,7 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_HOSTAP_STATS_MEASUREMENT: {
         auto request_in =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_HOSTAP_STATS_MEASUREMENT>();
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_HOSTAP_STATS_MEASUREMENT>();
         if (request_in == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_HOSTAP_STATS_MEASUREMENT failed";
             isOK = false;
@@ -183,7 +183,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST failed";
             isOK = false;
@@ -210,7 +211,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST failed";
             isOK = false;
@@ -237,7 +239,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS failed";
             isOK = false;
@@ -273,7 +276,8 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_CLIENT_ALLOW_REQUEST: {
-        auto cli_request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_ALLOW_REQUEST>();
+        auto cli_request =
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_CLIENT_ALLOW_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_ALLOW_REQUEST failed";
             isOK = false;
@@ -317,7 +321,7 @@ void son_management::handle_cli_message(Socket *sd,
     case beerocks_message::ACTION_CLI_CROSS_RX_RSSI_MEASUREMENT: {
 
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT>();
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CROSS_RX_RSSI_MEASUREMENT failed";
             isOK = false;
@@ -356,7 +360,7 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_CLIENT_DISALLOW_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_DISALLOW_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_CLIENT_DISALLOW_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_DISALLOW_REQUEST failed";
             isOK = false;
@@ -400,7 +404,7 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_CLIENT_DISCONNECT_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_DISCONNECT_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_CLIENT_DISCONNECT_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_DISCONNECT_REQUEST failed";
             isOK = false;
@@ -430,7 +434,7 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_CLIENT_BEACON_11K_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_BEACON_11K_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_CLIENT_BEACON_11K_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_BEACON_11K_REQUEST failed";
             isOK = false;
@@ -504,7 +508,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST failed";
             isOK = false;
@@ -554,7 +559,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_CLIENT_STATISTICS_11K_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_STATISTICS_11K_REQUEST failed";
             isOK = false;
@@ -642,7 +648,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST failed";
             isOK = false;
@@ -671,7 +678,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST: {
         auto cli_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST failed";
             isOK = false;
@@ -698,7 +706,8 @@ void son_management::handle_cli_message(Socket *sd,
     }
     case beerocks_message::ACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS failed";
             isOK = false;
@@ -713,7 +722,7 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_ENABLE_DEBUG: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_ENABLE_DEBUG>();
+        auto request = beerocks_header->addClass<beerocks_message::cACTION_CLI_ENABLE_DEBUG>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_ENABLE_DEBUG failed";
             isOK = false;
@@ -731,7 +740,8 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_DUMP_NODE_INFO: {
-        auto cli_request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_DUMP_NODE_INFO>();
+        auto cli_request =
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_DUMP_NODE_INFO>();
         if (cli_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_DUMP_NODE_INFO failed";
             isOK = false;
@@ -777,7 +787,7 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_OPTIMAL_PATH_TASK: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_OPTIMAL_PATH_TASK>();
+        auto request = beerocks_header->addClass<beerocks_message::cACTION_CLI_OPTIMAL_PATH_TASK>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_OPTIMAL_PATH_TASK failed";
             isOK = false;
@@ -810,7 +820,8 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_LOAD_BALANCER_TASK: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_LOAD_BALANCER_TASK>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_LOAD_BALANCER_TASK>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_LOAD_BALANCER_TASK failed";
             isOK = false;
@@ -851,7 +862,8 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_BACKHAUL_ROAM_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_BACKHAUL_ROAM_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_BACKHAUL_ROAM_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_BACKHAUL_ROAM_REQUEST failed";
             isOK = false;
@@ -867,7 +879,8 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     case beerocks_message::ACTION_CLI_CLIENT_BSS_STEER_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_CLI_CLIENT_BSS_STEER_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_CLI_CLIENT_BSS_STEER_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_CLI_CLIENT_BSS_STEER_REQUEST failed";
             isOK = false;
@@ -886,7 +899,7 @@ void son_management::handle_cli_message(Socket *sd,
         break;
     }
     default: {
-        LOG(ERROR) << "Unsupported CLI action_op:" << int(header->action_op());
+        LOG(ERROR) << "Unsupported CLI action_op:" << int(beerocks_header->action_op());
         isOK = false;
         break;
     }
@@ -907,10 +920,10 @@ void son_management::handle_cli_message(Socket *sd,
     }
 }
 
-void son_management::handle_bml_message(
-    Socket *sd, std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-    ieee1905_1::CmduMessageRx &cmdu_rx, ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
-    task_pool &tasks)
+void son_management::handle_bml_message(Socket *sd,
+                                        std::shared_ptr<beerocks_header> beerocks_header,
+                                        ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
+                                        task_pool &tasks)
 {
     switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_BML_PING_REQUEST: {
@@ -1036,7 +1049,8 @@ void son_management::handle_bml_message(
     } break;
 
     case beerocks_message::ACTION_BML_SET_CLIENT_ROAMING_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_CLIENT_ROAMING_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_BML_SET_CLIENT_ROAMING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_SET_CLIENT_ROAMING_REQUEST failed";
             break;
@@ -1073,7 +1087,8 @@ void son_management::handle_bml_message(
 
     case beerocks_message::ACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST failed";
             break;
@@ -1107,7 +1122,7 @@ void son_management::handle_bml_message(
     } break;
 
     case beerocks_message::ACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST: {
-        auto request = cmdu_rx.addClass<
+        auto request = beerocks_header->addClass<
             beerocks_message::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR)
@@ -1151,7 +1166,8 @@ void son_management::handle_bml_message(
 
     case beerocks_message::ACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST failed";
             break;
@@ -1190,7 +1206,8 @@ void son_management::handle_bml_message(
     } break;
 
     case beerocks_message::ACTION_BML_SET_IRE_ROAMING_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_IRE_ROAMING_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_BML_SET_IRE_ROAMING_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_SET_IRE_ROAMING_REQUEST failed";
             break;
@@ -1228,7 +1245,8 @@ void son_management::handle_bml_message(
     } break;
 
     case beerocks_message::ACTION_BML_SET_LOAD_BALANCER_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_LOAD_BALANCER_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_BML_SET_LOAD_BALANCER_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_SET_LOAD_BALANCER_REQUEST failed";
             break;
@@ -1265,7 +1283,7 @@ void son_management::handle_bml_message(
 
     case beerocks_message::ACTION_BML_SET_SERVICE_FAIRNESS_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_SET_SERVICE_FAIRNESS_REQUEST failed";
             break;
@@ -1301,7 +1319,8 @@ void son_management::handle_bml_message(
     } break;
 
     case beerocks_message::ACTION_BML_SET_DFS_REENTRY_REQUEST: {
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_DFS_REENTRY_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_BML_SET_DFS_REENTRY_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_SET_DFS_REENTRY_REQUEST failed";
             break;
@@ -1339,7 +1358,8 @@ void son_management::handle_bml_message(
 
     case beerocks_message::ACTION_BML_SET_CERTIFICATION_MODE_REQUEST: {
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_SET_CERTIFICATION_MODE_REQUEST failed";
             break;
@@ -1378,7 +1398,8 @@ void son_management::handle_bml_message(
         LOG(TRACE) << "ACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST";
 
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST failed";
             break;
@@ -1418,7 +1439,8 @@ void son_management::handle_bml_message(
     case beerocks_message::ACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST: {
         LOG(TRACE) << "ACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST failed";
             break;
@@ -1445,7 +1467,8 @@ void son_management::handle_bml_message(
     } break;
     case beerocks_message::ACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST: {
         auto bml_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST>();
         if (bml_request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST failed";
             break;
@@ -1505,7 +1528,8 @@ void son_management::handle_bml_message(
         uint32_t result = 1; //1-fail 0-success
 
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST failed";
             return;
@@ -1610,7 +1634,8 @@ void son_management::handle_bml_message(
 #ifdef BEEROCKS_RDKB
     case beerocks_message::ACTION_BML_STEERING_SET_GROUP_REQUEST: {
         LOG(TRACE) << "ACTION_BML_STEERING_SET_GROUP_REQUEST";
-        auto request = cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_SET_GROUP_REQUEST>();
+        auto request =
+            beerocks_header->addClass<beerocks_message::cACTION_BML_STEERING_SET_GROUP_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass ACTION_BML_STEERING_SET_GROUP_REQUEST failed";
             break;
@@ -1630,7 +1655,7 @@ void son_management::handle_bml_message(
     case beerocks_message::ACTION_BML_STEERING_CLIENT_SET_REQUEST: {
         LOG(TRACE) << "cACTION_BML_STEERING_CLIENT_SET_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_SET_REQUEST>();
+            beerocks_header->addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_SET_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_STEERING_CLIENT_SET_REQUEST failed";
             break;
@@ -1651,7 +1676,7 @@ void son_management::handle_bml_message(
     }
     case beerocks_message::ACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST: {
         LOG(TRACE) << "ACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST";
-        auto request = cmdu_rx.addClass<
+        auto request = beerocks_header->addClass<
             beerocks_message::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST failed";
@@ -1674,7 +1699,8 @@ void son_management::handle_bml_message(
     case beerocks_message::ACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST: {
         LOG(TRACE) << "ACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST failed";
             break;
@@ -1695,7 +1721,8 @@ void son_management::handle_bml_message(
     case beerocks_message::ACTION_BML_STEERING_CLIENT_MEASURE_REQUEST: {
         LOG(TRACE) << "ACTION_BML_STEERING_CLIENT_MEASURE_REQUEST";
         auto request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST>();
         if (request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST failed";
             break;
@@ -1724,7 +1751,8 @@ void son_management::handle_bml_message(
 
     case beerocks_message::ACTION_BML_TRIGGER_TOPOLOGY_QUERY: {
 
-        auto bml_request = cmdu_rx.addClass<beerocks_message::cACTION_BML_TRIGGER_TOPOLOGY_QUERY>();
+        auto bml_request =
+            beerocks_header->addClass<beerocks_message::cACTION_BML_TRIGGER_TOPOLOGY_QUERY>();
 
         auto al_mac = network_utils::mac_to_string(bml_request->al_mac());
 
@@ -1745,7 +1773,8 @@ void son_management::handle_bml_message(
     case beerocks_message::ACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST: {
 
         auto bml_request =
-            cmdu_rx.addClass<beerocks_message::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST>();
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST>();
 
         if (bml_request == nullptr) {
             LOG(ERROR) << "addClass cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST failed";

--- a/controller/src/beerocks/master/son_management.h
+++ b/controller/src/beerocks/master/son_management.h
@@ -15,16 +15,14 @@ namespace son {
 
 class son_management {
 public:
-    static void
-    handle_cli_message(Socket *sd,
-                       std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-                       ieee1905_1::CmduMessageRx &cmdu_rx, ieee1905_1::CmduMessageTx &cmdu_tx,
-                       db &database, task_pool &tasks);
-    static void
-    handle_bml_message(Socket *sd,
-                       std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-                       ieee1905_1::CmduMessageRx &cmdu_rx, ieee1905_1::CmduMessageTx &cmdu_tx,
-                       db &database, task_pool &tasks);
+    static void handle_cli_message(Socket *sd,
+                                   std::shared_ptr<beerocks::beerocks_header> beerocks_header,
+                                   ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
+                                   task_pool &tasks);
+    static void handle_bml_message(Socket *sd,
+                                   std::shared_ptr<beerocks::beerocks_header> beerocks_header,
+                                   ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
+                                   task_pool &tasks);
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -695,7 +695,7 @@ bool master_thread::autoconfig_wsc_add_m2(std::shared_ptr<ieee1905_1::tlvWscM1> 
 
     // Create ConfigData
     uint8_t buf[1024];
-    WSC::cConfigData config_data(buf, sizeof(buf), false, true);
+    WSC::cConfigData config_data(buf, sizeof(buf), false);
     if (bss_info_conf) {
         config_data.set_ssid(bss_info_conf->ssid);
         config_data.authentication_type_attr().data = bss_info_conf->authentication_type;

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -50,10 +50,8 @@ protected:
 
 private:
     bool handle_cmdu_1905_1_message(const std::string &src_mac, ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool
-    handle_cmdu_control_message(const std::string &src_mac,
-                                std::shared_ptr<beerocks_message::cACTION_HEADER> beerocks_header,
-                                ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_control_message(const std::string &src_mac,
+                                     std::shared_ptr<beerocks::beerocks_header> beerocks_header);
     void handle_cmdu_control_ieee1905_1_message(const std::string &src_mac,
                                                 ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_intel_slave_join(const std::string &src_mac,

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -242,18 +242,17 @@ void association_handling_task::work()
 }
 
 void association_handling_task::handle_response(std::string mac,
-                                                beerocks_message::eActionOp_CONTROL action_op,
-                                                ieee1905_1::CmduMessageRx &cmdu_rx)
+                                                std::shared_ptr<beerocks_header> beerocks_header)
 {
-    switch (action_op) {
+    switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE: {
         break;
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE: {
         const std::string parent_mac = database.get_node_parent(sta_mac);
         auto response =
-            message_com::get_vs_class<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE>(
-                cmdu_rx);
+            beerocks_header
+                ->getClass<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE>();
         if (!response) {
             TASK_LOG(ERROR) << "getClass failed for cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE";
             return;
@@ -312,7 +311,7 @@ void association_handling_task::handle_response(std::string mac,
         break;
     }
     default: {
-        LOG(ERROR) << "Unsupported action_op:" << int(action_op);
+        LOG(ERROR) << "Unsupported action_op:" << int(beerocks_header->action_op());
         break;
     }
     }

--- a/controller/src/beerocks/master/tasks/association_handling_task.h
+++ b/controller/src/beerocks/master/tasks/association_handling_task.h
@@ -23,9 +23,9 @@ public:
 
 protected:
     virtual void work() override;
-    virtual void handle_response(std::string radio_mac,
-                                 beerocks_message::eActionOp_CONTROL action_op,
-                                 ieee1905_1::CmduMessageRx &cmdu_rx) override;
+    virtual void
+    handle_response(std::string radio_mac,
+                    std::shared_ptr<beerocks::beerocks_header> beerocks_header) override;
     virtual void handle_responses_timeout(
         std::unordered_multimap<std::string, beerocks_message::eActionOp_CONTROL> timed_out_macs)
         override;

--- a/controller/src/beerocks/master/tasks/channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.cpp
@@ -48,7 +48,7 @@ channel_selection_task::channel_selection_task(db &database_, ieee1905_1::CmduMe
 //     //DO NOT USE THIS FUNCTION, ONLY USE handle_event FUNCTION
 // }
 
-// void channel_selection_task::handle_response(std::string mac, beerocks::message::eActionOp_CONTROL action_op, uint8_t *buffer)
+// void channel_selection_task::handle_response(std::string mac, std::shared_ptr<beerocks_header> beerocks_header)
 // {
 //     //DO NOT USE THIS FUNCTION, ONLY USE handle_event FUNCTION
 // }

--- a/controller/src/beerocks/master/tasks/channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.h
@@ -118,7 +118,7 @@ public:
 protected:
     virtual void work() override;
     // virtual void handle_responses_timeout(std::unordered_multimap<std::string, beerocks::message::eActionOp_CONTROL> timed_out_macs) override;
-    // virtual void handle_response(std::string mac, beerocks::message::eActionOp_CONTROL action_op, uint8_t *buffer) override;
+    // virtual void handle_response(std::string mac, std::shared_ptr<beerocks_header> beerocks_header) override;
     virtual void handle_event(int event_type, void *obj) override;
     virtual void handle_events_timeout(std::multiset<int> pending_events) override;
     /*

--- a/controller/src/beerocks/master/tasks/client_locating_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_locating_task.cpp
@@ -178,15 +178,12 @@ void client_locating_task::work()
 }
 
 void client_locating_task::handle_response(std::string mac,
-                                           beerocks_message::eActionOp_CONTROL action_op,
-                                           ieee1905_1::CmduMessageRx &cmdu_rx)
+                                           std::shared_ptr<beerocks_header> beerocks_header)
 {
-    switch (action_op) {
+    switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_CONTROL_ARP_QUERY_RESPONSE: {
         auto response =
-            message_com::get_vs_class<beerocks_message::cACTION_CONTROL_ARP_QUERY_RESPONSE>(
-                cmdu_rx);
-
+            beerocks_header->getClass<beerocks_message::cACTION_CONTROL_ARP_QUERY_RESPONSE>();
         if (!response) {
             TASK_LOG(ERROR) << "getClass failed for cACTION_CONTROL_ARP_QUERY_RESPONSE";
             return;
@@ -228,7 +225,7 @@ void client_locating_task::handle_response(std::string mac,
         break;
     }
     default: {
-        TASK_LOG(ERROR) << "Unsupported action_op:" << int(action_op);
+        TASK_LOG(ERROR) << "Unsupported action_op:" << int(beerocks_header->action_op());
         break;
     }
     }

--- a/controller/src/beerocks/master/tasks/client_locating_task.h
+++ b/controller/src/beerocks/master/tasks/client_locating_task.h
@@ -27,9 +27,9 @@ public:
 
 protected:
     virtual void work() override;
-    virtual void handle_response(std::string slave_mac,
-                                 beerocks_message::eActionOp_CONTROL action_op,
-                                 ieee1905_1::CmduMessageRx &cmdu_rx) override;
+    virtual void
+    handle_response(std::string slave_mac,
+                    std::shared_ptr<beerocks::beerocks_header> beerocks_header) override;
 
 private:
     db &database;

--- a/controller/src/beerocks/master/tasks/network_health_check_task.cpp
+++ b/controller/src/beerocks/master/tasks/network_health_check_task.cpp
@@ -111,15 +111,12 @@ void network_health_check_task::work()
 }
 
 void network_health_check_task::handle_response(std::string mac,
-                                                beerocks_message::eActionOp_CONTROL action_op,
-                                                ieee1905_1::CmduMessageRx &cmdu_rx)
+                                                std::shared_ptr<beerocks_header> beerocks_header)
 {
-    switch (action_op) {
+    switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_CONTROL_ARP_QUERY_RESPONSE: {
         auto response =
-            message_com::get_vs_class<beerocks_message::cACTION_CONTROL_ARP_QUERY_RESPONSE>(
-                cmdu_rx);
-
+            beerocks_header->getClass<beerocks_message::cACTION_CONTROL_ARP_QUERY_RESPONSE>();
         if (!response) {
             TASK_LOG(ERROR) << "getClass failed for cACTION_CONTROL_ARP_QUERY_RESPONSE";
             return;
@@ -149,7 +146,7 @@ void network_health_check_task::handle_response(std::string mac,
         break;
     }
     default: {
-        TASK_LOG(ERROR) << "Unsupported action_op:" << int(action_op);
+        TASK_LOG(ERROR) << "Unsupported action_op:" << int(beerocks_header->action_op());
         break;
     }
     }

--- a/controller/src/beerocks/master/tasks/network_health_check_task.h
+++ b/controller/src/beerocks/master/tasks/network_health_check_task.h
@@ -25,9 +25,9 @@ public:
 
 protected:
     virtual void work() override;
-    virtual void handle_response(std::string slave_mac,
-                                 beerocks_message::eActionOp_CONTROL action_op,
-                                 ieee1905_1::CmduMessageRx &cmdu_rx) override;
+    virtual void
+    handle_response(std::string slave_mac,
+                    std::shared_ptr<beerocks::beerocks_header> beerocks_header) override;
     virtual void handle_responses_timeout(
         std::unordered_multimap<std::string, beerocks_message::eActionOp_CONTROL> timed_out_macs)
         override;

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -1286,15 +1286,13 @@ void optimal_path_task::handle_responses_timeout(
 }
 
 void optimal_path_task::handle_response(std::string mac,
-                                        beerocks_message::eActionOp_CONTROL action_op,
-                                        ieee1905_1::CmduMessageRx &cmdu_rx)
+                                        std::shared_ptr<beerocks_header> beerocks_header)
 {
 
-    switch (action_op) {
+    switch (beerocks_header->action_op()) {
     case beerocks_message::ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION: {
-        auto notification = message_com::get_vs_class<
-            beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>(
-            cmdu_rx);
+        auto notification = beerocks_header->getClass<
+            beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>();
 
         if (!notification) {
             TASK_LOG(ERROR) << "getClass failed for "
@@ -1327,8 +1325,8 @@ void optimal_path_task::handle_response(std::string mac,
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE: {
         auto response =
-            message_com::get_vs_class<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE>(
-                cmdu_rx);
+            beerocks_header
+                ->getClass<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE>();
 
         if (!response) {
             TASK_LOG(ERROR) << "getClass failed for ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE";
@@ -1358,7 +1356,7 @@ void optimal_path_task::handle_response(std::string mac,
         break;
     }
     default: {
-        TASK_LOG(ERROR) << "Unsupported action_op:" << int(action_op);
+        TASK_LOG(ERROR) << "Unsupported action_op:" << int(beerocks_header->action_op());
         break;
     }
     }

--- a/controller/src/beerocks/master/tasks/optimal_path_task.h
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.h
@@ -32,9 +32,9 @@ public:
 
 protected:
     virtual void work() override;
-    virtual void handle_response(std::string slave_mac,
-                                 beerocks_message::eActionOp_CONTROL action_op,
-                                 ieee1905_1::CmduMessageRx &cmdu_rx) override;
+    virtual void
+    handle_response(std::string slave_mac,
+                    std::shared_ptr<beerocks::beerocks_header> beerocks_header) override;
     virtual void handle_responses_timeout(
         std::unordered_multimap<std::string, beerocks_message::eActionOp_CONTROL> timed_out_macs)
         override;

--- a/controller/src/beerocks/master/tasks/statistics_polling_task.cpp
+++ b/controller/src/beerocks/master/tasks/statistics_polling_task.cpp
@@ -80,9 +80,8 @@ void statistics_polling_task::work()
     }
 }
 
-void statistics_polling_task::handle_response(std::string mac,
-                                              beerocks_message::eActionOp_CONTROL action_op,
-                                              ieee1905_1::CmduMessageRx &cmdu_rx)
+void statistics_polling_task::handle_response(
+    std::string mac, std::shared_ptr<beerocks::beerocks_header> beerocks_header)
 {
     valid_hostaps.insert(mac);
 }

--- a/controller/src/beerocks/master/tasks/statistics_polling_task.h
+++ b/controller/src/beerocks/master/tasks/statistics_polling_task.h
@@ -21,9 +21,9 @@ public:
 
 protected:
     virtual void work() override;
-    virtual void handle_response(std::string slave_mac,
-                                 beerocks_message::eActionOp_CONTROL action_op,
-                                 ieee1905_1::CmduMessageRx &cmdu_rx) override;
+    virtual void
+    handle_response(std::string slave_mac,
+                    std::shared_ptr<beerocks::beerocks_header> beerocks_header) override;
     virtual void handle_responses_timeout(
         std::unordered_multimap<std::string, beerocks_message::eActionOp_CONTROL> timed_out_macs)
         override;

--- a/controller/src/beerocks/master/tasks/task.cpp
+++ b/controller/src/beerocks/master/tasks/task.cpp
@@ -24,15 +24,15 @@ task::task(std::string task_name_, std::string node_mac)
     TASK_LOG(DEBUG) << "start new task: " << task_name << ", id=" << id;
 }
 
-void task::response_received(std::string mac, beerocks_message::eActionOp_CONTROL action_op,
-                             ieee1905_1::CmduMessageRx &cmdu_rx)
+void task::response_received(std::string mac,
+                             std::shared_ptr<beerocks::beerocks_header> beerocks_header)
 {
     // removing the responding mac with specific action_op from pending_macs
     auto range = pending_macs.equal_range(mac);
     for (auto it = range.first; it != range.second;) {
-        if ((it->second == action_op) && (it->first == mac)) {
+        if ((it->second == beerocks_header->action_op()) && (it->first == mac)) {
             it = pending_macs.erase(it);
-            handle_response(mac, action_op, cmdu_rx);
+            handle_response(mac, beerocks_header);
             return;
         } else {
             it++;
@@ -40,7 +40,7 @@ void task::response_received(std::string mac, beerocks_message::eActionOp_CONTRO
     }
 
     // Handle the response even if we are not expecting it
-    handle_response(mac, action_op, cmdu_rx);
+    handle_response(mac, beerocks_header);
 }
 
 void task::event_received(int event_type, void *obj)

--- a/controller/src/beerocks/master/tasks/task.h
+++ b/controller/src/beerocks/master/tasks/task.h
@@ -28,8 +28,8 @@ public:
     task(std::string task_name_ = std::string(""), std::string node_mac = std::string());
     virtual ~task() {}
     void execute();
-    void response_received(std::string mac, beerocks_message::eActionOp_CONTROL action_op,
-                           ieee1905_1::CmduMessageRx &cmdu_rx);
+    void response_received(std::string mac,
+                           std::shared_ptr<beerocks::beerocks_header> beerocks_header);
     void event_received(int event_type, void *obj = nullptr);
     void pending_task_ended(int task_id);
     bool is_done();
@@ -59,8 +59,7 @@ protected:
     virtual void handle_task_end() {}
     virtual void handle_event(int event_type, void *obj) {}
     virtual void handle_response(std::string slave_mac,
-                                 beerocks_message::eActionOp_CONTROL action_op,
-                                 ieee1905_1::CmduMessageRx &cmdu_rx)
+                                 std::shared_ptr<beerocks::beerocks_header> beerocks_header)
     {
     }
     virtual void handle_responses_timeout(

--- a/controller/src/beerocks/master/tasks/task_pool.cpp
+++ b/controller/src/beerocks/master/tasks/task_pool.cpp
@@ -61,13 +61,13 @@ void task_pool::pending_task_ended(int task_id)
     }
 }
 
-void task_pool::response_received(int id, std::string mac,
-                                  beerocks_message::eActionOp_CONTROL action_op,
-                                  ieee1905_1::CmduMessageRx &cmdu_rx)
+void task_pool::response_received(std::string mac,
+                                  std::shared_ptr<beerocks::beerocks_header> beerocks_header)
 {
-    std::unordered_map<int, std::shared_ptr<task>>::const_iterator got = scheduled_tasks.find(id);
+    std::unordered_map<int, std::shared_ptr<task>>::const_iterator got =
+        scheduled_tasks.find(beerocks_header->id());
     if (got != scheduled_tasks.end()) {
-        got->second->response_received(mac, action_op, cmdu_rx);
+        got->second->response_received(mac, beerocks_header);
     }
 }
 

--- a/controller/src/beerocks/master/tasks/task_pool.h
+++ b/controller/src/beerocks/master/tasks/task_pool.h
@@ -25,8 +25,8 @@ public:
     bool is_task_running(int id);
     void kill_task(int id);
     void push_event(int task_id, int event_type, void *obj = nullptr);
-    void response_received(int id, std::string mac, beerocks_message::eActionOp_CONTROL action_op,
-                           ieee1905_1::CmduMessageRx &cmdu_rx);
+    void response_received(std::string mac,
+                           std::shared_ptr<beerocks::beerocks_header> beerocks_header);
     void pending_task_ended(int task_id);
     void run_tasks();
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -474,8 +474,8 @@ typedef struct sWscAttrAuthenticator {
 class cConfigData : public BaseClass
 {
     public:
-        cConfigData(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cConfigData(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cConfigData(uint8_t* buff, size_t buff_len, bool parse = false);
+        cConfigData(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cConfigData();
 
         eWscAttributes& ssid_type();
@@ -519,8 +519,8 @@ class cConfigData : public BaseClass
 class cWscAttrEncryptedSettings : public BaseClass
 {
     public:
-        cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cWscAttrEncryptedSettings();
 
         const eWscAttributes& type();
@@ -552,8 +552,8 @@ class cWscAttrEncryptedSettings : public BaseClass
 class cWscVendorExtWfa : public BaseClass
 {
     public:
-        cWscVendorExtWfa(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cWscVendorExtWfa(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cWscVendorExtWfa(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscVendorExtWfa(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cWscVendorExtWfa();
 
         eWscAttributes& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/cCmduHeader.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/cCmduHeader.h
@@ -28,8 +28,8 @@ namespace ieee1905_1 {
 class cCmduHeader : public BaseClass
 {
     public:
-        cCmduHeader(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cCmduHeader(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cCmduHeader(uint8_t* buff, size_t buff_len, bool parse = false);
+        cCmduHeader(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cCmduHeader();
 
         typedef struct sFlags {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
@@ -29,8 +29,8 @@ namespace ieee1905_1 {
 class tlv1905NeighborDevice : public BaseClass
 {
     public:
-        tlv1905NeighborDevice(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlv1905NeighborDevice(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlv1905NeighborDevice(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlv1905NeighborDevice(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlv1905NeighborDevice();
 
         enum eBridgesExist: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvAlMacAddressType.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvAlMacAddressType.h
@@ -28,8 +28,8 @@ namespace ieee1905_1 {
 class tlvAlMacAddressType : public BaseClass
 {
     public:
-        tlvAlMacAddressType(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvAlMacAddressType(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvAlMacAddressType(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvAlMacAddressType(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvAlMacAddressType();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvAutoconfigFreqBand : public BaseClass
 {
     public:
-        tlvAutoconfigFreqBand(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvAutoconfigFreqBand(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvAutoconfigFreqBand(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvAutoconfigFreqBand(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvAutoconfigFreqBand();
 
         enum eValue: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.h
@@ -31,8 +31,8 @@ class cMacList;
 class tlvDeviceBridgingCapability : public BaseClass
 {
     public:
-        tlvDeviceBridgingCapability(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvDeviceBridgingCapability(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvDeviceBridgingCapability(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvDeviceBridgingCapability(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvDeviceBridgingCapability();
 
         const eTlvType& type();
@@ -59,8 +59,8 @@ class tlvDeviceBridgingCapability : public BaseClass
 class cMacList : public BaseClass
 {
     public:
-        cMacList(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cMacList(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cMacList(uint8_t* buff, size_t buff_len, bool parse = false);
+        cMacList(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cMacList();
 
         uint8_t& mac_list_length();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceInformation.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvDeviceInformation.h
@@ -30,8 +30,8 @@ namespace ieee1905_1 {
 class tlvDeviceInformation : public BaseClass
 {
     public:
-        tlvDeviceInformation(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvDeviceInformation(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvDeviceInformation(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvDeviceInformation(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvDeviceInformation();
 
         typedef struct sInfo {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvEndOfMessage.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvEndOfMessage.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvEndOfMessage : public BaseClass
 {
     public:
-        tlvEndOfMessage(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvEndOfMessage(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvEndOfMessage(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvEndOfMessage(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvEndOfMessage();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvLinkMetricQuery.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvLinkMetricQuery.h
@@ -28,8 +28,8 @@ namespace ieee1905_1 {
 class tlvLinkMetricQuery : public BaseClass
 {
     public:
-        tlvLinkMetricQuery(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvLinkMetricQuery(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvLinkMetricQuery(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvLinkMetricQuery(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvLinkMetricQuery();
 
         enum eNeighborType: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvLinkMetricResultCode.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvLinkMetricResultCode.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvLinkMetricResultCode : public BaseClass
 {
     public:
-        tlvLinkMetricResultCode(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvLinkMetricResultCode(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvLinkMetricResultCode(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvLinkMetricResultCode(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvLinkMetricResultCode();
 
         enum eValue: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvMacAddress.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvMacAddress.h
@@ -28,8 +28,8 @@ namespace ieee1905_1 {
 class tlvMacAddress : public BaseClass
 {
     public:
-        tlvMacAddress(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvMacAddress(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvMacAddress(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvMacAddress(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvMacAddress();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.h
@@ -29,8 +29,8 @@ namespace ieee1905_1 {
 class tlvNon1905neighborDeviceList : public BaseClass
 {
     public:
-        tlvNon1905neighborDeviceList(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvNon1905neighborDeviceList(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvNon1905neighborDeviceList(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvNon1905neighborDeviceList(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvNon1905neighborDeviceList();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonEventNotification.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonEventNotification.h
@@ -30,8 +30,8 @@ namespace ieee1905_1 {
 class tlvPushButtonEventNotification : public BaseClass
 {
     public:
-        tlvPushButtonEventNotification(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvPushButtonEventNotification(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvPushButtonEventNotification(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvPushButtonEventNotification(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvPushButtonEventNotification();
 
         typedef struct sMediaType {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.h
@@ -28,8 +28,8 @@ namespace ieee1905_1 {
 class tlvPushButtonJoinNotification : public BaseClass
 {
     public:
-        tlvPushButtonJoinNotification(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvPushButtonJoinNotification(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvPushButtonJoinNotification(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvPushButtonJoinNotification(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvPushButtonJoinNotification();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvReceiverLinkMetric.h
@@ -30,8 +30,8 @@ namespace ieee1905_1 {
 class tlvReceiverLinkMetric : public BaseClass
 {
     public:
-        tlvReceiverLinkMetric(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvReceiverLinkMetric(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvReceiverLinkMetric(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvReceiverLinkMetric(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvReceiverLinkMetric();
 
         typedef struct sLinkMetricInfo {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvSearchedRole.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvSearchedRole.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvSearchedRole : public BaseClass
 {
     public:
-        tlvSearchedRole(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSearchedRole(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSearchedRole(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSearchedRole(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSearchedRole();
 
         enum eValue: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvSupportedFreqBand.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvSupportedFreqBand.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvSupportedFreqBand : public BaseClass
 {
     public:
-        tlvSupportedFreqBand(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSupportedFreqBand(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSupportedFreqBand(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSupportedFreqBand(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSupportedFreqBand();
 
         enum eValue: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvSupportedRole.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvSupportedRole.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvSupportedRole : public BaseClass
 {
     public:
-        tlvSupportedRole(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSupportedRole(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSupportedRole(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSupportedRole(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSupportedRole();
 
         enum eValue: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.h
@@ -30,8 +30,8 @@ namespace ieee1905_1 {
 class tlvTransmitterLinkMetric : public BaseClass
 {
     public:
-        tlvTransmitterLinkMetric(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvTransmitterLinkMetric(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvTransmitterLinkMetric(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvTransmitterLinkMetric(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvTransmitterLinkMetric();
 
         enum eIEEE802_1BridgeFlag: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvUnknown.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvUnknown.h
@@ -27,8 +27,8 @@ namespace ieee1905_1 {
 class tlvUnknown : public BaseClass
 {
     public:
-        tlvUnknown(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvUnknown(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvUnknown(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvUnknown(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvUnknown();
 
         uint8_t& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
@@ -29,8 +29,8 @@ namespace ieee1905_1 {
 class tlvVendorSpecific : public BaseClass
 {
     public:
-        tlvVendorSpecific(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvVendorSpecific(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvVendorSpecific(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvVendorSpecific(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvVendorSpecific();
 
         enum eVendorOUI: uint32_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvVendorSpecific.h
@@ -21,6 +21,7 @@
 #include <tlvf/BaseClass.h>
 #include "tlvf/ieee_1905_1/eTlvType.h"
 #include "tlvf/ieee_1905_1/sVendorOUI.h"
+#include <tuple>
 
 namespace ieee1905_1 {
 
@@ -38,8 +39,11 @@ class tlvVendorSpecific : public BaseClass
         };
         
         const eTlvType& type();
-        uint16_t& length();
+        const uint16_t& length();
         sVendorOUI& vendor_oui();
+        size_t payload_length() { return m_payload_idx__ * sizeof(uint8_t); }
+        uint8_t* payload(size_t idx = 0);
+        bool alloc_payload(size_t count = 1);
         void class_swap();
         static size_t get_initial_size();
 
@@ -48,6 +52,9 @@ class tlvVendorSpecific : public BaseClass
         eTlvType* m_type = nullptr;
         uint16_t* m_length = nullptr;
         sVendorOUI* m_vendor_oui = nullptr;
+        uint8_t* m_payload = nullptr;
+        size_t m_payload_idx__ = 0;
+        int m_lock_order_counter__ = 0;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
@@ -30,8 +30,8 @@ namespace ieee1905_1 {
 class tlvWscM1 : public BaseClass
 {
     public:
-        tlvWscM1(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvWscM1(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvWscM1(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvWscM1(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvWscM1();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
@@ -30,8 +30,8 @@ namespace ieee1905_1 {
 class tlvWscM2 : public BaseClass
 {
     public:
-        tlvWscM2(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvWscM2(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvWscM2(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvWscM2(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvWscM2();
 
         const eTlvType& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/test/tlvVarList.h
@@ -27,8 +27,8 @@ class cInner;
 class tlvTestVarList : public BaseClass
 {
     public:
-        tlvTestVarList(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvTestVarList(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvTestVarList(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvTestVarList(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvTestVarList();
 
         const uint8_t& type();
@@ -94,8 +94,8 @@ class tlvTestVarList : public BaseClass
 class cInner : public BaseClass
 {
     public:
-        cInner(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cInner(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cInner(uint8_t* buff, size_t buff_len, bool parse = false);
+        cInner(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cInner();
 
         const uint16_t& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApCapability.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApCapability.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvApCapability : public BaseClass
 {
     public:
-        tlvApCapability(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvApCapability(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvApCapability(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApCapability(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvApCapability();
 
         typedef struct sValue {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetric.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetric.h
@@ -30,8 +30,8 @@ namespace wfa_map {
 class tlvApMetric : public BaseClass
 {
     public:
-        tlvApMetric(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvApMetric(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvApMetric(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApMetric(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvApMetric();
 
         typedef struct sEstimatedService {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetricQuery.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApMetricQuery.h
@@ -29,8 +29,8 @@ namespace wfa_map {
 class tlvApMetricQuery : public BaseClass
 {
     public:
-        tlvApMetricQuery(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvApMetricQuery(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvApMetricQuery(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApMetricQuery(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvApMetricQuery();
 
         const eTlvTypeMap& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioBasicCapabilities.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioBasicCapabilities.h
@@ -31,8 +31,8 @@ class cOperatingClassesInfo;
 class tlvApRadioBasicCapabilities : public BaseClass
 {
     public:
-        tlvApRadioBasicCapabilities(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvApRadioBasicCapabilities(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvApRadioBasicCapabilities(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApRadioBasicCapabilities(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvApRadioBasicCapabilities();
 
         const eTlvTypeMap& type();
@@ -63,8 +63,8 @@ class tlvApRadioBasicCapabilities : public BaseClass
 class cOperatingClassesInfo : public BaseClass
 {
     public:
-        cOperatingClassesInfo(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cOperatingClassesInfo(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cOperatingClassesInfo(uint8_t* buff, size_t buff_len, bool parse = false);
+        cOperatingClassesInfo(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cOperatingClassesInfo();
 
         uint8_t& operating_class();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioIdentifier.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApRadioIdentifier.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvApRadioIdentifier : public BaseClass
 {
     public:
-        tlvApRadioIdentifier(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvApRadioIdentifier(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvApRadioIdentifier(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApRadioIdentifier(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvApRadioIdentifier();
 
         const eTlvTypeMap& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
@@ -32,8 +32,8 @@ class cPreferenceOperatingClasses;
 class tlvChannelPreference : public BaseClass
 {
     public:
-        tlvChannelPreference(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvChannelPreference(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvChannelPreference(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvChannelPreference(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvChannelPreference();
 
         const eTlvTypeMap& type();
@@ -62,8 +62,8 @@ class tlvChannelPreference : public BaseClass
 class cPreferenceOperatingClasses : public BaseClass
 {
     public:
-        cPreferenceOperatingClasses(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cPreferenceOperatingClasses(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cPreferenceOperatingClasses(uint8_t* buff, size_t buff_len, bool parse = false);
+        cPreferenceOperatingClasses(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cPreferenceOperatingClasses();
 
         enum eReasonCode {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelSelectionResponse.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelSelectionResponse.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvChannelSelectionResponse : public BaseClass
 {
     public:
-        tlvChannelSelectionResponse(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvChannelSelectionResponse(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvChannelSelectionResponse(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvChannelSelectionResponse(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvChannelSelectionResponse();
 
         enum eResponseCode: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientAssociationControlRequest.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientAssociationControlRequest.h
@@ -29,8 +29,8 @@ namespace wfa_map {
 class tlvClientAssociationControlRequest : public BaseClass
 {
     public:
-        tlvClientAssociationControlRequest(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvClientAssociationControlRequest(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvClientAssociationControlRequest(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvClientAssociationControlRequest(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvClientAssociationControlRequest();
 
         enum eAssociationControl: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientAssociationEvent.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientAssociationEvent.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvClientAssociationEvent : public BaseClass
 {
     public:
-        tlvClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvClientAssociationEvent();
 
         enum eAssociationEvent: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvHigherLayerData.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvHigherLayerData.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvHigherLayerData : public BaseClass
 {
     public:
-        tlvHigherLayerData(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvHigherLayerData(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvHigherLayerData(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvHigherLayerData(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvHigherLayerData();
 
         enum eProtocol: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvOperatingChannelReport.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvOperatingChannelReport.h
@@ -29,8 +29,8 @@ namespace wfa_map {
 class tlvOperatingChannelReport : public BaseClass
 {
     public:
-        tlvOperatingChannelReport(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvOperatingChannelReport(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvOperatingChannelReport(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvOperatingChannelReport(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvOperatingChannelReport();
 
         typedef struct sOperatingClasses {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvRadioOperationRestriction.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvRadioOperationRestriction.h
@@ -31,8 +31,8 @@ class cRestrictedOperatingClasses;
 class tlvRadioOperationRestriction : public BaseClass
 {
     public:
-        tlvRadioOperationRestriction(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvRadioOperationRestriction(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvRadioOperationRestriction(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvRadioOperationRestriction(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvRadioOperationRestriction();
 
         const eTlvTypeMap& type();
@@ -61,8 +61,8 @@ class tlvRadioOperationRestriction : public BaseClass
 class cRestrictedOperatingClasses : public BaseClass
 {
     public:
-        cRestrictedOperatingClasses(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        cRestrictedOperatingClasses(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        cRestrictedOperatingClasses(uint8_t* buff, size_t buff_len, bool parse = false);
+        cRestrictedOperatingClasses(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cRestrictedOperatingClasses();
 
         typedef struct sChannelInfo {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSearchedService.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSearchedService.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvSearchedService : public BaseClass
 {
     public:
-        tlvSearchedService(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSearchedService(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSearchedService(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSearchedService(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSearchedService();
 
         enum eSearchedService: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringBTMReport.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringBTMReport.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvSteeringBTMReport : public BaseClass
 {
     public:
-        tlvSteeringBTMReport(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSteeringBTMReport(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSteeringBTMReport(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSteeringBTMReport(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSteeringBTMReport();
 
         const eTlvTypeMap& type();

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringRequest.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSteeringRequest.h
@@ -30,8 +30,8 @@ namespace wfa_map {
 class tlvSteeringRequest : public BaseClass
 {
     public:
-        tlvSteeringRequest(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSteeringRequest(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSteeringRequest(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSteeringRequest(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSteeringRequest();
 
         typedef struct sRequestFlags {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSupportedService.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvSupportedService.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvSupportedService : public BaseClass
 {
     public:
-        tlvSupportedService(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvSupportedService(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvSupportedService(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvSupportedService(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvSupportedService();
 
         enum eSupportedService: uint8_t {

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvTransmitPowerLimit.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvTransmitPowerLimit.h
@@ -28,8 +28,8 @@ namespace wfa_map {
 class tlvTransmitPowerLimit : public BaseClass
 {
     public:
-        tlvTransmitPowerLimit(uint8_t* buff, size_t buff_len, bool parse = false, bool swap_needed = false);
-        tlvTransmitPowerLimit(std::shared_ptr<BaseClass> base, bool parse = false, bool swap_needed = false);
+        tlvTransmitPowerLimit(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvTransmitPowerLimit(std::shared_ptr<BaseClass> base, bool parse = false);
         ~tlvTransmitPowerLimit();
 
         const eTlvTypeMap& type();

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -15,12 +15,12 @@
 
 using namespace WSC;
 
-cConfigData::cConfigData(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cConfigData::cConfigData(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cConfigData::cConfigData(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cConfigData::cConfigData(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cConfigData::~cConfigData() {
@@ -236,7 +236,7 @@ bool cConfigData::init()
     }
     m_ssid = (char*)m_buff_ptr__;
     uint16_t ssid_length = *m_ssid_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&ssid_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&ssid_length)); }
     m_ssid_idx__ = ssid_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (ssid_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (ssid_length) << ") Failed!";
@@ -268,7 +268,7 @@ bool cConfigData::init()
     }
     m_network_key = (char*)m_buff_ptr__;
     uint16_t network_key_length = *m_network_key_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&network_key_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&network_key_length)); }
     m_network_key_idx__ = network_key_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (network_key_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (network_key_length) << ") Failed!";
@@ -286,16 +286,16 @@ bool cConfigData::init()
         return false;
     }
     if (!m_parse__) { m_multiap_attr->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 
-cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cWscAttrEncryptedSettings::cWscAttrEncryptedSettings(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cWscAttrEncryptedSettings::~cWscAttrEncryptedSettings() {
@@ -434,7 +434,7 @@ bool cWscAttrEncryptedSettings::init()
     m_encrypted_settings = (char*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_encrypted_settings_idx__ = len/sizeof(char);
         if (!buffPtrIncrementSafe(len)) {
@@ -442,7 +442,7 @@ bool cWscAttrEncryptedSettings::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eWscAttributes::ATTR_ENCR_SETTINGS) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eWscAttributes::ATTR_ENCR_SETTINGS) << ", received value: " << int(*m_type);
@@ -452,12 +452,12 @@ bool cWscAttrEncryptedSettings::init()
     return true;
 }
 
-cWscVendorExtWfa::cWscVendorExtWfa(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cWscVendorExtWfa::cWscVendorExtWfa(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cWscVendorExtWfa::cWscVendorExtWfa(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cWscVendorExtWfa::cWscVendorExtWfa(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cWscVendorExtWfa::~cWscVendorExtWfa() {
@@ -579,7 +579,7 @@ bool cWscVendorExtWfa::init()
     m_vs_data = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_vs_data_idx__ = len/sizeof(uint8_t);
         if (!buffPtrIncrementSafe(len)) {
@@ -587,7 +587,7 @@ bool cWscVendorExtWfa::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/cCmduHeader.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-cCmduHeader::cCmduHeader(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cCmduHeader::cCmduHeader(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cCmduHeader::cCmduHeader(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cCmduHeader::cCmduHeader(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cCmduHeader::~cCmduHeader() {
@@ -109,7 +109,7 @@ bool cCmduHeader::init()
         return false;
     }
     if (!m_parse__) { m_flags->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlv1905NeighborDevice.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlv1905NeighborDevice::tlv1905NeighborDevice(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlv1905NeighborDevice::tlv1905NeighborDevice(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlv1905NeighborDevice::tlv1905NeighborDevice(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlv1905NeighborDevice::tlv1905NeighborDevice(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlv1905NeighborDevice::~tlv1905NeighborDevice() {
@@ -125,7 +125,7 @@ bool tlv1905NeighborDevice::init()
     m_mac_al_1905_device = (sMacAl1905Device*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_mac_al_1905_device_idx__ = len/sizeof(sMacAl1905Device);
         if (!buffPtrIncrementSafe(len)) {
@@ -133,7 +133,7 @@ bool tlv1905NeighborDevice::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_1905_NEIGHBOR_DEVICE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_1905_NEIGHBOR_DEVICE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAlMacAddressType.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvAlMacAddressType::tlvAlMacAddressType(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvAlMacAddressType::tlvAlMacAddressType(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvAlMacAddressType::tlvAlMacAddressType(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvAlMacAddressType::tlvAlMacAddressType(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvAlMacAddressType::~tlvAlMacAddressType() {
@@ -77,7 +77,7 @@ bool tlvAlMacAddressType::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_AL_MAC_ADDRESS_TYPE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AL_MAC_ADDRESS_TYPE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvAutoconfigFreqBand::tlvAutoconfigFreqBand(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvAutoconfigFreqBand::tlvAutoconfigFreqBand(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvAutoconfigFreqBand::tlvAutoconfigFreqBand(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvAutoconfigFreqBand::tlvAutoconfigFreqBand(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvAutoconfigFreqBand::~tlvAutoconfigFreqBand() {
@@ -75,7 +75,7 @@ bool tlvAutoconfigFreqBand::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_AUTOCONFIG_FREQ_BAND) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_AUTOCONFIG_FREQ_BAND) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvDeviceBridgingCapability::tlvDeviceBridgingCapability(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvDeviceBridgingCapability::tlvDeviceBridgingCapability(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvDeviceBridgingCapability::tlvDeviceBridgingCapability(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvDeviceBridgingCapability::tlvDeviceBridgingCapability(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvDeviceBridgingCapability::~tlvDeviceBridgingCapability() {
@@ -67,7 +67,7 @@ std::shared_ptr<cMacList> tlvDeviceBridgingCapability::create_bridging_tuples_li
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<cMacList>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cMacList>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvDeviceBridgingCapability::add_bridging_tuples_list(std::shared_ptr<cMacList> ptr) {
@@ -162,7 +162,7 @@ bool tlvDeviceBridgingCapability::init()
         // swap back since bridging_tuples_list will be swapped as part of the whole class swap
         bridging_tuples_list->class_swap();
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_BRIDGING_CAPABILITY) << ", received value: " << int(*m_type);
@@ -172,12 +172,12 @@ bool tlvDeviceBridgingCapability::init()
     return true;
 }
 
-cMacList::cMacList(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cMacList::cMacList(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cMacList::cMacList(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cMacList::cMacList(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cMacList::~cMacList() {
@@ -261,7 +261,7 @@ bool cMacList::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (mac_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvDeviceInformation::tlvDeviceInformation(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvDeviceInformation::tlvDeviceInformation(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvDeviceInformation::tlvDeviceInformation(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvDeviceInformation::tlvDeviceInformation(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvDeviceInformation::~tlvDeviceInformation() {
@@ -142,7 +142,7 @@ bool tlvDeviceInformation::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sInfo) * (info_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_DEVICE_INFORMATION) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_DEVICE_INFORMATION) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvEndOfMessage.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvEndOfMessage::tlvEndOfMessage(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvEndOfMessage::tlvEndOfMessage(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvEndOfMessage::tlvEndOfMessage(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvEndOfMessage::tlvEndOfMessage(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvEndOfMessage::~tlvEndOfMessage() {
@@ -64,7 +64,7 @@ bool tlvEndOfMessage::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_END_OF_MESSAGE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_END_OF_MESSAGE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvLinkMetricQuery::tlvLinkMetricQuery(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvLinkMetricQuery::tlvLinkMetricQuery(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvLinkMetricQuery::tlvLinkMetricQuery(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvLinkMetricQuery::tlvLinkMetricQuery(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvLinkMetricQuery::~tlvLinkMetricQuery() {
@@ -99,7 +99,7 @@ bool tlvLinkMetricQuery::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eLinkMetricsType); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_LINK_METRIC_QUERY) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_QUERY) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvLinkMetricResultCode::tlvLinkMetricResultCode(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvLinkMetricResultCode::tlvLinkMetricResultCode(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvLinkMetricResultCode::tlvLinkMetricResultCode(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvLinkMetricResultCode::tlvLinkMetricResultCode(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvLinkMetricResultCode::~tlvLinkMetricResultCode() {
@@ -75,7 +75,7 @@ bool tlvLinkMetricResultCode::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_LINK_METRIC_RESULT_CODE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_LINK_METRIC_RESULT_CODE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvMacAddress.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvMacAddress::tlvMacAddress(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvMacAddress::tlvMacAddress(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvMacAddress::tlvMacAddress(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvMacAddress::tlvMacAddress(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvMacAddress::~tlvMacAddress() {
@@ -77,7 +77,7 @@ bool tlvMacAddress::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_mac->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_MAC_ADDRESS) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_MAC_ADDRESS) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvNon1905neighborDeviceList.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvNon1905neighborDeviceList::tlvNon1905neighborDeviceList(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvNon1905neighborDeviceList::tlvNon1905neighborDeviceList(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvNon1905neighborDeviceList::tlvNon1905neighborDeviceList(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvNon1905neighborDeviceList::tlvNon1905neighborDeviceList(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvNon1905neighborDeviceList::~tlvNon1905neighborDeviceList() {
@@ -125,7 +125,7 @@ bool tlvNon1905neighborDeviceList::init()
     m_mac_non_1905_device = (sMacAddr*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_mac_non_1905_device_idx__ = len/sizeof(sMacAddr);
         if (!buffPtrIncrementSafe(len)) {
@@ -133,7 +133,7 @@ bool tlvNon1905neighborDeviceList::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_NON_1905_NEIGHBOR_DEVICE_LIST) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvPushButtonEventNotification::tlvPushButtonEventNotification(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvPushButtonEventNotification::tlvPushButtonEventNotification(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvPushButtonEventNotification::tlvPushButtonEventNotification(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvPushButtonEventNotification::tlvPushButtonEventNotification(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvPushButtonEventNotification::~tlvPushButtonEventNotification() {
@@ -129,7 +129,7 @@ bool tlvPushButtonEventNotification::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMediaType) * (media_type_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_EVENT_NOTIFICATION) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonJoinNotification.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvPushButtonJoinNotification::tlvPushButtonJoinNotification(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvPushButtonJoinNotification::tlvPushButtonJoinNotification(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvPushButtonJoinNotification::tlvPushButtonJoinNotification(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvPushButtonJoinNotification::tlvPushButtonJoinNotification(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvPushButtonJoinNotification::~tlvPushButtonJoinNotification() {
@@ -115,7 +115,7 @@ bool tlvPushButtonJoinNotification::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_iface_mac_of_new_device_joined->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_PUSH_BUTTON_JOIN_NOTIFICATION) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvReceiverLinkMetric.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvReceiverLinkMetric::tlvReceiverLinkMetric(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvReceiverLinkMetric::tlvReceiverLinkMetric(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvReceiverLinkMetric::tlvReceiverLinkMetric(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvReceiverLinkMetric::tlvReceiverLinkMetric(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvReceiverLinkMetric::~tlvReceiverLinkMetric() {
@@ -138,7 +138,7 @@ bool tlvReceiverLinkMetric::init()
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_interface_pair_info_idx__ = len/sizeof(sInterfacePairInfo);
         if (!buffPtrIncrementSafe(len)) {
@@ -146,7 +146,7 @@ bool tlvReceiverLinkMetric::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_RECEIVER_LINK_METRIC) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_RECEIVER_LINK_METRIC) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvSearchedRole::tlvSearchedRole(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSearchedRole::tlvSearchedRole(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSearchedRole::tlvSearchedRole(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSearchedRole::tlvSearchedRole(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSearchedRole::~tlvSearchedRole() {
@@ -75,7 +75,7 @@ bool tlvSearchedRole::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_SEARCHED_ROLE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SEARCHED_ROLE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvSupportedFreqBand::tlvSupportedFreqBand(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSupportedFreqBand::tlvSupportedFreqBand(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSupportedFreqBand::tlvSupportedFreqBand(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSupportedFreqBand::tlvSupportedFreqBand(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSupportedFreqBand::~tlvSupportedFreqBand() {
@@ -75,7 +75,7 @@ bool tlvSupportedFreqBand::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_SUPPORTED_FREQ_BAND) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_FREQ_BAND) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvSupportedRole::tlvSupportedRole(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSupportedRole::tlvSupportedRole(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSupportedRole::tlvSupportedRole(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSupportedRole::tlvSupportedRole(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSupportedRole::~tlvSupportedRole() {
@@ -75,7 +75,7 @@ bool tlvSupportedRole::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eValue); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_SUPPORTED_ROLE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_SUPPORTED_ROLE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvTransmitterLinkMetric.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvTransmitterLinkMetric::tlvTransmitterLinkMetric(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvTransmitterLinkMetric::tlvTransmitterLinkMetric(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvTransmitterLinkMetric::tlvTransmitterLinkMetric(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvTransmitterLinkMetric::tlvTransmitterLinkMetric(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvTransmitterLinkMetric::~tlvTransmitterLinkMetric() {
@@ -138,7 +138,7 @@ bool tlvTransmitterLinkMetric::init()
     m_interface_pair_info = (sInterfacePairInfo*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_interface_pair_info_idx__ = len/sizeof(sInterfacePairInfo);
         if (!buffPtrIncrementSafe(len)) {
@@ -146,7 +146,7 @@ bool tlvTransmitterLinkMetric::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_TRANSMITTER_LINK_METRIC) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_TRANSMITTER_LINK_METRIC) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvUnknown.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvUnknown::tlvUnknown(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvUnknown::tlvUnknown(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvUnknown::tlvUnknown(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvUnknown::tlvUnknown(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvUnknown::~tlvUnknown() {
@@ -104,7 +104,7 @@ bool tlvUnknown::init()
     m_data = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_data_idx__ = len/sizeof(uint8_t);
         if (!buffPtrIncrementSafe(len)) {
@@ -112,7 +112,7 @@ bool tlvUnknown::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvVendorSpecific::tlvVendorSpecific(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvVendorSpecific::tlvVendorSpecific(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvVendorSpecific::tlvVendorSpecific(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvVendorSpecific::tlvVendorSpecific(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvVendorSpecific::~tlvVendorSpecific() {
@@ -118,7 +118,7 @@ bool tlvVendorSpecific::init()
     m_payload = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_payload_idx__ = len/sizeof(uint8_t);
         if (!buffPtrIncrementSafe(len)) {
@@ -126,7 +126,7 @@ bool tlvVendorSpecific::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_VENDOR_SPECIFIC) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_VENDOR_SPECIFIC) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvVendorSpecific.cpp
@@ -29,12 +29,50 @@ const eTlvType& tlvVendorSpecific::type() {
     return (const eTlvType&)(*m_type);
 }
 
-uint16_t& tlvVendorSpecific::length() {
-    return (uint16_t&)(*m_length);
+const uint16_t& tlvVendorSpecific::length() {
+    return (const uint16_t&)(*m_length);
 }
 
 sVendorOUI& tlvVendorSpecific::vendor_oui() {
     return (sVendorOUI&)(*m_vendor_oui);
+}
+
+uint8_t* tlvVendorSpecific::payload(size_t idx) {
+    if ( (m_payload_idx__ <= 0) || (m_payload_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_payload[idx]);
+}
+
+bool tlvVendorSpecific::alloc_payload(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list payload, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_payload;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_payload_idx__ += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
 }
 
 void tlvVendorSpecific::class_swap()
@@ -65,7 +103,7 @@ bool tlvVendorSpecific::init()
         return false;
     }
     m_length = (uint16_t*)m_buff_ptr__;
-    if (!m_parse__) *m_length = 0x3;
+    if (!m_parse__) *m_length = 0;
     if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;
@@ -75,8 +113,26 @@ bool tlvVendorSpecific::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sVendorOUI) << ") Failed!";
         return false;
     }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sVendorOUI); }
     if (!m_parse__) { m_vendor_oui->struct_init(); }
+    m_payload = (uint8_t*)m_buff_ptr__;
+    if (m_length && m_parse__) {
+        size_t len = *m_length;
+        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
+        m_payload_idx__ = len/sizeof(uint8_t);
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
+    }
     if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_VENDOR_SPECIFIC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_VENDOR_SPECIFIC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvWscM1::tlvWscM1(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvWscM1::tlvWscM1(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvWscM1::tlvWscM1(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvWscM1::tlvWscM1(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvWscM1::~tlvWscM1() {
@@ -506,7 +506,7 @@ std::shared_ptr<WSC::cWscVendorExtWfa> tlvWscM1::create_vendor_ext() {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<WSC::cWscVendorExtWfa>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<WSC::cWscVendorExtWfa>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvWscM1::add_vendor_ext(std::shared_ptr<WSC::cWscVendorExtWfa> ptr) {
@@ -718,7 +718,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (manufacturer_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (manufacturer_length) << ") Failed!";
@@ -740,7 +740,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (model_name_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_name_length) << ") Failed!";
@@ -762,7 +762,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (model_number_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_number_length) << ") Failed!";
@@ -784,7 +784,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (serial_number_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (serial_number_length) << ") Failed!";
@@ -813,7 +813,7 @@ bool tlvWscM1::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_device_name = (char*)m_buff_ptr__;
     uint16_t device_name_length = *m_device_name_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
     m_device_name_idx__ = device_name_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (device_name_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (device_name_length) << ") Failed!";
@@ -868,7 +868,7 @@ bool tlvWscM1::init()
         // swap back since vendor_ext will be swapped as part of the whole class swap
         vendor_ext->class_swap();
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_WSC) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -15,12 +15,12 @@
 
 using namespace ieee1905_1;
 
-tlvWscM2::tlvWscM2(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvWscM2::tlvWscM2(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvWscM2::tlvWscM2(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvWscM2::tlvWscM2(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvWscM2::~tlvWscM2() {
@@ -517,7 +517,7 @@ std::shared_ptr<WSC::cWscAttrEncryptedSettings> tlvWscM2::create_encrypted_setti
         std::copy_n(src, move_length, dst);
     }
     m_authenticator = (WSC::sWscAttrAuthenticator *)((uint8_t *)(m_authenticator) + len);
-    return std::make_shared<WSC::cWscAttrEncryptedSettings>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<WSC::cWscAttrEncryptedSettings>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvWscM2::add_encrypted_settings(std::shared_ptr<WSC::cWscAttrEncryptedSettings> ptr) {
@@ -729,7 +729,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_manufacturer = (char*)m_buff_ptr__;
     uint16_t manufacturer_length = *m_manufacturer_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&manufacturer_length)); }
     m_manufacturer_idx__ = manufacturer_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (manufacturer_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (manufacturer_length) << ") Failed!";
@@ -751,7 +751,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_name = (char*)m_buff_ptr__;
     uint16_t model_name_length = *m_model_name_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_name_length)); }
     m_model_name_idx__ = model_name_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (model_name_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_name_length) << ") Failed!";
@@ -773,7 +773,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_model_number = (char*)m_buff_ptr__;
     uint16_t model_number_length = *m_model_number_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&model_number_length)); }
     m_model_number_idx__ = model_number_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (model_number_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (model_number_length) << ") Failed!";
@@ -795,7 +795,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_serial_number = (char*)m_buff_ptr__;
     uint16_t serial_number_length = *m_serial_number_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&serial_number_length)); }
     m_serial_number_idx__ = serial_number_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (serial_number_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (serial_number_length) << ") Failed!";
@@ -824,7 +824,7 @@ bool tlvWscM2::init()
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
     m_device_name = (char*)m_buff_ptr__;
     uint16_t device_name_length = *m_device_name_length;
-    if (m_parse__ && m_swap__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&device_name_length)); }
     m_device_name_idx__ = device_name_length;
     if (!buffPtrIncrementSafe(sizeof(char) * (device_name_length))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (device_name_length) << ") Failed!";
@@ -893,7 +893,7 @@ bool tlvWscM2::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrAuthenticator); }
     if (!m_parse__) { m_authenticator->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvType::TLV_WSC) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -13,12 +13,12 @@
 #include <tlvf/test/tlvVarList.h>
 #include <tlvf/tlvflogging.h>
 
-tlvTestVarList::tlvTestVarList(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvTestVarList::tlvTestVarList(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvTestVarList::tlvTestVarList(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvTestVarList::tlvTestVarList(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvTestVarList::~tlvTestVarList() {
@@ -197,7 +197,7 @@ std::shared_ptr<cInner> tlvTestVarList::create_complex_list() {
     m_var3 = (cInner *)((uint8_t *)(m_var3) + len);
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len);
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
-    return std::make_shared<cInner>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cInner>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvTestVarList::add_complex_list(std::shared_ptr<cInner> ptr) {
@@ -271,7 +271,7 @@ std::shared_ptr<cInner> tlvTestVarList::create_var1() {
     m_var3 = (cInner *)((uint8_t *)(m_var3) + len);
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len);
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
-    return std::make_shared<cInner>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cInner>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvTestVarList::add_var1(std::shared_ptr<cInner> ptr) {
@@ -327,7 +327,7 @@ std::shared_ptr<cInner> tlvTestVarList::create_var3() {
     }
     m_var2 = (uint32_t *)((uint8_t *)(m_var2) + len);
     m_unknown_length_list = (cInner *)((uint8_t *)(m_unknown_length_list) + len);
-    return std::make_shared<cInner>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cInner>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvTestVarList::add_var3(std::shared_ptr<cInner> ptr) {
@@ -405,7 +405,7 @@ std::shared_ptr<cInner> tlvTestVarList::create_unknown_length_list() {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<cInner>(getBuffPtr(), getBuffRemainingBytes(), m_parse__, m_swap__);
+    return std::make_shared<cInner>(getBuffPtr(), getBuffRemainingBytes(), m_parse__);
 }
 
 bool tlvTestVarList::add_unknown_length_list(std::shared_ptr<cInner> ptr) {
@@ -581,7 +581,7 @@ bool tlvTestVarList::init()
     m_unknown_length_list = (cInner*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         while (len > 0) {
             if (len < cInner::get_initial_size()) {
@@ -602,7 +602,7 @@ bool tlvTestVarList::init()
             len -= unknown_length_list->getLen();
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != 0xff) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0xff) << ", received value: " << int(*m_type);
@@ -612,12 +612,12 @@ bool tlvTestVarList::init()
     return true;
 }
 
-cInner::cInner(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cInner::cInner(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cInner::cInner(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cInner::cInner(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cInner::~cInner() {
@@ -790,7 +790,7 @@ bool cInner::init()
     m_unknown_length_list_inner = (char*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_unknown_length_list_inner_idx__ = len/sizeof(char);
         if (!buffPtrIncrementSafe(len)) {
@@ -798,7 +798,7 @@ bool cInner::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != 0x1) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(0x1) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApCapability.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvApCapability::tlvApCapability(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvApCapability::tlvApCapability(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvApCapability::tlvApCapability(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvApCapability::tlvApCapability(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvApCapability::~tlvApCapability() {
@@ -77,7 +77,7 @@ bool tlvApCapability::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sValue); }
     if (!m_parse__) { m_value->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_CAPABILITY) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_CAPABILITY) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetric.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvApMetric::tlvApMetric(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvApMetric::tlvApMetric(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvApMetric::tlvApMetric(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvApMetric::tlvApMetric(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvApMetric::~tlvApMetric() {
@@ -154,7 +154,7 @@ bool tlvApMetric::init()
     m_estimated_service_info_field = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_estimated_service_info_field_idx__ = len/sizeof(uint8_t);
         if (!buffPtrIncrementSafe(len)) {
@@ -162,7 +162,7 @@ bool tlvApMetric::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_METRIC) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_METRIC) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvApMetricQuery::tlvApMetricQuery(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvApMetricQuery::tlvApMetricQuery(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvApMetricQuery::tlvApMetricQuery(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvApMetricQuery::tlvApMetricQuery(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvApMetricQuery::~tlvApMetricQuery() {
@@ -129,7 +129,7 @@ bool tlvApMetricQuery::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (bssid_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_METRIC_QUERY) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_METRIC_QUERY) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvApRadioBasicCapabilities::tlvApRadioBasicCapabilities(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvApRadioBasicCapabilities::tlvApRadioBasicCapabilities(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvApRadioBasicCapabilities::tlvApRadioBasicCapabilities(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvApRadioBasicCapabilities::tlvApRadioBasicCapabilities(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvApRadioBasicCapabilities::~tlvApRadioBasicCapabilities() {
@@ -75,7 +75,7 @@ std::shared_ptr<cOperatingClassesInfo> tlvApRadioBasicCapabilities::create_opera
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<cOperatingClassesInfo>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cOperatingClassesInfo>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvApRadioBasicCapabilities::add_operating_classes_info_list(std::shared_ptr<cOperatingClassesInfo> ptr) {
@@ -186,7 +186,7 @@ bool tlvApRadioBasicCapabilities::init()
         // swap back since operating_classes_info_list will be swapped as part of the whole class swap
         operating_classes_info_list->class_swap();
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_BASIC_CAPABILITIES) << ", received value: " << int(*m_type);
@@ -196,12 +196,12 @@ bool tlvApRadioBasicCapabilities::init()
     return true;
 }
 
-cOperatingClassesInfo::cOperatingClassesInfo(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cOperatingClassesInfo::cOperatingClassesInfo(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cOperatingClassesInfo::cOperatingClassesInfo(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cOperatingClassesInfo::cOperatingClassesInfo(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cOperatingClassesInfo::~cOperatingClassesInfo() {
@@ -298,7 +298,7 @@ bool cOperatingClassesInfo::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (statically_non_operable_channels_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioIdentifier.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvApRadioIdentifier::tlvApRadioIdentifier(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvApRadioIdentifier::tlvApRadioIdentifier(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvApRadioIdentifier::tlvApRadioIdentifier(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvApRadioIdentifier::tlvApRadioIdentifier(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvApRadioIdentifier::~tlvApRadioIdentifier() {
@@ -77,7 +77,7 @@ bool tlvApRadioIdentifier::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_radio_uid->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_RADIO_IDENTIFIER) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvChannelPreference::tlvChannelPreference(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvChannelPreference::tlvChannelPreference(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvChannelPreference::tlvChannelPreference(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvChannelPreference::tlvChannelPreference(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvChannelPreference::~tlvChannelPreference() {
@@ -71,7 +71,7 @@ std::shared_ptr<cPreferenceOperatingClasses> tlvChannelPreference::create_operat
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<cPreferenceOperatingClasses>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cPreferenceOperatingClasses>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvChannelPreference::add_operating_classes_list(std::shared_ptr<cPreferenceOperatingClasses> ptr) {
@@ -175,7 +175,7 @@ bool tlvChannelPreference::init()
         // swap back since operating_classes_list will be swapped as part of the whole class swap
         operating_classes_list->class_swap();
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_CHANNEL_PREFERENCE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_PREFERENCE) << ", received value: " << int(*m_type);
@@ -185,12 +185,12 @@ bool tlvChannelPreference::init()
     return true;
 }
 
-cPreferenceOperatingClasses::cPreferenceOperatingClasses(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cPreferenceOperatingClasses::cPreferenceOperatingClasses(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cPreferenceOperatingClasses::cPreferenceOperatingClasses(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cPreferenceOperatingClasses::cPreferenceOperatingClasses(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cPreferenceOperatingClasses::~cPreferenceOperatingClasses() {
@@ -290,7 +290,7 @@ bool cPreferenceOperatingClasses::init()
         return false;
     }
     if (!m_parse__) { m_flags->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvChannelSelectionResponse::tlvChannelSelectionResponse(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvChannelSelectionResponse::tlvChannelSelectionResponse(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvChannelSelectionResponse::tlvChannelSelectionResponse(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvChannelSelectionResponse::tlvChannelSelectionResponse(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvChannelSelectionResponse::~tlvChannelSelectionResponse() {
@@ -88,7 +88,7 @@ bool tlvChannelSelectionResponse::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eResponseCode); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CHANNEL_SELECTION_RESPONSE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvClientAssociationControlRequest::tlvClientAssociationControlRequest(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvClientAssociationControlRequest::tlvClientAssociationControlRequest(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvClientAssociationControlRequest::tlvClientAssociationControlRequest(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvClientAssociationControlRequest::tlvClientAssociationControlRequest(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvClientAssociationControlRequest::~tlvClientAssociationControlRequest() {
@@ -165,7 +165,7 @@ bool tlvClientAssociationControlRequest::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) * (sta_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_CLIENT_ASSOCIATION_CONTROL_REQUEST) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CLIENT_ASSOCIATION_CONTROL_REQUEST) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvClientAssociationEvent::tlvClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvClientAssociationEvent::tlvClientAssociationEvent(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvClientAssociationEvent::tlvClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvClientAssociationEvent::tlvClientAssociationEvent(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvClientAssociationEvent::~tlvClientAssociationEvent() {
@@ -101,7 +101,7 @@ bool tlvClientAssociationEvent::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eAssociationEvent); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_CLIENT_ASSOCIATION_EVENT) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CLIENT_ASSOCIATION_EVENT) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvHigherLayerData::tlvHigherLayerData(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvHigherLayerData::tlvHigherLayerData(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvHigherLayerData::tlvHigherLayerData(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvHigherLayerData::tlvHigherLayerData(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvHigherLayerData::~tlvHigherLayerData() {
@@ -116,7 +116,7 @@ bool tlvHigherLayerData::init()
     m_payload = (uint8_t*)m_buff_ptr__;
     if (m_length && m_parse__) {
         size_t len = *m_length;
-        if (m_swap__) { tlvf_swap(16, reinterpret_cast<uint8_t*>(&len)); }
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
         len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
         m_payload_idx__ = len/sizeof(uint8_t);
         if (!buffPtrIncrementSafe(len)) {
@@ -124,7 +124,7 @@ bool tlvHigherLayerData::init()
             return false;
         }
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_HIGHER_LAYER_DATA) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_HIGHER_LAYER_DATA) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvOperatingChannelReport::tlvOperatingChannelReport(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvOperatingChannelReport::tlvOperatingChannelReport(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvOperatingChannelReport::tlvOperatingChannelReport(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvOperatingChannelReport::tlvOperatingChannelReport(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvOperatingChannelReport::~tlvOperatingChannelReport() {
@@ -154,7 +154,7 @@ bool tlvOperatingChannelReport::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(int8_t); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_OPERATING_CHANNEL_REPORT) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvRadioOperationRestriction::tlvRadioOperationRestriction(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvRadioOperationRestriction::tlvRadioOperationRestriction(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvRadioOperationRestriction::tlvRadioOperationRestriction(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvRadioOperationRestriction::tlvRadioOperationRestriction(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvRadioOperationRestriction::~tlvRadioOperationRestriction() {
@@ -71,7 +71,7 @@ std::shared_ptr<cRestrictedOperatingClasses> tlvRadioOperationRestriction::creat
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
-    return std::make_shared<cRestrictedOperatingClasses>(src, getBuffRemainingBytes(src), m_parse__, m_swap__);
+    return std::make_shared<cRestrictedOperatingClasses>(src, getBuffRemainingBytes(src), m_parse__);
 }
 
 bool tlvRadioOperationRestriction::add_operating_classes_list(std::shared_ptr<cRestrictedOperatingClasses> ptr) {
@@ -175,7 +175,7 @@ bool tlvRadioOperationRestriction::init()
         // swap back since operating_classes_list will be swapped as part of the whole class swap
         operating_classes_list->class_swap();
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_RADIO_OPERATION_RESTRICTION) << ", received value: " << int(*m_type);
@@ -185,12 +185,12 @@ bool tlvRadioOperationRestriction::init()
     return true;
 }
 
-cRestrictedOperatingClasses::cRestrictedOperatingClasses(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+cRestrictedOperatingClasses::cRestrictedOperatingClasses(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-cRestrictedOperatingClasses::cRestrictedOperatingClasses(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+cRestrictedOperatingClasses::cRestrictedOperatingClasses(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 cRestrictedOperatingClasses::~cRestrictedOperatingClasses() {
@@ -284,7 +284,7 @@ bool cRestrictedOperatingClasses::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sChannelInfo) * (channel_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     return true;
 }
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSearchedService.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvSearchedService::tlvSearchedService(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSearchedService::tlvSearchedService(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSearchedService::tlvSearchedService(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSearchedService::tlvSearchedService(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSearchedService::~tlvSearchedService() {
@@ -123,7 +123,7 @@ bool tlvSearchedService::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eSearchedService) * (searched_service_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_SEARCHED_SERVICE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SEARCHED_SERVICE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringBTMReport.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvSteeringBTMReport::tlvSteeringBTMReport(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSteeringBTMReport::tlvSteeringBTMReport(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSteeringBTMReport::tlvSteeringBTMReport(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSteeringBTMReport::tlvSteeringBTMReport(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSteeringBTMReport::~tlvSteeringBTMReport() {
@@ -114,7 +114,7 @@ bool tlvSteeringBTMReport::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
     if (!m_parse__) { m_target_bssid->struct_init(); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_STEERING_BTM_REPORT) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_STEERING_BTM_REPORT) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvSteeringRequest::tlvSteeringRequest(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSteeringRequest::tlvSteeringRequest(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSteeringRequest::tlvSteeringRequest(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSteeringRequest::tlvSteeringRequest(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSteeringRequest::~tlvSteeringRequest() {
@@ -245,7 +245,7 @@ bool tlvSteeringRequest::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sTargetBssidInfo) * (target_bssid_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_STEERING_REQUEST) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_STEERING_REQUEST) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSupportedService.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvSupportedService::tlvSupportedService(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvSupportedService::tlvSupportedService(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvSupportedService::tlvSupportedService(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvSupportedService::tlvSupportedService(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvSupportedService::~tlvSupportedService() {
@@ -123,7 +123,7 @@ bool tlvSupportedService::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eSupportedService) * (supported_service_list_length) << ") Failed!";
         return false;
     }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_SUPPORTED_SERVICE) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_SUPPORTED_SERVICE) << ", received value: " << int(*m_type);

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvTransmitPowerLimit.cpp
@@ -15,12 +15,12 @@
 
 using namespace wfa_map;
 
-tlvTransmitPowerLimit::tlvTransmitPowerLimit(uint8_t* buff, size_t buff_len, bool parse, bool swap_needed) :
-    BaseClass(buff, buff_len, parse, swap_needed) {
+tlvTransmitPowerLimit::tlvTransmitPowerLimit(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
     m_init_succeeded = init();
 }
-tlvTransmitPowerLimit::tlvTransmitPowerLimit(std::shared_ptr<BaseClass> base, bool parse, bool swap_needed) :
-BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse, swap_needed){
+tlvTransmitPowerLimit::tlvTransmitPowerLimit(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
     m_init_succeeded = init();
 }
 tlvTransmitPowerLimit::~tlvTransmitPowerLimit() {
@@ -88,7 +88,7 @@ bool tlvTransmitPowerLimit::init()
         return false;
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
-    if (m_parse__ && m_swap__) { class_swap(); }
+    if (m_parse__) { class_swap(); }
     if (m_parse__) {
         if (*m_type != eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) {
             TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT) << ", received value: " << int(*m_type);

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -16,8 +16,7 @@
 
 class BaseClass {
 protected:
-    BaseClass(uint8_t *buff_, const size_t buff_len_, const bool parse_ = false,
-              const bool swap_needed = false);
+    BaseClass(uint8_t *buff_, const size_t buff_len_, const bool parse_ = false);
     ~BaseClass();
 
 public:
@@ -35,7 +34,6 @@ protected:
     uint8_t *m_buff_ptr__;
     const size_t m_buff_len__;
     const bool m_parse__;
-    const bool m_swap__;
     bool m_init_succeeded = false;
 
 private:

--- a/framework/tlvf/src/include/tlvf/BaseClass.h
+++ b/framework/tlvf/src/include/tlvf/BaseClass.h
@@ -25,7 +25,6 @@ public:
     uint8_t *getStartBuffPtr();
     size_t getBuffRemainingBytes(void *start = nullptr);
     bool buffPtrIncrementSafe(size_t length);
-
     size_t getLen();
     bool isInitialized();
     virtual bool isPostInitSucceeded() { return true; };
@@ -38,6 +37,19 @@ protected:
     const bool m_parse__;
     const bool m_swap__;
     bool m_init_succeeded = false;
+
+private:
+    /**
+     * @brief trim buffer by tailroom size
+     *
+     * This is intended to be used __only__ by friend class TlvList on finalize
+     * When resizing buffers.
+     *
+     * @param tailroom size to trim
+     * @return true on success
+     * @return false on failure
+     */
+    friend void trim(BaseClass &obj, size_t tailroom) { obj.m_buff_ptr__ -= tailroom; };
 };
 
 #endif //_BaseClass_H_

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -31,10 +31,6 @@ public:
     TlvList tlvs;
 
     template <class T> std::shared_ptr<T> addClass() { return tlvs.addClass<T>(); }
-    template <class T> std::shared_ptr<T> dynamicCast(std::shared_ptr<BaseClass> ptr) const
-    {
-        return tlvs.dynamicCast<T>(ptr);
-    }
 
     /**
      * @brief Get the Class object at index idx in the all classes array

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -10,11 +10,10 @@
 #define _CmduMessage_H_
 
 #include <memory>
-#include <tlvf/ieee_1905_1/cCmduHeader.h>
-#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
-#include <tlvf/ieee_1905_1/eTlvType.h>
 #include <tlvf/TlvList.h>
-#include <memory>
+#include <tlvf/ieee_1905_1/cCmduHeader.h>
+#include <tlvf/ieee_1905_1/eTlvType.h>
+#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <vector>
 
 namespace ieee1905_1 {
@@ -48,7 +47,10 @@ public:
      * @param idx index in the class T array
      * @return std::shared_ptr<T> to the T class at index `idx` in the class T array
      */
-    template <class T> std::shared_ptr<T> getClass(size_t idx) const { return tlvs.getClass<T>(idx); }
+    template <class T> std::shared_ptr<T> getClass(size_t idx) const
+    {
+        return tlvs.getClass<T>(idx);
+    }
 
     /**
      * @brief Get the number of classes of type T
@@ -70,7 +72,7 @@ public:
     uint16_t getNextTlvLength() const;
     uint8_t *getNextTlvData() const;
     void swap();
-    bool swap_needed() {return tlvs.swap_needed(); }
+    bool swap_needed() { return tlvs.swap_needed(); }
     bool is_finalized() const { return tlvs.is_finalized(); };
     bool is_swapped() const { return tlvs.is_swapped(); };
     eMessageType getMessageType();
@@ -88,7 +90,8 @@ private:
     // a TLV max size can't be larger than the MTU - CMDU header length - EOM TLV length.
     // However, when the CMDU is sent internally via UDS, this restriction does not apply.
     // So we allo changing it via set_max_tlv_length() API.
-    size_t m_max_tlv_length = kMaxCmduLength - kCmduHeaderLength - ieee1905_1::tlvEndOfMessage::get_initial_size();
+    size_t m_max_tlv_length =
+        kMaxCmduLength - kCmduHeaderLength - ieee1905_1::tlvEndOfMessage::get_initial_size();
 };
 
 }; // namespace ieee1905_1

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <tlvf/ieee_1905_1/cCmduHeader.h>
+#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <tlvf/ieee_1905_1/eTlvType.h>
 #include <tlvf/TlvList.h>
 #include <memory>
@@ -86,10 +87,20 @@ public:
     bool is_swapped() const { return tlvs.is_swapped(); };
     eMessageType getMessageType();
     uint16_t getMessageId();
+    void set_max_tlv_length(size_t length) { m_max_tlv_length = length; };
+    size_t max_tlv_length() { return m_max_tlv_length; };
 
     static const uint16_t kCmduHeaderLength;
     static const uint16_t kTlvHeaderLength;
     static const size_t kMaxCmduLength;
+
+private:
+    // By default, we assume that the CMDU will be sent over the ieee1905_1 transport.
+    // Since the ieee1905_1 transport only supports CMDU fragmantation on TLVs boundaries,
+    // a TLV max size can't be larger than the MTU - CMDU header length - EOM TLV length.
+    // However, when the CMDU is sent internally via UDS, this restriction does not apply.
+    // So we allo changing it via set_max_tlv_length() API.
+    size_t m_max_tlv_length = kMaxCmduLength - kCmduHeaderLength - ieee1905_1::tlvEndOfMessage::get_initial_size();
 };
 
 }; // namespace ieee1905_1

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -33,14 +33,6 @@ public:
     template <class T> std::shared_ptr<T> addClass() { return tlvs.addClass<T>(); }
 
     /**
-     * @brief Get the Class object at index idx in the all classes array
-     * 
-     * @param idx index in the all classes array
-     * @return std::shared_ptr<BaseClass> to the class object at index idx, nullptr if not found
-     */
-    std::shared_ptr<BaseClass> getClass(size_t idx) const { return tlvs.getClass(idx);}
-
-    /**
      * @brief Get the (first) Class object
      * 
      * @tparam T class template
@@ -65,7 +57,7 @@ public:
      * @return size_t number of classes of type T
      */
     template <class T> size_t getClassCount() const { return tlvs.getClassCount<T>(); }
-    size_t getClassCount() const { return tlvs.getClassCount(); }
+
     const std::vector<std::shared_ptr<BaseClass>> &getClassVector() const
     {
         return tlvs.getClassVector();

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -72,7 +72,6 @@ public:
     uint16_t getNextTlvLength() const;
     uint8_t *getNextTlvData() const;
     void swap();
-    bool swap_needed() { return tlvs.swap_needed(); }
     bool is_finalized() const { return tlvs.is_finalized(); };
     bool is_swapped() const { return tlvs.is_swapped(); };
     eMessageType getMessageType();

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -12,6 +12,8 @@
 #include <memory>
 #include <tlvf/ieee_1905_1/cCmduHeader.h>
 #include <tlvf/ieee_1905_1/eTlvType.h>
+#include <tlvf/TlvList.h>
+#include <memory>
 #include <vector>
 
 namespace ieee1905_1 {
@@ -19,34 +21,19 @@ namespace ieee1905_1 {
 class CmduMessage {
 
 public:
-    CmduMessage();
+    CmduMessage() = delete;
+    CmduMessage(uint8_t *buff, size_t buff_len);
     ~CmduMessage();
 
-public:
     std::shared_ptr<cCmduHeader> getCmduHeader() const;
 
-    template <class T, class = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
-    std::shared_ptr<T> addClass()
-    {
-        std::shared_ptr<T> ptr;
-        if (m_cmdu_header) {
-            if (m_class_vector.size() == 0) {
-                ptr = std::make_shared<T>(m_cmdu_header, m_parse, m_swap);
-            } else {
-                ptr = std::make_shared<T>(m_class_vector.back(), m_parse, m_swap);
-            }
-            if (!ptr || ptr->isInitialized() == false) {
-                return std::shared_ptr<T>();
-            } else {
-                m_class_vector.push_back(std::shared_ptr<BaseClass>(ptr));
-            }
-        } else {
-            return std::shared_ptr<T>();
-        }
-        return ptr;
-    }
+    TlvList tlvs;
 
-    static uint16_t getCmduHeaderLength() { return kCmduHeaderLength; }
+    template <class T> std::shared_ptr<T> addClass() { return tlvs.addClass<T>(); }
+    template <class T> std::shared_ptr<T> dynamicCast(std::shared_ptr<BaseClass> ptr) const
+    {
+        return tlvs.dynamicCast<T>(ptr);
+    }
 
     /**
      * @brief Get the Class object at index idx in the all classes array
@@ -54,7 +41,7 @@ public:
      * @param idx index in the all classes array
      * @return std::shared_ptr<BaseClass> to the class object at index idx, nullptr if not found
      */
-    std::shared_ptr<BaseClass> getClass(size_t idx) const;
+    std::shared_ptr<BaseClass> getClass(size_t idx) const { return tlvs.getClass(idx);}
 
     /**
      * @brief Get the (first) Class object
@@ -62,14 +49,7 @@ public:
      * @tparam T class template
      * @return std::shared_ptr<T> to the first object found of type T, nullptr if not found
      */
-    template <class T> std::shared_ptr<T> getClass() const
-    {
-        for (size_t idx = 0; idx < getClassCount(); idx++) {
-            if (auto c = std::dynamic_pointer_cast<T>(getClass(idx)))
-                return c;
-        }
-        return nullptr;
-    }
+    template <class T> std::shared_ptr<T> getClass() const { return tlvs.getClass<T>(); }
 
     /**
      * @brief Get a class object of type T in index `idx` in the logical array containing
@@ -79,17 +59,7 @@ public:
      * @param idx index in the class T array
      * @return std::shared_ptr<T> to the T class at index `idx` in the class T array
      */
-    template <class T> std::shared_ptr<T> getClass(size_t idx) const
-    {
-        size_t idx_ = 0;
-        for (size_t i = 0; i < getClassCount(); i++) {
-            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
-                if (idx_++ == idx)
-                    return c;
-            }
-        }
-        return nullptr;
-    }
+    template <class T> std::shared_ptr<T> getClass(size_t idx) const { return tlvs.getClass<T>(idx); }
 
     /**
      * @brief Get the number of classes of type T
@@ -97,19 +67,12 @@ public:
      * @tparam T class template
      * @return size_t number of classes of type T
      */
-    template <class T> size_t getClassCount() const
+    template <class T> size_t getClassCount() const { return tlvs.getClassCount<T>(); }
+    size_t getClassCount() const { return tlvs.getClassCount(); }
+    const std::vector<std::shared_ptr<BaseClass>> &getClassVector() const
     {
-        size_t count = 0;
-        for (size_t i = 0; i < getClassCount(); i++) {
-            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
-                count++;
-            }
-        }
-        return count;
+        return tlvs.getClassVector();
     }
-
-    size_t getClassCount() const;
-    const std::vector<std::shared_ptr<BaseClass>> &getClassVector() const;
     size_t getMessageLength() const;
     size_t getMessageBuffLength() const;
     uint8_t *getMessageBuff() const;
@@ -118,26 +81,15 @@ public:
     uint16_t getNextTlvLength() const;
     uint8_t *getNextTlvData() const;
     void swap();
-    bool swap_needed() { return m_swap; }
-    bool is_finalized() const { return m_finalized; };
-    bool is_swapped() const { return m_swapped; };
+    bool swap_needed() {return tlvs.swap_needed(); }
+    bool is_finalized() const { return tlvs.is_finalized(); };
+    bool is_swapped() const { return tlvs.is_swapped(); };
     eMessageType getMessageType();
     uint16_t getMessageId();
 
-protected:
-    void reset();
-
-    size_t m_buff_len            = 0;
-    bool m_finalized             = false;
-    bool m_swapped               = false;
-    bool m_parse                 = false;
-    bool m_swap                  = false;
-    bool m_dynamically_allocated = false;
-    uint8_t *m_buff              = nullptr;
-    std::shared_ptr<cCmduHeader> m_cmdu_header;
-    std::vector<std::shared_ptr<BaseClass>> m_class_vector;
-    static const uint16_t kCmduHeaderLength = 8;
-    static const uint16_t kTlvHeaderLength  = 3;
+    static const uint16_t kCmduHeaderLength;
+    static const uint16_t kTlvHeaderLength;
+    static const size_t kMaxCmduLength;
 };
 
 }; // namespace ieee1905_1

--- a/framework/tlvf/src/include/tlvf/CmduMessageRx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageRx.h
@@ -22,14 +22,14 @@ class CmduParser;
 class CmduMessageRx : public CmduMessage {
 
 public:
-    CmduMessageRx();
-    CmduMessageRx(CmduMessageRx &original);
+    CmduMessageRx() = delete;
+    CmduMessageRx(uint8_t *buff, size_t buff_len);
     ~CmduMessageRx();
-    bool parse(uint8_t *buff, size_t buff_len, bool swap_needed = true, bool parse_tlvs = false);
+    bool parse(bool swap_needed = true, bool parse_tlvs = false);
     CmduMessageRx &operator=(const CmduMessageRx &) = delete;
 
 private:
-    std::list<std::shared_ptr<CmduParser>> parsers_;
+    std::shared_ptr<CmduParser> parser;
 };
 
 }; // namespace ieee1905_1

--- a/framework/tlvf/src/include/tlvf/CmduMessageRx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageRx.h
@@ -25,7 +25,7 @@ public:
     CmduMessageRx() = delete;
     CmduMessageRx(uint8_t *buff, size_t buff_len);
     ~CmduMessageRx();
-    bool parse(bool swap_needed = true, bool parse_tlvs = false);
+    bool parse(bool parse_tlvs = false);
     CmduMessageRx &operator=(const CmduMessageRx &) = delete;
 
 private:

--- a/framework/tlvf/src/include/tlvf/CmduMessageTx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageTx.h
@@ -20,7 +20,6 @@ public:
     CmduMessageTx(uint8_t *buff, size_t buff_len);
     ~CmduMessageTx();
 
-public:
     std::shared_ptr<cCmduHeader> create(uint16_t id, eMessageType message_type);
     std::shared_ptr<cCmduHeader> load();
     std::shared_ptr<tlvVendorSpecific> add_vs_tlv(tlvVendorSpecific::eVendorOUI voui);

--- a/framework/tlvf/src/include/tlvf/CmduMessageTx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageTx.h
@@ -24,7 +24,7 @@ public:
     std::shared_ptr<cCmduHeader> load();
     std::shared_ptr<tlvVendorSpecific> add_vs_tlv(tlvVendorSpecific::eVendorOUI voui);
 
-    bool finalize(bool swap_needed);
+    bool finalize();
 };
 
 }; // namespace ieee1905_1

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -18,6 +18,11 @@
 
 namespace ieee1905_1 {
 
+typedef struct TlvHeader {
+    uint8_t type;
+    uint16_t length;
+} __attribute__((packed)) TlvHeader;
+
 class TlvList {
 
 public:

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -10,11 +10,11 @@
 #ifndef _TlvList_H_
 #define _TlvList_H_
 
-#include <tlvf/ieee_1905_1/eTlvType.h>
 #include <memory>
-#include <vector>
-#include <unordered_map>
 #include <tlvf/BaseClass.h>
+#include <tlvf/ieee_1905_1/eTlvType.h>
+#include <unordered_map>
+#include <vector>
 
 namespace ieee1905_1 {
 
@@ -58,10 +58,7 @@ public:
      * @tparam T class template
      * @return std::shared_ptr<T> to the first object found of type T, nullptr if not found
      */
-    template <class T> std::shared_ptr<T> getClass() const
-    {
-        return getClass<T>(0);
-    }
+    template <class T> std::shared_ptr<T> getClass() const { return getClass<T>(0); }
 
     /**
      * @brief Get a class object of type T in index `idx` in the logical array containing
@@ -105,7 +102,7 @@ public:
     size_t getMessageBuffLength() const;
     uint8_t *getMessageBuff() const;
     void swap();
-    bool swap_needed() {return m_swap; }
+    bool swap_needed() { return m_swap; }
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
     virtual bool finalize(bool swap_needed);
@@ -114,17 +111,15 @@ public:
     {
         m_inner_tlv_lists[type] = list;
     }
-    template <class T> std::shared_ptr<T>
-    getInnerTlvList(eTlvType type)
+    template <class T> std::shared_ptr<T> getInnerTlvList(eTlvType type)
     {
         return std::dynamic_pointer_cast<T>(m_inner_tlv_lists[type]);
     }
 
 protected:
-
-    uint8_t * const m_buff;
+    uint8_t *const m_buff;
     size_t m_buff_len;
-    
+
     bool m_parse                 = false;
     bool m_swap                  = false;
     bool m_finalized             = false;
@@ -145,8 +140,7 @@ private:
      * @param idx TLV index out of all TLVs with the same type
      * @return pointer to a TlvHeader structure if found, nullptr otherwise
      */
-    std::shared_ptr<BaseClass>
-    getTlv(eTlvType type, size_t idx = 0)
+    std::shared_ptr<BaseClass> getTlv(eTlvType type, size_t idx = 0)
     {
         size_t idx_ = 0;
         for (auto it : m_class_vector) {
@@ -183,6 +177,6 @@ private:
     friend void trim(BaseClass &obj, size_t tailroom);
 };
 
-}; // close namespace: ieee1905_1
+}; // namespace ieee1905_1
 
 #endif //_TlvList_H_

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019 Arnout Vandecappelle (Essensium/Mind)
+ * Copyright (c) 2019 Tomer Eliyahu (Intel)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TlvList_H_
+#define _TlvList_H_
+
+#include <tlvf/ieee_1905_1/eTlvType.h>
+#include <memory>
+#include <vector>
+#include <tlvf/BaseClass.h>
+
+namespace ieee1905_1 {
+
+class TlvList {
+
+public:
+    TlvList() = delete;
+    TlvList(uint8_t *buff, size_t buff_len, bool parse = false, bool swap = false);
+
+    ~TlvList();
+
+public:
+    template <class T> std::shared_ptr<T> addClass()
+    {
+        std::shared_ptr<T> ptr;
+        if (m_buff) {
+            if (m_class_vector.size() == 0) {
+                ptr = std::make_shared<T>(m_buff, m_buff_len, m_parse, m_swap);
+            } else {
+                ptr = std::make_shared<T>(m_class_vector.back(), m_parse, m_swap);
+            }
+            if (!ptr || ptr->isInitialized() == false) {
+                return std::shared_ptr<T>();
+            } else {
+                m_class_vector.push_back(std::shared_ptr<BaseClass>(ptr));
+            }
+        } else {
+            return std::shared_ptr<T>();
+        }
+        return ptr;
+    }
+
+    template <class T> std::shared_ptr<T> dynamicCast(std::shared_ptr<BaseClass> ptr) const
+    {
+        return std::dynamic_pointer_cast<T>(ptr);
+    }
+
+    /**
+     * @brief Get the Class object at index idx in the all classes array
+     *
+     * @param idx index in the all classes array
+     * @return std::shared_ptr<BaseClass> to the class object at index idx, nullptr if not found
+     */
+    std::shared_ptr<BaseClass> getClass(size_t idx) const;
+
+    /**
+     * @brief Get the (first) Class object
+     *
+     * @tparam T class template
+     * @return std::shared_ptr<T> to the first object found of type T, nullptr if not found
+     */
+    template <class T> std::shared_ptr<T> getClass() const
+    {
+        for (size_t idx = 0; idx < getClassCount(); idx++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(idx)))
+                return c;
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Get a class object of type T in index `idx` in the logical array containing
+     *        all classes of type T.
+     *
+     * @tparam T class template
+     * @param idx index in the class T array
+     * @return std::shared_ptr<T> to the T class at index `idx` in the class T array
+     */
+    template <class T> std::shared_ptr<T> getClass(size_t idx) const
+    {
+        size_t idx_ = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+                if (idx_++ == idx)
+                    return c;
+            }
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief Get the number of classes of type T
+     *
+     * @tparam T class template
+     * @return size_t number of classes of type T
+     */
+    template <class T> size_t getClassCount() const
+    {
+        size_t count = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    size_t getClassCount() const;
+    const std::vector<std::shared_ptr<BaseClass>> &getClassVector() const;
+    size_t getMessageLength() const;
+    size_t getMessageBuffLength() const;
+    uint8_t *getMessageBuff() const;
+    void swap();
+    bool swap_needed() {return m_swap; }
+    bool is_finalized() const { return m_finalized; };
+    bool is_swapped() const { return m_swapped; };
+    bool finalize(bool swap_needed);
+    void reset(bool parse, bool swap);
+
+protected:
+
+    uint8_t * const m_buff;
+    size_t m_buff_len;
+    
+    bool m_parse                 = false;
+    bool m_swap                  = false;
+    bool m_finalized             = false;
+    bool m_swapped               = false;
+    bool m_dynamically_allocated = false;
+    std::vector<std::shared_ptr<BaseClass>> m_class_vector;
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_TlvList_H_

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -27,7 +27,7 @@ class TlvList {
 
 public:
     TlvList() = delete;
-    TlvList(uint8_t *buff, size_t buff_len, bool parse = false, bool swap = false);
+    TlvList(uint8_t *buff, size_t buff_len, bool parse = false);
 
     ~TlvList();
 
@@ -37,9 +37,9 @@ public:
         std::shared_ptr<T> ptr;
         if (m_buff) {
             if (m_class_vector.size() == 0) {
-                ptr = std::make_shared<T>(m_buff, m_buff_len, m_parse, m_swap);
+                ptr = std::make_shared<T>(m_buff, m_buff_len, m_parse, true);
             } else {
-                ptr = std::make_shared<T>(m_class_vector.back(), m_parse, m_swap);
+                ptr = std::make_shared<T>(m_class_vector.back(), m_parse, true);
             }
             if (!ptr || ptr->isInitialized() == false) {
                 return std::shared_ptr<T>();
@@ -102,11 +102,10 @@ public:
     size_t getMessageBuffLength() const;
     uint8_t *getMessageBuff() const;
     void swap();
-    bool swap_needed() { return m_swap; }
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
-    virtual bool finalize(bool swap_needed);
-    void reset(bool parse, bool swap);
+    virtual bool finalize();
+    void reset(bool parse);
     void addInnerTlvList(eTlvType type, std::shared_ptr<TlvList> list)
     {
         m_inner_tlv_lists[type] = list;
@@ -121,7 +120,6 @@ protected:
     size_t m_buff_len;
 
     bool m_parse                 = false;
-    bool m_swap                  = false;
     bool m_finalized             = false;
     bool m_swapped               = false;
     bool m_dynamically_allocated = false;
@@ -169,11 +167,10 @@ private:
      * If an inner TLV has tailroom, it is reduced from the parent TLV length, and the
      * rest of the TLVlist buffer is moved accordingly to the new end of the current TLV.
      *
-     * @param swap_needed swap_needed
      * @return true on success
      * @return false on error
      */
-    bool resizeTlvs(bool swap_needed);
+    bool resizeTlvs();
     friend void trim(BaseClass &obj, size_t tailroom);
 };
 

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -150,6 +150,31 @@ protected:
     bool m_dynamically_allocated = false;
     std::vector<std::shared_ptr<BaseClass>> m_class_vector;
     std::unordered_map<eTlvType, std::shared_ptr<TlvList>> m_inner_tlv_lists;
+
+private:
+    /**
+     * @brief Get the Tlv. If multiple exist, get the one at index idx
+     *
+     * This method returns the n'th TLV header by comparing the startBuffPtr
+     * to the type parameter. It has no meaning when using on non-TLV classes.
+     * TODO add is_tlv_class to the TLVF BaseClass and set it to true for TLV classes.
+     *
+     * @param type TLV type
+     * @param idx TLV index out of all TLVs with the same type
+     * @return pointer to a TlvHeader structure if found, nullptr otherwise
+     */
+    std::shared_ptr<BaseClass>
+    getTlv(eTlvType type, size_t idx = 0)
+    {
+        size_t idx_ = 0;
+        for (size_t i = 0; i < getClassCount(); i++) {
+            auto c = getClass(i);
+            TlvHeader *tlvhdr = (TlvHeader *)c->getStartBuffPtr();
+            if ((static_cast<eTlvType>(tlvhdr->type) == type) && (idx_++ == idx))
+                return c;
+        }
+        return nullptr;
+    }
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -53,14 +53,6 @@ public:
     }
 
     /**
-     * @brief Get the Class object at index idx in the all classes array
-     *
-     * @param idx index in the all classes array
-     * @return std::shared_ptr<BaseClass> to the class object at index idx, nullptr if not found
-     */
-    std::shared_ptr<BaseClass> getClass(size_t idx) const;
-
-    /**
      * @brief Get the (first) Class object
      *
      * @tparam T class template
@@ -68,11 +60,7 @@ public:
      */
     template <class T> std::shared_ptr<T> getClass() const
     {
-        for (size_t idx = 0; idx < getClassCount(); idx++) {
-            if (auto c = std::dynamic_pointer_cast<T>(getClass(idx)))
-                return c;
-        }
-        return nullptr;
+        return getClass<T>(0);
     }
 
     /**
@@ -86,8 +74,8 @@ public:
     template <class T> std::shared_ptr<T> getClass(size_t idx) const
     {
         size_t idx_ = 0;
-        for (size_t i = 0; i < getClassCount(); i++) {
-            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+        for (auto it : m_class_vector) {
+            if (auto c = std::dynamic_pointer_cast<T>(it)) {
                 if (idx_++ == idx)
                     return c;
             }
@@ -104,10 +92,9 @@ public:
     template <class T> size_t getClassCount() const
     {
         size_t count = 0;
-        for (size_t i = 0; i < getClassCount(); i++) {
-            if (auto c = std::dynamic_pointer_cast<T>(getClass(i))) {
+        for (auto it : m_class_vector) {
+            if (auto c = std::dynamic_pointer_cast<T>(it))
                 count++;
-            }
         }
         return count;
     }
@@ -162,11 +149,10 @@ private:
     getTlv(eTlvType type, size_t idx = 0)
     {
         size_t idx_ = 0;
-        for (size_t i = 0; i < getClassCount(); i++) {
-            auto c = getClass(i);
-            TlvHeader *tlvhdr = (TlvHeader *)c->getStartBuffPtr();
+        for (auto it : m_class_vector) {
+            TlvHeader *tlvhdr = (TlvHeader *)it->getStartBuffPtr();
             if ((static_cast<eTlvType>(tlvhdr->type) == type) && (idx_++ == idx))
-                return c;
+                return it;
         }
         return nullptr;
     }

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -13,6 +13,7 @@
 #include <tlvf/ieee_1905_1/eTlvType.h>
 #include <memory>
 #include <vector>
+#include <unordered_map>
 #include <tlvf/BaseClass.h>
 
 namespace ieee1905_1 {
@@ -122,6 +123,15 @@ public:
     bool is_swapped() const { return m_swapped; };
     bool finalize(bool swap_needed);
     void reset(bool parse, bool swap);
+    void addInnerTlvList(eTlvType type, std::shared_ptr<TlvList> list)
+    {
+        m_inner_tlv_lists[type] = list;
+    }
+    template <class T> std::shared_ptr<T>
+    getInnerTlvList(eTlvType type)
+    {
+        return std::dynamic_pointer_cast<T>(m_inner_tlv_lists[type]);
+    }
 
 protected:
 
@@ -134,6 +144,7 @@ protected:
     bool m_swapped               = false;
     bool m_dynamically_allocated = false;
     std::vector<std::shared_ptr<BaseClass>> m_class_vector;
+    std::unordered_map<eTlvType, std::shared_ptr<TlvList>> m_inner_tlv_lists;
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -52,11 +52,6 @@ public:
         return ptr;
     }
 
-    template <class T> std::shared_ptr<T> dynamicCast(std::shared_ptr<BaseClass> ptr) const
-    {
-        return std::dynamic_pointer_cast<T>(ptr);
-    }
-
     /**
      * @brief Get the Class object at index idx in the all classes array
      *

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -37,9 +37,9 @@ public:
         std::shared_ptr<T> ptr;
         if (m_buff) {
             if (m_class_vector.size() == 0) {
-                ptr = std::make_shared<T>(m_buff, m_buff_len, m_parse, true);
+                ptr = std::make_shared<T>(m_buff, m_buff_len, m_parse);
             } else {
-                ptr = std::make_shared<T>(m_class_vector.back(), m_parse, true);
+                ptr = std::make_shared<T>(m_class_vector.back(), m_parse);
             }
             if (!ptr || ptr->isInitialized() == false) {
                 return std::shared_ptr<T>();

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -126,7 +126,7 @@ public:
     bool swap_needed() {return m_swap; }
     bool is_finalized() const { return m_finalized; };
     bool is_swapped() const { return m_swapped; };
-    bool finalize(bool swap_needed);
+    virtual bool finalize(bool swap_needed);
     void reset(bool parse, bool swap);
     void addInnerTlvList(eTlvType type, std::shared_ptr<TlvList> list)
     {

--- a/framework/tlvf/src/include/tlvf/TlvList.h
+++ b/framework/tlvf/src/include/tlvf/TlvList.h
@@ -175,6 +175,31 @@ private:
         }
         return nullptr;
     }
+
+    /**
+     * @brief resize all inner TLV lists
+     *
+     * Inner TLV lists are using outer TLV unknown length uint8_t list, which is
+     * allocated the maximum allowed TLV size since we don't know in advance the
+     * size of the needed allocation due to inner TLVlist TLVs unknown / variable
+     * length lists.
+     *
+     * It is illegal for some TLV lists to have a longer buffer than actually used
+     * (such as WSC AttrList), so this function resizes the TLVs and moves the buffer.
+     * It is *private* and expected to only be called from finalize() when no more
+     * modifications to the buffer are made.
+     *
+     * The way it works is by iterating through all the inner tlv lists, and calculating
+     * the tailroom for each.
+     * If an inner TLV has tailroom, it is reduced from the parent TLV length, and the
+     * rest of the TLVlist buffer is moved accordingly to the new end of the current TLV.
+     *
+     * @param swap_needed swap_needed
+     * @return true on success
+     * @return false on error
+     */
+    bool resizeTlvs(bool swap_needed);
+    friend void trim(BaseClass &obj, size_t tailroom);
 };
 
 }; // close namespace: ieee1905_1

--- a/framework/tlvf/src/src/BaseClass.cpp
+++ b/framework/tlvf/src/src/BaseClass.cpp
@@ -8,9 +8,8 @@
 
 #include <tlvf/BaseClass.h>
 
-BaseClass::BaseClass(uint8_t *buff, const size_t buff_len, const bool parse, const bool swap_needed)
-    : m_buff__(buff), m_buff_ptr__(buff), m_buff_len__(buff_len), m_parse__(parse),
-      m_swap__(swap_needed)
+BaseClass::BaseClass(uint8_t *buff, const size_t buff_len, const bool parse)
+    : m_buff__(buff), m_buff_ptr__(buff), m_buff_len__(buff_len), m_parse__(parse)
 {
 }
 BaseClass::~BaseClass() {}

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -10,141 +10,69 @@
 
 using namespace ieee1905_1;
 
-CmduMessage::CmduMessage() {}
+const uint16_t CmduMessage::kCmduHeaderLength = 8;
+const uint16_t CmduMessage::kTlvHeaderLength = 3;
+// CMDUs are fragmanted on TLV boundary so they can't be larger than the MTU.
+// In most cases the MTU is 1500 - so use this value as the default.
+const size_t CmduMessage::kMaxCmduLength = 1500;
+
+CmduMessage::CmduMessage(uint8_t *buff, size_t buff_len)
+    : tlvs(buff, buff_len) {}
 
 CmduMessage::~CmduMessage() {}
 
-std::shared_ptr<cCmduHeader> CmduMessage::getCmduHeader() const { return m_cmdu_header; }
-
-std::shared_ptr<BaseClass> CmduMessage::getClass(size_t idx) const
-{
-    if (m_class_vector.size() > idx) {
-        return std::shared_ptr<BaseClass>(m_class_vector.at(idx));
-    } else {
-        return nullptr;
-    }
-}
+std::shared_ptr<cCmduHeader> CmduMessage::getCmduHeader() const { return tlvs.getClass<cCmduHeader>(); }
 
 int CmduMessage::getNextTlvType() const
 {
-    uint8_t tlvValue = 0;
-    if (!m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() < kTlvHeaderLength)) {
+    if (!getCmduHeader())
         return -1;
-    }
-
-    if (m_class_vector.size() == 0) {
-        tlvValue = *m_cmdu_header->getBuffPtr();
-    } else {
-        tlvValue = *m_class_vector.back()->getBuffPtr();
-    }
-
-    return int(tlvValue);
+    uint8_t *tlv = tlvs.getClassVector().back()->getBuffPtr();
+    return *tlv;
 }
 
 bool CmduMessage::getNextTlvType(eTlvType &tlvType) const
 {
-    uint16_t tlvValue = 0;
-    if (!m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() < kTlvHeaderLength)) {
+    int tlvValue = getNextTlvType();
+    if (tlvValue < 0)
         return false;
-    }
-
-    if (m_class_vector.size() == 0) {
-        tlvValue = *m_cmdu_header->getBuffPtr();
-    } else {
-        tlvValue = *m_class_vector.back()->getBuffPtr();
-    }
-    if (eTlvTypeValidate::check(tlvValue)) {
-        tlvType = (eTlvType)tlvValue;
-        return true;
-    } else {
-        return false;
-    }
+    tlvType = (eTlvType)tlvValue;
+    return eTlvTypeValidate::check(tlvValue);
 }
 
 uint16_t CmduMessage::getNextTlvLength() const
 {
-    uint16_t tlvLength;
-    if (m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() > kTlvHeaderLength)) {
-        if (m_class_vector.size() == 0) {
-            tlvLength = *((uint16_t *)(m_cmdu_header->getBuffPtr() + sizeof(uint8_t)));
-        } else {
-            tlvLength = *((uint16_t *)(m_class_vector.back()->getBuffPtr() + sizeof(uint8_t)));
-        }
-
-        if (m_swap) {
-            swap_16((uint16_t &)tlvLength);
-        }
-    } else {
-        tlvLength = 0;
-    }
-    return tlvLength;
+    if (!getCmduHeader())
+        return -1;
+    uint8_t *tlv = tlvs.getClassVector().back()->getBuffPtr();
+    return *(uint16_t *)(tlv + sizeof(uint8_t));
 }
 
 uint8_t *CmduMessage::getNextTlvData() const
 {
-    uint8_t *tlvData = nullptr;
-    if (m_cmdu_header && (m_cmdu_header->getBuffRemainingBytes() > kTlvHeaderLength)) {
-        if (m_class_vector.size() == 0) {
-            tlvData = m_cmdu_header->getBuffPtr() + sizeof(uint8_t) + sizeof(uint16_t);
-        } else {
-            tlvData = m_class_vector.back()->getBuffPtr() + sizeof(uint8_t) + sizeof(uint16_t);
-        }
-    }
-    return tlvData;
-}
+    if (!getCmduHeader())
+        return nullptr;
 
-size_t CmduMessage::getClassCount() const { return m_class_vector.size(); }
-
-const std::vector<std::shared_ptr<BaseClass>> &CmduMessage::getClassVector() const
-{
-    return (const std::vector<std::shared_ptr<BaseClass>> &)m_class_vector;
+    uint8_t *tlv = tlvs.getClassVector().back()->getBuffPtr();
+    return tlv + kTlvHeaderLength;
 }
 
 size_t CmduMessage::getMessageLength() const
 {
-    if (m_cmdu_header == nullptr)
-        return 0;
-    size_t msg_len = m_cmdu_header->getLen();
-    for (auto const &c : m_class_vector) {
+    size_t msg_len = 0;
+    for (auto const &c : tlvs.getClassVector()) {
         msg_len += c->getLen();
     }
     return msg_len;
 }
 
-size_t CmduMessage::getMessageBuffLength() const { return m_buff_len; }
+size_t CmduMessage::getMessageBuffLength() const { return tlvs.getMessageBuffLength(); }
 
-uint8_t *CmduMessage::getMessageBuff() const
-{
-    return (m_cmdu_header ? m_cmdu_header->getStartBuffPtr() : nullptr);
-}
+uint8_t *CmduMessage::getMessageBuff() const { return tlvs.getMessageBuff(); }
 
 void CmduMessage::swap()
 {
-    if (!m_cmdu_header)
-        return;
-
-    m_cmdu_header
-        ->class_swap(); // the header isn't part of the m_class_vector, so we should swap it separately
-
-    // call all tlv finalize functions
-    for (auto const &c : m_class_vector) {
-        c->class_swap();
-    }
-
-    m_swapped = !m_swapped;
-}
-
-void CmduMessage::reset()
-{
-    m_finalized = false;
-    m_swapped   = false;
-    m_swap      = false;
-    if (m_cmdu_header)
-        m_cmdu_header.reset();
-    for (auto &c : m_class_vector) {
-        c.reset();
-    }
-    m_class_vector.clear();
+    tlvs.swap();
 }
 
 eMessageType CmduMessage::getMessageType()
@@ -152,7 +80,7 @@ eMessageType CmduMessage::getMessageType()
     uint16_t msgValue = 0;
 
     msgValue = (uint16_t)getCmduHeader()->message_type();
-    if (m_swap && !m_swapped) {
+    if (swap_needed() && !is_swapped()) {
         swap_16((uint16_t &)msgValue);
     }
 
@@ -163,7 +91,7 @@ uint16_t CmduMessage::getMessageId()
 {
     uint16_t mid = getCmduHeader()->message_id();
 
-    if (m_swap && !m_swapped) {
+    if (swap_needed() && !is_swapped()) {
         swap_16((uint16_t &)mid);
     }
 

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -11,17 +11,19 @@
 using namespace ieee1905_1;
 
 const uint16_t CmduMessage::kCmduHeaderLength = 8;
-const uint16_t CmduMessage::kTlvHeaderLength = 3;
+const uint16_t CmduMessage::kTlvHeaderLength  = 3;
 // CMDUs are fragmanted on TLV boundary so they can't be larger than the MTU.
 // In most cases the MTU is 1500 - so use this value as the default.
 const size_t CmduMessage::kMaxCmduLength = 1500;
 
-CmduMessage::CmduMessage(uint8_t *buff, size_t buff_len)
-    : tlvs(buff, buff_len) {}
+CmduMessage::CmduMessage(uint8_t *buff, size_t buff_len) : tlvs(buff, buff_len) {}
 
 CmduMessage::~CmduMessage() {}
 
-std::shared_ptr<cCmduHeader> CmduMessage::getCmduHeader() const { return tlvs.getClass<cCmduHeader>(); }
+std::shared_ptr<cCmduHeader> CmduMessage::getCmduHeader() const
+{
+    return tlvs.getClass<cCmduHeader>();
+}
 
 int CmduMessage::getNextTlvType() const
 {
@@ -70,10 +72,7 @@ size_t CmduMessage::getMessageBuffLength() const { return tlvs.getMessageBuffLen
 
 uint8_t *CmduMessage::getMessageBuff() const { return tlvs.getMessageBuff(); }
 
-void CmduMessage::swap()
-{
-    tlvs.swap();
-}
+void CmduMessage::swap() { tlvs.swap(); }
 
 eMessageType CmduMessage::getMessageType()
 {

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -79,7 +79,7 @@ eMessageType CmduMessage::getMessageType()
     uint16_t msgValue = 0;
 
     msgValue = (uint16_t)getCmduHeader()->message_type();
-    if (swap_needed() && !is_swapped()) {
+    if (!is_swapped()) {
         swap_16((uint16_t &)msgValue);
     }
 
@@ -90,7 +90,7 @@ uint16_t CmduMessage::getMessageId()
 {
     uint16_t mid = getCmduHeader()->message_id();
 
-    if (swap_needed() && !is_swapped()) {
+    if (!is_swapped()) {
         swap_16((uint16_t &)mid);
     }
 

--- a/framework/tlvf/src/src/CmduMessageRx.cpp
+++ b/framework/tlvf/src/src/CmduMessageRx.cpp
@@ -19,14 +19,13 @@ CmduMessageRx::CmduMessageRx(uint8_t *buff, size_t buff_len)
 
 CmduMessageRx::~CmduMessageRx() {}
 
-bool CmduMessageRx::parse(bool swap_needed, bool parse_tlvs)
+bool CmduMessageRx::parse(bool parse_tlvs)
 {
-    tlvs.reset(true, swap_needed);
+    tlvs.reset(true);
     auto cmduhdr = tlvs.addClass<cCmduHeader>();
     if (!cmduhdr)
         return false;
-    if (swap_needed)
-        cmduhdr->class_swap(); //swap back cmduheader
+    cmduhdr->class_swap(); //swap back cmduheader
 
     if (!parse_tlvs)
         return true;

--- a/framework/tlvf/src/src/CmduMessageRx.cpp
+++ b/framework/tlvf/src/src/CmduMessageRx.cpp
@@ -12,8 +12,10 @@
 
 using namespace ieee1905_1;
 
-CmduMessageRx::CmduMessageRx(uint8_t *buff, size_t buff_len) 
-    : CmduMessage(buff, buff_len), parser(std::make_shared<CmduTlvParser>(*this)) {}
+CmduMessageRx::CmduMessageRx(uint8_t *buff, size_t buff_len)
+    : CmduMessage(buff, buff_len), parser(std::make_shared<CmduTlvParser>(*this))
+{
+}
 
 CmduMessageRx::~CmduMessageRx() {}
 
@@ -24,13 +26,13 @@ bool CmduMessageRx::parse(bool swap_needed, bool parse_tlvs)
     if (!cmduhdr)
         return false;
     if (swap_needed)
-        cmduhdr->class_swap(); //swap back cmduheader 
-    
+        cmduhdr->class_swap(); //swap back cmduheader
+
     if (!parse_tlvs)
         return true;
 
     if (parser->parse())
         return true;
-    
+
     return false;
 }

--- a/framework/tlvf/src/src/CmduMessageRx.cpp
+++ b/framework/tlvf/src/src/CmduMessageRx.cpp
@@ -12,50 +12,25 @@
 
 using namespace ieee1905_1;
 
-CmduMessageRx::CmduMessageRx() : CmduMessage()
-{
-    parsers_.emplace_back(std::make_shared<CmduTlvParser>(*this)); // default parser
-}
+CmduMessageRx::CmduMessageRx(uint8_t *buff, size_t buff_len) 
+    : CmduMessage(buff, buff_len), parser(std::make_shared<CmduTlvParser>(*this)) {}
 
-CmduMessageRx::CmduMessageRx(CmduMessageRx &original) : CmduMessage()
-{
-    m_dynamically_allocated = true;
-    size_t buff_len         = original.getMessageBuffLength();
-    m_buff                  = new uint8_t[buff_len];
-    std::copy(original.getMessageBuff(), original.getMessageBuff() + buff_len, m_buff);
-    parse(m_buff, buff_len, original.m_swap);
-    if (m_swap) {
-        m_cmdu_header->class_swap();
-    }
-}
+CmduMessageRx::~CmduMessageRx() {}
 
-CmduMessageRx::~CmduMessageRx()
+bool CmduMessageRx::parse(bool swap_needed, bool parse_tlvs)
 {
-    if (m_dynamically_allocated) {
-        delete m_buff;
-    }
-}
-
-bool CmduMessageRx::parse(uint8_t *buff, size_t buff_len, bool swap_needed, bool parse_tlvs)
-{
-    reset();
-    m_parse       = true;
-    m_swap        = swap_needed;
-    m_buff        = buff;
-    m_buff_len    = buff_len;
-    m_cmdu_header = std::make_shared<cCmduHeader>(buff, buff_len, true, false);
-    if (!m_cmdu_header || m_cmdu_header->isInitialized() == false) {
-        m_cmdu_header = nullptr;
+    tlvs.reset(true, swap_needed);
+    auto cmduhdr = tlvs.addClass<cCmduHeader>();
+    if (!cmduhdr)
         return false;
-    }
-
+    if (swap_needed)
+        cmduhdr->class_swap(); //swap back cmduheader 
+    
     if (!parse_tlvs)
         return true;
 
-    for (auto parser : parsers_) {
-        if (parser->parse())
-            return true;
-    }
-
+    if (parser->parse())
+        return true;
+    
     return false;
 }

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -20,8 +20,7 @@ CmduMessageTx::~CmduMessageTx() {}
 std::shared_ptr<cCmduHeader> CmduMessageTx::create(uint16_t id, eMessageType message_type)
 {
     // parse - false since this is for TX
-    // swap - false since on TX we do swap in Finalize(swap_needed)
-    tlvs.reset(false, false);
+    tlvs.reset(false);
     auto cmduhdr = tlvs.addClass<cCmduHeader>();
     if (!cmduhdr)
         return nullptr;
@@ -34,7 +33,7 @@ std::shared_ptr<cCmduHeader> CmduMessageTx::create(uint16_t id, eMessageType mes
 std::shared_ptr<cCmduHeader> CmduMessageTx::load()
 {
     LOG(DEBUG) << "CmduMessageTx::load";
-    tlvs.reset(true, false);
+    tlvs.reset(true);
     return addClass<cCmduHeader>();
 }
 
@@ -53,4 +52,4 @@ std::shared_ptr<tlvVendorSpecific> CmduMessageTx::add_vs_tlv(tlvVendorSpecific::
     return tlv;
 }
 
-bool CmduMessageTx::finalize(bool swap_needed) { return tlvs.finalize(swap_needed); }
+bool CmduMessageTx::finalize() { return tlvs.finalize(); }

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -13,62 +13,40 @@
 
 using namespace ieee1905_1;
 
-CmduMessageTx::CmduMessageTx(uint8_t *buff, size_t buff_len) : CmduMessage()
-{
-    m_buff     = buff;
-    m_buff_len = buff_len;
-}
+CmduMessageTx::CmduMessageTx(uint8_t *buff, size_t buff_len) : CmduMessage(buff, buff_len) {}
 
 CmduMessageTx::~CmduMessageTx() {}
 
 std::shared_ptr<cCmduHeader> CmduMessageTx::create(uint16_t id, eMessageType message_type)
 {
-    if (!m_buff || !m_buff_len)
+    // parse - false since this is for TX
+    // swap - false since on TX we do swap in Finalize(swap_needed)
+    tlvs.reset(false, false);
+    auto cmduhdr = tlvs.addClass<cCmduHeader>();
+    if (!cmduhdr)
         return nullptr;
 
-    m_parse = false;
-    memset(m_buff, 0, m_buff_len);
-    reset();
-    m_cmdu_header = std::make_shared<cCmduHeader>(m_buff, m_buff_len);
-    if (!m_cmdu_header || m_cmdu_header->isInitialized() == false) {
-        return nullptr;
-    }
-
-    m_cmdu_header->message_type() = message_type;
-    m_cmdu_header->message_id()   = id;
-    return m_cmdu_header;
+    cmduhdr->message_type() = message_type;
+    cmduhdr->message_id()   = id;
+    return cmduhdr;
 }
 
 std::shared_ptr<cCmduHeader> CmduMessageTx::load()
 {
-    if (!m_buff || !m_buff_len)
-        return nullptr;
-
-    m_parse = true;
-    reset();
-    m_cmdu_header = std::make_shared<cCmduHeader>(m_buff, m_buff_len, m_parse);
-    if (!m_cmdu_header || m_cmdu_header->isInitialized() == false) {
-        return nullptr;
-    }
-
-    return m_cmdu_header;
+    LOG(DEBUG)<<"CmduMessageTx::load";
+    tlvs.reset(true, false);
+    return addClass<cCmduHeader>();
 }
 
 std::shared_ptr<tlvVendorSpecific> CmduMessageTx::add_vs_tlv(tlvVendorSpecific::eVendorOUI voui)
 {
-    if (!m_buff || !m_buff_len)
+    if (!getCmduHeader())
         return nullptr;
-
-    if (!m_cmdu_header || m_cmdu_header->isInitialized() == false) {
-        return nullptr;
-    }
 
     auto tlv = addClass<tlvVendorSpecific>();
-    if (!tlv) {
-        m_cmdu_header.reset();
-        m_cmdu_header = nullptr;
+    if (!tlv)
         return nullptr;
-    }
+
     //set vendor specific oui
     tlv->vendor_oui() = (uint32_t)voui;
 
@@ -77,42 +55,5 @@ std::shared_ptr<tlvVendorSpecific> CmduMessageTx::add_vs_tlv(tlvVendorSpecific::
 
 bool CmduMessageTx::finalize(bool swap_needed)
 {
-    if (m_finalized)
-        return true;
-
-    if (!m_cmdu_header)
-        return false;
-
-    // Update vendor specific length which is seperated to 3 classes
-    for (auto class_it = m_class_vector.begin(); class_it != m_class_vector.end(); class_it++) {
-        if (!(*class_it)->isPostInitSucceeded()) {
-            TLVF_LOG(ERROR) << "TLV post init failed";
-            return false;
-        }
-        // Type is the first byte in the tlv buffer
-        uint8_t tlv_type = *(*class_it)->getStartBuffPtr();
-        if (tlv_type == uint8_t(eTlvType::TLV_VENDOR_SPECIFIC)) {
-            uint16_t *tlv_length = reinterpret_cast<uint16_t *>(
-                (class_it->get())->getStartBuffPtr() + sizeof(uint8_t));
-            // tlv vendor specific length already include OUI and beerocks header length
-            // need to add only beerocks message length.
-            // Classes order: +0 = tlvVendorSpecific, +1 = beerocks_header, +2 = beerocks_message
-            if (std::next(class_it, 1) == m_class_vector.end() ||
-                std::next(class_it, 2) == m_class_vector.end()) {
-                TLVF_LOG(ERROR) << "vendor specific TLV has not been added correctly";
-                return false;
-            }
-            *tlv_length += (std::next(class_it, 2)->get())->getLen();
-            class_it += 2;
-        }
-    }
-
-    if (!addClass<tlvEndOfMessage>())
-        return false;
-
-    if (swap_needed)
-        swap();
-
-    m_finalized = true;
-    return true;
+    return tlvs.finalize(swap_needed);
 }

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<cCmduHeader> CmduMessageTx::create(uint16_t id, eMessageType mes
 
 std::shared_ptr<cCmduHeader> CmduMessageTx::load()
 {
-    LOG(DEBUG)<<"CmduMessageTx::load";
+    LOG(DEBUG) << "CmduMessageTx::load";
     tlvs.reset(true, false);
     return addClass<cCmduHeader>();
 }
@@ -53,7 +53,4 @@ std::shared_ptr<tlvVendorSpecific> CmduMessageTx::add_vs_tlv(tlvVendorSpecific::
     return tlv;
 }
 
-bool CmduMessageTx::finalize(bool swap_needed)
-{
-    return tlvs.finalize(swap_needed);
-}
+bool CmduMessageTx::finalize(bool swap_needed) { return tlvs.finalize(swap_needed); }

--- a/framework/tlvf/src/src/CmduTlvParser.cpp
+++ b/framework/tlvf/src/src/CmduTlvParser.cpp
@@ -75,12 +75,11 @@ std::shared_ptr<BaseClass> CmduTlvParser::parseWscTlv()
     if (eTlvType(cmdu_.getNextTlvType()) != eTlvType::TLV_WSC)
         return nullptr;
 
-    bool swap     = cmdu_.swap_needed();
     wscAttr *wsc  = reinterpret_cast<wscAttr *>(cmdu_.getNextTlvData());
-    uint16_t type = wsc->type(swap);
+    uint16_t type = wsc->type(true);
     while (type != WSC::ATTR_MSG_TYPE) {
-        wsc  = wsc->next(swap);
-        type = wsc->type(swap);
+        wsc  = wsc->next(true);
+        type = wsc->type(true);
     }
     if (*wsc->data() == WSC::WSC_MSG_TYPE_M2)
         return cmdu_.addClass<tlvWscM2>();

--- a/framework/tlvf/src/src/TlvList.cpp
+++ b/framework/tlvf/src/src/TlvList.cpp
@@ -1,0 +1,102 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019 Arnout Vandecappelle (Essensium/Mind)
+ * Copyright (c) 2019 Tomer Eliyahu (Intel)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/TlvList.h>
+#include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace ieee1905_1;
+
+TlvList::TlvList(uint8_t *buff, size_t buff_len, bool parse, bool swap)
+    : m_buff(buff), m_buff_len(buff_len), m_parse(parse), m_swap(swap) {}
+
+TlvList::~TlvList() {}
+
+std::shared_ptr<BaseClass> TlvList::getClass(size_t idx) const
+{
+    if (m_class_vector.size() > idx) {
+        return std::shared_ptr<BaseClass>(m_class_vector.at(idx));
+    } else {
+        return nullptr;
+    }
+}
+
+size_t TlvList::getClassCount() const { return m_class_vector.size(); }
+
+const std::vector<std::shared_ptr<BaseClass>> &TlvList::getClassVector() const
+{
+    return (const std::vector<std::shared_ptr<BaseClass>> &)m_class_vector;
+}
+
+size_t TlvList::getMessageLength() const
+{
+    if (m_buff == nullptr)
+        return 0;
+    size_t msg_len = 0;
+    for (auto const &c : m_class_vector) {
+        msg_len += c->getLen();
+    }
+    return msg_len;
+}
+
+size_t TlvList::getMessageBuffLength() const { return m_buff_len; }
+
+uint8_t *TlvList::getMessageBuff() const
+{
+    return m_buff;
+}
+
+void TlvList::swap()
+{
+    if (!m_buff)
+        return;
+
+    // call all tlv finalize functions
+    for (auto const &c : m_class_vector) {
+        c->class_swap();
+    }
+
+    m_swapped = !m_swapped;
+}
+
+void TlvList::reset(bool parse, bool swap)
+{
+    if (!parse)
+        memset(m_buff, 0, m_buff_len);
+    m_parse = parse;
+    m_swap = swap;
+    m_finalized = false;
+    m_swapped   = false;
+    for (auto &c : m_class_vector) {
+        c.reset();
+    }
+    m_class_vector.clear();
+}
+
+bool TlvList::finalize(bool swap_needed)
+{
+    if (m_finalized)
+        return true;
+
+    for (auto &it: m_class_vector){
+        if(!(it->isPostInitSucceeded())){
+            TLVF_LOG(ERROR) << "TLV post init failed";
+            return false;
+        }
+    }
+
+    if (!addClass<tlvEndOfMessage>())
+        return false;
+
+    if (swap_needed)
+        swap();
+
+    m_finalized = true;
+    return true;
+}

--- a/framework/tlvf/src/src/TlvList.cpp
+++ b/framework/tlvf/src/src/TlvList.cpp
@@ -7,15 +7,17 @@
  * See LICENSE file for more details.
  */
 
+#include <algorithm>
 #include <tlvf/TlvList.h>
 #include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <tlvf/tlvflogging.h>
-#include <algorithm>
 
 using namespace ieee1905_1;
 
 TlvList::TlvList(uint8_t *buff, size_t buff_len, bool parse, bool swap)
-    : m_buff(buff), m_buff_len(buff_len), m_parse(parse), m_swap(swap) {}
+    : m_buff(buff), m_buff_len(buff_len), m_parse(parse), m_swap(swap)
+{
+}
 
 TlvList::~TlvList() {}
 
@@ -37,10 +39,7 @@ size_t TlvList::getMessageLength() const
 
 size_t TlvList::getMessageBuffLength() const { return m_buff_len; }
 
-uint8_t *TlvList::getMessageBuff() const
-{
-    return m_buff;
-}
+uint8_t *TlvList::getMessageBuff() const { return m_buff; }
 
 void TlvList::swap()
 {
@@ -59,8 +58,8 @@ void TlvList::reset(bool parse, bool swap)
 {
     if (!parse)
         memset(m_buff, 0, m_buff_len);
-    m_parse = parse;
-    m_swap = swap;
+    m_parse     = parse;
+    m_swap      = swap;
     m_finalized = false;
     m_swapped   = false;
     for (auto &c : m_class_vector) {
@@ -81,15 +80,15 @@ bool TlvList::resizeTlvs(bool swap_needed)
             return false;
         TlvHeader *tlvhdr = reinterpret_cast<TlvHeader *>(tlv->getStartBuffPtr());
         if (swap_needed)
-            tlvf_swap(16, reinterpret_cast<uint8_t*>(&tlvhdr->length));
+            tlvf_swap(16, reinterpret_cast<uint8_t *>(&tlvhdr->length));
         tlvhdr->length -= tailroom;
         // move the rest of the buffer
         uint8_t *dst = reinterpret_cast<uint8_t *>(tlvhdr) + tlvhdr->length + sizeof(*tlvhdr);
         uint8_t *src = dst + tailroom;
         uint8_t *end = m_class_vector.back()->getBuffPtr();
-        size_t len = end - src;
+        size_t len   = end - src;
         if (swap_needed)
-            tlvf_swap(16, reinterpret_cast<uint8_t*>(&tlvhdr->length));
+            tlvf_swap(16, reinterpret_cast<uint8_t *>(&tlvhdr->length));
         std::copy_n(src, len, dst);
         // update parent TLV class size by trimming the end of the buffer (m_buff_ptr__)
         trim(*tlv, tailroom);
@@ -103,8 +102,8 @@ bool TlvList::finalize(bool swap_needed)
     if (m_finalized)
         return true;
 
-    for (auto &it: m_class_vector){
-        if(!(it->isPostInitSucceeded())){
+    for (auto &it : m_class_vector) {
+        if (!(it->isPostInitSucceeded())) {
             TLVF_LOG(ERROR) << "TLV post init failed";
             return false;
         }

--- a/framework/tlvf/src/src/TlvList.cpp
+++ b/framework/tlvf/src/src/TlvList.cpp
@@ -19,17 +19,6 @@ TlvList::TlvList(uint8_t *buff, size_t buff_len, bool parse, bool swap)
 
 TlvList::~TlvList() {}
 
-std::shared_ptr<BaseClass> TlvList::getClass(size_t idx) const
-{
-    if (m_class_vector.size() > idx) {
-        return std::shared_ptr<BaseClass>(m_class_vector.at(idx));
-    } else {
-        return nullptr;
-    }
-}
-
-size_t TlvList::getClassCount() const { return m_class_vector.size(); }
-
 const std::vector<std::shared_ptr<BaseClass>> &TlvList::getClassVector() const
 {
     return (const std::vector<std::shared_ptr<BaseClass>> &)m_class_vector;

--- a/framework/tlvf/src/src/TlvList.cpp
+++ b/framework/tlvf/src/src/TlvList.cpp
@@ -10,6 +10,7 @@
 #include <tlvf/TlvList.h>
 #include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <tlvf/tlvflogging.h>
+#include <algorithm>
 
 using namespace ieee1905_1;
 
@@ -80,6 +81,34 @@ void TlvList::reset(bool parse, bool swap)
     m_inner_tlv_lists.clear();
 }
 
+bool TlvList::resizeTlvs(bool swap_needed)
+{
+    for (auto list : m_inner_tlv_lists) {
+        size_t tailroom = list.second->getMessageBuffLength() - list.second->getMessageLength();
+        if (!tailroom)
+            continue;
+        auto tlv = getTlv(list.first);
+        if (!tlv)
+            return false;
+        TlvHeader *tlvhdr = reinterpret_cast<TlvHeader *>(tlv->getStartBuffPtr());
+        if (swap_needed)
+            tlvf_swap(16, reinterpret_cast<uint8_t*>(&tlvhdr->length));
+        tlvhdr->length -= tailroom;
+        // move the rest of the buffer
+        uint8_t *dst = reinterpret_cast<uint8_t *>(tlvhdr) + tlvhdr->length + sizeof(*tlvhdr);
+        uint8_t *src = dst + tailroom;
+        uint8_t *end = m_class_vector.back()->getBuffPtr();
+        size_t len = end - src;
+        if (swap_needed)
+            tlvf_swap(16, reinterpret_cast<uint8_t*>(&tlvhdr->length));
+        std::copy_n(src, len, dst);
+        // update parent TLV class size by trimming the end of the buffer (m_buff_ptr__)
+        trim(*tlv, tailroom);
+    }
+
+    return true;
+}
+
 bool TlvList::finalize(bool swap_needed)
 {
     if (m_finalized)
@@ -100,6 +129,10 @@ bool TlvList::finalize(bool swap_needed)
 
     if (swap_needed)
         swap();
+
+    // shrink back inner tlv lists
+    if (!resizeTlvs(swap_needed))
+        return false;
 
     m_finalized = true;
     return true;

--- a/framework/tlvf/src/src/TlvList.cpp
+++ b/framework/tlvf/src/src/TlvList.cpp
@@ -77,6 +77,7 @@ void TlvList::reset(bool parse, bool swap)
         c.reset();
     }
     m_class_vector.clear();
+    m_inner_tlv_lists.clear();
 }
 
 bool TlvList::finalize(bool swap_needed)
@@ -90,6 +91,9 @@ bool TlvList::finalize(bool swap_needed)
             return false;
         }
     }
+
+    for (auto list : m_inner_tlv_lists)
+        list.second->finalize(swap_needed);
 
     if (!addClass<tlvEndOfMessage>())
         return false;

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -161,8 +161,8 @@ int test_complex_list()
     uint8_t recv_buffer[sizeof(tx_buffer)];
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
 
-    CmduMessageRx received_message;
-    received_message.parse(recv_buffer, sizeof(recv_buffer), true);
+    CmduMessageRx received_message(recv_buffer, sizeof(recv_buffer));
+    received_message.parse(true);
 
     auto tlv4 = received_message.addClass<tlvTestVarList>();
     if (tlv4 == nullptr) {
@@ -296,7 +296,7 @@ int test_parser()
     int errors = 0;
     uint8_t tx_buffer[4096];
     //creating cmdu message class and setting the header
-    CmduMessageTx msg = CmduMessageTx(tx_buffer, sizeof(tx_buffer));
+    CmduMessageTx msg(tx_buffer, sizeof(tx_buffer));
 
     //create method initializes the buffer and returns shared pointer to the message header
     auto header = msg.create(0, eMessageType::BACKHAUL_STEERING_REQUEST_MESSAGE);
@@ -330,8 +330,8 @@ int test_parser()
     uint8_t recv_buffer[sizeof(tx_buffer)];
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
 
-    CmduMessageRx received_message;
-    received_message.parse(recv_buffer, sizeof(recv_buffer), true, true);
+    CmduMessageRx received_message(recv_buffer, sizeof(recv_buffer));
+    received_message.parse(true, true);
     auto tlv4_ = received_message.getClass<tlvUnknown>();
     if (!tlv4_) {
         LOG(ERROR) << "getClass<tlvUnknown> failed";
@@ -367,7 +367,7 @@ int test_all()
     memset(tx_buffer, 0, sizeof(tx_buffer));
 
     //creating cmdu message class and setting the header
-    CmduMessageTx msg = CmduMessageTx(tx_buffer, sizeof(tx_buffer));
+    CmduMessageTx msg(tx_buffer, sizeof(tx_buffer));
 
     //create method initializes the buffer and returns shared pointer to the message header
     auto header = msg.create(0, eMessageType::BACKHAUL_STEERING_REQUEST_MESSAGE);
@@ -560,8 +560,8 @@ int test_all()
     uint8_t recv_buffer[sizeof(tx_buffer)];
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
 
-    CmduMessageRx received_message;
-    received_message.parse(recv_buffer, sizeof(recv_buffer), true);
+    CmduMessageRx received_message(recv_buffer, sizeof(recv_buffer));
+    received_message.parse(true);
 
     eTlvType type;
     if (received_message.getNextTlvType(type) &&
@@ -760,8 +760,8 @@ int test_all()
     uint8_t invalidBuffer[invalidBufferSize];
     memcpy(invalidBuffer, recv_buffer, 26);
 
-    CmduMessageRx invmsg;
-    if (!invmsg.parse(invalidBuffer, invalidBufferSize, false)) {
+    CmduMessageRx invmsg(invalidBuffer, invalidBufferSize);
+    if (!invmsg.parse(false)) {
         MAPF_DBG("HEADER PROTECTION SUCCESS");
     }
 

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -151,7 +151,7 @@ int test_complex_list()
 
     LOG(DEBUG) << "Finalize";
     //MANDATORY - swaps to little indian.
-    if (!msg.finalize(true)) {
+    if (!msg.finalize()) {
         LOG(ERROR) << "Finalize step failed";
         errors++;
     }
@@ -162,7 +162,7 @@ int test_complex_list()
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
 
     CmduMessageRx received_message(recv_buffer, sizeof(recv_buffer));
-    received_message.parse(true);
+    received_message.parse();
 
     auto tlv4 = received_message.addClass<tlvTestVarList>();
     if (tlv4 == nullptr) {
@@ -313,14 +313,14 @@ int test_parser()
     tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
-    if (msg.finalize(true)) {
+    if (msg.finalize()) {
         LOG(ERROR) << "Finalize should fail since the CMDU is not fully initialized";
         errors++;
     }
 
     tlv4->add_var3(tlv4->create_var3());
     LOG(DEBUG) << "Finalize";
-    if (!msg.finalize(true)) {
+    if (!msg.finalize()) {
         LOG(ERROR) << "Finalize step failed";
         errors++;
     }
@@ -331,7 +331,7 @@ int test_parser()
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
 
     CmduMessageRx received_message(recv_buffer, sizeof(recv_buffer));
-    received_message.parse(true, true);
+    received_message.parse(true);
     auto tlv4_ = received_message.getClass<tlvUnknown>();
     if (!tlv4_) {
         LOG(ERROR) << "getClass<tlvUnknown> failed";
@@ -549,8 +549,8 @@ int test_all()
     LOG(DEBUG) << "Total Message length=" << int(msg.getMessageLength());
 
     LOG(DEBUG) << "Finalize";
-    //MANDATORY - swaps to little indian.
-    if (!msg.finalize(true)) {
+
+    if (!msg.finalize()) {
         LOG(ERROR) << "Finalize step failed";
         errors++;
     }
@@ -561,7 +561,7 @@ int test_all()
     memcpy(recv_buffer, tx_buffer, sizeof(recv_buffer));
 
     CmduMessageRx received_message(recv_buffer, sizeof(recv_buffer));
-    received_message.parse(true);
+    received_message.parse();
 
     eTlvType type;
     if (received_message.getNextTlvType(type) &&

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -49,7 +49,7 @@ int test_int_len_list()
     MAPF_INFO(__FUNCTION__ << " start");
     memset(tx_buffer, 0, sizeof(tx_buffer));
     {
-        auto tlv = tlvMacAddress(tx_buffer, sizeof(tx_buffer), false, true);
+        auto tlv = tlvMacAddress(tx_buffer, sizeof(tx_buffer), false);
         std::copy_n(gTlvMacAddress, 6, tlv.mac().oct);
         tlv.class_swap(); //finalize
         LOG(DEBUG) << "TX: " << std::endl << utils::dump_buffer(tx_buffer, tlv.getLen());
@@ -58,7 +58,7 @@ int test_int_len_list()
     uint8_t rx_buffer[sizeof(tx_buffer)];
     memcpy(rx_buffer, tx_buffer, sizeof(rx_buffer));
     {
-        auto tlv = tlvMacAddress(tx_buffer, sizeof(tx_buffer), true, true);
+        auto tlv = tlvMacAddress(tx_buffer, sizeof(tx_buffer), true);
         auto mac = tlv.mac();
         if (!std::equal(mac.oct, mac.oct + 6, gTlvMacAddress)) {
             MAPF_ERR("MAC address in received TLV does not match expected result");
@@ -213,7 +213,7 @@ bool add_encrypted_settings(std::shared_ptr<tlvWscM2> m2, uint8_t *keywrapkey, u
     // Then copy it to the encrypted data, add an IV and encrypt.
     // Finally, add HMAC
     uint8_t buf[1024];
-    WSC::cConfigData config_data(buf, sizeof(buf), false, true);
+    WSC::cConfigData config_data(buf, sizeof(buf), false);
     config_data.set_ssid("test_ssid");
     config_data.authentication_type_attr().data = WSC::eWscAuth::WSC_AUTH_WPA2; //DUMMY
     config_data.encryption_type_attr().data     = WSC::eWscEncr::WSC_ENCR_AES;
@@ -275,7 +275,7 @@ bool parse_encrypted_settings(std::shared_ptr<tlvWscM2> m2, uint8_t *keywrapkey,
     mapf::encryption::aes_decrypt(keywrapkey, iv,
                                   (uint8_t *)encrypted_settings->encrypted_settings(),
                                   encrypted_settings->encrypted_settings_length(), buf, dlen);
-    WSC::cConfigData config_data(buf, dlen, true, true);
+    WSC::cConfigData config_data(buf, dlen, true);
 
     LOG(DEBUG) << "WSC config_data:" << std::endl
                << "     ssid: " << config_data.ssid() << std::endl

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvVendorSpecific.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvVendorSpecific.yaml
@@ -3,20 +3,20 @@
 _namespace: ieee1905_1
 
 tlvVendorSpecific:
-  _type: class  
+  _type: class
+  _is_tlv_class: True
   type:
     _type: eTlvType
     _value_const: TLV_VENDOR_SPECIFIC
-  length:
-    _type: uint16_t
-    _value: 3
-    _length_var: True
+  length: uint16_t
   vendor_oui:
     _type: sVendorOUI
+  payload:
+    _type: uint8_t
+    _length: [ ]
 
 eVendorOUI:
   _type: enum
   _enum_storage: uint32_t
-  # FIXME: https://github.com/prplfoundation/prplMesh/issues/33
   OUI_BYTES: 3
   OUI_INTEL: 0x470300


### PR DESCRIPTION
Currently, CmduMessage (and its derived classes CmduMessageTx & CmduMessageRx) include the TLV class vector and the buffer.

Some TLVs, such as vendor-specific and WSC, may contain arbitrary data that can be parsed/created with the same mechanics that we use in the CmduMessage and are required by multiple features (#471, #160, #318).

It would be easier to implement support for such TLVs using a TLV list class, which will include all the buffer handling that is currently part of the CmduMessage classes.

This PR refactors TLVF base files and adds a new class, `TlvList`, which can be used to create and parse TLVs with arbitrary data represented with an internal TLV list.

It also adds support for the first outer TLV, the vendor-specific TLV, by adding an unknown length buffer to the end of its YAML file, which is used as the buffer for the inner TLV list.
The inner TLV list is the `beerocks_header` which derives from `TlvList` and adds some backward compatible APIs so the change will not be too big to swallow in a single PR (Nevertheless, this kind of change is pretty big since in order for not breaking the build in each commit).

Now, each vendor-specific CMDU is built using a vendor-specific TLV with a payload buffer (`uint8_t`).
The buffer size is preallocated in`add_intel_vs_data()` to the maximum allowed TLV size - which is `MTU - CMDU header length - EOM TLV length - TS TLV init length` for standard CMDUs since the ieee1905 transport performs fragmentation on TLV boundary and the maximum buffer size for CMDUs containing oversized TLVs (referred to as "jumbo" CMDUs) which are not meant to be sent externally.
Having a preallocated big enough buffer allows the internal TLV list to accommodate variable-length data in the internal classes, which is mandatory since by the time we are allocating the buffer we do not know if the caller will need more space.

This brings the need to resize the inner TLVs and update the outer TLVs length on `finalize()`, which does so by going through the CMDU's inner tlv map, resizing each inner TLVlist to its final message length and moving the rest of the CMDU buffer back to the new end of the inner TLV list.
