### PR TITLE
Feature/ci unique openwrt builder names

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ run-tests:
   stage: build
   script:
     - cd tools/docker/builder/openwrt
-    - ./build.sh targets/$TARGET.args 2>&1 | tee build.log | grep -E '^make\[[12]\]|^Step' --color=never --line-buffered
+    - ./build.sh -v -d "$TARGET" -t "prplmesh-builder-$TARGET:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee build.log | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
   artifacts:
     paths:
       - tools/docker/builder/openwrt/*.ipk
@@ -70,7 +70,7 @@ run-tests:
 build-for-turris-omnia:
   extends: .build-for-openwrt
   variables:
-    TARGET: turris-omnia
+    TARGET: "turris-omnia"
 
 test-on-turris-omnia:
   extends: .test-on-target

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ run-tests:
   stage: build
   script:
     - cd tools/docker/builder/openwrt
-    - ./build.sh -v -d "$TARGET" -t "prplmesh-builder-$TARGET:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee build.log | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
+    - ./build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee build.log | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
   artifacts:
     paths:
       - tools/docker/builder/openwrt/*.ipk
@@ -62,18 +62,18 @@ run-tests:
 .test-on-target:
   stage: test
   script:
-    - tools/deploy_ipk.sh $TARGET_DEVICE tools/docker/builder/openwrt/*.ipk
-    - tools/docker/tests/openwrt/test_status.sh $TARGET_DEVICE
+    - tools/deploy_ipk.sh $TARGET_DEVICE_NAME tools/docker/builder/openwrt/*.ipk
+    - tools/docker/tests/openwrt/test_status.sh $TARGET_DEVICE_NAME
   tags:
     - targets
 
 build-for-turris-omnia:
   extends: .build-for-openwrt
   variables:
-    TARGET: "turris-omnia"
+    TARGET_DEVICE: "turris-omnia"
 
 test-on-turris-omnia:
   extends: .test-on-target
   variables:
-    TARGET_DEVICE: turris-omnia-1
+    TARGET_DEVICE_NAME: turris-omnia-1
   needs: ["build-for-turris-omnia"]

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -3,75 +3,120 @@
 scriptdir="$(cd "${0%/*}"; pwd)"
 rootdir="${scriptdir%/*/*/*/*}"
 
-if [ ! -f "$1" ] ; then
-    echo "Please specify a file containing the build args as the
-    first argument"
-    exit 1
-fi
+. "${rootdir}/tools/docker/functions.sh"
 
-# Source the args file:
-. "$(realpath "$1")"
+usage() {
+    echo "usage: $(basename $0) -d <target_device> [-hfiortv]"
+    echo "  options:"
+    echo "      -h|--help - show this help menu"
+    echo "      -d|--target-device the device to build for"
+    echo "      -f|--prpl-feed the prpl feed to use"
+    echo "      -i|--image - build the docker image only"
+    echo "      -o|--openwrt-version - the openwrt version to use"
+    echo "      -r|--openwrt-repository - the openwrt repository to use"
+    echo "      -t|--tag - the tag to use for the builder image"
+    echo "      -v|--verbose - verbosity on"
+    echo " -d is always required."
+}
 
-if [ -z "$OPENWRT_REPOSITORY" ] ; then
-    OPENWRT_REPOSITORY=https://git.prpl.dev/prplmesh/prplwrt.git
-    echo "OPENWRT_REPOSITORY not set, using default value $OPENWRT_REPOSITORY"
+build_image() {
+    # We first need to build the corresponding images
+    docker build --tag "$image_tag" \
+           --build-arg OPENWRT_REPOSITORY \
+           --build-arg OPENWRT_VERSION \
+           --build-arg TARGET \
+           --build-arg PRPL_FEED \
+           "$scriptdir/"
+}
 
-fi
+build_prplmesh() {
+    dbg "Container name will be $container_name"
+    container_name="prplmesh-builder-$(date +%F_%H-%M-%S)"
+    docker run -i \
+           --name "$container_name" \
+           -e TARGET \
+           -e TARGET_PLATFORM_TYPE \
+           -e OPENWRT_VERSION \
+           -e PRPLMESH_VERSION \
+           -v "$scriptdir/scripts:/home/openwrt/openwrt_sdk/build_scripts/:ro" \
+           -v "${rootdir}:/prplMesh:ro" \
+           "$image_tag" \
+           ./build_scripts/build.sh
 
-if [ -z "$OPENWRT_VERSION" ] ; then
-    OPENWRT_VERSION=9d2efd
-    echo "OPENWRT_VERSION not set, using default value $OPENWRT_VERSION"
-fi
+    docker cp "${container_name}:/home/openwrt/openwrt_sdk/prplmesh-${TARGET}-${TARGET_PLATFORM_TYPE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" .
 
-if [ -z "$TARGET" ] ; then
-    TARGET=mvebu
-    echo "TARGET not set, using default value $TARGET"
-fi
+    docker rm "${container_name}"
+}
 
-if [ -z "$TARGET_PLATFORM_TYPE" ] ; then
-    TARGET_PLATFORM_TYPE=turris-omnia
-    echo "TARGET_PLATFORM_TYPE not set, using default value $TARGET_PLATFORM_TYPE"
-fi
+main() {
+    OPTS=`getopt -o 'hd:f:io:r:t:v' --long help,device:,prpl-feed:,image,openwrt-version:,openwrt-repository:,tag:,verbose -n 'parse-options' -- "$@"`
 
-if [ -z "$PRPL_FEED" ] ; then
-    PRPL_FEED='https://git.prpl.dev/prplmesh/iwlwav.git^06a0126d5fb53b1d65bad90757a5f9f5f77419ca'
-    echo "PRPL_FEED not set, using default value $PRPL_FEED"
-fi
+    if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
-export OPENWRT_REPOSITORY
-export OPENWRT_VERSION
-export TARGET
-export TARGET_PLATFORM_TYPE
-PRPLMESH_VERSION="$(git describe --always --dirty --exclude '*')"
-export PRPLMESH_VERSION
-export PRPL_FEED
+    eval set -- "$OPTS"
 
-image_tag="prplmesh-builder-${TARGET}:${OPENWRT_VERSION}"
-container_name="prplmesh-builder-$(date +%F_%H-%M-%S)"
+    while true; do
+        case "$1" in
+            -h | --help)               usage; exit 0; shift ;;
+            -d | --target-device)
+                TARGET_DEVICE="$2"; shift ; shift
+                case "$TARGET_DEVICE" in
+                    turris-omnia)
+                        TARGET=mvebu
+                        ;;
+                    *)
+                        err "Unknown target device: $TARGET_DEVICE"
+                        info "Currently supported targets are: turris-omnia"
+                        ;;
+                esac
+                ;;
+            -f | --prpl-feed)          PRPL_FEED="$2"; shift; shift ;;
+            -i | --image)              IMAGE_ONLY=true; shift ;;
+            -o | --openwrt-version)    OPENWRT_VERSION="$2"; shift; shift ;;
+            -r | --openwrt-repository) OPENWRT_REPOSITORY="$2"; shift; shift ;;
+            -t | --tag)                TAG="$2"; shift ; shift ;;
+            -v | --verbose)            VERBOSE=true; shift ;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1 ;;
+        esac
+    done
 
-echo "Image will be tagged as $image_tag"
-echo "Container name will be $container_name"
+    dbg "OPENWRT_REPOSITORY=$OPENWRT_REPOSITORY"
+    dbg "OPENWRT_VERSION=$OPENWRT_VERSION"
+    dbg "PRPL_FEED=$PRPL_FEED"
+    dbg "IMAGE_ONlY=IMAGE_ONLY"
+    dbg "TARGET_DEVICE=$TARGET_DEVICE"
+    dbg "TAG=$TAG"
 
-# We first need to build the corresponding images
-docker build --tag "$image_tag" \
-       --build-arg OPENWRT_REPOSITORY \
-       --build-arg OPENWRT_VERSION \
-       --build-arg TARGET \
-       --build-arg PRPL_FEED \
-       "$scriptdir/"
+    if [ -n "$TAG" ] ; then
+        image_tag="$TAG"
+    else
+        image_tag="prplmesh-builder-${TARGET}:${OPENWRT_VERSION}"
+        dbg "image tag not set, using default value $image_tag"
+    fi
 
-# Next we'll build the specified prplMesh version and copy out the ipk
-docker run -i \
-       --name "$container_name" \
-       -e TARGET \
-       -e TARGET_PLATFORM_TYPE \
-       -e OPENWRT_VERSION \
-       -e PRPLMESH_VERSION \
-       -v "$scriptdir/scripts:/home/openwrt/openwrt_sdk/build_scripts/:ro" \
-       -v "${rootdir}:/prplMesh:ro" \
-       "$image_tag" \
-       ./build_scripts/build.sh
+    export OPENWRT_REPOSITORY
+    export OPENWRT_VERSION
+    export TARGET
+    export TARGET_PLATFORM_TYPE
+    PRPLMESH_VERSION="$(git describe --always --dirty --exclude '*')"
+    export PRPLMESH_VERSION
+    export PRPL_FEED
 
-docker cp "${container_name}:/home/openwrt/openwrt_sdk/prplmesh-${TARGET}-${TARGET_PLATFORM_TYPE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" .
+    if [ $IMAGE_ONLY = true ] ; then
+        build_image
+        exit $?
+    fi
 
-docker rm "${container_name}"
+    build_image
+    build_prplmesh
+
+}
+
+IMAGE_ONLY=false
+VERBOSE=false
+OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
+OPENWRT_VERSION='9d2efd'
+PRPL_FEED='https://git.prpl.dev/prplmesh/iwlwav.git^06a0126d5fb53b1d65bad90757a5f9f5f77419ca'
+
+main "$@"

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -35,15 +35,14 @@ build_prplmesh() {
     docker run -i \
            --name "$container_name" \
            -e TARGET \
-           -e TARGET_PLATFORM_TYPE \
            -e OPENWRT_VERSION \
            -e PRPLMESH_VERSION \
            -v "$scriptdir/scripts:/home/openwrt/openwrt_sdk/build_scripts/:ro" \
-           -v "${rootdir}:/prplMesh:ro" \
+           -v "${rootdir}:/home/openwrt/prplMesh_source:ro" \
            "$image_tag" \
            ./build_scripts/build.sh
 
-    docker cp "${container_name}:/home/openwrt/openwrt_sdk/prplmesh-${TARGET}-${TARGET_PLATFORM_TYPE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" .
+    docker cp "${container_name}:/home/openwrt/openwrt_sdk/prplmesh-${TARGET}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" .
 
     docker rm "${container_name}"
 }
@@ -98,7 +97,6 @@ main() {
     export OPENWRT_REPOSITORY
     export OPENWRT_VERSION
     export TARGET
-    export TARGET_PLATFORM_TYPE
     PRPLMESH_VERSION="$(git describe --always --dirty --exclude '*')"
     export PRPLMESH_VERSION
     export PRPL_FEED

--- a/tools/docker/builder/openwrt/scripts/build.sh
+++ b/tools/docker/builder/openwrt/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 sed -ri "s/-DTARGET_PLATFORM_TYPE=[^ ]*/-DTARGET_PLATFORM_TYPE=${TARGET_PLATFORM_TYPE}/" feeds/prpl/prplmesh/Makefile
 
