### PR TITLE
Feature/wsc attrlist infrastructure

### DIFF
--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/WSC_Attributes.h
@@ -42,6 +42,25 @@ namespace WSC {
 
 class cWscAttrEncryptedSettings;
 class cWscVendorExtWfa;
+class cWscAttrVersion;
+class cWscAttrMessageType;
+class cWscAttrEnrolleeNonce;
+class cWscAttrPublicKey;
+class cWscAttrAuthenticationTypeFlags;
+class cWscAttrEncryptionTypeFlags;
+class cWscAttrConnectionTypeFlags;
+class cWscAttrConfigurationMethods;
+class cWscAttrManufacturer;
+class cWscAttrModelName;
+class cWscAttrModelNumber;
+class cWscAttrSerialNumber;
+class cWscAttrPrimaryDeviceType;
+class cWscAttrDeviceName;
+class cWscAttrRfBands;
+class cWscAttrAssociationState;
+class cWscAttrDevicePasswordID;
+class cWscAttrConfigurationError;
+class cWscAttrOsVersion;
 typedef struct sWscAttrVersion {
     eWscAttributes attribute_type;
     uint16_t data_length;
@@ -116,7 +135,7 @@ typedef struct sWscAttrMac {
     }
 } __attribute__((packed)) sWscAttrMac;
 
-typedef struct sWscAttrEnroleeNonce {
+typedef struct sWscAttrEnrolleeNonce {
     eWscAttributes attribute_type;
     uint16_t data_length;
     uint8_t data[WSC_NONCE_LENGTH];
@@ -128,7 +147,7 @@ typedef struct sWscAttrEnroleeNonce {
         attribute_type = ATTR_ENROLLEE_NONCE;
         data_length = WSC_NONCE_LENGTH;
     }
-} __attribute__((packed)) sWscAttrEnroleeNonce;
+} __attribute__((packed)) sWscAttrEnrolleeNonce;
 
 typedef struct sWscAttrRegistrarNonce {
     eWscAttributes attribute_type;
@@ -581,6 +600,443 @@ class cWscVendorExtWfa : public BaseClass
         uint8_t* m_vs_data = nullptr;
         size_t m_vs_data_idx__ = 0;
         int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrVersion : public BaseClass
+{
+    public:
+        cWscAttrVersion(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrVersion(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrVersion();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscValues8& data();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscValues8* m_data = nullptr;
+};
+
+class cWscAttrMessageType : public BaseClass
+{
+    public:
+        cWscAttrMessageType(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrMessageType(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrMessageType();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscMessageType& msg_type();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscMessageType* m_msg_type = nullptr;
+};
+
+class cWscAttrEnrolleeNonce : public BaseClass
+{
+    public:
+        cWscAttrEnrolleeNonce(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrEnrolleeNonce(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrEnrolleeNonce();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint8_t* nonce(size_t idx = 0);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_nonce = nullptr;
+        size_t m_nonce_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrPublicKey : public BaseClass
+{
+    public:
+        cWscAttrPublicKey(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrPublicKey(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrPublicKey();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint8_t* public_key(size_t idx = 0);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_public_key = nullptr;
+        size_t m_public_key_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrAuthenticationTypeFlags : public BaseClass
+{
+    public:
+        cWscAttrAuthenticationTypeFlags(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrAuthenticationTypeFlags(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrAuthenticationTypeFlags();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint16_t& auth_type_flags();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint16_t* m_auth_type_flags = nullptr;
+};
+
+class cWscAttrEncryptionTypeFlags : public BaseClass
+{
+    public:
+        cWscAttrEncryptionTypeFlags(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrEncryptionTypeFlags(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrEncryptionTypeFlags();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint16_t& encr_type_flags();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint16_t* m_encr_type_flags = nullptr;
+};
+
+class cWscAttrConnectionTypeFlags : public BaseClass
+{
+    public:
+        cWscAttrConnectionTypeFlags(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrConnectionTypeFlags(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrConnectionTypeFlags();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscConn& conn_type_flags();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscConn* m_conn_type_flags = nullptr;
+};
+
+class cWscAttrConfigurationMethods : public BaseClass
+{
+    public:
+        cWscAttrConfigurationMethods(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrConfigurationMethods(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrConfigurationMethods();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint16_t& conf_methods();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint16_t* m_conf_methods = nullptr;
+};
+
+class cWscAttrManufacturer : public BaseClass
+{
+    public:
+        cWscAttrManufacturer(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrManufacturer(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrManufacturer();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        std::string manufacturer_str();
+        char* manufacturer(size_t length = 0);
+        bool set_manufacturer(const std::string& str);
+        bool set_manufacturer(const char buffer[], size_t size);
+        bool alloc_manufacturer(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        char* m_manufacturer = nullptr;
+        size_t m_manufacturer_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrModelName : public BaseClass
+{
+    public:
+        cWscAttrModelName(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrModelName(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrModelName();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        std::string model_str();
+        char* model(size_t length = 0);
+        bool set_model(const std::string& str);
+        bool set_model(const char buffer[], size_t size);
+        bool alloc_model(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        char* m_model = nullptr;
+        size_t m_model_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrModelNumber : public BaseClass
+{
+    public:
+        cWscAttrModelNumber(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrModelNumber(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrModelNumber();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        std::string model_number_str();
+        char* model_number(size_t length = 0);
+        bool set_model_number(const std::string& str);
+        bool set_model_number(const char buffer[], size_t size);
+        bool alloc_model_number(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        char* m_model_number = nullptr;
+        size_t m_model_number_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrSerialNumber : public BaseClass
+{
+    public:
+        cWscAttrSerialNumber(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrSerialNumber(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrSerialNumber();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        std::string model_number_str();
+        char* model_number(size_t length = 0);
+        bool set_model_number(const std::string& str);
+        bool set_model_number(const char buffer[], size_t size);
+        bool alloc_model_number(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        char* m_model_number = nullptr;
+        size_t m_model_number_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrPrimaryDeviceType : public BaseClass
+{
+    public:
+        cWscAttrPrimaryDeviceType(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrPrimaryDeviceType(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrPrimaryDeviceType();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint16_t& category_id();
+        uint32_t& oui();
+        uint16_t& sub_category_id();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint16_t* m_category_id = nullptr;
+        uint32_t* m_oui = nullptr;
+        uint16_t* m_sub_category_id = nullptr;
+};
+
+class cWscAttrDeviceName : public BaseClass
+{
+    public:
+        cWscAttrDeviceName(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrDeviceName(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrDeviceName();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        std::string device_name_str();
+        char* device_name(size_t length = 0);
+        bool set_device_name(const std::string& str);
+        bool set_device_name(const char buffer[], size_t size);
+        bool alloc_device_name(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        char* m_device_name = nullptr;
+        size_t m_device_name_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+class cWscAttrRfBands : public BaseClass
+{
+    public:
+        cWscAttrRfBands(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrRfBands(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrRfBands();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscRfBands& bands();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscRfBands* m_bands = nullptr;
+};
+
+class cWscAttrAssociationState : public BaseClass
+{
+    public:
+        cWscAttrAssociationState(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrAssociationState(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrAssociationState();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscAssoc& assoc_state();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscAssoc* m_assoc_state = nullptr;
+};
+
+class cWscAttrDevicePasswordID : public BaseClass
+{
+    public:
+        cWscAttrDevicePasswordID(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrDevicePasswordID(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrDevicePasswordID();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscValues16& pw();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscValues16* m_pw = nullptr;
+};
+
+class cWscAttrConfigurationError : public BaseClass
+{
+    public:
+        cWscAttrConfigurationError(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrConfigurationError(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrConfigurationError();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        eWscValues16& cfg_err();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eWscValues16* m_cfg_err = nullptr;
+};
+
+class cWscAttrOsVersion : public BaseClass
+{
+    public:
+        cWscAttrOsVersion(uint8_t* buff, size_t buff_len, bool parse = false);
+        cWscAttrOsVersion(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~cWscAttrOsVersion();
+
+        eWscAttributes& type();
+        const uint16_t& length();
+        uint32_t& os_version();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eWscAttributes* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint32_t* m_os_version = nullptr;
 };
 
 }; // close namespace: WSC

--- a/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscMessageType.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/WSC/eWscMessageType.h
@@ -22,6 +22,7 @@ namespace WSC {
 enum eWscMessageType: uint8_t {
     WSC_MSG_TYPE_M1 = 0x4,
     WSC_MSG_TYPE_M2 = 0x5,
+    WSC_MSG_TYPE_INVALID = 0xff,
 };
 
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWsc.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWsc.h
@@ -1,0 +1,56 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_IEEE_1905_1_TLVWSC_H_
+#define _TLVF_IEEE_1905_1_TLVWSC_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/ieee_1905_1/eTlvType.h"
+#include <tuple>
+
+namespace ieee1905_1 {
+
+
+class tlvWsc : public BaseClass
+{
+    public:
+        tlvWsc(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvWsc(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvWsc();
+
+        const eTlvType& type();
+        const uint16_t& length();
+        size_t payload_length() { return m_payload_idx__ * sizeof(uint8_t); }
+        uint8_t* payload(size_t idx = 0);
+        bool alloc_payload(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvType* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        uint8_t* m_payload = nullptr;
+        size_t m_payload_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+}; // close namespace: ieee1905_1
+
+#endif //_TLVF/IEEE_1905_1_TLVWSC_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM1.h
@@ -41,7 +41,7 @@ class tlvWscM1 : public BaseClass
         WSC::sWscAttrMessageType& message_type_attr();
         WSC::sWscAttrUuidE& uuid_e_attr();
         WSC::sWscAttrMac& mac_attr();
-        WSC::sWscAttrEnroleeNonce& enrolee_nonce_attr();
+        WSC::sWscAttrEnrolleeNonce& enrolee_nonce_attr();
         WSC::sWscAttrPublicKey& public_key_attr();
         WSC::sWscAttrAuthenticationTypeFlags& authentication_type_flags_attr();
         WSC::sWscAttrEncryptionTypeFlags& encryption_type_flags_attr();
@@ -105,7 +105,7 @@ class tlvWscM1 : public BaseClass
         WSC::sWscAttrMessageType* m_message_type_attr = nullptr;
         WSC::sWscAttrUuidE* m_uuid_e_attr = nullptr;
         WSC::sWscAttrMac* m_mac_attr = nullptr;
-        WSC::sWscAttrEnroleeNonce* m_enrolee_nonce_attr = nullptr;
+        WSC::sWscAttrEnrolleeNonce* m_enrolee_nonce_attr = nullptr;
         WSC::sWscAttrPublicKey* m_public_key_attr = nullptr;
         WSC::sWscAttrAuthenticationTypeFlags* m_authentication_type_flags_attr = nullptr;
         WSC::sWscAttrEncryptionTypeFlags* m_encryption_type_flags_attr = nullptr;

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvWscM2.h
@@ -39,7 +39,7 @@ class tlvWscM2 : public BaseClass
         const uint16_t& length();
         WSC::sWscAttrVersion& version_attr();
         WSC::sWscAttrMessageType& message_type_attr();
-        WSC::sWscAttrEnroleeNonce& enrolee_nonce_attr();
+        WSC::sWscAttrEnrolleeNonce& enrolee_nonce_attr();
         WSC::sWscAttrRegistrarNonce& registrar_nonce_attr();
         WSC::sWscAttrUuidR& uuid_r_attr();
         WSC::sWscAttrPublicKey& public_key_attr();
@@ -104,7 +104,7 @@ class tlvWscM2 : public BaseClass
         uint16_t* m_length = nullptr;
         WSC::sWscAttrVersion* m_version_attr = nullptr;
         WSC::sWscAttrMessageType* m_message_type_attr = nullptr;
-        WSC::sWscAttrEnroleeNonce* m_enrolee_nonce_attr = nullptr;
+        WSC::sWscAttrEnrolleeNonce* m_enrolee_nonce_attr = nullptr;
         WSC::sWscAttrRegistrarNonce* m_registrar_nonce_attr = nullptr;
         WSC::sWscAttrUuidR* m_uuid_r_attr = nullptr;
         WSC::sWscAttrPublicKey* m_public_key_attr = nullptr;

--- a/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/WSC/WSC_Attributes.cpp
@@ -674,4 +674,2089 @@ bool cWscVendorExtWfa::init()
     return true;
 }
 
+cWscAttrVersion::cWscAttrVersion(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrVersion::cWscAttrVersion(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrVersion::~cWscAttrVersion() {
+}
+eWscAttributes& cWscAttrVersion::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrVersion::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscValues8& cWscAttrVersion::data() {
+    return (eWscValues8&)(*m_data);
+}
+
+void cWscAttrVersion::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrVersion::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrVersion::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscValues8); // data
+    return class_size;
+}
+
+bool cWscAttrVersion::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_VERSION;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_data = (eWscValues8*)m_buff_ptr__;
+    if (!m_parse__) *m_data = WSC_VERSION;
+    if (!buffPtrIncrementSafe(sizeof(eWscValues8))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscValues8) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscValues8); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrMessageType::cWscAttrMessageType(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrMessageType::cWscAttrMessageType(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrMessageType::~cWscAttrMessageType() {
+}
+eWscAttributes& cWscAttrMessageType::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrMessageType::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscMessageType& cWscAttrMessageType::msg_type() {
+    return (eWscMessageType&)(*m_msg_type);
+}
+
+void cWscAttrMessageType::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrMessageType::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrMessageType::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscMessageType); // msg_type
+    return class_size;
+}
+
+bool cWscAttrMessageType::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_MSG_TYPE;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_msg_type = (eWscMessageType*)m_buff_ptr__;
+    if (!m_parse__) *m_msg_type = WSC_MSG_TYPE_INVALID;
+    if (!buffPtrIncrementSafe(sizeof(eWscMessageType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscMessageType) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscMessageType); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrEnrolleeNonce::cWscAttrEnrolleeNonce(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrEnrolleeNonce::cWscAttrEnrolleeNonce(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrEnrolleeNonce::~cWscAttrEnrolleeNonce() {
+}
+eWscAttributes& cWscAttrEnrolleeNonce::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrEnrolleeNonce::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t* cWscAttrEnrolleeNonce::nonce(size_t idx) {
+    if ( (m_nonce_idx__ <= 0) || (m_nonce_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_nonce[idx]);
+}
+
+void cWscAttrEnrolleeNonce::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrEnrolleeNonce::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrEnrolleeNonce::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += WSC_NONCE_LENGTH * sizeof(uint8_t); // nonce
+    return class_size;
+}
+
+bool cWscAttrEnrolleeNonce::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_ENROLLEE_NONCE;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_nonce = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (WSC_NONCE_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (WSC_NONCE_LENGTH) << ") Failed!";
+        return false;
+    }
+    m_nonce_idx__  = WSC_NONCE_LENGTH;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * WSC_NONCE_LENGTH); }
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrPublicKey::cWscAttrPublicKey(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrPublicKey::cWscAttrPublicKey(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrPublicKey::~cWscAttrPublicKey() {
+}
+eWscAttributes& cWscAttrPublicKey::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrPublicKey::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t* cWscAttrPublicKey::public_key(size_t idx) {
+    if ( (m_public_key_idx__ <= 0) || (m_public_key_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_public_key[idx]);
+}
+
+void cWscAttrPublicKey::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrPublicKey::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrPublicKey::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += WSC_PUBLIC_KEY_LENGTH * sizeof(uint8_t); // public_key
+    return class_size;
+}
+
+bool cWscAttrPublicKey::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_PUBLIC_KEY;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_public_key = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (WSC_PUBLIC_KEY_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (WSC_PUBLIC_KEY_LENGTH) << ") Failed!";
+        return false;
+    }
+    m_public_key_idx__  = WSC_PUBLIC_KEY_LENGTH;
+    if (!m_parse__) {
+        if (m_length) { (*m_length) += (sizeof(uint8_t) * WSC_PUBLIC_KEY_LENGTH); }
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrAuthenticationTypeFlags::cWscAttrAuthenticationTypeFlags(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrAuthenticationTypeFlags::cWscAttrAuthenticationTypeFlags(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrAuthenticationTypeFlags::~cWscAttrAuthenticationTypeFlags() {
+}
+eWscAttributes& cWscAttrAuthenticationTypeFlags::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrAuthenticationTypeFlags::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint16_t& cWscAttrAuthenticationTypeFlags::auth_type_flags() {
+    return (uint16_t&)(*m_auth_type_flags);
+}
+
+void cWscAttrAuthenticationTypeFlags::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_auth_type_flags));
+}
+
+bool cWscAttrAuthenticationTypeFlags::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrAuthenticationTypeFlags::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint16_t); // auth_type_flags
+    return class_size;
+}
+
+bool cWscAttrAuthenticationTypeFlags::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_AUTH_TYPE_FLAGS;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_auth_type_flags = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_auth_type_flags = uint16_t(eWscAuth::WSC_AUTH_OPEN) | uint16_t(eWscAuth::WSC_AUTH_WPA2PSK);
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrEncryptionTypeFlags::cWscAttrEncryptionTypeFlags(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrEncryptionTypeFlags::cWscAttrEncryptionTypeFlags(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrEncryptionTypeFlags::~cWscAttrEncryptionTypeFlags() {
+}
+eWscAttributes& cWscAttrEncryptionTypeFlags::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrEncryptionTypeFlags::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint16_t& cWscAttrEncryptionTypeFlags::encr_type_flags() {
+    return (uint16_t&)(*m_encr_type_flags);
+}
+
+void cWscAttrEncryptionTypeFlags::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_encr_type_flags));
+}
+
+bool cWscAttrEncryptionTypeFlags::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrEncryptionTypeFlags::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint16_t); // encr_type_flags
+    return class_size;
+}
+
+bool cWscAttrEncryptionTypeFlags::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_ENCR_TYPE_FLAGS;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_encr_type_flags = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_encr_type_flags = uint16_t(eWscEncr::WSC_ENCR_NONE) | uint16_t(eWscEncr::WSC_ENCR_AES);
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrConnectionTypeFlags::cWscAttrConnectionTypeFlags(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrConnectionTypeFlags::cWscAttrConnectionTypeFlags(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrConnectionTypeFlags::~cWscAttrConnectionTypeFlags() {
+}
+eWscAttributes& cWscAttrConnectionTypeFlags::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrConnectionTypeFlags::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscConn& cWscAttrConnectionTypeFlags::conn_type_flags() {
+    return (eWscConn&)(*m_conn_type_flags);
+}
+
+void cWscAttrConnectionTypeFlags::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrConnectionTypeFlags::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrConnectionTypeFlags::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscConn); // conn_type_flags
+    return class_size;
+}
+
+bool cWscAttrConnectionTypeFlags::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_CONN_TYPE_FLAGS;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_conn_type_flags = (eWscConn*)m_buff_ptr__;
+    if (!m_parse__) *m_conn_type_flags = WSC_CONN_ESS;
+    if (!buffPtrIncrementSafe(sizeof(eWscConn))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscConn) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscConn); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrConfigurationMethods::cWscAttrConfigurationMethods(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrConfigurationMethods::cWscAttrConfigurationMethods(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrConfigurationMethods::~cWscAttrConfigurationMethods() {
+}
+eWscAttributes& cWscAttrConfigurationMethods::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrConfigurationMethods::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint16_t& cWscAttrConfigurationMethods::conf_methods() {
+    return (uint16_t&)(*m_conf_methods);
+}
+
+void cWscAttrConfigurationMethods::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_conf_methods));
+}
+
+bool cWscAttrConfigurationMethods::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrConfigurationMethods::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint16_t); // conf_methods
+    return class_size;
+}
+
+bool cWscAttrConfigurationMethods::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_CONFIG_METHODS;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_conf_methods = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_conf_methods = (WSC_CONFIG_PHY_PUSHBUTTON | WSC_CONFIG_VIRT_PUSHBUTTON);
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrManufacturer::cWscAttrManufacturer(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrManufacturer::cWscAttrManufacturer(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrManufacturer::~cWscAttrManufacturer() {
+}
+eWscAttributes& cWscAttrManufacturer::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrManufacturer::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+std::string cWscAttrManufacturer::manufacturer_str() {
+    char *manufacturer_ = manufacturer();
+    if (!manufacturer_) { return std::string(); }
+    return std::string(manufacturer_, m_manufacturer_idx__);
+}
+
+char* cWscAttrManufacturer::manufacturer(size_t length) {
+    if( (m_manufacturer_idx__ <= 0) || (m_manufacturer_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "manufacturer length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_manufacturer);
+}
+
+bool cWscAttrManufacturer::set_manufacturer(const std::string& str) { return set_manufacturer(str.c_str(), str.size()); }
+bool cWscAttrManufacturer::set_manufacturer(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_manufacturer received an empty string.";
+        return false;
+    }
+    if (!alloc_manufacturer(size)) { return false; }
+    std::copy(str, str + size, m_manufacturer);
+    return true;
+}
+bool cWscAttrManufacturer::alloc_manufacturer(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list manufacturer, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_manufacturer[*m_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_manufacturer_idx__ += count;
+    *m_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscAttrManufacturer::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrManufacturer::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrManufacturer::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool cWscAttrManufacturer::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_MANUFACTURER;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_manufacturer = (char*)m_buff_ptr__;
+    uint16_t length = *m_length;
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&length)); }
+    m_manufacturer_idx__ = length;
+    if (!buffPtrIncrementSafe(sizeof(char) * (length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrModelName::cWscAttrModelName(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrModelName::cWscAttrModelName(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrModelName::~cWscAttrModelName() {
+}
+eWscAttributes& cWscAttrModelName::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrModelName::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+std::string cWscAttrModelName::model_str() {
+    char *model_ = model();
+    if (!model_) { return std::string(); }
+    return std::string(model_, m_model_idx__);
+}
+
+char* cWscAttrModelName::model(size_t length) {
+    if( (m_model_idx__ <= 0) || (m_model_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "model length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_model);
+}
+
+bool cWscAttrModelName::set_model(const std::string& str) { return set_model(str.c_str(), str.size()); }
+bool cWscAttrModelName::set_model(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_model received an empty string.";
+        return false;
+    }
+    if (!alloc_model(size)) { return false; }
+    std::copy(str, str + size, m_model);
+    return true;
+}
+bool cWscAttrModelName::alloc_model(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list model, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_model[*m_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_model_idx__ += count;
+    *m_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscAttrModelName::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrModelName::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrModelName::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool cWscAttrModelName::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_MODEL_NAME;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_model = (char*)m_buff_ptr__;
+    uint16_t length = *m_length;
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&length)); }
+    m_model_idx__ = length;
+    if (!buffPtrIncrementSafe(sizeof(char) * (length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrModelNumber::cWscAttrModelNumber(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrModelNumber::cWscAttrModelNumber(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrModelNumber::~cWscAttrModelNumber() {
+}
+eWscAttributes& cWscAttrModelNumber::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrModelNumber::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+std::string cWscAttrModelNumber::model_number_str() {
+    char *model_number_ = model_number();
+    if (!model_number_) { return std::string(); }
+    return std::string(model_number_, m_model_number_idx__);
+}
+
+char* cWscAttrModelNumber::model_number(size_t length) {
+    if( (m_model_number_idx__ <= 0) || (m_model_number_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "model_number length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_model_number);
+}
+
+bool cWscAttrModelNumber::set_model_number(const std::string& str) { return set_model_number(str.c_str(), str.size()); }
+bool cWscAttrModelNumber::set_model_number(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_model_number received an empty string.";
+        return false;
+    }
+    if (!alloc_model_number(size)) { return false; }
+    std::copy(str, str + size, m_model_number);
+    return true;
+}
+bool cWscAttrModelNumber::alloc_model_number(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list model_number, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_model_number[*m_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_model_number_idx__ += count;
+    *m_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscAttrModelNumber::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrModelNumber::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrModelNumber::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool cWscAttrModelNumber::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_MODEL_NUMBER;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_model_number = (char*)m_buff_ptr__;
+    uint16_t length = *m_length;
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&length)); }
+    m_model_number_idx__ = length;
+    if (!buffPtrIncrementSafe(sizeof(char) * (length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrSerialNumber::cWscAttrSerialNumber(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrSerialNumber::cWscAttrSerialNumber(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrSerialNumber::~cWscAttrSerialNumber() {
+}
+eWscAttributes& cWscAttrSerialNumber::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrSerialNumber::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+std::string cWscAttrSerialNumber::model_number_str() {
+    char *model_number_ = model_number();
+    if (!model_number_) { return std::string(); }
+    return std::string(model_number_, m_model_number_idx__);
+}
+
+char* cWscAttrSerialNumber::model_number(size_t length) {
+    if( (m_model_number_idx__ <= 0) || (m_model_number_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "model_number length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_model_number);
+}
+
+bool cWscAttrSerialNumber::set_model_number(const std::string& str) { return set_model_number(str.c_str(), str.size()); }
+bool cWscAttrSerialNumber::set_model_number(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_model_number received an empty string.";
+        return false;
+    }
+    if (!alloc_model_number(size)) { return false; }
+    std::copy(str, str + size, m_model_number);
+    return true;
+}
+bool cWscAttrSerialNumber::alloc_model_number(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list model_number, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_model_number[*m_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_model_number_idx__ += count;
+    *m_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscAttrSerialNumber::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrSerialNumber::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrSerialNumber::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool cWscAttrSerialNumber::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_SERIAL_NUMBER;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_model_number = (char*)m_buff_ptr__;
+    uint16_t length = *m_length;
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&length)); }
+    m_model_number_idx__ = length;
+    if (!buffPtrIncrementSafe(sizeof(char) * (length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrPrimaryDeviceType::cWscAttrPrimaryDeviceType(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrPrimaryDeviceType::cWscAttrPrimaryDeviceType(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrPrimaryDeviceType::~cWscAttrPrimaryDeviceType() {
+}
+eWscAttributes& cWscAttrPrimaryDeviceType::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrPrimaryDeviceType::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint16_t& cWscAttrPrimaryDeviceType::category_id() {
+    return (uint16_t&)(*m_category_id);
+}
+
+uint32_t& cWscAttrPrimaryDeviceType::oui() {
+    return (uint32_t&)(*m_oui);
+}
+
+uint16_t& cWscAttrPrimaryDeviceType::sub_category_id() {
+    return (uint16_t&)(*m_sub_category_id);
+}
+
+void cWscAttrPrimaryDeviceType::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_category_id));
+    tlvf_swap(32, reinterpret_cast<uint8_t*>(m_oui));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_sub_category_id));
+}
+
+bool cWscAttrPrimaryDeviceType::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrPrimaryDeviceType::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint16_t); // category_id
+    class_size += sizeof(uint32_t); // oui
+    class_size += sizeof(uint16_t); // sub_category_id
+    return class_size;
+}
+
+bool cWscAttrPrimaryDeviceType::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_PRIMARY_DEV_TYPE;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_category_id = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_category_id = WSC_DEV_NETWORK_INFRA;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_oui = (uint32_t*)m_buff_ptr__;
+    if (!m_parse__) *m_oui = 0x50f204;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint32_t); }
+    m_sub_category_id = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrDeviceName::cWscAttrDeviceName(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrDeviceName::cWscAttrDeviceName(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrDeviceName::~cWscAttrDeviceName() {
+}
+eWscAttributes& cWscAttrDeviceName::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrDeviceName::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+std::string cWscAttrDeviceName::device_name_str() {
+    char *device_name_ = device_name();
+    if (!device_name_) { return std::string(); }
+    return std::string(device_name_, m_device_name_idx__);
+}
+
+char* cWscAttrDeviceName::device_name(size_t length) {
+    if( (m_device_name_idx__ <= 0) || (m_device_name_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "device_name length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_device_name);
+}
+
+bool cWscAttrDeviceName::set_device_name(const std::string& str) { return set_device_name(str.c_str(), str.size()); }
+bool cWscAttrDeviceName::set_device_name(const char str[], size_t size) {
+    if (str == nullptr || size == 0) {
+        TLVF_LOG(WARNING) << "set_device_name received an empty string.";
+        return false;
+    }
+    if (!alloc_device_name(size)) { return false; }
+    std::copy(str, str + size, m_device_name);
+    return true;
+}
+bool cWscAttrDeviceName::alloc_device_name(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list device_name, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_device_name[*m_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_device_name_idx__ += count;
+    *m_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void cWscAttrDeviceName::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrDeviceName::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrDeviceName::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool cWscAttrDeviceName::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_DEV_NAME;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_device_name = (char*)m_buff_ptr__;
+    uint16_t length = *m_length;
+    if (m_parse__) {  tlvf_swap(16, reinterpret_cast<uint8_t*>(&length)); }
+    m_device_name_idx__ = length;
+    if (!buffPtrIncrementSafe(sizeof(char) * (length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrRfBands::cWscAttrRfBands(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrRfBands::cWscAttrRfBands(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrRfBands::~cWscAttrRfBands() {
+}
+eWscAttributes& cWscAttrRfBands::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrRfBands::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscRfBands& cWscAttrRfBands::bands() {
+    return (eWscRfBands&)(*m_bands);
+}
+
+void cWscAttrRfBands::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool cWscAttrRfBands::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrRfBands::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscRfBands); // bands
+    return class_size;
+}
+
+bool cWscAttrRfBands::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_RF_BANDS;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_bands = (eWscRfBands*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(eWscRfBands))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscRfBands) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscRfBands); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrAssociationState::cWscAttrAssociationState(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrAssociationState::cWscAttrAssociationState(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrAssociationState::~cWscAttrAssociationState() {
+}
+eWscAttributes& cWscAttrAssociationState::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrAssociationState::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscAssoc& cWscAttrAssociationState::assoc_state() {
+    return (eWscAssoc&)(*m_assoc_state);
+}
+
+void cWscAttrAssociationState::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_assoc_state));
+}
+
+bool cWscAttrAssociationState::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrAssociationState::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscAssoc); // assoc_state
+    return class_size;
+}
+
+bool cWscAttrAssociationState::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_ASSOC_STATE;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_assoc_state = (eWscAssoc*)m_buff_ptr__;
+    if (!m_parse__) *m_assoc_state = WSC_ASSOC_NOT_ASSOC;
+    if (!buffPtrIncrementSafe(sizeof(eWscAssoc))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAssoc) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscAssoc); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrDevicePasswordID::cWscAttrDevicePasswordID(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrDevicePasswordID::cWscAttrDevicePasswordID(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrDevicePasswordID::~cWscAttrDevicePasswordID() {
+}
+eWscAttributes& cWscAttrDevicePasswordID::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrDevicePasswordID::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscValues16& cWscAttrDevicePasswordID::pw() {
+    return (eWscValues16&)(*m_pw);
+}
+
+void cWscAttrDevicePasswordID::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_pw));
+}
+
+bool cWscAttrDevicePasswordID::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrDevicePasswordID::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscValues16); // pw
+    return class_size;
+}
+
+bool cWscAttrDevicePasswordID::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_DEV_PASSWORD_ID;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_pw = (eWscValues16*)m_buff_ptr__;
+    if (!m_parse__) *m_pw = DEV_PW_PUSHBUTTON;
+    if (!buffPtrIncrementSafe(sizeof(eWscValues16))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscValues16) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscValues16); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrConfigurationError::cWscAttrConfigurationError(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrConfigurationError::cWscAttrConfigurationError(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrConfigurationError::~cWscAttrConfigurationError() {
+}
+eWscAttributes& cWscAttrConfigurationError::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrConfigurationError::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+eWscValues16& cWscAttrConfigurationError::cfg_err() {
+    return (eWscValues16&)(*m_cfg_err);
+}
+
+void cWscAttrConfigurationError::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_cfg_err));
+}
+
+bool cWscAttrConfigurationError::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrConfigurationError::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eWscValues16); // cfg_err
+    return class_size;
+}
+
+bool cWscAttrConfigurationError::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_CONFIG_ERROR;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_cfg_err = (eWscValues16*)m_buff_ptr__;
+    if (!m_parse__) *m_cfg_err = WSC_CFG_NO_ERROR;
+    if (!buffPtrIncrementSafe(sizeof(eWscValues16))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscValues16) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eWscValues16); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
+cWscAttrOsVersion::cWscAttrOsVersion(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+cWscAttrOsVersion::cWscAttrOsVersion(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+cWscAttrOsVersion::~cWscAttrOsVersion() {
+}
+eWscAttributes& cWscAttrOsVersion::type() {
+    return (eWscAttributes&)(*m_type);
+}
+
+const uint16_t& cWscAttrOsVersion::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint32_t& cWscAttrOsVersion::os_version() {
+    return (uint32_t&)(*m_os_version);
+}
+
+void cWscAttrOsVersion::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(32, reinterpret_cast<uint8_t*>(m_os_version));
+}
+
+bool cWscAttrOsVersion::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t cWscAttrOsVersion::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eWscAttributes); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(uint32_t); // os_version
+    return class_size;
+}
+
+bool cWscAttrOsVersion::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eWscAttributes*)m_buff_ptr__;
+    if (!m_parse__) *m_type = ATTR_OS_VERSION;
+    if (!buffPtrIncrementSafe(sizeof(eWscAttributes))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eWscAttributes) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_os_version = (uint32_t*)m_buff_ptr__;
+    if (!m_parse__) *m_os_version = 0x80000001;
+    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint32_t); }
+    if (m_parse__) { class_swap(); }
+    return true;
+}
+
 

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWsc.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWsc.cpp
@@ -1,0 +1,154 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/ieee_1905_1/tlvWsc.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace ieee1905_1;
+
+tlvWsc::tlvWsc(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvWsc::tlvWsc(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvWsc::~tlvWsc() {
+}
+const eTlvType& tlvWsc::type() {
+    return (const eTlvType&)(*m_type);
+}
+
+const uint16_t& tlvWsc::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+uint8_t* tlvWsc::payload(size_t idx) {
+    if ( (m_payload_idx__ <= 0) || (m_payload_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_payload[idx]);
+}
+
+bool tlvWsc::alloc_payload(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list payload, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_payload;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_payload_idx__ += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void tlvWsc::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+}
+
+bool tlvWsc::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvWsc::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvType); // type
+    class_size += sizeof(uint16_t); // length
+    return class_size;
+}
+
+bool tlvWsc::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvType*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvType::TLV_WSC;
+    if (!buffPtrIncrementSafe(sizeof(eTlvType))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvType) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_payload = (uint8_t*)m_buff_ptr__;
+    if (m_length && m_parse__) {
+        size_t len = *m_length;
+        tlvf_swap(16, reinterpret_cast<uint8_t*>(&len));
+        len -= (m_buff_ptr__ - sizeof(*m_type) - sizeof(*m_length) - m_buff__);
+        m_payload_idx__ = len/sizeof(uint8_t);
+        if (!buffPtrIncrementSafe(len)) {
+            LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+            return false;
+        }
+    }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvType::TLV_WSC) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvType::TLV_WSC) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM1.cpp
@@ -49,8 +49,8 @@ WSC::sWscAttrMac& tlvWscM1::mac_attr() {
     return (WSC::sWscAttrMac&)(*m_mac_attr);
 }
 
-WSC::sWscAttrEnroleeNonce& tlvWscM1::enrolee_nonce_attr() {
-    return (WSC::sWscAttrEnroleeNonce&)(*m_enrolee_nonce_attr);
+WSC::sWscAttrEnrolleeNonce& tlvWscM1::enrolee_nonce_attr() {
+    return (WSC::sWscAttrEnrolleeNonce&)(*m_enrolee_nonce_attr);
 }
 
 WSC::sWscAttrPublicKey& tlvWscM1::public_key_attr() {
@@ -609,7 +609,7 @@ size_t tlvWscM1::get_initial_size()
     class_size += sizeof(WSC::sWscAttrMessageType); // message_type_attr
     class_size += sizeof(WSC::sWscAttrUuidE); // uuid_e_attr
     class_size += sizeof(WSC::sWscAttrMac); // mac_attr
-    class_size += sizeof(WSC::sWscAttrEnroleeNonce); // enrolee_nonce_attr
+    class_size += sizeof(WSC::sWscAttrEnrolleeNonce); // enrolee_nonce_attr
     class_size += sizeof(WSC::sWscAttrPublicKey); // public_key_attr
     class_size += sizeof(WSC::sWscAttrAuthenticationTypeFlags); // authentication_type_flags_attr
     class_size += sizeof(WSC::sWscAttrEncryptionTypeFlags); // encryption_type_flags_attr
@@ -681,12 +681,12 @@ bool tlvWscM1::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMac); }
     if (!m_parse__) { m_mac_attr->struct_init(); }
-    m_enrolee_nonce_attr = (WSC::sWscAttrEnroleeNonce*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEnroleeNonce) << ") Failed!";
+    m_enrolee_nonce_attr = (WSC::sWscAttrEnrolleeNonce*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnrolleeNonce))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEnrolleeNonce) << ") Failed!";
         return false;
     }
-    if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnroleeNonce); }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnrolleeNonce); }
     if (!m_parse__) { m_enrolee_nonce_attr->struct_init(); }
     m_public_key_attr = (WSC::sWscAttrPublicKey*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrPublicKey))) {

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvWscM2.cpp
@@ -41,8 +41,8 @@ WSC::sWscAttrMessageType& tlvWscM2::message_type_attr() {
     return (WSC::sWscAttrMessageType&)(*m_message_type_attr);
 }
 
-WSC::sWscAttrEnroleeNonce& tlvWscM2::enrolee_nonce_attr() {
-    return (WSC::sWscAttrEnroleeNonce&)(*m_enrolee_nonce_attr);
+WSC::sWscAttrEnrolleeNonce& tlvWscM2::enrolee_nonce_attr() {
+    return (WSC::sWscAttrEnrolleeNonce&)(*m_enrolee_nonce_attr);
 }
 
 WSC::sWscAttrRegistrarNonce& tlvWscM2::registrar_nonce_attr() {
@@ -624,7 +624,7 @@ size_t tlvWscM2::get_initial_size()
     class_size += sizeof(uint16_t); // length
     class_size += sizeof(WSC::sWscAttrVersion); // version_attr
     class_size += sizeof(WSC::sWscAttrMessageType); // message_type_attr
-    class_size += sizeof(WSC::sWscAttrEnroleeNonce); // enrolee_nonce_attr
+    class_size += sizeof(WSC::sWscAttrEnrolleeNonce); // enrolee_nonce_attr
     class_size += sizeof(WSC::sWscAttrRegistrarNonce); // registrar_nonce_attr
     class_size += sizeof(WSC::sWscAttrUuidR); // uuid_r_attr
     class_size += sizeof(WSC::sWscAttrPublicKey); // public_key_attr
@@ -685,12 +685,12 @@ bool tlvWscM2::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrMessageType); }
     if (!m_parse__) { m_message_type_attr->struct_init(); }
-    m_enrolee_nonce_attr = (WSC::sWscAttrEnroleeNonce*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnroleeNonce))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEnroleeNonce) << ") Failed!";
+    m_enrolee_nonce_attr = (WSC::sWscAttrEnrolleeNonce*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrEnrolleeNonce))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(WSC::sWscAttrEnrolleeNonce) << ") Failed!";
         return false;
     }
-    if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnroleeNonce); }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(WSC::sWscAttrEnrolleeNonce); }
     if (!m_parse__) { m_enrolee_nonce_attr->struct_init(); }
     m_registrar_nonce_attr = (WSC::sWscAttrRegistrarNonce*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(WSC::sWscAttrRegistrarNonce))) {

--- a/framework/tlvf/CMakeLists.txt
+++ b/framework/tlvf/CMakeLists.txt
@@ -45,7 +45,7 @@ add_custom_command(
     COMMENT "Generating the tlvf files."
 )
 
-file(GLOB TLVF_SOURCES ${TLVF_DIR}/src/src/*.c*)
+file(GLOB_RECURSE TLVF_SOURCES ${TLVF_DIR}/src/src/*.c*)
 add_library(tlvf SHARED ${TLVF_OUTPUTS} ${TLVF_SOURCES})
 set_target_properties(tlvf PROPERTIES VERSION ${${PROJECT}_VERSION_STRING} SOVERSION ${${PROJECT}_VERSION_MAJOR})
 target_link_libraries(tlvf PRIVATE mapf::elpp)

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -229,7 +229,7 @@ class MetaData:
                         else:
                             self.type = value
                 elif key == MetaData.DECELERATION_IS_TLV_CLASS:
-                    self.is_tlv_class = True
+                    self.is_tlv_class = value
                 elif key == MetaData.KEY_ENUM_STORAGE:
                     self.enum_storage = value
                     self.type_info = TypeInfo(value)

--- a/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/WSC_Attributes.yaml
@@ -68,7 +68,7 @@ sWscAttrMac:
     _value: WSC_MAC_LENGTH
   data: sMacAddr
 
-sWscAttrEnroleeNonce:
+sWscAttrEnrolleeNonce:
   _type: struct
   attribute_type: 
     _type: eWscAttributes
@@ -429,3 +429,254 @@ cWscVendorExtWfa:
   vs_data:
     _type: uint8_t
     _length: []
+
+cWscAttrVersion:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_VERSION
+  length:
+    _type: uint16_t
+    _value_const: 1
+  data:
+    _type: eWscValues8
+    _value: WSC_VERSION
+
+cWscAttrMessageType:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_MSG_TYPE
+  length:
+    _type: uint16_t
+    _value_const: 1
+  msg_type:
+    _type: eWscMessageType
+    _value: WSC_MSG_TYPE_INVALID
+
+cWscAttrEnrolleeNonce:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_ENROLLEE_NONCE
+  length:
+    _type: uint16_t
+    _value_const: WSC_NONCE_LENGTH
+  nonce:
+    _type: uint8_t
+    _length: [ WSC_NONCE_LENGTH ]
+
+cWscAttrPublicKey:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_PUBLIC_KEY
+  length:
+    _type: uint16_t
+    _value_const: WSC_PUBLIC_KEY_LENGTH
+  public_key:
+    _type: uint8_t
+    _length: [ WSC_PUBLIC_KEY_LENGTH ]
+
+cWscAttrAuthenticationTypeFlags:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_AUTH_TYPE_FLAGS
+  length: 
+    _type: uint16_t
+    _value_const: 2
+  auth_type_flags: 
+    _type: uint16_t
+    _value: uint16_t(eWscAuth::WSC_AUTH_OPEN) | uint16_t(eWscAuth::WSC_AUTH_WPA2PSK)
+
+cWscAttrEncryptionTypeFlags:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_ENCR_TYPE_FLAGS
+  length:
+    _type: uint16_t
+    _value_const: 2
+  encr_type_flags:
+    _type: uint16_t
+    _value: uint16_t(eWscEncr::WSC_ENCR_NONE) | uint16_t(eWscEncr::WSC_ENCR_AES)
+  
+cWscAttrConnectionTypeFlags:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_CONN_TYPE_FLAGS
+  length:
+    _type: uint16_t
+    _value_const: 1
+  conn_type_flags:
+    _type: eWscConn
+    _value: WSC_CONN_ESS
+  
+cWscAttrConfigurationMethods:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_CONFIG_METHODS
+  length:
+    _type: uint16_t
+    _value_const: 2
+  conf_methods:
+    _type: uint16_t
+    _value: (WSC_CONFIG_PHY_PUSHBUTTON | WSC_CONFIG_VIRT_PUSHBUTTON)
+
+cWscAttrManufacturer:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_MANUFACTURER
+  length:
+    _type: uint16_t
+    _length_var: True
+  manufacturer:
+    _type: char
+    _length: [ length ]
+
+cWscAttrModelName:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_MODEL_NAME
+  length:
+    _type: uint16_t
+    _length_var: True
+  model:
+    _type: char
+    _length: [ length ]
+
+cWscAttrModelNumber:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_MODEL_NUMBER
+  length:
+    _type: uint16_t
+    _length_var: True
+  model_number:
+    _type: char
+    _length: [ length ]
+
+cWscAttrSerialNumber:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_SERIAL_NUMBER
+  length:
+    _type: uint16_t
+    _length_var: True
+  model_number:
+    _type: char
+    _length: [ length ]
+
+cWscAttrPrimaryDeviceType:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_PRIMARY_DEV_TYPE
+  length:
+    _type: uint16_t
+    _value_const: WSC_PRIMARY_DEV_TYPE_LENGTH
+  category_id:
+    _type: uint16_t 
+    _value: WSC_DEV_NETWORK_INFRA
+  oui:
+    _type: uint32_t
+    _value: 0x0050F204
+  sub_category_id:
+    _type: uint16_t
+
+cWscAttrDeviceName:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_DEV_NAME
+  length:
+    _type: uint16_t
+    _length_var: True
+  device_name:
+    _type: char
+    _length: [ length ]
+
+cWscAttrRfBands:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_RF_BANDS
+  length:
+    _type: uint16_t
+    _value_const: 1
+  bands:
+    _type: eWscRfBands
+
+cWscAttrAssociationState:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_ASSOC_STATE
+  length:
+    _type: uint16_t
+    _value_const: 2
+  assoc_state:
+    _type: eWscAssoc
+    _value: WSC_ASSOC_NOT_ASSOC
+
+cWscAttrDevicePasswordID:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_DEV_PASSWORD_ID
+  length:
+    _type: uint16_t
+    _value_const: 2
+  pw:
+    _type: eWscValues16
+    _value: DEV_PW_PUSHBUTTON
+
+cWscAttrConfigurationError:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_CONFIG_ERROR
+  length:
+    _type: uint16_t
+    _value_const: 2
+  cfg_err:
+    _type: eWscValues16
+    _value: WSC_CFG_NO_ERROR
+
+cWscAttrOsVersion:
+  _type: class
+  _is_tlv_class: True
+  type:
+    _type: eWscAttributes
+    _value: ATTR_OS_VERSION
+  length:
+    _type: uint16_t
+    _value_const: WSC_OS_VERSION_LENGTH
+  os_version:
+    _type: uint32_t
+    _value: 0x80000001

--- a/framework/tlvf/yaml/tlvf/WSC/eWscMessageType.yaml
+++ b/framework/tlvf/yaml/tlvf/WSC/eWscMessageType.yaml
@@ -7,4 +7,5 @@ eWscMessageType:
   _enum_storage: uint8_t
   WSC_MSG_TYPE_M1: 0x04
   WSC_MSG_TYPE_M2: 0x05
+  WSC_MSG_TYPE_INVALID: 0xFF
   

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWsc.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWsc.yaml
@@ -1,0 +1,15 @@
+#
+---
+_namespace: ieee1905_1
+
+tlvWsc:
+  _type: class
+  _is_tlv_class : True
+  type:
+    _type: eTlvType
+    _value_const: TLV_WSC
+  length: uint16_t
+  # M2 attributes are stored in an inner TlvList
+  payload:
+    _type: uint8_t
+    _length: []

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM1.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM1.yaml
@@ -24,7 +24,7 @@ tlvWscM1:
   message_type_attr: WSC::sWscAttrMessageType
   uuid_e_attr: WSC::sWscAttrUuidE
   mac_attr: WSC::sWscAttrMac
-  enrolee_nonce_attr: WSC::sWscAttrEnroleeNonce
+  enrolee_nonce_attr: WSC::sWscAttrEnrolleeNonce
   public_key_attr: WSC::sWscAttrPublicKey
   authentication_type_flags_attr: WSC::sWscAttrAuthenticationTypeFlags
   encryption_type_flags_attr: WSC::sWscAttrEncryptionTypeFlags

--- a/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM2.yaml
+++ b/framework/tlvf/yaml/tlvf/ieee_1905_1/tlvWscM2.yaml
@@ -21,7 +21,7 @@ tlvWscM2:
   # a variable length list.
   version_attr: WSC::sWscAttrVersion
   message_type_attr: WSC::sWscAttrMessageType
-  enrolee_nonce_attr: WSC::sWscAttrEnroleeNonce
+  enrolee_nonce_attr: WSC::sWscAttrEnrolleeNonce
   registrar_nonce_attr: WSC::sWscAttrRegistrarNonce
   uuid_r_attr: WSC::sWscAttrUuidR
   public_key_attr: WSC::sWscAttrPublicKey


### PR DESCRIPTION
Once #572 is merged, we can start adding support for having WSC TLVs as an inner TLV list of the WSC TLV. In order to do that, all WSC attributes will need to be classes (not TLV classes but TLVF classes instead of structs).
As an effort not to make an enormous PR, this commit just adds all the M2 and M1 common attributes as TLV classes instead of structs in the `WSC_Attributes.yaml` file. The new classes are not yet used so this can be safely merged now - and be used by the AttrList implementation later.

In addition, this PR adds a couple of small fixes to TLVF.