### PR TITLE
Bugfix: replace addClass with getClass in UCC listener

### DIFF
--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -266,8 +266,6 @@ bool beerocks_ucc_listener::create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
 {
     std::shared_ptr<ieee1905_1::cCmduHeader> cmdu_header;
 
-    int tlv_type;
-
     switch (message_type) {
     case ieee1905_1::eMessageType::CHANNEL_SELECTION_REQUEST_MESSAGE: {
 
@@ -277,23 +275,18 @@ bool beerocks_ucc_listener::create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
             return false;
         }
 
-        tlv_type = cmdu_tx.getNextTlvType();
-        while (tlv_type != int(ieee1905_1::eTlvType::TLV_END_OF_MESSAGE)) {
-            if (tlv_type == int(wfa_map::eTlvTypeMap::TLV_CHANNEL_PREFERENCE)) {
-                if (!cmdu_tx.addClass<wfa_map::tlvChannelPreference>()) {
-                    LOG(ERROR) << "addClass tlvChannelPreference has failed";
-                    err_string = err_internal;
-                    return false;
-                }
-            } else if (tlv_type == int(wfa_map::eTlvTypeMap::TLV_TRANSMIT_POWER_LIMIT)) {
-                if (!cmdu_tx.addClass<wfa_map::tlvTransmitPowerLimit>()) {
-                    LOG(ERROR) << "addClass tlvTransmitPowerLimit has failed";
-                    err_string = err_internal;
-                    return false;
-                }
-            }
-            tlv_type = cmdu_tx.getNextTlvType();
+        auto tlvChannelPreference = cmdu_tx.getClass<wfa_map::tlvChannelPreference>();
+        if (!tlvChannelPreference) {
+            LOG(ERROR) << "getClass<tlvChannelPreference> failed";
+            return false;
         }
+
+        auto tlvTransmitPowerLimit = cmdu_tx.getClass<wfa_map::tlvTransmitPowerLimit>();
+        if (!tlvTransmitPowerLimit) {
+            LOG(ERROR) << "getClass<tlvTransmitPowerLimit> failed";
+            return false;
+        }
+
         break;
     }
     case ieee1905_1::eMessageType::COMBINED_INFRASTRUCTURE_METRICS_MESSAGE: {
@@ -303,29 +296,23 @@ bool beerocks_ucc_listener::create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
             LOG(ERROR) << "load cmdu has failed";
             return false;
         }
-        tlv_type = cmdu_tx.getNextTlvType();
-        while (tlv_type != int(ieee1905_1::eTlvType::TLV_END_OF_MESSAGE)) {
-            if (tlv_type == int(wfa_map::eTlvTypeMap::TLV_AP_METRIC)) {
-                if (!cmdu_tx.addClass<wfa_map::tlvApMetric>()) {
-                    LOG(ERROR) << "addClass tlvApMetric has failed";
-                    err_string = err_internal;
-                    return false;
-                }
-            } else if (tlv_type == int(ieee1905_1::eTlvType::TLV_RECEIVER_LINK_METRIC)) {
-                if (!cmdu_tx.addClass<ieee1905_1::tlvReceiverLinkMetric>()) {
-                    LOG(ERROR) << "addClass tlvReceiverLinkMetric has failed";
-                    err_string = err_internal;
-                    return false;
-                }
-            } else if (tlv_type == int(ieee1905_1::eTlvType::TLV_TRANSMITTER_LINK_METRIC)) {
-                if (!cmdu_tx.addClass<ieee1905_1::tlvTransmitterLinkMetric>()) {
-                    LOG(ERROR) << "addClass tlvTransmitterLinkMetric has failed";
-                    err_string = err_internal;
-                    return false;
-                }
-            }
-            tlv_type = cmdu_tx.getNextTlvType();
+        auto tlvApMetric = cmdu_tx.getClass<wfa_map::tlvApMetric>();
+        if (!tlvApMetric) {
+            LOG(ERROR) << "getClass<tlvApMetric> failed";
+            return false;
         }
+        auto tlvRxLimkMetric = cmdu_tx.getClass<ieee1905_1::tlvReceiverLinkMetric>();
+        if (!tlvRxLimkMetric) {
+            LOG(ERROR) << "getClass<tlvReceiverLinkMetric> failed";
+            return false;
+        }
+
+        auto tlvTxLimkMetric = cmdu_tx.getClass<ieee1905_1::tlvTransmitterLinkMetric>();
+        if (!tlvTxLimkMetric) {
+            LOG(ERROR) << "getClass<tlvTransmitterLinkMetric> failed";
+            return false;
+        }
+
         break;
     }
     default:

--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -287,6 +287,10 @@ bool beerocks_ucc_listener::create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
             return false;
         }
 
+        //if we got here it means that all TLVs that should be in this CMDU were there
+        LOG(DEBUG) << "certification buffer with CHANNEL_SELECTION_REQUEST_MESSAGE CMDU was loaded "
+                      "successfully!";
+
         break;
     }
     case ieee1905_1::eMessageType::COMBINED_INFRASTRUCTURE_METRICS_MESSAGE: {
@@ -312,6 +316,10 @@ bool beerocks_ucc_listener::create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
             LOG(ERROR) << "getClass<tlvTransmitterLinkMetric> failed";
             return false;
         }
+        //if we got here it means that all TLVs that should be in this CMDU were there
+        //TODO: add a test for combined_infra_metrics and grep this line
+        LOG(DEBUG) << "certification buffer with COMBINED_INFRASTRUCTURE_METRICS_MESSAGE CMDU was "
+                      "loaded successfully!";
 
         break;
     }

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -136,6 +136,9 @@ test_channel_selection() {
     check docker exec repeater1 sh -c \
         'grep -i -q "CHANNEL_SELECTION_REQUEST_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent_wlan2.log'
     
+    check docker exec gateway sh -c \
+        'grep -i -q "certification buffer with CHANNEL_SELECTION_REQUEST_MESSAGE CMDU was loaded successfully!" /tmp/$USER/beerocks/logs/beerocks_controller.log'
+
     dbg "Confirming 1905.1 Ack Message request was received on agent"
     # TODO: When creating handler for the ACK message on the agent, replace lookup of this string
     check docker exec repeater1 sh -c \


### PR DESCRIPTION
Currently, when trying to send a 1905 message of type
`CHANNEL_SELECTION_REQUEST_MESSAGE` or `COMBINED_INFRASTRUCTURE_METRICS_MESSAGE`,
the UCC listener replay status running and stack there.

The reason for this is the using of addClass in `beerocks_ucc_listener::create_cmdu`
was not replaced with the new `getClass` method as it should.

As a result, the UCC listener got stuck in an infinite loop, since the
parse of the TLVs already happened, which caused a timeout error.

In order to solve it, both while loops are removed and replaced with two
simple calls to `getClass` method.
Also, `tlv_type` is removed since it is not needed anymore.

Fixes #622 (checked on testbed)

Signed-off-by: Coral Malachi <coral.malachi@intel.com>