@@ -10,4 +10,4 @@ rm -rf /home/openwrt/prplMesh/build
 
 make package/feeds/prpl/prplmesh/prepare USE_SOURCE_DIR="/home/openwrt/prplMesh" V=s
 make package/feeds/prpl/prplmesh/compile V=sc -j"$(nproc)"
-find bin -name 'prplmesh_*.ipk' -exec cp {} "prplmesh-${TARGET}-${TARGET_PLATFORM_TYPE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" \;
+find bin -name 'prplmesh_*.ipk' -exec cp -v {} "prplmesh-${TARGET}-${TARGET_PLATFORM_TYPE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" \;

--- a/tools/docker/builder/openwrt/scripts/build.sh
+++ b/tools/docker/builder/openwrt/scripts/build.sh
@@ -1,13 +1,11 @@
 #!/bin/sh -e
 
-sed -ri "s/-DTARGET_PLATFORM_TYPE=[^ ]*/-DTARGET_PLATFORM_TYPE=${TARGET_PLATFORM_TYPE}/" feeds/prpl/prplmesh/Makefile
-
 # We have to copy the source directory, because we may not have
 # write access to it, and openwrt needs to at least write '.source_dir':
-cp -r /prplMesh /home/openwrt/prplMesh
+cp -r /home/openwrt/prplMesh_source /home/openwrt/prplMesh
 # We want to make sure that we do not keep anything built from the host:
 rm -rf /home/openwrt/prplMesh/build
 
 make package/feeds/prpl/prplmesh/prepare USE_SOURCE_DIR="/home/openwrt/prplMesh" V=s
 make package/feeds/prpl/prplmesh/compile V=sc -j"$(nproc)"
-find bin -name 'prplmesh_*.ipk' -exec cp -v {} "prplmesh-${TARGET}-${TARGET_PLATFORM_TYPE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" \;
+find bin -name 'prplmesh_*.ipk' -exec cp -v {} "prplmesh-${TARGET}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" \;

--- a/tools/docker/builder/openwrt/targets/turris-omnia.args
+++ b/tools/docker/builder/openwrt/targets/turris-omnia.args
@@ -1,2 +1,0 @@
-TARGET=mvebu
-TARGET_PLATFORM_TYPE=turris-omnia


### PR DESCRIPTION
- Make it possible to choose the image tag. While doing that, switch to using command line options instead of files when calling the build script.
- Use unique names for the openwrt builder, so that we can safely run multiple jobs at the same time. 

This should make the CI pipelines to be picked up faster, since it will no longer be limited to 1 job at a time (once we make the related change to the runner).