### PR TITLE
.gitlab-ci.yml: build for the Turris Omnia

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,14 +36,30 @@ run-tests:
       - logs
     when: always
 
-  artifacts:
-    paths:
-      - logs
-    when: always
-
   tags:
     - docker
     - docker-build
 
   after_script:
     - tools/docker/stop.sh -k -r
+  needs:
+    - job: build-in-docker
+
+.build-for-openwrt:
+  stage: build
+  script:
+    - cd tools/docker/builder/openwrt
+    - ./build.sh targets/$TARGET.args 2>&1 | tee build.log | grep -E '^make\[[12]\]|^Step' --color=never --line-buffered
+  artifacts:
+    paths:
+      - tools/docker/builder/openwrt/*.ipk
+      - tools/docker/builder/openwrt/build.log
+    when: always
+  tags:
+    - shell
+    - docker-build
+
+build-for-turris-omnia:
+  extends: .build-for-openwrt
+  variables:
+    TARGET: turris-omnia


### PR DESCRIPTION
Add a new hidden job: build-for-openwrt. It is defined to make it easy
to build for different targets. It has to be a hidden job because it's
not supposed to be run as-is.

Also add a new job extending .build-for-openwrt, to build for the
Turris Omnia.

Add a "needs" for build-in-docker to the run-tests job, so that it
doesn't wait for the OpenWrt build nor use its artifacts.

While we're at it, remove the duplicate "artifacts" for the
run_tests job.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>