### PR TITLE
Enhance logging configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,13 @@ endif()
 set(BEEROCKS_NOTIFY 0)
 set(BEEROCKS_REPEATER_MODE 0)
 set(BEEROCKS_ENABLE_ARP_MONITOR 1)
-set(BEEROCKS_LOG_PATH "${TMP_PATH}/logs")
+
+# Logging configuration
+set(BEEROCKS_LOG_FILES_ENABLED      "true")
+set(BEEROCKS_LOG_FILES_PATH         "${TMP_PATH}/logs")
+set(BEEROCKS_LOG_FILES_AUTO_ROLL    "true")
+set(BEEROCKS_LOG_STDOUT_ENABLED     "false")
+set(BEEROCKS_LOG_SYSLOG_ENABLED     "false")
 
 # Platform specific flags
 if (TARGET_PLATFORM STREQUAL "openwrt")
@@ -89,7 +95,9 @@ elseif (TARGET_PLATFORM STREQUAL "rdkb")
     set(BEEROCKS_BRIDGE_IFACE "brlan0")
     set(BEEROCKS_BH_WIRE_IFACE "nsgmii0")
     set(BEEROCKS_ENABLE_ARP_MONITOR 0)
-    set(BEEROCKS_LOG_PATH "/rdklogs/logs/")
+    # Disable file and enable syslog logging
+    set(BEEROCKS_LOG_FILES_ENABLED "false")
+    set(BEEROCKS_LOG_SYSLOG_ENABLED "true")
     set(CMAKE_SKIP_RPATH TRUE)
 elseif (TARGET_PLATFORM STREQUAL "linux")
     add_definitions(-DBEEROCKS_LINUX)

--- a/agent/config/beerocks_agent.conf.in
+++ b/agent/config/beerocks_agent.conf.in
@@ -50,9 +50,11 @@ enable_repeater_mode=0
 #sta_iface_filter_low=1
 
 [log]
-log_path=@BEEROCKS_LOG_PATH@
 log_global_levels=error,info,warning,fatal,trace,debug
 log_global_syslog_levels=error,info,warning,fatal,trace,debug
 log_global_size=1000000
-log_syslog_enabled=false
-
+log_files_enabled=@BEEROCKS_LOG_FILES_ENABLED@
+log_files_path=@BEEROCKS_LOG_FILES_PATH@
+log_files_auto_roll=@BEEROCKS_LOG_FILES_AUTO_ROLL@
+log_stdout_enabled=@BEEROCKS_LOG_STDOUT_ENABLED@
+log_syslog_enabled=@BEEROCKS_LOG_SYSLOG_ENABLED@

--- a/agent/src/beerocks/monitor/beerocks_monitor_main.cpp
+++ b/agent/src/beerocks/monitor/beerocks_monitor_main.cpp
@@ -163,10 +163,11 @@ int main(int argc, char *argv[])
               << std::endl;
     beerocks::version::log_version(argc, argv);
 
-    //redirect stdout / stderr to file
-    // int fd_log_file_std = beerocks::os_utils::redirect_console_std("/dev/null");
-    int fd_log_file_std = beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.path +
-                                                                   base_monitor_name + "_std.log");
+    // Redirect stdout / stderr to file
+    if (logger.get_log_files_enabled()) {
+        beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.files_path +
+                                                 base_monitor_name + "_std.log");
+    }
 
     //kill running monitor and write pid file
     beerocks::os_utils::kill_pid(beerocks_slave_conf.temp_path, base_monitor_name);
@@ -204,7 +205,6 @@ int main(int argc, char *argv[])
         LOG(ERROR) << "monitor.init(), iface=" << monitor_iface << " slave_uds=" << slave_uds;
     }
 
