### PR TITLE
Feature/move post init check to addClass

### DIFF
--- a/framework/tlvf/README.md
+++ b/framework/tlvf/README.md
@@ -715,6 +715,8 @@ Add an object of type <T> to the array.
 - For parsed message - parse this type from the buffer.
 - For created messages – allocate this type on the buffer.
 
+it is not allowed to use addClass method if the last tlv is not fully initialized!
+
 Returns a pointer to the added class.
 In case of an error, this pointer will point to null.
 

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <tlvf/ieee_1905_1/cCmduHeader.h>
 #include <tlvf/ieee_1905_1/eTlvType.h>
+#include <tlvf/tlvflogging.h>
 #include <vector>
 
 namespace ieee1905_1 {
@@ -28,6 +29,16 @@ public:
     template <class T, class = typename std::enable_if<std::is_base_of<BaseClass, T>::value>::type>
     std::shared_ptr<T> addClass()
     {
+
+        auto last_tlv = m_class_vector.empty() ? nullptr : m_class_vector.back();
+        // do not allow to use addClass method if the last tlv is not fully initialized
+        if (last_tlv) {
+            if (!last_tlv->isPostInitSucceeded()) {
+                TLVF_LOG(ERROR) << "TLV post init failed";
+                return nullptr;
+            }
+        }
+
         std::shared_ptr<T> ptr;
         if (m_cmdu_header) {
             if (m_class_vector.size() == 0) {

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -83,12 +83,17 @@ bool CmduMessageTx::finalize(bool swap_needed)
     if (!m_cmdu_header)
         return false;
 
-    // Update vendor specific length which is seperated to 3 classes
-    for (auto class_it = m_class_vector.begin(); class_it != m_class_vector.end(); class_it++) {
-        if (!(*class_it)->isPostInitSucceeded()) {
+    // validate that last tlv of the CMDU is fully initialized
+    auto last_tlv = m_class_vector.empty() ? nullptr : m_class_vector.back();
+    if (last_tlv) {
+        if (!last_tlv->isPostInitSucceeded()) {
             TLVF_LOG(ERROR) << "TLV post init failed";
             return false;
         }
+    }
+
+    // Update vendor specific length which is seperated to 3 classes
+    for (auto class_it = m_class_vector.begin(); class_it != m_class_vector.end(); class_it++) {
         // Type is the first byte in the tlv buffer
         uint8_t tlv_type = *(*class_it)->getStartBuffPtr();
         if (tlv_type == uint8_t(eTlvType::TLV_VENDOR_SPECIFIC)) {

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -306,15 +306,22 @@ int test_parser()
     auto tlv1 = msg.addClass<tlvNon1905neighborDeviceList>();
     auto tlv2 = msg.addClass<tlvLinkMetricQuery>();
     auto tlv3 = msg.addClass<tlvWscM1>();
+
+    // Trying to add a new class before fully initialize previous class should lead to error
+    auto tlv4 = msg.addClass<tlvTestVarList>();
+    if (tlv4) {
+        LOG(ERROR) << "addClass should fail since the the previous tlv is not fully initialized";
+        errors++;
+    }
     // TODO https://github.com/prplfoundation/prplMesh/issues/480
     tlv3->add_vendor_ext(tlv3->create_vendor_ext());
-    auto tlv4 = msg.addClass<tlvTestVarList>();
-    // TODO https://github.com/prplfoundation/prplMesh/issues/480
+    tlv4 = msg.addClass<tlvTestVarList>();
     tlv4->add_var1(tlv4->create_var1());
 
     LOG(DEBUG) << "Finalize";
     if (msg.finalize(true)) {
-        LOG(ERROR) << "Finalize should fail since the CMDU is not fully initialized";
+        LOG(ERROR)
+            << "Finalize should fail since the last tlv of the CMDU is not fully initialized";
         errors++;
     }
 


### PR DESCRIPTION
Preparative PR.

Move the post init check to addClass method to prevent the user from adding a
new TLV before the last inserted TLV is not fully initialized.

In the future, this check also validate that last TLV does not contain a
tailroom the was not trimmed yet.

Also, a test is added to demonstrate a situation of trying to use the addClass
method before fully initialize the last TLV
