### PR TITLE
Bugfix/autoconfig fix credentials set

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -854,7 +854,6 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
                 return false;
             }
             auto &config_data = std::get<1>(config_data_tuple);
-            config_data.class_swap();
 
             bss_info_conf.ssid                = config_data.ssid_str();
             bss_info_conf.authentication_type = config_data.authentication_type_attr().data;

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -177,13 +177,25 @@ bool ap_wlan_hal_dummy::update_vap_credentials(
     std::list<son::wireless_utils::sBssInfoConf> &bss_info_conf_list)
 {
     for (auto bss_info_conf : bss_info_conf_list) {
-        LOG(DEBUG) << "Received credentials for ssid: " << bss_info_conf.ssid << " auth_type: "
-                   << son::wireless_utils::wsc_to_bwl_authentication(
-                          bss_info_conf.authentication_type)
-                   << " encr_type: "
-                   << son::wireless_utils::wsc_to_bwl_encryption(bss_info_conf.encryption_type)
-                   << " network_key: " << bss_info_conf.network_key << " bss_type: "
-                   << son::wireless_utils::wsc_to_bwl_bss_type(bss_info_conf.bss_type);
+        auto auth_type =
+            son::wireless_utils::wsc_to_bwl_authentication(bss_info_conf.authentication_type);
+        if (auth_type == "INVALID") {
+            LOG(ERROR) << "Invalid auth_type " << int(bss_info_conf.authentication_type);
+            return false;
+        }
+        auto enc_type = son::wireless_utils::wsc_to_bwl_encryption(bss_info_conf.encryption_type);
+        if (enc_type == "INVALID") {
+            LOG(ERROR) << "Invalid enc_type " << int(bss_info_conf.encryption_type);
+            return false;
+        }
+        auto bss_type = son::wireless_utils::wsc_to_bwl_bss_type(bss_info_conf.bss_type);
+        if (bss_type == beerocks::BSS_TYPE_INVALID) {
+            LOG(ERROR) << "Invalid bss_type";
+            return false;
+        }
+        LOG(DEBUG) << "Received credentials for ssid: " << bss_info_conf.ssid
+                   << " auth_type: " << auth_type << " encr_type: " << enc_type
+                   << " network_key: " << bss_info_conf.network_key << " bss_type: " << bss_type;
     }
 
     return true;

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -58,6 +58,12 @@ test_initial_ap_config() {
     check docker exec repeater1 sh -c \
         'grep -i -q "Controller configuration (WSC M2 Encrypted Settings)" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
 
+    return $check_error
+}
+
+test_ap_config_renew() {
+    status "test initial autoconfig"
+
     # Regression test: MAC address should be case insensitive
     MAC_AGENT1=$(echo $mac_agent1 | tr a-z A-Z)
     # Configure the controller and send renew
@@ -77,11 +83,6 @@ test_initial_ap_config() {
         'grep -i -q "ssid: .* teardown" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
 
     return $check_error
-}
-
-test_ap_config_renew() {
-    err "ap_config_renew not implemented yet."
-    return 0
 }
 
 test_ap_config_bss_tear_down() {

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -70,9 +70,9 @@ test_initial_ap_config() {
     sleep 3
 
     check docker exec repeater1 sh -c \
-        'grep -i -q "ssid: Multi-AP-24G-1, .* fronthaul" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+        'grep -i -q "Received credentials for ssid: Multi-AP-24G-1 .* bss_type: 2" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
     check docker exec repeater1 sh -c \
-        'grep -i -q "ssid: Multi-AP-24G-2, .* backhaul" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
+        'grep -i -q "Received credentials for ssid: Multi-AP-24G-2 .* bss_type: 1" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log'
     check docker exec repeater1 sh -c \
         'grep -i -q "ssid: .* teardown" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
 


### PR DESCRIPTION
Fix bug in autoconfig which got passed test_flows.sh - the ap manager thread on receipt of the config_data containing the credentials that needs to be updated, did an extra class_swap which caused some of the fields to be swapped.

So fixed that - but while we're at it, make sure this doesn't happen again by updating test_flows.sh and the dummy implementation to test the final credentials.

Also - since the initial_autoconfig included also the renew part, split it to a separate test.