### PR TITLE
framework: bpl: allow any target folder when looking for libbridge

### DIFF
--- a/framework/platform/bpl/CMakeLists.txt
+++ b/framework/platform/bpl/CMakeLists.txt
@@ -28,7 +28,7 @@ if (TARGET_PLATFORM STREQUAL "openwrt")
         include_directories(${PLATFORM_INCLUDE_DIR})
 
         # libbridge
-        file(GLOB LIBBRIDGE_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/linux-intel_mips*/bridge-utils*/libbridge")
+        file(GLOB LIBBRIDGE_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/*/bridge-utils*/libbridge")
         find_path(LIBBRIDGE_INCLUDE_DIR NAMES "libbridge.h" PATHS "${LIBBRIDGE_SEARCH_PATHS}" NO_CMAKE_FIND_ROOT_PATH)
         include_directories(${LIBBRIDGE_INCLUDE_DIR})
         link_directories(${LIBBRIDGE_INCLUDE_DIR})


### PR DESCRIPTION
When compiling for the rax40 using OpenWrt, libbridge is not found
because it doesn't match the GLOB that is being used.

When compiling with OpenWrt's SDK for example, libbridge can be in:
target-mips_24kc_musl/linux-ath79_generic/bridge-utils-1.6/libbridge/libbridge.h

Change the GLOB so that libbridge can be found no matter what the
target folder is.
