### PR TITLE
Feature: add code snippets

### DIFF
--- a/.vscode/prplmesh-snippets.code-snippets
+++ b/.vscode/prplmesh-snippets.code-snippets
@@ -1,0 +1,29 @@
+{
+	// Place your prplMesh workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+	"Create and check a variable that might be null": {
+		"prefix": "mbnull",
+		"body": [
+			"auto ${1:varname} = ${2:declaration};",
+			"if(!$1){",
+			"\tLOG(ERROR) << \"${3:failed creating $1}\";",
+			"\t${4://BODY}",
+			"}"
+		],
+		"description": "Create and check a variable that might be null, name is short for 'may be null'"
+	  }
+}


### PR DESCRIPTION
### Description
During work on solving static analysis issues, one might encounter a common critical issue: a reference is created and later on dereferenced without a null check.
Unrelated to static analysis,  it's generally good to check for possible failures of getter functions.
Writing such a code block a few times in a row could be quite tedious, therefore code snippets might make the work more efficient.
### Changes
VS Code supports code snippets, and one of these might be handy for such case.
Therefore, create a code snippets file in the `.vscode` directory, currently with one snippet, implementing the following skeleton:
```
auto varname = declaration;
    if(!varname){
        LOG(DEBUG) << "failed creating varname";
        //BODY
    }
```
To use, start typing `mbnull` and then hit enter or tab once the autocomplete prompt pops up, then hit tab to edit each field.
You can easily create code snippets at https://snippet-generator.app/ (make sure you're on the VSCode snippets tab) and the syntax is extremely simple.
Then, you can just add them to the `.vscode/prplmesh-snippets.code-snippets` file.
### Additional Notes
- Keep in mind that you'll want to keep the prefix short and simple, otherwise you're not achieving much.
- Also note that you can create local, personal snippets: hit F1 and type "snippets", then, select 'Configure User Snippets', there you can choose whichever type of snippet configuration you want, so you can live your custom snippet dreams without fears of being judged by people on GitHub.
