### PR TITLE
Feature/port repeater from rdkb to prpl with ugw

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1435,8 +1435,9 @@ void ap_manager_thread::handle_hostapd_attached()
 
             usleep(ACS_READ_SLEEP_USC);
         }
-    } else
+    } else {
         ap_wlan_hal->read_supported_channels();
+    }
 
     auto notification =
         message_com::create_vs_message<beerocks_message::cACTION_APMANAGER_JOINED_NOTIFICATION>(

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -998,14 +998,15 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
             } else {
                 UTILS_SLEEP_MSEC(1000);
             }
+            break;
         }
+
+        state_attempts = 0; // for next state
 
         if (connected) {
             FSM_MOVE_STATE(MASTER_DISCOVERY);
-            state_attempts = 0; // for next state
         } else {
             FSM_MOVE_STATE(INITIATE_SCAN);
-            state_attempts = 0; // for next state
         }
 
         break;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1037,7 +1037,6 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
             break;
         }
 
-        bool success                     = true;
         bool preferred_band_is_available = false;
 
         // Check if backhaul preferred band is supported (supporting radio is available)
@@ -1058,6 +1057,9 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
         }
 
         LOG_IF(!preferred_band_is_available, DEBUG) << "Preferred backhaul band is not available";
+
+        bool success        = true;
+        bool scan_triggered = false;
 
         for (auto soc : slaves_sockets) {
             if (soc->sta_iface.empty())
@@ -1086,10 +1088,12 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
                 success = false;
                 break;
             }
+            scan_triggered = true;
             LOG(INFO) << "wait for scan results on iface " << iface;
         }
 
-        if (!success) {
+        if (!success || !scan_triggered) {
+            LOG_IF(!scan_triggered, DEBUG) << "no sta hal is available for scan";
             FSM_MOVE_STATE(RESTART);
         } else {
             FSM_MOVE_STATE(WAIT_FOR_SCAN_RESULTS);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1805,8 +1805,6 @@ bool backhaul_manager::handle_1905_autoconfiguration_response(ieee1905_1::CmduMe
 bool backhaul_manager::send_slaves_enable()
 {
     auto iface_hal = get_wireless_hal();
-    iface_hal->refresh_radio_info();
-    const auto &radio_info = iface_hal->get_radio_info();
 
     for (auto soc : slaves_sockets) {
         auto notification =
@@ -1814,15 +1812,10 @@ bool backhaul_manager::send_slaves_enable()
                 cmdu_tx);
 
         if (soc->sta_iface == m_sConfig.wireless_iface) {
-            notification->channel()   = iface_hal->get_channel();
-            notification->bandwidth() = radio_info.bandwidth;
-            notification->center_channel() =
-                beerocks::utils::wifi_freq_to_channel(radio_info.vht_center_freq);
+            notification->channel() = iface_hal->get_channel();
         }
         LOG(DEBUG) << "Sending enable to slave " << soc->radio_mac
-                   << ", channel=" << int(notification->channel())
-                   << ", bandwidth=" << int(notification->bandwidth())
-                   << ", center_channel=" << int(notification->center_channel());
+                   << ", channel=" << int(notification->channel());
 
         message_com::send_cmdu(soc->slave, cmdu_tx);
     }

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1191,7 +1191,8 @@ bool db::set_hostap_supported_channels(std::string mac, beerocks::message::sWifi
                eFreqType::FREQ_24G) {
         n->supports_24ghz = true;
     } else {
-        LOG(ERROR) << "unknown frequency! channel:" << n->hostap->supported_channels[0].channel;
+        LOG(ERROR) << "unknown frequency! channel:"
+                   << int(n->hostap->supported_channels[0].channel);
         return false;
     }
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1861,17 +1861,21 @@ bool master_thread::handle_intel_slave_join(
 
     if (!is_gw_slave) {
 
-        // rejecting join if gw haven't joined yet
-        if ((parent_bssid_mac != network_utils::ZERO_MAC_STRING) &&
-            (!database.has_node(network_utils::mac_from_string(parent_bssid_mac)) ||
-             (database.get_node_state(parent_bssid_mac) != beerocks::STATE_CONNECTED))) {
-            LOG(DEBUG) << "sending back join reject!";
-            LOG(DEBUG) << "reject_debug: parent_bssid_has_node="
-                       << (int)(database.has_node(
-                              network_utils::mac_from_string(parent_bssid_mac)));
+        // if not local GW but local master - then the parent bssid is remote AP (aka "far AP")
+        // and is not yet in map
+        if (!notification->platform_settings().local_master) {
+            // rejecting join if gw haven't joined yet
+            if ((parent_bssid_mac != network_utils::ZERO_MAC_STRING) &&
+                (!database.has_node(network_utils::mac_from_string(parent_bssid_mac)) ||
+                 (database.get_node_state(parent_bssid_mac) != beerocks::STATE_CONNECTED))) {
+                LOG(DEBUG) << "sending back join reject!";
+                LOG(DEBUG) << "reject_debug: parent_bssid_has_node="
+                           << (int)(database.has_node(
+                                  network_utils::mac_from_string(parent_bssid_mac)));
 
-            join_response->err_code() = beerocks::JOIN_RESP_REJECT;
-            return son_actions::send_cmdu_to_agent(src_mac, cmdu_tx, database);
+                join_response->err_code() = beerocks::JOIN_RESP_REJECT;
+                return son_actions::send_cmdu_to_agent(src_mac, cmdu_tx, database);
+            }
         }
 
         // sending to BML listeners, client disconnect notification on ire backhaul before changing it type from TYPE_CLIENT to TYPE_IRE_BACKHAUL


### PR DESCRIPTION
This PR is for porting exiting RDKB repeater functionality to the PRPL
 #556

Testing of the changes in this PR was done over Linux as well as UGW.

As part of RDKB implementation (not supporting MESH) a waiver was introduced:
- check if Agent tries to join before GW joined was commented out
- the above-mentioned condition is required for MESH and waiver could not be ported as-is
- the waiver was removed in the slave-join handling and a fix to the flow was introduced