-    beerocks::os_utils::close_file(fd_log_file_std);
     s_pLogger = nullptr;
 
     return 0;

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -199,9 +199,11 @@ static int system_hang_test(beerocks::config_file::sConfigSlave &beerocks_slave_
               << std::endl;
     beerocks::version::log_version(argc, argv);
 
-    //redirect stdout / stderr to file
-    //beerocks::os_utils::redirect_console_std("/dev/null");
-    beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.path + name + "_std.log");
+    // Redirect stdout / stderr to file
+    if (logger.get_log_files_enabled()) {
+        beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.files_path + name +
+                                                 "_std.log");
+    }
 
     //write pid file
     beerocks::os_utils::write_pid_file(beerocks_slave_conf.temp_path, name);
@@ -265,8 +267,10 @@ static int run_beerocks_slave(beerocks::config_file::sConfigSlave &beerocks_slav
 
     //redirect stdout / stderr to file
     // int fd_log_file_std = beerocks::os_utils::redirect_console_std("/dev/null");
-    int fd_log_file_std = beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.path +
-                                                                   base_slave_name + "_std.log");
+    if (slave_logger.get_log_files_enabled()) {
+        beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.files_path +
+                                                 base_slave_name + "_std.log");
+    }
 
     //write pid file
     beerocks::os_utils::write_pid_file(beerocks_slave_conf.temp_path, base_slave_name);
@@ -353,8 +357,6 @@ static int run_beerocks_slave(beerocks::config_file::sConfigSlave &beerocks_slav
         platform_mgr.stop(false);
     }
 
-    LOG(DEBUG) << "Closing process PID file";
-    beerocks::os_utils::close_file(fd_log_file_std);
     LOG(DEBUG) << "Bye Bye!";
     s_pLogger = nullptr;
 
@@ -379,8 +381,10 @@ static int run_son_slave(int slave_num, beerocks::config_file::sConfigSlave &bee
 
     //redirect stdout / stderr to file
     //int fd_log_file_std = beerocks::os_utils::redirect_console_std("/dev/null");
-    int fd_log_file_std = beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.path +
-                                                                   base_slave_name + "_std.log");
+    if (slave_logger.get_log_files_enabled()) {
+        beerocks::os_utils::redirect_console_std(beerocks_slave_conf.sLog.files_path +
+                                                 base_slave_name + "_std.log");
+    }
 
     //write pid file
     beerocks::os_utils::write_pid_file(beerocks_slave_conf.temp_path, base_slave_name);
@@ -422,7 +426,6 @@ static int run_son_slave(int slave_num, beerocks::config_file::sConfigSlave &bee
         LOG(ERROR) << "son_slave.init(), slave_num=" << slave_num;
     }
 
-    beerocks::os_utils::close_file(fd_log_file_std);
     s_pLogger = nullptr;
 
     return 0;

--- a/cmake/Findelpp.cmake
+++ b/cmake/Findelpp.cmake
@@ -2,10 +2,11 @@ set(ELPP_LIB_NAME "mapf::elpp")
 set(ELPP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/framework/external/easylogging)
 set(ELPP_LIBRARY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libelpp.so.1.4.0)
 
-add_definitions(-DELPP_THREAD_SAFE)
-add_definitions(-DELPP_FORCE_USE_STD_THREAD)
-add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
 add_library(${ELPP_LIB_NAME} UNKNOWN IMPORTED)
