### PR TITLE
tools: docker: openwrt: increase the status test timeout

### DIFF
--- a/tools/docker/tests/openwrt/test_status.sh
+++ b/tools/docker/tests/openwrt/test_status.sh
@@ -14,7 +14,7 @@ TARGET="$1"
 # the first start currently never succeeds, we need to restart it first.
 ssh "$TARGET" <<"EOF"
 /opt/prplmesh/prplmesh_utils.sh restart
-TIMEOUT=10
+TIMEOUT=30
 for _ in $(seq 1 "$TIMEOUT") ; do
     if /opt/prplmesh/prplmesh_utils.sh status ; then
         exit 0


### PR DESCRIPTION
When running the status test, we only wait for a specified time for
prplMesh to become operational. This time was set to 10 seconds, which
can be a little bit too small. As a consequence, the test would fail
from time to time, while re-running it would make it succeed.

Set the timeout to 30 seconds, to give prplMesh more time to restart.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>