### PR TITLE
gitignore: add build directory to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 analyzer-venv
+build/*


### PR DESCRIPTION
the build directory is not specified in .gitignore file.
this results in many irrelevant temporary files in the
git status and interferes with the development

added build directory and files contained in it to the
.gitignore file.

after this change, files from the build directory and the
directory itself will not show up in the git changes and
git status.