+
+set_target_properties(${ELPP_LIB_NAME} PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "ELPP_SYSLOG;ELPP_THREAD_SAFE;ELPP_NO_DEFAULT_LOG_FILE;ELPP_FORCE_USE_STD_THREAD"
+)
 
 # Include directory
 set_target_properties(${ELPP_LIB_NAME} PROPERTIES

--- a/common/beerocks/bcl/CMakeLists.txt
+++ b/common/beerocks/bcl/CMakeLists.txt
@@ -36,6 +36,7 @@ target_compile_definitions(${PROJECT_NAME}
         ELPP_FORCE_USE_STD_THREAD
         ELPP_NO_DEFAULT_LOG_FILE
         ELPP_THREAD_SAFE
+        ELPP_SYSLOG
 )
 
 install(TARGETS ${PROJECT_NAME} EXPORT bclConfig

--- a/common/beerocks/bcl/include/bcl/beerocks_config_file.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_config_file.h
@@ -20,13 +20,14 @@ public:
 
     struct SConfigLog {
         //[log]
-        std::string path;
         std::string global_levels;
         std::string syslog_levels;
         std::string global_size;
+        std::string files_enabled;
+        std::string files_path;
+        std::string files_auto_roll;
+        std::string stdout_enabled;
         std::string syslog_enabled;
-        std::string netlog_host;
-        std::string netlog_port;
     };
 
     // config file parameters master / slave

--- a/common/beerocks/bcl/include/bcl/beerocks_logging.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_logging.h
@@ -84,13 +84,16 @@ public:
     void apply_settings();
 
     std::string get_module_name();
-    std::string get_log_path();
-    std::string get_log_filepath();
-    std::string get_log_filename();
-    std::string get_log_max_size_setting();
     log_levels get_log_levels();
     log_levels get_syslog_levels();
-    std::string get_syslog_enabled();
+    std::string get_log_max_size_setting();
+    bool get_log_files_enabled();
+    std::string get_log_files_path();
+    std::string get_log_filepath();
+    std::string get_log_filename();
+    bool get_log_files_auto_roll();
+    bool get_stdout_enabled();
+    bool get_syslog_enabled();
 
     void set_log_level_state(const eLogLevel &log_level, const bool &new_state);
 
@@ -116,13 +119,14 @@ private:
     std::string m_module_name;
 
     size_t m_logfile_size;
-    std::string m_log_path;
+    bool m_log_files_enabled;
+    std::string m_log_files_path;
     std::string m_log_filename;
+    bool m_log_files_auto_roll;
     log_levels m_levels;
     log_levels m_syslog_levels;
-    std::string m_netlog_host;
-    uint16_t m_netlog_port;
-    std::string m_syslog_enabled;
+    bool m_stdout_enabled;
+    bool m_syslog_enabled;
 
     settings_t m_settings_map;
 };

--- a/common/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/common/beerocks/bcl/source/beerocks_config_file.cpp
@@ -21,20 +21,21 @@ static bool read_log_section(std::string config_file_path, config_file::SConfigL
     int optional  = 0;
 
     config_file::tConfig log_conf_args = {
-        std::make_tuple("log_path=", &sLogConf.path, mandatory),
         std::make_tuple("log_global_levels=", &sLogConf.global_levels, mandatory),
         std::make_tuple("log_global_syslog_levels=", &sLogConf.syslog_levels, mandatory),
         std::make_tuple("log_global_size=", &sLogConf.global_size, mandatory),
-        std::make_tuple("log_syslog_enabled=", &sLogConf.syslog_enabled, optional),
-        std::make_tuple("log_netlog_host=", &sLogConf.netlog_host, optional),
-        std::make_tuple("log_netlog_port=", &sLogConf.netlog_port, optional)};
+        std::make_tuple("log_files_enabled=", &sLogConf.files_enabled, mandatory),
+        std::make_tuple("log_files_path=", &sLogConf.files_path, mandatory),
+        std::make_tuple("log_files_auto_roll=", &sLogConf.files_auto_roll, mandatory),
+        std::make_tuple("log_stdout_enabled=", &sLogConf.stdout_enabled, mandatory),
+        std::make_tuple("log_syslog_enabled=", &sLogConf.syslog_enabled, optional)};
 
     std::string section = "log";
     bool ret_val        = config_file::read_config_file(config_file_path, log_conf_args, section);
 
     // check path has trailing slash
-    if (sLogConf.path.back() != '/') {
-        sLogConf.path += '/';
+    if (sLogConf.files_path.back() != '/') {
+        sLogConf.files_path += '/';
     }
     return ret_val;
 }

--- a/controller/config/beerocks_controller.conf.in
+++ b/controller/config/beerocks_controller.conf.in
@@ -78,8 +78,11 @@ fail_safe_5G_bw=80
 fail_safe_5G_vht_frequency=5210
 
 [log]
-log_path=@BEEROCKS_LOG_PATH@
 log_global_levels=error,info,warning,fatal,trace,debug
 log_global_syslog_levels=error,info,warning,fatal,trace,debug
 log_global_size=1000000
-log_syslog_enabled=false
+log_files_enabled=@BEEROCKS_LOG_FILES_ENABLED@
+log_files_path=@BEEROCKS_LOG_FILES_PATH@
+log_files_auto_roll=@BEEROCKS_LOG_FILES_AUTO_ROLL@
+log_stdout_enabled=@BEEROCKS_LOG_STDOUT_ENABLED@
+log_syslog_enabled=@BEEROCKS_LOG_SYSLOG_ENABLED@

--- a/controller/src/beerocks/cli/beerocks_cli_main.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_main.cpp
@@ -494,8 +494,15 @@ int main(int argc, char *argv[])
 
     int status_return = 0;
 
-    std::string log_file = beerocks_slave_conf.sLog.path + std::string(BEEROCKS_CLI) + ".log";
-    init_logger(cli_role == CLI_PROXY, log_file);
+    bool log_stdout =
+        ((beerocks_slave_conf.sLog.stdout_enabled == "true") || (cli_role == CLI_PROXY));
+
+    std::string log_file;
+    if (beerocks_slave_conf.sLog.files_enabled == "true") {
+        log_file = beerocks_slave_conf.sLog.files_path + std::string(BEEROCKS_CLI) + ".log";
+    }
+
+    init_logger(log_stdout, log_file);
     switch (cli_role) {
     case CLI_PROXY: {
         cli_tcp_proxy(beerocks_slave_conf.temp_path);

--- a/controller/src/beerocks/master/beerocks_master_main.cpp
+++ b/controller/src/beerocks/master/beerocks_master_main.cpp
@@ -285,10 +285,11 @@ int main(int argc, char *argv[])
     versionfile << BEEROCKS_VERSION << std::endl << BEEROCKS_REVISION;
     versionfile.close();
 
-    //redirect stdout / stderr
-    // int fd_log_file_std = beerocks::os_utils::redirect_console_std("/dev/null");
-    int fd_log_file_std = beerocks::os_utils::redirect_console_std(beerocks_master_conf.sLog.path +
-                                                                   base_master_name + "_std.log");
+    // Redirect stdout / stderr
+    if (logger.get_log_files_enabled()) {
+        beerocks::os_utils::redirect_console_std(beerocks_master_conf.sLog.files_path +
+                                                 base_master_name + "_std.log");
+    }
 
     //write pid file
     beerocks::os_utils::write_pid_file(beerocks_master_conf.temp_path, base_master_name);
@@ -340,8 +341,6 @@ int main(int argc, char *argv[])
     s_pLogger = nullptr;
 
     son_master.stop();
-
-    beerocks::os_utils::close_file(fd_log_file_std);
 
     return 0;
 }

--- a/framework/external/easylogging/CMakeLists.txt
+++ b/framework/external/easylogging/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 add_definitions(-DELPP_THREAD_SAFE)
 add_definitions(-DELPP_FORCE_USE_STD_THREAD)
 add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
+add_definitions(-DELPP_SYSLOG)
 
 set(ELPP_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/framework/external/easylogging/easylogging++.h
+++ b/framework/external/easylogging/easylogging++.h
@@ -752,7 +752,7 @@ static const char* kPerformanceLoggerId                    =      "performance";
 #endif
 
 #if defined(ELPP_SYSLOG)
-static const char* kSysLogLoggerId                         =      "syslog";
+static const char* kSysLogLoggerId __attribute__((unused)) =      "syslog";
 #endif  // defined(ELPP_SYSLOG)
 
 #if ELPP_OS_WINDOWS


### PR DESCRIPTION
This PR adds several improvements to the existing logging configuration:
- Allow controlling files/stdout/syslog output from the configuration file
- Allow controlling the internal log files rolling mechanism
- Enable easylogging++ syslog support (ELPP_SYSLOG)

NOTE: Some commits in this PR are not independent, but were separated to ease the review process.