### PR TITLE
Klocwork - solving the nullptr issue

### DIFF
--- a/agent/src/beerocks/monitor/monitor_rssi.cpp
+++ b/agent/src/beerocks/monitor/monitor_rssi.cpp
@@ -100,11 +100,11 @@ void monitor_rssi::arp_recv()
     std::string sta_mac = network_utils::mac_to_string(arphdr->sender_mac);
     std::string sta_ip  = network_utils::ipv4_to_string(arphdr->sender_ip);
     auto sta_node       = mon_db->sta_find(sta_mac);
-    if (sta_node == nullptr) {
+    if (!sta_node) {
         sta_node = mon_db->sta_find_by_ipv4(sta_ip);
     }
 
-    if (sta_node == nullptr) {
+    if (!sta_node) {
         //LOG(DEBUG) << "can't find node by mac=" << sta_mac << " or by ipv4=" << sta_ip << " in db! dropping arp reply";
         return;
     }
@@ -119,7 +119,7 @@ void monitor_rssi::arp_recv()
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>(
                 cmdu_tx, request_id);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building "
                               "cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION "
                               "message!";
@@ -141,7 +141,7 @@ void monitor_rssi::arp_recv()
         // send arp burst
         auto sta_vap_id = sta_node->get_vap_id();
         auto vap_node   = mon_db->vap_get_by_id(sta_vap_id);
-        if (vap_node == nullptr) {
+        if (!vap_node) {
             LOG(ERROR) << "can't find sta vap_id=" << sta_vap_id;
             return;
         }
@@ -222,7 +222,7 @@ void monitor_rssi::process()
                     auto notification = message_com::create_vs_message<
                         beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION>(
                         cmdu_tx);
-                    if (notification == nullptr) {
+                    if (!notification) {
                         LOG(ERROR) << "Failed building "
                                       "ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUES message!";
                         break;
@@ -273,7 +273,7 @@ void monitor_rssi::process()
                 if (sta_node->arp_recv_count_get() == 0) {
                     auto notification = message_com::create_vs_message<
                         beerocks_message::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION>(cmdu_tx);
-                    if (notification == nullptr) {
+                    if (!notification) {
                         LOG(ERROR) << "Failed building "
                                       "cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION message!";
                         break;
@@ -309,7 +309,7 @@ void monitor_rssi::process()
 
             auto sta_vap_id = sta_node->get_vap_id();
             auto vap_node   = mon_db->vap_get_by_id(sta_vap_id);
-            if (vap_node == nullptr) {
+            if (!vap_node) {
                 LOG(ERROR) << "can't find sta vap_id=" << sta_vap_id;
                 return;
             }
@@ -360,7 +360,7 @@ void monitor_rssi::send_rssi_measurement_response(std::string &sta_mac, monitor_
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(cmdu_tx,
                                                                                    request_id);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUES message!";
             break;
@@ -403,7 +403,7 @@ void monitor_rssi::monitor_idle_station(std::string &sta_mac, monitor_sta_node *
             LOG(DEBUG) << "IDLE notification MAC: " << sta_mac;
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION>(cmdu_tx);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR)
                     << "Failed building ACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION message!";
                 return;

--- a/agent/src/beerocks/monitor/monitor_stats.cpp
+++ b/agent/src/beerocks/monitor/monitor_stats.cpp
@@ -109,7 +109,7 @@ void monitor_stats::process()
     if (send_activity_mode_notification) {
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION message!";
             return;
         }
@@ -122,7 +122,7 @@ void monitor_stats::process()
     if (!requests_list.empty()) {
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR)
                 << "Failed building cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE message!";
             return;
@@ -153,7 +153,7 @@ void monitor_stats::process()
         for (auto it = mon_db->sta_begin(); it != mon_db->sta_end(); ++it) {
             auto sta_mac  = it->first;
             auto sta_node = it->second;
-            if (sta_node == nullptr) {
+            if (!sta_node) {
                 continue;
             }
 
@@ -181,7 +181,12 @@ void monitor_stats::process()
             sta_stats_msg.rx_rssi           = sta_stats.rx_rssi_curr;
         }
 
-        beerocks_header->actionhdr()->id() = requests_list.front();
+        auto actionhdr = beerocks_header->actionhdr();
+        if (!actionhdr) {
+            return;
+        }
+
+        actionhdr->id() = requests_list.front();
         requests_list.pop_front();
         message_com::send_cmdu(slave_socket, cmdu_tx);
     }
@@ -209,8 +214,8 @@ void monitor_stats::process()
     for (auto it = mon_db->sta_begin(); it != mon_db->sta_end(); ++it) {
         auto sta_mac  = it->first;
         auto sta_node = it->second;
-        if (sta_node == nullptr) {
-            LOG(ERROR) << "sta_node == nullptr !";
+        if (!sta_node) {
+            LOG(ERROR) << "!sta_node !";
             return;
         }
 

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -68,7 +68,7 @@ void monitor_thread::stop_monitor_thread()
         auto notification =
             message_com::create_vs_message<beerocks_message::cACTION_MONITOR_ERROR_NOTIFICATION>(
                 cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building cACTION_MONITOR_ERROR_NOTIFICATION message!";
             return;
         }
@@ -180,7 +180,7 @@ bool monitor_thread::init()
         message_com::create_vs_message<beerocks_message::cACTION_MONITOR_JOINED_NOTIFICATION>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building message!";
         return false;
     }
@@ -195,8 +195,8 @@ bool monitor_thread::init()
 void monitor_thread::after_select(bool timeout)
 {
     // Continue only if slave is connected
-    if (slave_socket == nullptr) {
-        LOG(DEBUG) << "slave_socket == nullptr";
+    if (!slave_socket) {
+        LOG(DEBUG) << "!slave_socket";
         return;
     }
 
@@ -218,7 +218,7 @@ void monitor_thread::after_select(bool timeout)
     }
 
     // If the HAL is not yet attached
-    if (mon_hal_int_events == nullptr) { // monitor not attached
+    if (!mon_hal_int_events) { // monitor not attached
         auto attach_state = mon_wlan_hal->attach();
         if (last_attach_state != attach_state) {
             LOG(DEBUG) << "attach_state = " << int(attach_state);
@@ -390,7 +390,7 @@ void monitor_thread::after_select(bool timeout)
                     LOG(ERROR) << "Failed ping hostap, notify agent...";
                     auto notification = message_com::create_vs_message<
                         beerocks_message::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION>(cmdu_tx);
-                    if (notification == nullptr) {
+                    if (!notification) {
                         LOG(ERROR) << "Failed building "
                                       "cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION message!";
                         stop_monitor_thread();
@@ -427,7 +427,7 @@ void monitor_thread::after_select(bool timeout)
 
                 auto notification = message_com::create_vs_message<
                     beerocks_message::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION>(cmdu_tx);
-                if (notification == nullptr) {
+                if (!notification) {
                     LOG(ERROR) << "Failed building message!";
                     return;
                 }
@@ -455,7 +455,7 @@ bool monitor_thread::update_sta_stats()
         auto sta_mac  = it->first;
         auto sta_node = it->second;
 
-        if (sta_node == nullptr) {
+        if (!sta_node) {
             LOG(WARNING) << "Invalid node pointer for STA = " << sta_mac;
             continue;
         }
@@ -598,7 +598,7 @@ bool monitor_thread::update_ap_stats()
 bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto beerocks_header = message_com::parse_intel_vs_message(cmdu_rx);
-    if (beerocks_header == nullptr) {
+    if (!beerocks_header) {
         LOG(ERROR) << "Not a vendor specific message";
         return false;
     }
@@ -616,7 +616,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         LOG(TRACE) << "received ACTION_MONITOR_SON_CONFIG_UPDATE";
         auto update =
             beerocks_header->addClass<beerocks_message::cACTION_MONITOR_SON_CONFIG_UPDATE>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass cACTION_MONITOR_SON_CONFIG_UPDATE failed";
             return false;
         }
@@ -645,7 +645,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass ACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST failed";
             return false;
         }
@@ -660,7 +660,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL failed";
             return false;
         }
@@ -678,7 +678,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST failed";
             return false;
         }
@@ -696,7 +696,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         }
 
         auto vap_node = mon_db.vap_get_by_id(vap_id);
-        if (vap_node == nullptr) {
+        if (!vap_node) {
             LOG(ERROR) << "vap_id " << vap_id << " doesn't not exists";
             return false;
         }
@@ -722,7 +722,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST failed";
             send_steering_return_status(
                 beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE,
@@ -765,7 +765,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             break;
         }
         auto ap = mon_rdkb_hal.conf_add_ap(vap_id);
-        if (ap == nullptr) {
+        if (!ap) {
             LOG(ERROR) << "add rdkb_hall ap configuration fail";
             send_steering_return_status(
                 beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE,
@@ -789,7 +789,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST failed";
             send_steering_return_status(
                 beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE, OPERATION_FAIL);
@@ -826,7 +826,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         }
 
         auto client = mon_rdkb_hal.conf_add_client(sta_mac);
-        if (client == nullptr) {
+        if (!client) {
             LOG(ERROR) << "add rdkb_hall client configuration fail";
             send_steering_return_status(
                 beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE, OPERATION_FAIL);
@@ -848,7 +848,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST failed";
             return false;
         }
@@ -864,13 +864,13 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;
         }
         std::string sta_mac = network_utils::mac_to_string(request->params().mac);
         auto sta_node       = mon_db.sta_find(sta_mac);
-        if (sta_node == nullptr) {
+        if (!sta_node) {
             LOG(ERROR) << "RX_RSSI_MEASUREMENT REQUEST sta_mac=" << sta_mac
                        << " sta not assoc, id=" << beerocks_header->id();
             break;
@@ -888,7 +888,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>(
                 cmdu_tx, beerocks_header->id());
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "Failed building message!";
                 break;
             }
@@ -918,7 +918,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST failed";
             return false;
         }
@@ -973,7 +973,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST failed";
             return false;
         }
@@ -1011,7 +1011,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST failed";
             return false;
         }
@@ -1094,7 +1094,7 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST failed";
             return false;
         }
@@ -1123,7 +1123,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
     }
 
     if (!slave_socket) {
-        LOG(ERROR) << "slave_socket == nullptr";
+        LOG(ERROR) << "!slave_socket";
         return false;
     }
 
@@ -1140,7 +1140,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR)
                 << "Failed building cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE message!";
             return false;
@@ -1218,7 +1218,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
                 auto response = message_com::create_vs_message<
                     beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE>(cmdu_tx, id);
-                if (response == nullptr) {
+                if (!response) {
                     LOG(ERROR)
                         << "Failed building cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE message!";
                     break;
@@ -1268,7 +1268,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE message!";
             break;
         }
@@ -1300,7 +1300,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
         auto hal_data = static_cast<bwl::SLinkMeasurementsResponse11k *>(data);
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR)
                 << "Failed building cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE message!";
             break;
@@ -1357,7 +1357,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
         if (msg->vap_id == beerocks::IFACE_RADIO_ID) {
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR)
                     << "Failed building cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION message!";
                 break;
@@ -1571,7 +1571,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
 void monitor_thread::send_heartbeat()
 {
-    if (slave_socket == nullptr) {
+    if (!slave_socket) {
         LOG(ERROR) << "process_keep_alive(): slave_socket is nullptr!";
         return;
     }
@@ -1580,7 +1580,7 @@ void monitor_thread::send_heartbeat()
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_MONITOR_HEARTBEAT_NOTIFICATION>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building message!";
         return;
     }
@@ -1630,7 +1630,7 @@ void monitor_thread::send_steering_return_status(beerocks_message::eActionOp_MON
     case beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE: {
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -1641,7 +1641,7 @@ void monitor_thread::send_steering_return_status(beerocks_message::eActionOp_MON
     case beerocks_message::ACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE: {
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             break;
         }

--- a/agent/src/beerocks/monitor/rdkb/monitor_rdkb_hal.cpp
+++ b/agent/src/beerocks/monitor/rdkb/monitor_rdkb_hal.cpp
@@ -83,7 +83,7 @@ void monitor_rdkb_hal::print_debug_info(mon_rdkb_debug_info_t &mdi, bool pkts_co
 void monitor_rdkb_hal::process()
 {
 
-    if (mon_db == nullptr) {
+    if (!mon_db) {
         LOG(ERROR) << "mon_db not initialized";
         return;
     }
@@ -99,7 +99,7 @@ void monitor_rdkb_hal::process()
 
         auto sta_node = mon_db->sta_find(sta_mac);
         //client not connected.
-        if (sta_node == nullptr) {
+        if (!sta_node) {
             continue;
         }
 
@@ -223,13 +223,13 @@ void monitor_rdkb_hal::send_activity_event(const std::string &sta_mac, bool acti
 
     auto response = message_com::create_vs_message<
         beerocks_message::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION>(cmdu_tx);
-    if (response == nullptr) {
+    if (!response) {
         LOG(ERROR) << "Failed building cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION "
                       "message!";
         return;
     }
 
-    if (mon_db == nullptr) {
+    if (!mon_db) {
         LOG(ERROR) << "mon_db not initialized";
         return;
     }
@@ -255,13 +255,13 @@ void monitor_rdkb_hal::send_snr_crossing_event(const std::string &sta_mac,
 
     auto response = message_com::create_vs_message<
         beerocks_message::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION>(cmdu_tx);
-    if (response == nullptr) {
+    if (!response) {
         LOG(ERROR)
             << "Failed building cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION message!";
         return;
     }
 
-    if (mon_db == nullptr) {
+    if (!mon_db) {
         LOG(ERROR) << "mon_db not initialized";
         return;
     }
@@ -285,7 +285,7 @@ std::shared_ptr<rdkb_hal_sta_config> monitor_rdkb_hal::conf_add_client(const std
 {
 
     auto cp = conf_find_client(sta_mac);
-    if (cp == nullptr) {
+    if (!cp) {
         auto node = std::make_shared<son::rdkb_hal_sta_config>(sta_mac);
         auto ret  = conf_stas.insert(std::make_pair(sta_mac, node));
         if (ret.second == true) {
@@ -318,7 +318,7 @@ std::shared_ptr<rdkb_hal_ap_config> monitor_rdkb_hal::conf_add_ap(const int8_t v
 {
 
     auto cp = conf_find_ap(vap_id);
-    if (cp == nullptr) {
+    if (!cp) {
         auto ap  = std::make_shared<son::rdkb_hal_ap_config>(vap_id);
         auto ret = conf_aps.insert(std::make_pair(vap_id, ap));
         if (ret.second == false) {

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -215,7 +215,7 @@ bool ap_manager_thread::init()
         message_com::create_vs_message<beerocks_message::cACTION_APMANAGER_INIT_DONE_NOTIFICATION>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building message!";
         return false;
     }
@@ -228,7 +228,7 @@ bool ap_manager_thread::init()
 void ap_manager_thread::after_select(bool timeout)
 {
     // continue only if slave is connected
-    if (slave_socket == nullptr) {
+    if (!slave_socket) {
         return;
     }
 
@@ -250,7 +250,7 @@ void ap_manager_thread::after_select(bool timeout)
                 auto notification = message_com::create_vs_message<
                     beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION>(cmdu_tx);
 
-                if (notification == nullptr) {
+                if (!notification) {
                     LOG(ERROR) << "Failed building message!";
                     return;
                 }
@@ -273,7 +273,7 @@ void ap_manager_thread::after_select(bool timeout)
         return false;
     });
 
-    if (ap_hal_int_events == nullptr) { // ap not attached
+    if (!ap_hal_int_events) { // ap not attached
         auto attach_state = ap_wlan_hal->attach();
 
         if (attach_state == bwl::HALState::Operational) {
@@ -417,7 +417,7 @@ std::string ap_manager_thread::print_cmdu_types(const message::sUdsHeader *cmdu_
 bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto beerocks_header = message_com::parse_intel_vs_message(cmdu_rx);
-    if (beerocks_header == nullptr) {
+    if (!beerocks_header) {
         LOG(ERROR) << "Not a vendor specific message";
         return false;
     }
@@ -500,7 +500,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
         auto request = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass "
                           "cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST failed";
             return false;
@@ -547,7 +547,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE>(
             cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -559,7 +559,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START failed";
             return false;
         }
@@ -584,7 +584,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION>(
                 cmdu_tx, beerocks_header->id());
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -622,7 +622,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto update =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE failed";
             return false;
         }
@@ -635,7 +635,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto update =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE failed";
             return false;
         }
@@ -648,7 +648,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST failed";
             send_steering_return_status(
                 beerocks_message::ACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE, OPERATION_FAIL);
@@ -677,7 +677,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST failed";
             return false;
         }
@@ -692,7 +692,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     case beerocks_message::ACTION_APMANAGER_CLIENT_ALLOW_REQUEST: {
         auto request =
             beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_ALLOW_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_ALLOW_REQUEST failed";
             return false;
         }
@@ -726,7 +726,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST: {
         auto request = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;
         }
@@ -740,7 +740,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>(
                 cmdu_tx, beerocks_header->id());
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -779,7 +779,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(
                 cmdu_tx, beerocks_header->id());
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -795,7 +795,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST failed";
             return false;
         }
@@ -874,7 +874,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto update =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION failed";
             return false;
         }
@@ -887,7 +887,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST failed";
             send_steering_return_status(
                 beerocks_message::ACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE, OPERATION_FAIL);
@@ -933,7 +933,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
     case beerocks_message::ACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST: {
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -969,7 +969,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
     }
 
     if (!slave_socket) {
-        LOG(ERROR) << "slave_socket == nullptr";
+        LOG(ERROR) << "!slave_socket";
         return false;
     }
 
@@ -1017,7 +1017,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         if (event == Event::ACS_Completed) {
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION>(cmdu_tx);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1028,7 +1028,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         } else {
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION>(cmdu_tx);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1074,7 +1074,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1141,7 +1141,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION>(cmdu_tx);
 
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1179,7 +1179,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1210,7 +1210,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(
                 cmdu_tx, sta_unassociated_rssi_measurement_header_id);
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "Failed building "
                               "cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE message!";
                 break;
@@ -1251,7 +1251,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         // Build the response message
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION "
                           "message!";
             break;
@@ -1282,7 +1282,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         // Build the response message
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION "
                           "message!";
             break;
@@ -1312,7 +1312,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION "
                           "message!";
             break;
@@ -1346,7 +1346,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building "
                           "ACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION message!";
             break;
@@ -1372,7 +1372,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR)
                 << "Failed building cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION message!";
             break;
@@ -1396,7 +1396,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION>(cmdu_tx);
 
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR)
                 << "Failed building cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION message!";
             break;
@@ -1451,7 +1451,7 @@ void ap_manager_thread::handle_hostapd_attached()
         message_com::create_vs_message<beerocks_message::cACTION_APMANAGER_JOINED_NOTIFICATION>(
             cmdu_tx);
 
-    if (notification == nullptr) {
+    if (!notification) {
         LOG(ERROR) << "Failed building message!";
         return;
     }
@@ -1535,7 +1535,7 @@ void ap_manager_thread::stop_ap_manager_thread()
 
 void ap_manager_thread::send_heartbeat()
 {
-    if (slave_socket == nullptr) {
+    if (!slave_socket) {
         LOG(ERROR) << "process_keep_alive(): slave_socket is nullptr!";
         return;
     }
@@ -1545,7 +1545,7 @@ void ap_manager_thread::send_heartbeat()
         message_com::create_vs_message<beerocks_message::cACTION_APMANAGER_HEARTBEAT_NOTIFICATION>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_APMANAGER_HEARTBEAT_NOTIFICATION message!";
         return;
     }
@@ -1583,7 +1583,7 @@ bool ap_manager_thread::handle_ap_enabled(int vap_id)
 
     auto notification = message_com::create_vs_message<
         beerocks_message::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION>(cmdu_tx);
-    if (notification == nullptr) {
+    if (!notification) {
         LOG(ERROR) << "Failed building cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION message!";
         return false;
     }
@@ -1609,7 +1609,7 @@ void ap_manager_thread::send_steering_return_status(beerocks_message::eActionOp_
     case beerocks_message::ACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE: {
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -1620,7 +1620,7 @@ void ap_manager_thread::send_steering_return_status(beerocks_message::eActionOp_
     case beerocks_message::ACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE: {
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             break;
         }

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -292,7 +292,7 @@ void backhaul_manager::platform_notify_error(bpl::eErrorCode code, const std::st
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ERROR_NOTIFICATION>(
             cmdu_tx);
 
-    if (error == nullptr) {
+    if (!error) {
         LOG(ERROR) << "Failed building message!";
         return;
     }
@@ -363,7 +363,7 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_BACKHAUL_CONNECTED_NOTIFICATION>(cmdu_tx);
 
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -508,7 +508,7 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
                            << " skipping " << sc->hostap_iface;
                 continue;
             }
-            if (sc->slave == nullptr) {
+            if (!sc->slave) {
                 LOG(ERROR) << "slave " << sc->hostap_iface << " socket is nullptr!";
                 continue;
             }
@@ -539,7 +539,7 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
                 continue;
             }
 
-            if (sc->slave == nullptr) {
+            if (!sc->slave) {
                 continue;
             }
 
@@ -547,7 +547,7 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
 
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION>(cmdu_tx);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1487,7 +1487,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         } else if (pending_enable) {
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_BUSY_NOTIFICATION>(cmdu_tx);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building cACTION_BACKHAUL_BUSY_NOTIFICATION message!";
                 break;
             }
@@ -1602,7 +1602,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>(
                 cmdu_tx, beerocks_header->id());
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "Failed building "
                               "ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE message!";
                 break;
@@ -1639,7 +1639,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(
                 cmdu_tx, beerocks_header->id());
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "Failed building ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE "
                               "message!";
                 break;
@@ -1873,6 +1873,11 @@ bool backhaul_manager::send_slaves_enable()
         auto notification =
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_ENABLE_APS_REQUEST>(
                 cmdu_tx);
+
+        if (!notification) {
+            LOG(ERROR) << "create_vs_message method failed";
+            return true;
+        }
 
         if (soc->sta_iface == m_sConfig.wireless_iface) {
             notification->channel() = iface_hal->get_channel();

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -454,7 +454,7 @@ void main_thread::send_dhcp_notification(std::string op, std::string mac, std::s
     auto dhcp_notif = message_com::create_vs_message<
         beerocks_message::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION>(cmdu_tx);
 
-    if (dhcp_notif == nullptr) {
+    if (!dhcp_notif) {
         LOG(ERROR) << "Failed building ACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION message!";
         return;
     }
@@ -559,7 +559,7 @@ bool main_thread::wlan_params_changed_check()
 {
     bool any_slave_changed = false;
     for (auto &elm : bpl_iface_wlan_params_map) {
-        if (elm.second == nullptr) {
+        if (!elm.second) {
             LOG(ERROR) << "invalid map - pointer to NULL";
             return false;
         }
@@ -607,7 +607,7 @@ bool main_thread::wlan_params_changed_check()
             any_slave_changed = true;
             auto notification = message_com::create_vs_message<
                 beerocks_message::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION>(cmdu_tx);
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -733,7 +733,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST failed";
             return false;
         }
@@ -755,7 +755,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             auto register_response = message_com::create_vs_message<
                 beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE>(cmdu_tx);
 
-            if (register_response == nullptr) {
+            if (!register_response) {
                 LOG(ERROR) << "Failed building message!";
                 return;
             }
@@ -795,7 +795,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL failed";
             return false;
         }
@@ -809,7 +809,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 
         auto request =
             beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ARP_QUERY_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_ARP_QUERY_REQUEST failed";
             return false;
         }
@@ -853,7 +853,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -882,7 +882,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST: {
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE failed";
             return false;
         }
@@ -903,7 +903,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION failed";
             return false;
         }
@@ -923,7 +923,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION failed";
             return false;
         }
@@ -935,7 +935,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION failed";
             return false;
         }
@@ -973,7 +973,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
                 // Response message
                 auto notification = message_com::create_vs_message<
                     beerocks_message::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION>(cmdu_tx);
-                if (notification == nullptr) {
+                if (!notification) {
                     LOG(ERROR) << "Failed building message!";
                     return false;
                 }
@@ -992,7 +992,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto notification = cmdu_rx.addClass<
             beerocks_message::
                 cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass "
                           "cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION "
                           "failed";
@@ -1024,7 +1024,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         LOG(TRACE) << "ACTION_PLATFORM_ONBOARD_QUERY_REQUEST";
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ONBOARD RESPONSE message!";
             return false;
         }
@@ -1039,7 +1039,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         LOG(TRACE) << "ACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST";
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1057,7 +1057,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto request =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST failed";
             break;
         }
@@ -1069,7 +1069,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -1143,7 +1143,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         // Request message
         auto request =
             beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ONBOARD_SET_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_ONBOARD_SET_REQUEST failed";
             break;
         }
@@ -1160,7 +1160,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 
         auto request =
             beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_WPS_ONBOARDING_REQUEST failed";
             break;
         }
@@ -1182,7 +1182,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -1226,7 +1226,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     case beerocks_message::ACTION_PLATFORM_ERROR_NOTIFICATION: {
         auto error =
             beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ERROR_NOTIFICATION>();
-        if (error == nullptr) {
+        if (!error) {
             LOG(ERROR) << "addClass failed";
             break;
         }
@@ -1258,7 +1258,7 @@ bool main_thread::handle_arp_monitor()
     auto arp_notif =
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION>(
             cmdu_tx);
-    if (arp_notif == nullptr) {
+    if (!arp_notif) {
         LOG(ERROR) << "Failed building message!";
         return false;
     }
@@ -1312,7 +1312,7 @@ bool main_thread::handle_arp_monitor()
     sd = get_slave_socket_from_hostap_iface_name(strIfaceName);
 
     // Use the Backhaul Manager Slave as the default destination
-    if ((sd == nullptr) && ((sd = get_backhaul_socket()) == nullptr)) {
+    if ((!sd) && ((sd = get_backhaul_socket()))) {
         LOG(WARNING) << "Failed obtaining slave socket";
         return false;
     }
@@ -1404,7 +1404,7 @@ bool main_thread::handle_arp_raw()
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ARP_QUERY_RESPONSE>(
             cmdu_tx, task_id);
 
-    if (arp_resp == nullptr) {
+    if (!arp_resp) {
         LOG(ERROR) << "Failed building cACTION_PLATFORM_ARP_QUERY_RESPONSE message!";
         return false;
     }

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -168,7 +168,7 @@ void slave_thread::slave_reset()
 void slave_thread::platform_notify_error(beerocks::bpl::eErrorCode code,
                                          const std::string &error_data)
 {
-    if (platform_manager_socket == nullptr) {
+    if (!platform_manager_socket) {
         LOG(ERROR) << "Invalid Platform Manager socket!";
         return;
     }
@@ -177,7 +177,7 @@ void slave_thread::platform_notify_error(beerocks::bpl::eErrorCode code,
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ERROR_NOTIFICATION>(
             cmdu_tx);
 
-    if (error == nullptr) {
+    if (!error) {
         LOG(ERROR) << "Failed building message!";
         return;
     }
@@ -270,7 +270,7 @@ void slave_thread::process_keep_alive()
         return;
     }
 
-    if (master_socket == nullptr) {
+    if (!master_socket) {
         LOG(ERROR) << "process_keep_alive(): master_socket is nullptr!";
         return;
     }
@@ -294,7 +294,7 @@ void slave_thread::process_keep_alive()
                        << "ms, sending PING_MSG_REQUEST, tries=" << keep_alive_retries;
             auto request = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_AGENT_PING_REQUEST>(cmdu_tx);
-            if (request == nullptr) {
+            if (!request) {
                 LOG(ERROR) << "Failed building message!";
                 return;
             }
@@ -385,8 +385,8 @@ bool slave_thread::handle_cmdu_control_ieee1905_1_message(Socket *sd,
 {
     auto cmdu_message_type = cmdu_rx.getMessageType();
 
-    if (master_socket == nullptr) {
-        LOG(WARNING) << "master_socket == nullptr";
+    if (!master_socket) {
+        LOG(WARNING) << "getMessageType() failed";
         return true;
     } else if (master_socket != sd) {
         LOG(WARNING) << "Unknown socket, cmdu message type: " << int(cmdu_message_type);
@@ -455,8 +455,8 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         return true;
     }
 
-    if (master_socket == nullptr) {
-        // LOG(WARNING) << "master_socket == nullptr";
+    if (!master_socket) {
+        // LOG(WARNING) << "!master_socket";
         return true;
     } else if (master_socket != sd) {
         LOG(WARNING) << "Unknown socket, ACTION_CONTROL action_op: "
@@ -476,14 +476,14 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         LOG(TRACE) << "ACTION_CONTROL_ARP_QUERY_REQUEST";
         auto request_in =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_ARP_QUERY_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass cACTION_CONTROL_ARP_QUERY_REQUEST failed";
             return false;
         }
         auto request_out =
             message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ARP_QUERY_REQUEST>(
                 cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -496,7 +496,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         LOG(DEBUG) << "received ACTION_CONTROL_SON_CONFIG_UPDATE";
         auto update =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_SON_CONFIG_UPDATE>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass cACTION_CONTROL_SON_CONFIG_UPDATE failed";
             return false;
         }
@@ -509,7 +509,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
 
         auto request_in = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR)
                 << "addClass cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST failed";
             return false;
@@ -518,7 +518,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST>(
             cmdu_tx);
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -533,7 +533,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START failed";
             return false;
         }
@@ -541,7 +541,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -556,7 +556,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_START_MONITORING_REQUEST failed";
             return false;
         }
@@ -572,7 +572,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         if (request_in->params().is_ire) {
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION>(cmdu_tx);
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building ACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION "
                               "message!";
                 return false;
@@ -585,7 +585,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building ACTION_MONITOR_CLIENT_START_MONITORING_REQUEST message!";
             return false;
         }
@@ -599,7 +599,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST failed";
             return false;
         }
@@ -611,7 +611,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building ACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST message!";
             return false;
         }
@@ -627,7 +627,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST failed";
             return false;
         }
@@ -640,7 +640,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(
                 cmdu_tx, beerocks_header->id());
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building ACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST "
                               "message!";
                 return false;
@@ -654,7 +654,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(
                 cmdu_tx, beerocks_header->id());
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST "
                               "message!";
                 return false;
@@ -665,7 +665,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(
                 cmdu_tx, beerocks_header->id());
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR)
                     << "Failed building ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST message!";
                 return false;
@@ -688,7 +688,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_DISCONNECT_REQUEST failed";
             return false;
         }
@@ -696,7 +696,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST>(cmdu_tx,
                                                                            beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building ACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST message!";
             return false;
         }
@@ -713,14 +713,14 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         LOG(DEBUG) << "received ACTION_CONTROL_CONTROLLER_PING_REQUEST";
         auto request =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_CONTROLLER_PING_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_CONTROL_CONTROLLER_PING_REQUEST failed";
             return false;
         }
 
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CONTROLLER_PING_RESPONSE>(cmdu_tx);
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -742,14 +742,14 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         LOG(DEBUG) << "received ACTION_CONTROL_AGENT_PING_RESPONSE";
         auto response =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_AGENT_PING_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass cACTION_CONTROL_AGENT_PING_RESPONSE failed";
             return false;
         }
         if (response->seq() < (response->total() - 1)) { //send next ping request
             auto request = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_AGENT_PING_REQUEST>(cmdu_tx);
-            if (request == nullptr) {
+            if (!request) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -772,7 +772,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL failed";
             return false;
         }
@@ -787,7 +787,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         if (all || request_in->params().module_name == beerocks::BEEROCKS_PROCESS_MONITOR) {
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL>(cmdu_tx);
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -797,7 +797,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         if (all || request_in->params().module_name == beerocks::BEEROCKS_PROCESS_PLATFORM) {
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL>(cmdu_tx);
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -812,7 +812,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_in =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST>();
-            if (request_in == nullptr) {
+            if (!request_in) {
                 LOG(ERROR) << "addClass cACTION_CONTROL_BACKHAUL_ROAM_REQUEST failed";
                 return false;
             }
@@ -823,7 +823,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_out =
                 message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_ROAM_REQUEST>(
                     cmdu_tx, beerocks_header->id());
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -836,7 +836,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         LOG(TRACE) << "received ACTION_CONTROL_BACKHAUL_RESET";
         auto request =
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_RESET>(cmdu_tx);
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -848,7 +848,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             // LOG(TRACE) << "received ACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST"; // floods the log
             auto request_in = beerocks_header->addClass<
                 beerocks_message::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST>();
-            if (request_in == nullptr) {
+            if (!request_in) {
                 LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST failed";
                 return false;
             }
@@ -856,7 +856,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST>(
                 cmdu_tx, beerocks_header->id());
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -869,7 +869,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST failed";
             return false;
         }
@@ -877,7 +877,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -890,7 +890,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST failed";
             return false;
         }
@@ -898,7 +898,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -911,7 +911,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST failed";
             return false;
         }
@@ -927,7 +927,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST>(cmdu_tx,
                                                                          beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building ACTION_MONITOR_CLIENT_BEACON_11K_REQUEST message!";
             return false;
         }
@@ -939,7 +939,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST failed";
             return false;
         }
@@ -947,7 +947,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building ACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST message!";
             return false;
         }
@@ -960,7 +960,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST failed";
             return false;
         }
@@ -968,7 +968,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST>(cmdu_tx,
                                                                              beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR) << "Failed building ACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST message!";
             return false;
         }
@@ -981,7 +981,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST failed";
             return false;
         }
@@ -989,7 +989,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto request_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST>(
             cmdu_tx, beerocks_header->id());
-        if (request_out == nullptr) {
+        if (!request_out) {
             LOG(ERROR)
                 << "Failed building ACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST message!";
             return false;
@@ -1003,7 +1003,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
     case beerocks_message::ACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST: {
         auto request_in = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST>();
-        if (request_in == nullptr) {
+        if (!request_in) {
             LOG(ERROR)
                 << "addClass cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST failed";
             return false;
@@ -1017,7 +1017,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             auto request_out = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST>(
                 cmdu_tx);
-            if (request_out == nullptr) {
+            if (!request_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1037,7 +1037,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto update =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass failed";
             return false;
         }
@@ -1046,7 +1046,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST>(
             cmdu_tx, beerocks_header->id());
 
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR)
                 << "Failed building cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST message!";
             break;
@@ -1074,7 +1074,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         auto update =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST>();
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "addClass failed";
             return false;
         }
@@ -1084,7 +1084,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST>(cmdu_tx,
                                                                            beerocks_header->id());
 
-        if (notification_mon_out == nullptr) {
+        if (!notification_mon_out) {
             LOG(ERROR) << "Failed building cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST message!";
             break;
         }
@@ -1098,7 +1098,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
             beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST>(cmdu_tx,
                                                                              beerocks_header->id());
 
-        if (notification_ap_out == nullptr) {
+        if (!notification_ap_out) {
             LOG(ERROR) << "Failed building cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST message!";
             break;
         }
@@ -1147,8 +1147,8 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
 bool slave_thread::handle_cmdu_backhaul_manager_message(
     Socket *sd, std::shared_ptr<beerocks_header> beerocks_header)
 {
-    if (backhaul_manager_socket == nullptr) {
-        LOG(ERROR) << "backhaul_socket == nullptr";
+    if (!backhaul_manager_socket) {
+        LOG(ERROR) << "!backhaul_socket";
         return true;
     } else if (backhaul_manager_socket != sd) {
         LOG(ERROR) << "Unknown socket, ACTION_BACKHAUL action_op: "
@@ -1349,7 +1349,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(
             cmdu_tx, beerocks_header->id());
 
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE message!";
             break;
@@ -1450,7 +1450,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE failed";
                 return false;
             }
@@ -1487,14 +1487,14 @@ bool slave_thread::handle_cmdu_platform_manager_message(
             auto notification_in =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION>();
-            if (notification_in == nullptr) {
+            if (!notification_in) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION failed";
                 return false;
             }
 
             auto notification_out = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION>(cmdu_tx);
-            if (notification_out == nullptr) {
+            if (!notification_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1510,7 +1510,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION failed";
             return false;
         }
@@ -1526,7 +1526,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_OPERATIONAL_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_PLATFORM_OPERATIONAL_NOTIFICATION failed";
             return false;
         }
@@ -1537,7 +1537,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1552,7 +1552,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION failed";
             return false;
         }
@@ -1562,15 +1562,20 @@ bool slave_thread::handle_cmdu_platform_manager_message(
             std::string client_mac = network_utils::mac_to_string(notification->mac());
             std::string client_ip  = network_utils::ipv4_to_string(notification->ipv4());
 
+            auto hostname = notification->hostname(message::NODE_NAME_LENGTH);
+            if (!hostname) {
+                LOG(ERROR) << "hostname() failed";
+                return false;
+            }
+
             LOG(DEBUG) << "ACTION_DHCP_LEASE_ADDED_NOTIFICATION mac " << client_mac
-                       << " ip = " << client_ip << " name="
-                       << std::string(notification->hostname(message::NODE_NAME_LENGTH));
+                       << " ip = " << client_ip << " name=" << std::string(hostname);
 
             // notify master
             if (master_socket) {
                 auto master_notification = message_com::create_vs_message<
                     beerocks_message::cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION>(cmdu_tx);
-                if (master_notification == nullptr) {
+                if (!master_notification) {
                     LOG(ERROR) << "Failed building message!";
                     return false;
                 }
@@ -1595,7 +1600,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
         if (master_socket) {
             auto response =
                 beerocks_header->addClass<beerocks_message::cACTION_PLATFORM_ARP_QUERY_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ARP_QUERY_RESPONSE failed";
                 return false;
             }
@@ -1603,7 +1608,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
             auto response_out = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_ARP_QUERY_RESPONSE>(cmdu_tx,
                                                                       beerocks_header->id());
-            if (response_out == nullptr) {
+            if (!response_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1627,7 +1632,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
 bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
                                                   std::shared_ptr<beerocks_header> beerocks_header)
 {
-    if (ap_manager_socket == nullptr) {
+    if (!ap_manager_socket) {
         if (beerocks_header->action_op() !=
             beerocks_message::ACTION_APMANAGER_INIT_DONE_NOTIFICATION) {
             LOG(ERROR) << "Not ACTION_APMANAGER_INIT_DONE_NOTIFICATION, action_op: "
@@ -1645,8 +1650,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         ap_manager_last_seen       = std::chrono::steady_clock::now();
         ap_manager_retries_counter = 0;
         return true;
-    } else if (slave_state > STATE_BACKHAUL_MANAGER_CONNECTED && master_socket == nullptr) {
-        LOG(ERROR) << "master_socket == nullptr ACTION_APMANAGER action_op: "
+    } else if (slave_state > STATE_BACKHAUL_MANAGER_CONNECTED && !master_socket) {
+        LOG(ERROR) << "!master_socket ACTION_APMANAGER action_op: "
                    << int(beerocks_header->action_op());
     }
 
@@ -1661,7 +1666,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         LOG(INFO) << "received ACTION_APMANAGER_JOINED_NOTIFICATION";
         auto notification =
             beerocks_header->addClass<beerocks_message::cACTION_APMANAGER_JOINED_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_JOINED_NOTIFICATION failed";
             return false;
         }
@@ -1678,7 +1683,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE: {
         auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass "
                           "cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE "
                           "failed";
@@ -1689,7 +1694,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE>(
             cmdu_tx);
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1702,7 +1707,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION failed";
             return false;
         }
@@ -1719,7 +1724,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         } else {
             auto response_out = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION>(cmdu_tx);
-            if (response_out == nullptr) {
+            if (!response_out) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1756,7 +1761,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION failed";
             return false;
         }
@@ -1765,7 +1770,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1778,7 +1783,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION failed";
             return false;
         }
@@ -1787,7 +1792,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1801,14 +1806,14 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION failed";
             return false;
         }
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION>(cmdu_tx,
                                                                        beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1826,14 +1831,14 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION failed";
             return false;
         }
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION>(cmdu_tx,
                                                                        beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1855,14 +1860,14 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION failed";
             return false;
         }
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION>(cmdu_tx,
                                                                              beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -1873,7 +1878,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE: {
         auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE failed";
             return false;
         }
@@ -1886,7 +1891,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(
             cmdu_tx, beerocks_header->id());
 
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE message!";
             break;
@@ -1901,7 +1906,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION failed";
             return false;
         }
@@ -1915,7 +1920,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
                 beerocks_message::cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST>(
                 cmdu_tx, beerocks_header->id());
 
-            if (notification_out == nullptr) {
+            if (!notification_out) {
                 LOG(ERROR)
                     << "Failed building cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST message!";
                 break;
@@ -1989,7 +1994,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE failed";
             return false;
         }
@@ -2016,7 +2021,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE: {
         auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR)
                 << "addClass ACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE failed";
             return false;
@@ -2025,7 +2030,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE "
                           "message!";
             break;
@@ -2038,7 +2043,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass sACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION failed";
             return false;
         }
@@ -2046,7 +2051,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2058,7 +2063,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR)
                 << "addClass cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION failed";
             return false;
@@ -2067,7 +2072,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2128,7 +2133,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION failed";
             return false;
         }
@@ -2136,7 +2141,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION>(
             cmdu_tx, beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2149,7 +2154,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
     case beerocks_message::ACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass "
                           "cACTION_APMANAGER_CLIENT_ScACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_"
                           "NOTIFICATIONOFTBLOCK_NOTIFICATION failed";
@@ -2159,7 +2164,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION>(
             cmdu_tx, beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2172,14 +2177,14 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2192,14 +2197,14 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2298,7 +2303,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
 bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
                                                std::shared_ptr<beerocks_header> beerocks_header)
 {
-    if (monitor_socket == nullptr) {
+    if (!monitor_socket) {
         if (beerocks_header->action_op() != beerocks_message::ACTION_MONITOR_JOINED_NOTIFICATION) {
             LOG(ERROR) << "Not MONITOR_JOINED_NOTIFICATION, action_op: "
                        << int(beerocks_header->action_op());
@@ -2313,9 +2318,8 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         monitor_last_seen       = std::chrono::steady_clock::now();
         monitor_retries_counter = 0;
         return true;
-    } else if (master_socket == nullptr) {
-        LOG(WARNING) << "master_socket == nullptr, MONITOR action_op: "
-                     << int(beerocks_header->action_op());
+    } else if (!master_socket) {
+        LOG(WARNING) << "!master_socket, MONITOR action_op: " << int(beerocks_header->action_op());
     }
 
     switch (beerocks_header->action_op()) {
@@ -2335,7 +2339,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION failed";
             return false;
         }
@@ -2355,7 +2359,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_APMANAGER_HOSTAP_STATUS_CHANGED_NOTIFICATION failed";
             return false;
         }
@@ -2386,7 +2390,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE failed";
             break;
         }
@@ -2398,7 +2402,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE message!";
             break;
@@ -2412,7 +2416,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
     case beerocks_message::ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR)
                 << "addClass ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION failed";
             break;
@@ -2421,7 +2425,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>(
             cmdu_tx, beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE message!";
             break;
@@ -2443,7 +2447,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE failed";
             return false;
         }
@@ -2451,7 +2455,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2496,14 +2500,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION failed";
             break;
         }
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION>(
             cmdu_tx, beerocks_header->id());
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION message!";
             break;
         }
@@ -2516,14 +2520,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE failed";
             break;
         }
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE>(cmdu_tx,
                                                                           beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE message!";
             break;
         }
@@ -2535,14 +2539,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE failed";
             break;
         }
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE message!";
             break;
@@ -2555,14 +2559,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE failed";
             break;
         }
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE message!";
             break;
         }
@@ -2573,14 +2577,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
     case beerocks_message::ACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE: {
         auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE failed";
             break;
         }
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE message!";
             break;
@@ -2594,14 +2598,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
                   << int(beerocks_header->action_op());
         auto response_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE failed";
             break;
         }
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE "
                           "message!";
             break;
@@ -2614,14 +2618,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto response_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION>();
-        if (response_in == nullptr) {
+        if (!response_in) {
             LOG(ERROR) << "addClass ACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION failed";
             break;
         }
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION>(
             cmdu_tx, beerocks_header->id());
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION message!";
             break;
         }
@@ -2634,14 +2638,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2652,7 +2656,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
     case beerocks_message::ACTION_MONITOR_ERROR_NOTIFICATION: {
         auto notification =
             beerocks_header->addClass<beerocks_message::cACTION_MONITOR_ERROR_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_MONITOR_ERROR_NOTIFICATION failed";
             return false;
         }
@@ -2683,7 +2687,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
 
         auto response_out = message_com::create_vs_message<
             beerocks_message::cACTION_MONITOR_ERROR_NOTIFICATION_ACK>(cmdu_tx);
-        if (response_out == nullptr) {
+        if (!response_out) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -2694,14 +2698,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
     case beerocks_message::ACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2712,7 +2716,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
     case beerocks_message::ACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR)
                 << "addClass cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION failed";
             return false;
@@ -2720,7 +2724,7 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building  "
                           "cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION message!";
             return false;
@@ -2732,14 +2736,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
     case beerocks_message::ACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION: {
         auto notification_in = beerocks_header->addClass<
             beerocks_message::cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR)
                 << "Failed building cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION message!";
             return false;
@@ -2752,14 +2756,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR)
                 << "Failed building cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE message!";
             return false;
@@ -2772,14 +2776,14 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
         auto notification_in =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE>();
-        if (notification_in == nullptr) {
+        if (!notification_in) {
             LOG(ERROR) << "addClass cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE failed";
             return false;
         }
 
         auto notification_out = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE>(cmdu_tx);
-        if (notification_out == nullptr) {
+        if (!notification_out) {
             LOG(ERROR) << "Failed building cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE message!";
             return false;
         }
@@ -2842,7 +2846,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             auto request = message_com::create_vs_message<
                 beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST>(cmdu_tx);
 
-            if (request == nullptr) {
+            if (!request) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -2873,7 +2877,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         break;
     }
     case STATE_CONNECT_TO_BACKHAUL_MANAGER: {
-        if (backhaul_manager_socket == nullptr) {
+        if (!backhaul_manager_socket) {
             LOG(DEBUG) << "create backhaul_manager_socket";
             backhaul_manager_socket = new SocketClient(backhaul_manager_uds);
             std::string err         = backhaul_manager_socket->getError();
@@ -2898,7 +2902,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_REGISTER_REQUEST>(
                 cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -3042,7 +3046,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         // CMDU Message
         auto bh_enable =
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_ENABLE>(cmdu_tx);
-        if (bh_enable == nullptr) {
+        if (!bh_enable) {
             LOG(ERROR) << "Failed building message!";
             break;
         }
@@ -3167,7 +3171,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 beerocks_message::
                     cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION>(cmdu_tx);
 
-            if (notification == nullptr) {
+            if (!notification) {
                 LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -3194,8 +3198,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
     }
     case STATE_JOIN_MASTER: {
 
-        if (master_socket == nullptr) {
-            LOG(ERROR) << "master_socket == nullptr";
+        if (!master_socket) {
+            LOG(ERROR) << "!master_socket";
             platform_notify_error(bpl::eErrorCode::SLAVE_INVALID_MASTER_SOCKET,
                                   "Invalid master socket");
             stop_on_failure_attempts--;
@@ -3326,7 +3330,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         auto update =
             message_com::create_vs_message<beerocks_message::cACTION_MONITOR_SON_CONFIG_UPDATE>(
                 cmdu_tx);
-        if (update == nullptr) {
+        if (!update) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -3511,7 +3515,7 @@ void slave_thread::send_platform_iface_status_notif(eRadioStatus radio_status,
     auto platform_notification = message_com::create_vs_message<
         beerocks_message::cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION>(cmdu_tx);
 
-    if (platform_notification == nullptr) {
+    if (!platform_notification) {
         LOG(ERROR) << "Failed building message!";
         return;
     }
@@ -3546,7 +3550,7 @@ void slave_thread::send_platform_iface_status_notif(eRadioStatus radio_status,
 
 bool slave_thread::monitor_heartbeat_check()
 {
-    if (monitor_socket == nullptr) {
+    if (!monitor_socket) {
         return true;
     }
     auto now = std::chrono::steady_clock::now();
@@ -3570,7 +3574,7 @@ bool slave_thread::monitor_heartbeat_check()
 
 bool slave_thread::ap_manager_heartbeat_check()
 {
-    if (ap_manager_socket == nullptr) {
+    if (!ap_manager_socket) {
         return true;
     }
     auto now = std::chrono::steady_clock::now();
@@ -3607,8 +3611,13 @@ bool slave_thread::send_cmdu_to_controller(ieee1905_1::CmduMessageTx &cmdu_tx)
             return false;
         }
 
-        beerocks_header->actionhdr()->radio_mac() = hostap_params.iface_mac;
-        beerocks_header->actionhdr()->direction() = beerocks::BEEROCKS_DIRECTION_CONTROLLER;
+        auto actionhdr = beerocks_header->actionhdr();
+        if (!actionhdr) {
+            return false;
+        }
+
+        actionhdr->radio_mac() = hostap_params.iface_mac;
+        actionhdr->direction() = beerocks::BEEROCKS_DIRECTION_CONTROLLER;
     }
     return message_com::send_cmdu(master_socket, cmdu_tx, backhaul_params.controller_bridge_mac,
                                   backhaul_params.bridge_mac);
@@ -3940,6 +3949,10 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
                                                         fronthaul, teardown, credentials))
             return false;
 
+        if (!credentials) {
+            return false;
+        }
+
         LOG(DEBUG) << "Controller configuration (WSC M2 Encrypted Settings)";
         LOG(DEBUG) << "     Manufacturer: " << m2->manufacturer()
                    << ", ssid: " << credentials->ssid_str()
@@ -4012,7 +4025,7 @@ bool slave_thread::parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessage
 
     auto joined_response =
         beerocks_header->addClass<beerocks_message::cACTION_CONTROL_SLAVE_JOINED_RESPONSE>();
-    if (joined_response == nullptr) {
+    if (!joined_response) {
         LOG(ERROR) << "addClass cACTION_CONTROL_SLAVE_JOINED_RESPONSE failed";
         return false;
     }
@@ -4030,7 +4043,7 @@ bool slave_thread::parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessage
     // request the current vap list from ap_manager
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST message!";
         return false;
     }
@@ -4044,8 +4057,12 @@ bool slave_thread::parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessage
         return false;
     }
     message_com::send_cmdu(ap_manager_socket, cmdu_tx);
-
-    master_version.assign(joined_response->master_version(message::VERSION_LENGTH));
+    auto master_ver = joined_response->master_version(message::VERSION_LENGTH);
+    if (!master_ver) {
+        LOG(ERROR) << "master_version() has failed !";
+        return false;
+    }
+    master_version.assign(master_ver);
 
     LOG(DEBUG) << "Version (Master/Slave): " << master_version << "/" << BEEROCKS_VERSION;
     auto slave_version_s  = version::version_from_string(BEEROCKS_VERSION);
@@ -4062,7 +4079,7 @@ bool slave_thread::parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessage
                      "ACTION_CONTROL_VERSION_MISMATCH_NOTIFICATION";
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -4088,7 +4105,7 @@ bool slave_thread::parse_intel_join_response(Socket *sd, ieee1905_1::CmduMessage
         //Send master version + slave version to platform manager
         auto notification = message_com::create_vs_message<
             beerocks_message::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION>(cmdu_tx);
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -4113,7 +4130,7 @@ bool slave_thread::parse_non_intel_join_response(Socket *sd)
     // request the current vap list from ap_manager
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST message!";
         return false;
     }
@@ -4124,7 +4141,7 @@ bool slave_thread::parse_non_intel_join_response(Socket *sd)
     // TODO
     //        auto notification = message_com::create_vs_message<
     //            beerocks_message::cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION>(cmdu_tx);
-    //        if (notification == nullptr) {
+    //        if (!notification) {
     //            LOG(ERROR) << "Failed building message!";
     //            return false;
     //        }
@@ -4572,7 +4589,7 @@ bool slave_thread::add_radio_basic_capabilities()
 bool slave_thread::autoconfig_wsc_add_m1()
 {
     auto tlv = cmdu_tx.addClass<ieee1905_1::tlvWsc>();
-    if (tlv == nullptr) {
+    if (!tlv) {
         LOG(ERROR) << "Error creating tlvWsc";
         return false;
     }

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -203,8 +203,14 @@ bool socket_thread::verify_cmdu(message::sUdsHeader *uds_header)
 
             if (tlv_vendor_specific.vendor_oui() ==
                 ieee1905_1::tlvVendorSpecific::eVendorOUI::OUI_INTEL) {
+                auto payload = tlv_vendor_specific.payload();
+                if (!payload) {
+                    LOG(ERROR) << "payload() failed";
+                    ret = false;
+                    break;
+                }
                 // assuming that the magic is the first data on the beerocks header
-                auto beerocks_magic = *(uint32_t *)(tlv_vendor_specific.payload());
+                auto beerocks_magic = *(uint32_t *)(payload);
                 swap_32(beerocks_magic);
                 if (beerocks_magic != message::MESSAGE_MAGIC) {
                     THREAD_LOG(WARNING) << "mismatch magic " << std::hex << int(beerocks_magic)

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
@@ -461,6 +461,10 @@ bool sta_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std
     case Event::Disconnected: {
 
         auto msg_buff = ALLOC_SMART_BUFFER(sizeof(sACTION_BACKHAUL_DISCONNECT_REASON_NOTIFICATION));
+        if (!msg_buff) {
+            LOG(ERROR) << "ALLOC_SMART_BUFFER has failed";
+            return false;
+        }
         auto msg =
             reinterpret_cast<sACTION_BACKHAUL_DISCONNECT_REASON_NOTIFICATION *>(msg_buff.get());
         LOG_IF(!msg, FATAL) << "Memory allocation failed!";

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_header.h
@@ -39,10 +39,31 @@ public:
     }
     beerocks_message::eAction action()
     {
-        return actionhdr() ? actionhdr()->action() : beerocks_message::ACTION_NONE;
+        auto action_hdr = actionhdr();
+        if (!action_hdr) {
+            return beerocks_message::ACTION_NONE;
+        } else {
+            return action_hdr->action();
+        }
     }
-    uint8_t action_op() { return actionhdr() ? actionhdr()->action_op() : 0; };
-    uint16_t id() { return actionhdr() ? actionhdr()->id() : 0; }
+    uint8_t action_op()
+    {
+        auto action_hdr = actionhdr();
+        if (!action_hdr) {
+            return 0;
+        } else {
+            return action_hdr->action_op();
+        }
+    };
+    uint16_t id()
+    {
+        auto action_hdr = actionhdr();
+        if (!action_hdr) {
+            return 0;
+        } else {
+            return action_hdr->id();
+        }
+    }
 };
 
 } // namespace beerocks

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -108,9 +108,14 @@ public:
             return nullptr;
         }
 
-        hdr->actionhdr()->action()    = (beerocks_message::eAction)action;
-        hdr->actionhdr()->action_op() = action_op;
-        hdr->actionhdr()->id()        = id;
+        auto actionhdr = hdr->actionhdr();
+        if (!actionhdr) {
+            return nullptr;
+        }
+
+        actionhdr->action()    = (beerocks_message::eAction)action;
+        actionhdr->action_op() = action_op;
+        actionhdr->id()        = id;
         tlv->addInnerClassList(hdr);
 
         return hdr;

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -93,7 +93,7 @@ int bml_internal::send_bml_cmdu(int &result, uint8_t action_op)
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK)
             return iRet;
@@ -199,7 +199,7 @@ int bml_internal::connect(const std::string beerocks_conf_path)
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ONBOARD_QUERY_REQUEST>(
             cmdu_tx);
 
-    if (header_onboarding == nullptr) {
+    if (!header_onboarding) {
         LOG(ERROR) << "Failed building message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -229,7 +229,7 @@ int bml_internal::connect(const std::string beerocks_conf_path)
     auto header_local_master =
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST>(
             cmdu_tx);
-    if (header_local_master == nullptr) {
+    if (!header_local_master) {
         LOG(ERROR) << "Failed building message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -797,7 +797,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             if (m_prmSetVapListCreds) {
                 auto response = beerocks_header->addClass<
                     beerocks_message::cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE>();
-                if (response == nullptr) {
+                if (!response) {
                     LOG(ERROR) << "addClass cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE failed";
                     return BML_RET_OP_FAILED;
                 }
@@ -826,7 +826,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -835,7 +835,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
                 m_prmGetVapListCreds = nullptr;
             };
 
-            if (m_vaps == nullptr || m_pvaps_list_size == nullptr) {
+            if (!m_vaps || !m_pvaps_list_size) {
                 LOG(ERROR) << "The pointer to the user data buffer is null!";
                 release_waiting_thread();
                 break;
@@ -900,7 +900,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -920,7 +920,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -940,7 +940,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -962,7 +962,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -984,7 +984,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -1006,7 +1006,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
         case beerocks_message::ACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE: {
             auto response = beerocks_header->addClass<
                 beerocks_message::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE failed";
                 return BML_RET_OP_FAILED;
             }
@@ -1021,7 +1021,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
                                               message::VERSION_LENGTH);
                     m_prmMasterSlaveVersions->set_value(response->result() == 0);
                 } else {
-                    LOG(DEBUG) << "m_master_slave_versions == nullptr !";
+                    LOG(DEBUG) << "!m_master_slave_versions !";
                     m_prmMasterSlaveVersions->set_value(0);
                 }
                 m_prmMasterSlaveVersions = nullptr;
@@ -1053,8 +1053,8 @@ int bml_internal::bml_set_vap_list_credentials(const BML_VAP_INFO *vaps, const u
         return (-BML_RET_OP_NOT_SUPPORTED);
     }
 
-    if (vaps == nullptr) {
-        LOG(ERROR) << "vaps == nullptr";
+    if (!vaps) {
+        LOG(ERROR) << "!vaps";
         return (-BML_RET_INVALID_ARGS);
     }
 
@@ -1064,7 +1064,7 @@ int bml_internal::bml_set_vap_list_credentials(const BML_VAP_INFO *vaps, const u
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK) {
             LOG(ERROR) << "Set VAP list - connect_to_master failed";
@@ -1076,7 +1076,7 @@ int bml_internal::bml_set_vap_list_credentials(const BML_VAP_INFO *vaps, const u
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building SET VAP LIST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1141,7 +1141,7 @@ int bml_internal::bml_get_vap_list_credentials(BML_VAP_INFO *vaps, uint8_t &vaps
         return (-BML_RET_OP_NOT_SUPPORTED);
     }
 
-    if (vaps == nullptr) {
+    if (!vaps) {
         LOG(ERROR) << "Uninitialized vaps pointer!";
         return (-BML_RET_INVALID_ARGS);
     }
@@ -1152,7 +1152,7 @@ int bml_internal::bml_get_vap_list_credentials(BML_VAP_INFO *vaps, uint8_t &vaps
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK) {
             LOG(ERROR) << "get VAP list - connect_to_master failed";
@@ -1168,7 +1168,7 @@ int bml_internal::bml_get_vap_list_credentials(BML_VAP_INFO *vaps, uint8_t &vaps
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building GET VAP LIST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1215,7 +1215,7 @@ int bml_internal::ping()
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK) {
             LOG(ERROR) << "ping - connect_to_master failed";
@@ -1231,7 +1231,7 @@ int bml_internal::ping()
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_BML_PING_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building PING message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1272,13 +1272,13 @@ int bml_internal::register_nw_map_update_cb(BML_NW_MAP_QUERY_CB pCB)
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK)
             return iRet;
     }
 
-    if ((m_cbNetMapUpdate == nullptr) && (pCB == nullptr)) {
+    if ((!m_cbNetMapUpdate) && (!pCB)) {
         LOG(WARNING) << "Network map update callback function was NOT registered...";
         return (-BML_RET_OP_NOT_SUPPORTED);
     }
@@ -1290,7 +1290,7 @@ int bml_internal::register_nw_map_update_cb(BML_NW_MAP_QUERY_CB pCB)
         auto request = message_com::create_vs_message<
             beerocks_message::cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST>(cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building ACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST message!";
             return (-BML_RET_OP_FAILED);
         }
@@ -1303,7 +1303,7 @@ int bml_internal::register_nw_map_update_cb(BML_NW_MAP_QUERY_CB pCB)
         auto request = message_com::create_vs_message<
             beerocks_message::cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST>(cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR)
                 << "Failed building ACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST message!";
             return (-BML_RET_OP_FAILED);
@@ -1328,7 +1328,7 @@ int bml_internal::nw_map_query()
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK)
             return iRet;
@@ -1344,7 +1344,7 @@ int bml_internal::nw_map_query()
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_BML_NW_MAP_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_NW_MAP_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1366,13 +1366,13 @@ int bml_internal::register_stats_cb(BML_STATS_UPDATE_CB pCB)
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK)
             return iRet;
     }
 
-    if ((m_cbStatsUpdate == nullptr) && (pCB == nullptr)) {
+    if ((!m_cbStatsUpdate) && (!pCB)) {
         LOG(WARNING) << "Statistics update callback function was NOT registered...";
         return (-BML_RET_OP_NOT_SUPPORTED);
     }
@@ -1384,7 +1384,7 @@ int bml_internal::register_stats_cb(BML_STATS_UPDATE_CB pCB)
         auto request = message_com::create_vs_message<
             beerocks_message::cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST>(cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building REGISTER_TO_STATS_UPDATES_REQUEST message!";
             return (-BML_RET_OP_FAILED);
         }
@@ -1392,7 +1392,7 @@ int bml_internal::register_stats_cb(BML_STATS_UPDATE_CB pCB)
         auto request = message_com::create_vs_message<
             beerocks_message::cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST>(cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building UNREGISTER_TO_STATS_UPDATES_REQUEST message!";
             return (-BML_RET_OP_FAILED);
         }
@@ -1415,13 +1415,13 @@ int bml_internal::register_event_cb(BML_EVENT_CB pCB)
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK)
             return iRet;
     }
 
-    if ((m_cbEvent == nullptr) && (pCB == nullptr)) {
+    if ((!m_cbEvent) && (!pCB)) {
         LOG(WARNING) << "Event callback function was NOT registered...";
         return (-BML_RET_OP_FAILED);
     }
@@ -1433,7 +1433,7 @@ int bml_internal::register_event_cb(BML_EVENT_CB pCB)
         auto request = message_com::create_vs_message<
             beerocks_message::cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST>(cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building REGISTER_TO_EVENTS_UPDATES_REQUEST message!";
             return (-BML_RET_OP_FAILED);
         }
@@ -1441,7 +1441,7 @@ int bml_internal::register_event_cb(BML_EVENT_CB pCB)
         auto request = message_com::create_vs_message<
             beerocks_message::cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST>(cmdu_tx);
 
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building UNREGISTER_TO_EVENTS_UPDATES_REQUEST message!";
             return (-BML_RET_OP_FAILED);
         }
@@ -1460,7 +1460,7 @@ int bml_internal::set_wifi_credentials(const std::string ssid, const std::string
                                        int vap_id, int force)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
@@ -1518,7 +1518,7 @@ int bml_internal::set_wifi_credentials(const std::string ssid, const std::string
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK) {
             // Clear the promise holder
@@ -1530,7 +1530,7 @@ int bml_internal::set_wifi_credentials(const std::string ssid, const std::string
     auto config = message_com::create_vs_message<
         beerocks_message::cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST>(cmdu_tx);
 
-    if (config == nullptr) {
+    if (!config) {
         LOG(ERROR) << "Failed building ACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST message!";
         // Clear the promise holder
         m_prmWiFiCredentialsUpdate = nullptr;
@@ -1608,18 +1608,18 @@ int bml_internal::set_wifi_credentials(const std::string ssid, const std::string
 int bml_internal::get_wifi_credentials(int vap_id, char *ssid, char *pass, int *sec)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
     // Validate ssid
-    if (ssid == nullptr) {
+    if (!ssid) {
         LOG(ERROR) << "Invalid ssid ptr";
         return (-BML_RET_INVALID_ARGS);
     }
 
     // Validate ssid
-    if (sec == nullptr) {
+    if (!sec) {
         LOG(ERROR) << "Invalid sec ptr";
         return (-BML_RET_INVALID_ARGS);
     }
@@ -1642,7 +1642,7 @@ int bml_internal::get_wifi_credentials(int vap_id, char *ssid, char *pass, int *
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1689,7 +1689,7 @@ int bml_internal::get_wifi_credentials(int vap_id, char *ssid, char *pass, int *
 int bml_internal::get_onboarding_state(int *enable)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
@@ -1702,7 +1702,7 @@ int bml_internal::get_onboarding_state(int *enable)
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ONBOARD_QUERY_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_PLATFORM_ONBOARD_QUERY_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1732,7 +1732,7 @@ int bml_internal::get_onboarding_state(int *enable)
 int bml_internal::set_onboarding_state(int enable)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
@@ -1746,7 +1746,7 @@ int bml_internal::set_onboarding_state(int enable)
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_ONBOARD_SET_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_PLATFORM_ONBOARD_SET_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1766,7 +1766,7 @@ int bml_internal::set_onboarding_state(int enable)
 int bml_internal::bml_wps_onboarding(const char *iface)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
     // Query the platform manager about the onboarding state
@@ -1774,7 +1774,7 @@ int bml_internal::bml_wps_onboarding(const char *iface)
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_WPS_ONBOARDING_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_PLATFORM_WPS_ONBOARDING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1795,12 +1795,12 @@ int bml_internal::bml_wps_onboarding(const char *iface)
 int bml_internal::get_administrator_credentials(char *user_password)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
     // Validate user_password
-    if (user_password == nullptr) {
+    if (!user_password) {
         LOG(ERROR) << "Invalid user_password ptr";
         return (-BML_RET_INVALID_ARGS);
     }
@@ -1817,7 +1817,7 @@ int bml_internal::get_administrator_credentials(char *user_password)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1862,7 +1862,7 @@ int bml_internal::get_administrator_credentials(char *user_password)
 int bml_internal::get_device_info(BML_DEVICE_INFO &device_info)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
@@ -1879,7 +1879,7 @@ int bml_internal::get_device_info(BML_DEVICE_INFO &device_info)
         message_com::create_vs_message<beerocks_message::cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_PLATFORM_DEVICE_INFO_GET_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1934,7 +1934,7 @@ int bml_internal::set_client_roaming(bool enable)
         message_com::create_vs_message<beerocks_message::cACTION_BML_SET_CLIENT_ROAMING_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_SET_CLIENT_ROAMING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1954,7 +1954,7 @@ int bml_internal::get_client_roaming(int &result)
         message_com::create_vs_message<beerocks_message::cACTION_BML_GET_CLIENT_ROAMING_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_CLIENT_ROAMING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1970,7 +1970,7 @@ int bml_internal::set_legacy_client_roaming(bool enable)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -1989,7 +1989,7 @@ int bml_internal::get_legacy_client_roaming(int &result)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2004,7 +2004,7 @@ int bml_internal::set_client_band_steering(bool enable)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2022,7 +2022,7 @@ int bml_internal::get_client_band_steering(int &result)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2038,7 +2038,7 @@ int bml_internal::set_client_roaming_prefer_signal_strength(bool enable)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building "
                       "ACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST message!";
         return (-BML_RET_OP_FAILED);
@@ -2057,7 +2057,7 @@ int bml_internal::get_client_roaming_prefer_signal_strength(int &result)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building "
                       "ACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST message!";
         return (-BML_RET_OP_FAILED);
@@ -2074,7 +2074,7 @@ int bml_internal::set_ire_roaming(bool enable)
         message_com::create_vs_message<beerocks_message::cACTION_BML_SET_IRE_ROAMING_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_SET_IRE_ROAMING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2093,7 +2093,7 @@ int bml_internal::get_ire_roaming(int &result)
         message_com::create_vs_message<beerocks_message::cACTION_BML_GET_IRE_ROAMING_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_IRE_ROAMING_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2109,7 +2109,7 @@ int bml_internal::set_load_balancer(bool enable)
         message_com::create_vs_message<beerocks_message::cACTION_BML_SET_LOAD_BALANCER_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_SET_LOAD_BALANCER_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2128,7 +2128,7 @@ int bml_internal::get_load_balancer(int &result)
         message_com::create_vs_message<beerocks_message::cACTION_BML_GET_LOAD_BALANCER_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_LOAD_BALANCER_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2144,7 +2144,7 @@ int bml_internal::set_service_fairness(bool enable)
         message_com::create_vs_message<beerocks_message::cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_SET_SERVICE_FAIRNESS_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2163,7 +2163,7 @@ int bml_internal::get_service_fairness(int &result)
         message_com::create_vs_message<beerocks_message::cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_SERVICE_FAIRNESS_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2180,7 +2180,7 @@ int bml_internal::get_dfs_reentry(int &result)
         message_com::create_vs_message<beerocks_message::cACTION_BML_GET_DFS_REENTRY_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_GET_DFS_REENTRY_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2197,7 +2197,7 @@ int bml_internal::set_dfs_reentry(bool enable)
         message_com::create_vs_message<beerocks_message::cACTION_BML_SET_DFS_REENTRY_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_SET_DFS_REENTRY_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2216,7 +2216,7 @@ int bml_internal::get_certification_mode(int &result)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_GET_CERTIFICATION_MODE_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_GET_CERTIFICATION_MODE_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2232,7 +2232,7 @@ int bml_internal::set_certification_mode(bool enable)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_SET_CERTIFICATION_MODE_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_SET_CERTIFICATION_MODE_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2252,7 +2252,7 @@ int bml_internal::set_log_level(const std::string module_name, const std::string
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2302,18 +2302,18 @@ int bml_internal::set_log_level(const std::string module_name, const std::string
 int bml_internal::get_master_slave_versions(char *master_version, char *slave_version)
 {
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    if (!m_sockPlatform && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
     // Validate master_version
-    if (master_version == nullptr) {
+    if (!master_version) {
         LOG(ERROR) << "Invalid master_version ptr";
         return (-BML_RET_INVALID_ARGS);
     }
 
     // Validate slave_version
-    if (slave_version == nullptr) {
+    if (!slave_version) {
         LOG(ERROR) << "Invalid slave_version ptr";
         return (-BML_RET_INVALID_ARGS);
     }
@@ -2330,7 +2330,7 @@ int bml_internal::get_master_slave_versions(char *master_version, char *slave_ve
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2386,12 +2386,12 @@ int bml_internal::set_restricted_channels(const uint8_t *restricted_channels, co
                                           uint8_t is_global, uint8_t size)
 {
     // // If the socket is not valid, attempt to re-establish the connection
-    // if (m_sockPlatform == nullptr && !connect_to_platform()) {
+    // if (!m_sockPlatform && !connect_to_platform()) {
     //     return (-BML_RET_CONNECT_FAIL);
     // }
     LOG(DEBUG) << "bml_internal::set_restricted_channels entry";
     // Validate restricted_channels
-    if (restricted_channels == nullptr) {
+    if (!restricted_channels) {
         LOG(ERROR) << "Invalid restricted_channels ptr";
         return (-BML_RET_INVALID_ARGS);
     }
@@ -2414,7 +2414,7 @@ int bml_internal::set_restricted_channels(const uint8_t *restricted_channels, co
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2443,7 +2443,7 @@ int bml_internal::get_restricted_channels(uint8_t *restricted_channels, const st
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr) {
+    if (!m_sockMaster) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK)
             return iRet;
@@ -2469,7 +2469,7 @@ int bml_internal::get_restricted_channels(uint8_t *restricted_channels, const st
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_GET_RESTRICTED_CHANNELS_REQUES message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -2517,7 +2517,7 @@ int bml_internal::topology_discovery(const char *al_mac)
         message_com::create_vs_message<beerocks_message::cACTION_BML_TRIGGER_TOPOLOGY_QUERY>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_TRIGGER_TOPOLOGY_QUERY message";
         return (-BML_RET_OP_FAILED);
     }
@@ -2537,7 +2537,7 @@ int bml_internal::channel_selection(const char *al_mac, const char *ruid)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }

--- a/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.cpp
+++ b/controller/src/beerocks/bml/rdkb/internal/bml_rdkb_internal.cpp
@@ -28,7 +28,7 @@ int bml_rdkb_internal::steering_set_group(uint32_t steeringGroupIndex,
 {
     LOG(DEBUG) << "bml_rdkb_internal::steering_set_group - entry";
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr && !connect_to_master()) {
+    if (!m_sockMaster && !connect_to_master()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
@@ -41,7 +41,7 @@ int bml_rdkb_internal::steering_set_group(uint32_t steeringGroupIndex,
         message_com::create_vs_message<beerocks_message::cACTION_BML_STEERING_SET_GROUP_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_AP_SET_CONFIG message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -101,7 +101,7 @@ int bml_rdkb_internal::steering_client_set(uint32_t steeringGroupIndex, const BM
     LOG(DEBUG) << "bml_rdkb_internal::steering_client_set - entry";
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr && !connect_to_master()) {
+    if (!m_sockMaster && !connect_to_master()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
@@ -114,7 +114,7 @@ int bml_rdkb_internal::steering_client_set(uint32_t steeringGroupIndex, const BM
         message_com::create_vs_message<beerocks_message::cACTION_BML_STEERING_CLIENT_SET_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_STEERING_CLIENT_SET_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -170,11 +170,11 @@ int bml_rdkb_internal::steering_event_register(BML_EVENT_CB pCB)
     }
 
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr && !connect_to_master()) {
+    if (!m_sockMaster && !connect_to_master()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
-    if ((m_cbSteeringEvent == nullptr) && (pCB == nullptr)) {
+    if ((!m_cbSteeringEvent) && (!pCB)) {
         LOG(WARNING) << "Event callback function was NOT registered...";
         return (-BML_RET_OP_FAILED);
     }
@@ -188,12 +188,12 @@ int bml_rdkb_internal::steering_event_register(BML_EVENT_CB pCB)
 
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENT_REGISTER message!";
         return (-BML_RET_OP_FAILED);
     }
 
-    if (pCB == nullptr) {
+    if (!pCB) {
         request->unregister() = 1;
         LOG(DEBUG) << "Steering events unregister";
     } else {
@@ -231,7 +231,7 @@ int bml_rdkb_internal::steering_client_measure(uint32_t steeringGroupIndex,
 {
     LOG(DEBUG) << "bml_rdkb_internal::steering_client_measure - entry";
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr && !connect_to_master()) {
+    if (!m_sockMaster && !connect_to_master()) {
         return (-BML_RET_CONNECT_FAIL);
     }
     // Initialize the promise for receiving the response
@@ -241,7 +241,7 @@ int bml_rdkb_internal::steering_client_measure(uint32_t steeringGroupIndex,
 
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }
@@ -281,7 +281,7 @@ int bml_rdkb_internal::steering_client_disconnect(uint32_t steeringGroupIndex,
 {
     LOG(DEBUG) << "bml_rdkb_internal::steering_client_disconnect - entry";
     // If the socket is not valid, attempt to re-establish the connection
-    if (m_sockMaster == nullptr && !connect_to_master()) {
+    if (!m_sockMaster && !connect_to_master()) {
         return (-BML_RET_CONNECT_FAIL);
     }
     // Initialize the promise for receiving the response
@@ -291,7 +291,7 @@ int bml_rdkb_internal::steering_client_disconnect(uint32_t steeringGroupIndex,
 
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST message!";
         return (-BML_RET_OP_FAILED);
     }

--- a/controller/src/beerocks/cli/beerocks_cli_proxy.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_proxy.cpp
@@ -98,6 +98,10 @@ bool cli_proxy::socket_disconnected(Socket *sd)
 bool cli_proxy::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto uds_header = message_com::get_uds_header(cmdu_rx);
+    if (!uds_header) {
+        LOG(ERROR) << "message_com::get_uds_header() failed";
+        return false;
+    }
     uint16_t length = uds_header->length;
 
     auto beerocks_header = message_com::parse_intel_vs_message(cmdu_rx);

--- a/controller/src/beerocks/cli/beerocks_cli_socket.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_socket.cpp
@@ -215,7 +215,7 @@ bool cli_socket::waitResponseReady()
 bool cli_socket::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto beerocks_header = message_com::parse_intel_vs_message(cmdu_rx);
-    if (beerocks_header == nullptr) {
+    if (!beerocks_header) {
         LOG(ERROR) << "Not a vendor specific message";
         return false;
     }
@@ -516,7 +516,7 @@ int cli_socket::enable_debug(int8_t isEnable)
 {
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_ENABLE_DEBUG>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_ENABLE_DEBUG message!";
         return -1;
     }
@@ -532,7 +532,7 @@ int cli_socket::set_stop_on_failure_attempts(int32_t attempts)
 {
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS message!";
         return -1;
     }
@@ -549,7 +549,7 @@ int cli_socket::enable_diagnostics_measurements(int8_t isEnable)
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS>(cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS message!";
         return -1;
     }
@@ -565,6 +565,10 @@ int cli_socket::dump_node_info(std::string mac)
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_DUMP_NODE_INFO>(cmdu_tx);
 
+    if (!request) {
+        LOG(ERROR) << "create_vs_message failed !";
+        return -1;
+    }
     request->mac() = network_utils::mac_from_string(mac);
     wait_response  = true;
     message_com::send_cmdu(master_socket, cmdu_tx);
@@ -578,7 +582,7 @@ int cli_socket::cross_rx_rssi_measurement(std::string client_mac, std::string ho
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT message!";
         return -1;
     }
@@ -596,7 +600,7 @@ int cli_socket::steer_client(std::string client_mac, std::string bssid, int disa
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CLIENT_BSS_STEER_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_BSS_STEER_REQUEST message!";
         return -1;
     }
@@ -614,7 +618,7 @@ int cli_socket::steer_ire(std::string client_mac, std::string bssid)
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_BACKHAUL_ROAM_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_BACKHAUL_ROAM_REQUEST message!";
         return -1;
     }
@@ -630,7 +634,7 @@ int cli_socket::optimal_path(std::string client_mac)
 {
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_OPTIMAL_PATH_TASK>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_OPTIMAL_PATH_TASK message!";
         return -1;
     }
@@ -648,7 +652,7 @@ int cli_socket::ap_channel_switch(std::string ap_mac, uint8_t channel, uint8_t b
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST message!";
         return -1;
     }
@@ -669,7 +673,7 @@ int cli_socket::client_allow(std::string client_mac, std::string hostap_mac)
 {
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CLIENT_ALLOW_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_ALLOW_REQUEST message!";
         return -1;
     }
@@ -686,7 +690,7 @@ int cli_socket::client_disallow(std::string client_mac, std::string hostap_mac)
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CLIENT_DISALLOW_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_DISALLOW_REQUEST message!";
         return -1;
     }
@@ -703,7 +707,7 @@ int cli_socket::client_disconnect(std::string client_mac, uint32_t type, uint32_
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CLIENT_DISCONNECT_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_DISCONNECT_REQUEST message!";
         return -1;
     }
@@ -721,7 +725,7 @@ int cli_socket::hostap_stats_measurement(std::string ap_mac)
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_HOSTAP_STATS_MEASUREMENT>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_HOSTAP_STATS_MEASUREMENT message!";
         return -1;
     }
@@ -736,7 +740,7 @@ int cli_socket::load_balancer_task(std::string ap_mac)
 {
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_LOAD_BALANCER_TASK>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_LOAD_BALANCER_TASK message!";
         return -1;
     }
@@ -752,7 +756,7 @@ int cli_socket::ire_network_optimization_task()
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK message!";
         return -1;
     }
@@ -767,7 +771,7 @@ int cli_socket::client_channel_load_11k_req(std::string hostap_mac, std::string 
 {
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST message!";
         return -1;
     }
@@ -787,7 +791,7 @@ int cli_socket::client_beacon_11k_req(std::string client_mac, std::string bssid,
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CLIENT_BEACON_11K_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_BEACON_11K_REQUEST message!";
         return -1;
     }
@@ -822,7 +826,7 @@ int cli_socket::client_statistics_11k_req(std::string hostap_mac, std::string cl
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST message!";
         return -1;
     }
@@ -840,7 +844,7 @@ int cli_socket::client_link_measurement_11k_req(std::string hostap_mac, std::str
 {
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST message!";
         return -1;
     }
@@ -858,7 +862,7 @@ int cli_socket::set_neighbor_11k(std::string ap_mac, std::string bssid, uint8_t 
 {
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST message!";
         return -1;
     }
@@ -876,7 +880,7 @@ int cli_socket::rm_neighbor_11k(std::string ap_mac, std::string bssid, int8_t va
 {
     auto request = message_com::create_vs_message<
         beerocks_message::cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST message!";
         return -1;
     }
@@ -893,7 +897,7 @@ int cli_socket::ping_slave(std::string ire_mac, int num_of_req, int ping_size)
 {
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_PING_SLAVE_REQUEST>(cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_PING_SLAVE_REQUEST message!";
         return -1;
     }
@@ -911,7 +915,7 @@ int cli_socket::ping_all_slaves(int num_of_req, int ping_size)
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_PING_ALL_SLAVES_REQUEST>(
             cmdu_tx);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building cACTION_CLI_PING_ALL_SLAVES_REQUEST message!";
         return -1;
     }

--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -66,7 +66,7 @@ void son_actions::handle_completed_connection(db &database, ieee1905_1::CmduMess
 
             auto stop_request = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST>(cmdu_tx);
-            if (stop_request == nullptr) {
+            if (!stop_request) {
                 LOG(ERROR)
                     << "Failed building ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST message!";
                 return;
@@ -84,7 +84,7 @@ void son_actions::handle_completed_connection(db &database, ieee1905_1::CmduMess
             auto disassoc_request   = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST>(cmdu_tx);
 
-            if (disassoc_request == nullptr) {
+            if (!disassoc_request) {
                 LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_DISCONNECT_REQUEST message!";
                 return;
             }
@@ -226,7 +226,7 @@ void son_actions::disconnect_client(db &database, ieee1905_1::CmduMessageTx &cmd
         message_com::create_vs_message<beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST>(
             cmdu_tx);
 
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_DISCONNECT_REQUEST message!";
         return;
     }
@@ -246,7 +246,7 @@ void son_actions::send_cli_debug_message(db &database, ieee1905_1::CmduMessageTx
     auto response =
         message_com::create_vs_message<beerocks_message::cACTION_CLI_RESPONSE_STR>(cmdu_tx);
 
-    if (response == nullptr) {
+    if (!response) {
         LOG(ERROR) << "Failed building cACTION_CLI_RESPONSE_STR message!";
         return;
     }
@@ -300,7 +300,7 @@ void son_actions::handle_dead_node(std::string mac, std::string hostap_mac, db &
         LOG(DEBUG) << "STOP_MONITORING mac " << mac << " hostapd " << parent_hostap_mac;
         auto stop_request = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST>(cmdu_tx);
-        if (stop_request == nullptr) {
+        if (!stop_request) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST message!";
             return;
         }
@@ -463,13 +463,19 @@ bool son_actions::send_cmdu_to_agent(const std::string &dest_mac,
             return false;
         }
 
-        beerocks_header->actionhdr()->radio_mac() = network_utils::mac_from_string(radio_mac);
-        beerocks_header->actionhdr()->direction() = beerocks::BEEROCKS_DIRECTION_AGENT;
+        auto action_header = beerocks_header->actionhdr();
+        if (!action_header) {
+            LOG(ERROR) << "Failed getting action_header!";
+            return false;
+        }
+
+        action_header->radio_mac() = network_utils::mac_from_string(radio_mac);
+        action_header->direction() = beerocks::BEEROCKS_DIRECTION_AGENT;
     }
 
     auto master_thread_ctx = database.get_master_thread_ctx();
-    if (master_thread_ctx == nullptr) {
-        LOG(ERROR) << "master_thread_context == nullptr";
+    if (!master_thread_ctx) {
+        LOG(ERROR) << "get_master_thread_ctx failed ";
         return false;
     }
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -178,8 +178,8 @@ std::string master_thread::print_cmdu_types(const message::sUdsHeader *cmdu_head
 
 bool master_thread::socket_disconnected(Socket *sd)
 {
-    if (sd == nullptr) {
-        LOG(DEBUG) << "sd == nullptr, ignore";
+    if (!sd) {
+        LOG(DEBUG) << "!sd, ignore";
         return false;
     }
 
@@ -204,7 +204,7 @@ bool master_thread::socket_disconnected(Socket *sd)
 bool master_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto uds_header = message_com::get_uds_header(cmdu_rx);
-    if (uds_header == nullptr) {
+    if (!uds_header) {
         LOG(ERROR) << "get_uds_header() returns nullptr";
         return false;
     }
@@ -1394,6 +1394,10 @@ bool master_thread::construct_combined_infra_metric()
             auto &vrx = per_neighbor.second.receiverLinkMetrics;
             if (vrx.size()) {
                 auto link_metric_rx_tlv = cmdu_tx.addClass<ieee1905_1::tlvReceiverLinkMetric>();
+                if (!link_metric_rx_tlv) {
+                    LOG(ERROR) << "addClass<ieee1905_1::tlvTransmitterLinkMetric>() has failed!";
+                    return false;
+                }
                 link_metric_rx_tlv->reporter_al_mac() = agent.first;
                 link_metric_rx_tlv->neighbor_al_mac() = per_neighbor.first;
                 if (!link_metric_rx_tlv->alloc_interface_pair_info(vrx.size())) {
@@ -1415,6 +1419,10 @@ bool master_thread::construct_combined_infra_metric()
             auto &vtx = per_neighbor.second.transmitterLinkMetrics;
             if (vtx.size()) {
                 auto link_metric_tx_tlv = cmdu_tx.addClass<ieee1905_1::tlvTransmitterLinkMetric>();
+                if (!link_metric_tx_tlv) {
+                    LOG(ERROR) << "addClass<ieee1905_1::tlvTransmitterLinkMetric>() has failed!";
+                    return false;
+                }
                 link_metric_tx_tlv->reporter_al_mac() = agent.first;
                 link_metric_tx_tlv->neighbor_al_mac() = per_neighbor.first;
                 for (auto &interface_pair_info : vtx) {
@@ -1440,8 +1448,12 @@ bool master_thread::construct_combined_infra_metric()
     //getting reference for ap metric data storage from db
     auto &ap_metric_data = database.get_ap_metric_data_map();
     for (auto &it : ap_metric_data) {
-        auto metric_data_per_agent            = it.second;
-        auto ap_metrics_tlv                   = cmdu_tx.addClass<wfa_map::tlvApMetric>();
+        auto metric_data_per_agent = it.second;
+        auto ap_metrics_tlv        = cmdu_tx.addClass<wfa_map::tlvApMetric>();
+        if (!ap_metrics_tlv) {
+            LOG(ERROR) << "addClass<wfa_map::tlvApMetric>() has failed!";
+            return false;
+        }
         ap_metrics_tlv->bssid()               = metric_data_per_agent.bssid;
         ap_metrics_tlv->channel_utilization() = metric_data_per_agent.channel_utilization;
         ap_metrics_tlv->number_of_stas_currently_associated() =
@@ -2454,7 +2466,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto response = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE>();
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2473,7 +2485,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION>();
 
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2502,7 +2514,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION>();
 
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2539,7 +2551,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
 
         auto notification =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION failed";
             return false;
         }
@@ -2557,7 +2569,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
 
         auto notification =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION failed";
             return false;
         }
@@ -2578,7 +2590,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION failed";
             return false;
         }
@@ -2626,7 +2638,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION failed";
             return false;
         }
@@ -2752,7 +2764,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION failed";
             return false;
         }
@@ -2766,7 +2778,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR)
                 << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION failed";
             return false;
@@ -2777,7 +2789,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE failed";
             return false;
         }
@@ -2835,7 +2847,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION failed";
             return false;
         }
@@ -2889,7 +2901,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
 
         auto request =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_AGENT_PING_REQUEST>();
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "addClass cACTION_CONTROL_AGENT_PING_REQUEST failed";
             return false;
         }
@@ -2897,7 +2909,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto response =
             message_com::create_vs_message<beerocks_message::cACTION_CONTROL_AGENT_PING_RESPONSE>(
                 cmdu_tx);
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -2923,7 +2935,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             auto response =
                 beerocks_header
                     ->addClass<beerocks_message::cACTION_CONTROL_CONTROLLER_PING_RESPONSE>();
-            if (response == nullptr) {
+            if (!response) {
                 LOG(ERROR) << "addClass cACTION_CONTROL_CONTROLLER_PING_RESPONSE failed";
                 return false;
             }
@@ -2944,7 +2956,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             if (response->seq() < (response->total() - 1)) { //send next ping request
                 auto request = message_com::create_vs_message<
                     beerocks_message::cACTION_CONTROL_CONTROLLER_PING_REQUEST>(cmdu_tx);
-                if (request == nullptr) {
+                if (!request) {
                     LOG(ERROR) << "Failed building message!";
                     return false;
                 }
@@ -2983,7 +2995,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION failed";
             return false;
         }
@@ -3004,7 +3016,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION failed";
             return false;
         }
@@ -3075,7 +3087,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION failed";
             return false;
         }
@@ -3095,7 +3107,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR)
                 << "addClass cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION failed";
             return false;
@@ -3117,7 +3129,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto response =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE failed";
             return false;
         }
@@ -3225,7 +3237,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto response =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE failed";
             return false;
         }
@@ -3261,7 +3273,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto response =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE failed";
             return false;
         }
@@ -3289,7 +3301,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto response =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE failed";
             return false;
         }
@@ -3319,7 +3331,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE: {
         auto response = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE failed";
             return false;
         }
@@ -3355,7 +3367,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE: {
         auto response = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE failed";
             return false;
         }
@@ -3372,7 +3384,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION failed";
             return false;
         }
@@ -3393,7 +3405,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION failed";
             return false;
         }
@@ -3417,7 +3429,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
                    << " id=" << beerocks_header->id();
         auto response =
             beerocks_header->addClass<beerocks_message::cACTION_CONTROL_ARP_QUERY_RESPONSE>();
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "addClass cACTION_CONTROL_ARP_QUERY_RESPONSE failed";
             return false;
         }
@@ -3427,7 +3439,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR)
                 << "addClass cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION failed";
             return false;
@@ -3445,7 +3457,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION failed";
             return false;
         }
@@ -3461,7 +3473,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION failed";
             return false;
         }
@@ -3478,7 +3490,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
     case beerocks_message::ACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION: {
         auto notification = beerocks_header->addClass<
             beerocks_message::cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION failed";
             return false;
         }
@@ -3496,7 +3508,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST failed";
             return false;
         }
@@ -3513,7 +3525,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE failed";
             return false;
         }
@@ -3532,7 +3544,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         auto notification =
             beerocks_header
                 ->addClass<beerocks_message::cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE>();
-        if (notification == nullptr) {
+        if (!notification) {
             LOG(ERROR) << "addClass cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE failed";
             return false;
         }

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -83,7 +83,7 @@ void association_handling_task::work()
             auto request = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST>(cmdu_tx);
 
-            if (request == nullptr) {
+            if (!request) {
                 LOG(ERROR)
                     << "Failed building ACTION_CONTROL_CLIENT_START_MONITORING_REQUEST message!";
                 return;
@@ -137,7 +137,7 @@ void association_handling_task::work()
         auto measurement_request = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>(cmdu_tx, id);
 
-        if (measurement_request == nullptr) {
+        if (!measurement_request) {
             LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST message!";
             return;
         }
@@ -203,7 +203,7 @@ void association_handling_task::work()
 
         auto measurement_request = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(cmdu_tx, id);
-        if (measurement_request == nullptr) {
+        if (!measurement_request) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST message!";
             return;

--- a/controller/src/beerocks/master/tasks/bml_task.cpp
+++ b/controller/src/beerocks/master/tasks/bml_task.cpp
@@ -295,7 +295,7 @@ void bml_task::update_bml_nw_map(std::string mac, bool force_client_disconnect)
         auto response =
             message_com::create_vs_message<beerocks_message::cACTION_BML_NW_MAP_UPDATE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ACTION_BML_NW_MAP_UPDATE message!";
             return;
         }

--- a/controller/src/beerocks/master/tasks/client_locating_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_locating_task.cpp
@@ -74,7 +74,7 @@ void client_locating_task::work()
             auto request =
                 message_com::create_vs_message<beerocks_message::cACTION_CONTROL_ARP_QUERY_REQUEST>(
                     cmdu_tx, id);
-            if (request == nullptr) {
+            if (!request) {
                 LOG(ERROR) << "Failed building message!";
                 continue;
             }

--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -138,7 +138,7 @@ void client_steering_task::steer_sta()
         auto roam_request =
             message_com::create_vs_message<beerocks_message::cACTION_CONTROL_BACKHAUL_ROAM_REQUEST>(
                 cmdu_tx, 0);
-        if (roam_request == nullptr) {
+        if (!roam_request) {
             LOG(ERROR) << "Failed building message!";
             return;
         }

--- a/controller/src/beerocks/master/tasks/network_health_check_task.cpp
+++ b/controller/src/beerocks/master/tasks/network_health_check_task.cpp
@@ -157,7 +157,7 @@ bool network_health_check_task::send_arp_query(std::string mac)
     auto request =
         message_com::create_vs_message<beerocks_message::cACTION_CONTROL_ARP_QUERY_REQUEST>(cmdu_tx,
                                                                                             id);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building message!";
         return false;
     }

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -299,7 +299,7 @@ void optimal_path_task::work()
                     auto request = message_com::create_vs_message<
                         beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>(cmdu_tx, id);
 
-                    if (request == nullptr) {
+                    if (!request) {
                         LOG(ERROR)
                             << "Failed building ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST message!";
                         break;
@@ -422,7 +422,7 @@ void optimal_path_task::work()
                 !database.settings_client_optimal_path_roaming_prefer_signal_strength()) {
                 //get sta capabilities....
                 sta_capabilities = database.get_station_capabilities(sta_mac, hostap_is_5ghz);
-                if (sta_capabilities == nullptr) {
+                if (!sta_capabilities) {
                     get_station_default_capabilities(hostap_is_5ghz, default_sta_cap);
                     sta_capabilities = &default_sta_cap;
                 }
@@ -748,7 +748,7 @@ void optimal_path_task::work()
         auto agent_mac = database.get_node_parent_ire(current_hostap);
         auto request   = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(cmdu_tx, id);
-        if (request == nullptr) {
+        if (!request) {
             LOG(ERROR)
                 << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST message!";
             return;
@@ -924,7 +924,7 @@ void optimal_path_task::work()
 
             //get sta capabilities....
             sta_capabilities = database.get_station_capabilities(sta_mac, hostap_params.is_5ghz);
-            if (sta_capabilities == nullptr) {
+            if (!sta_capabilities) {
                 TASK_LOG(WARNING) << "STA capabilities are empty - use default capabilities";
                 get_station_default_capabilities(hostap_params.is_5ghz, default_sta_cap);
                 sta_capabilities = &default_sta_cap;
@@ -1247,7 +1247,7 @@ void optimal_path_task::send_rssi_measurement_request(const std::string &agent_m
     auto hostap_mac = database.get_node_parent(client_mac);
     auto request    = message_com::create_vs_message<
         beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(cmdu_tx, id);
-    if (request == nullptr) {
+    if (!request) {
         LOG(ERROR) << "Failed building ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST message!";
         return;
     }

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
@@ -136,7 +136,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
             for (const auto &radio_mac : radios) {
                 auto update = message_com::create_vs_message<
                     beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST>(cmdu_tx);
-                if (update == nullptr) {
+                if (!update) {
                     TASK_LOG(ERROR) << "Failed building message!";
                     send_bml_response(int(STEERING_SET_GROUP_RESPONSE), event_obj->sd,
                                       -BML_RET_CMDU_FAIL);
@@ -202,7 +202,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
             }
             auto update = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST>(cmdu_tx);
-            if (update == nullptr) {
+            if (!update) {
                 TASK_LOG(ERROR) << "Failed building message!";
                 send_bml_response(int(STEERING_CLIENT_SET_RESPONSE), event_obj->sd,
                                   -BML_RET_CMDU_FAIL);
@@ -303,7 +303,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto update = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(cmdu_tx, id);
-            if (update == nullptr) {
+            if (!update) {
                 TASK_LOG(ERROR) << "Failed building "
                                    "cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST message!";
                 send_bml_response(int(STEERING_RSSI_MEASUREMENT_RESPONSE), event_obj->sd,
@@ -414,7 +414,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -469,7 +469,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -529,7 +529,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -582,7 +582,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -638,7 +638,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -699,7 +699,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -775,7 +775,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
 
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BML_STEERING_EVENTS_UPDATE>(cmdu_tx);
-            if (response == nullptr) {
+            if (!response) {
                 TASK_LOG(ERROR) << "Failed building cACTION_BML_STEERING_EVENTS_UPDATE message!";
                 return;
             }
@@ -928,7 +928,7 @@ bool rdkb_wlan_task::send_steering_conf_to_agent(const std::string &radio_mac)
     for (const auto &steering_group : rdkb_db.get_steering_group_list()) {
         auto update = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST>(cmdu_tx);
-        if (update == nullptr) {
+        if (!update) {
             TASK_LOG(ERROR) << "Failed building message!";
             return false;
         }
@@ -949,7 +949,7 @@ bool rdkb_wlan_task::send_steering_conf_to_agent(const std::string &radio_mac)
         for (auto client_entry : client_list) {
             auto update = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST>(cmdu_tx);
-            if (update == nullptr) {
+            if (!update) {
                 TASK_LOG(ERROR) << "Failed building message!";
                 return false;
             }
@@ -1013,7 +1013,7 @@ void rdkb_wlan_task::send_bml_response(int event, Socket *sd, int32_t ret)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE "
                           "message!";
             break;
@@ -1029,7 +1029,7 @@ void rdkb_wlan_task::send_bml_response(int event, Socket *sd, int32_t ret)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_BML_STEERING_SET_GROUP_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ACTION_BML_STEERING_SET_GROUP_RESPONSE message!";
             break;
         }
@@ -1044,7 +1044,7 @@ void rdkb_wlan_task::send_bml_response(int event, Socket *sd, int32_t ret)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_BML_STEERING_CLIENT_SET_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ACTION_BML_STEERING_SET_GROUP_RESPONSE message!";
             break;
         }
@@ -1059,7 +1059,7 @@ void rdkb_wlan_task::send_bml_response(int event, Socket *sd, int32_t ret)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR)
                 << "Failed building cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE message!";
             break;
@@ -1075,7 +1075,7 @@ void rdkb_wlan_task::send_bml_response(int event, Socket *sd, int32_t ret)
         auto response = message_com::create_vs_message<
             beerocks_message::cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE>(cmdu_tx);
 
-        if (response == nullptr) {
+        if (!response) {
             LOG(ERROR) << "Failed building ACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE message!";
             break;
         }

--- a/framework/tlvf/src/src/CmduMessage.cpp
+++ b/framework/tlvf/src/src/CmduMessage.cpp
@@ -14,7 +14,12 @@ int CmduMessage::getNextTlvType() const
 {
     if (!getCmduHeader())
         return -1;
-    sTlvHeader *tlv = reinterpret_cast<sTlvHeader *>(msg.prevClass()->getBuffPtr());
+
+    auto prev_class = msg.prevClass();
+    if (!prev_class) {
+        return -1;
+    }
+    sTlvHeader *tlv = reinterpret_cast<sTlvHeader *>(prev_class->getBuffPtr());
     return tlv->type;
 }
 
@@ -31,7 +36,12 @@ uint16_t CmduMessage::getNextTlvLength() const
 {
     if (!getCmduHeader())
         return -1;
-    sTlvHeader *tlv = reinterpret_cast<sTlvHeader *>(msg.prevClass()->getBuffPtr());
+
+    auto prev_class = msg.prevClass();
+    if (!prev_class) {
+        return -1;
+    }
+    sTlvHeader *tlv = reinterpret_cast<sTlvHeader *>(prev_class->getBuffPtr());
     return tlv->length;
 }
 
@@ -40,7 +50,12 @@ uint8_t *CmduMessage::getNextTlvData() const
     if (!getCmduHeader())
         return nullptr;
 
-    sTlvHeader *tlv = reinterpret_cast<sTlvHeader *>(msg.prevClass()->getBuffPtr());
+    auto prev_class = msg.prevClass();
+    if (!prev_class) {
+        return nullptr;
+    }
+
+    sTlvHeader *tlv = reinterpret_cast<sTlvHeader *>(prev_class->getBuffPtr());
     return reinterpret_cast<uint8_t *>(tlv) + sizeof(*tlv);
 }
 
@@ -58,6 +73,9 @@ eMessageType CmduMessage::getMessageType()
 uint16_t CmduMessage::getMessageId()
 {
     auto cmduhdr = getCmduHeader();
+    if (!cmduhdr) {
+        return -1;
+    }
     uint16_t mid = cmduhdr->message_id();
 
     if (cmduhdr->is_finalized())


### PR DESCRIPTION
Resolving a klocwork issue which leads to many errors.

Since a null pointer may cause undefined behavior when the program attempts to
access memory through it, each time we tried to access to an object that
may be null without validates it is not, the klocwork created an issue
for it with the following message:

`Pointer *** returned from call to function *** may be NULL and will be dereferenced at ...`

To solve all of those issues, a validation check is added each time we try
to call a member function on an object that can be an invalid object (a
null pointer doesn't point to a valid object).

Signed-off-by: CoralMalachi <coral.malachi@intel.com>