### PR TITLE
Hotfix/remove add class from cmdu message

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1666,7 +1666,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         LOG(DEBUG) << "ACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION received from iface "
                    << soc->hostap_iface;
         if (m_agent_ucc_listener) {
-            auto msg = cmdu_rx.addClass<
+            auto msg = cmdu_rx.getClass<
                 beerocks_message::cACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
             if (!msg) {
                 LOG(ERROR)

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3858,7 +3858,7 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
     LOG(DEBUG) << "Received AP_AUTOCONFIGURATION_WSC_MESSAGE";
 
     std::list<WSC::m2> m2_list;
-    for (auto tlv : cmdu_rx.msg.getClassList<ieee1905_1::tlvWsc>()) {
+    for (auto tlv : cmdu_rx.getClassList<ieee1905_1::tlvWsc>()) {
         auto m2 = std::dynamic_pointer_cast<WSC::m2>(WSC::AttrList::parse(*tlv));
         if (!m2) {
             LOG(INFO) << "Not a valid M2 - Ignoring WSC CMDU";
@@ -4317,7 +4317,7 @@ bool slave_thread::handle_channel_selection_request(Socket *sd, ieee1905_1::Cmdu
     // parse all tlvs in cmdu
     // parse channel preference report message
 
-    for (auto channel_preference_tlv : cmdu_rx.msg.getClassList<wfa_map::tlvChannelPreference>()) {
+    for (auto channel_preference_tlv : cmdu_rx.getClassList<wfa_map::tlvChannelPreference>()) {
 
         const auto &ruid = channel_preference_tlv->radio_uid();
         if (network_utils::mac_to_string(ruid) != config.radio_identifier) {

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -341,6 +341,10 @@ bool base_wlan_hal_dummy::process_ext_events()
     }
     std::string event;
     std::getline(stream, event);
+    if (event.empty()) {
+        LOG(DEBUG) << "Received empty event, ignoring";
+        return true;
+    }
     LOG(DEBUG) << "Received event " << event;
 
     parsed_obj_map_t event_obj;

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -52,7 +52,7 @@ public:
 
     static std::shared_ptr<beerocks_header> get_beerocks_header(ieee1905_1::CmduMessage &cmdu)
     {
-        auto tlv = cmdu.msg.getClass<ieee1905_1::tlvVendorSpecific>();
+        auto tlv = cmdu.getClass<ieee1905_1::tlvVendorSpecific>();
         if (!tlv)
             return nullptr;
         if (!intel_oui(tlv))

--- a/common/beerocks/tlvf/src/src/beerocks_message.cpp
+++ b/common/beerocks/tlvf/src/src/beerocks_message.cpp
@@ -107,7 +107,7 @@ std::string message_com::print_cmdu_types(ieee1905_1::CmduMessageRx &cmdu_rx, sC
         cmdu_info->cmdu_type = message_type;
     info = "cmdu_type=" + std::to_string(int(message_type));
     if (message_type == ieee1905_1::eMessageType::VENDOR_SPECIFIC_MESSAGE) {
-        auto tlv_header = cmdu_rx.addClass<ieee1905_1::tlvVendorSpecific>();
+        auto tlv_header = cmdu_rx.getClass<ieee1905_1::tlvVendorSpecific>();
         if (!intel_oui(tlv_header))
             return std::string();
         if (!tlv_header) {
@@ -120,7 +120,7 @@ std::string message_com::print_cmdu_types(ieee1905_1::CmduMessageRx &cmdu_rx, sC
             LOG(ERROR) << "addClass<cACTION_HEADER> failed!";
             return info;
         }
-
+        tlv_header->addInnerClassList(hdr); // so it will also be swapped back
         if (cmdu_info) {
             cmdu_info->intel_vs_action    = hdr->action();
             cmdu_info->intel_vs_action_op = hdr->action_op();

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1037,7 +1037,7 @@ bool master_thread::handle_cmdu_1905_channel_selection_response(const std::strin
     LOG(INFO) << "Received CHANNEL_SELECTION_RESPONSE_MESSAGE, mid=" << std::dec << int(mid);
 
     for (auto channel_selection_response_tlv :
-         cmdu_rx.msg.getClassList<wfa_map::tlvChannelSelectionResponse>()) {
+         cmdu_rx.getClassList<wfa_map::tlvChannelSelectionResponse>()) {
         auto &ruid         = channel_selection_response_tlv->radio_uid();
         auto response_code = channel_selection_response_tlv->response_code();
 
@@ -1348,7 +1348,7 @@ bool master_thread::handle_cmdu_1905_ap_metric_response(const std::string &src_m
     //getting reference for ap metric data storage from db
     auto &ap_metric_data = database.get_ap_metric_data_map();
 
-    for (auto ap_metric_tlv : cmdu_rx.msg.getClassList<wfa_map::tlvApMetric>()) {
+    for (auto ap_metric_tlv : cmdu_rx.getClassList<wfa_map::tlvApMetric>()) {
         //parse tx_ap_metric_data
         sMacAddr reporting_agent_bssid = ap_metric_tlv->bssid();
 
@@ -1374,7 +1374,7 @@ bool master_thread::handle_cmdu_1905_operating_channel_report(const std::string 
     LOG(INFO) << "Received OPERATING_CHANNEL_REPORT_MESSAGE, mid=" << std::dec << int(mid);
 
     for (auto operating_channel_report_tlv :
-         cmdu_rx.msg.getClassList<wfa_map::tlvOperatingChannelReport>()) {
+         cmdu_rx.getClassList<wfa_map::tlvOperatingChannelReport>()) {
         auto &ruid    = operating_channel_report_tlv->radio_uid();
         auto tx_power = operating_channel_report_tlv->current_transmit_power();
 

--- a/framework/platform/bpl/linux/prplmesh_platform_db
+++ b/framework/platform/bpl/linux/prplmesh_platform_db
@@ -1,4 +1,4 @@
 management_mode=Multi-AP-Controller-and-Agent
 operating_mode=Gateway
-stop_on_failure_attempts=0
+stop_on_failure_attempts=1
 certification_mode=1

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -43,7 +43,6 @@ public:
 
     // Forward wrapper functions
     // TODO check which of them can be removed
-    template <class T> std::shared_ptr<T> addClass() { return msg.addClass<T>(); }
     template <class T> std::shared_ptr<T> getClass() const { return msg.getClass<T>(); };
     size_t getMessageLength() const { return msg.getMessageLength(); };
     size_t getMessageBuffLength() const { return msg.getMessageBuffLength(); };

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -30,8 +30,6 @@ public:
     CmduMessage(uint8_t *buff, size_t buff_len) : msg(buff, buff_len){};
     ~CmduMessage(){};
 
-    ClassList msg;
-
     std::shared_ptr<cCmduHeader> getCmduHeader() const { return msg.getClass<cCmduHeader>(); };
     static uint16_t getCmduHeaderLength() { return kCmduHeaderLength; }
     eMessageType getMessageType();
@@ -44,9 +42,14 @@ public:
     // Forward wrapper functions
     // TODO check which of them can be removed
     template <class T> std::shared_ptr<T> getClass() const { return msg.getClass<T>(); };
+    template <class T> std::list<std::shared_ptr<T>> getClassList() const
+    {
+        return msg.getClassList<T>();
+    };
     size_t getMessageLength() const { return msg.getMessageLength(); };
     size_t getMessageBuffLength() const { return msg.getMessageBuffLength(); };
     uint8_t *getMessageBuff() const { return msg.getMessageBuff(); };
+    template <class T> std::shared_ptr<T> getClass() { return msg.getClass<T>(); }
     void swap() { msg.swap(); };
     bool is_finalized() const { return msg.is_finalized(); };
     bool is_swapped() const { return msg.is_swapped(); };
@@ -54,6 +57,9 @@ public:
     static const size_t kMaxCmduLength      = 1500;
     static const uint16_t kCmduHeaderLength = 8;
     static const uint16_t kTlvHeaderLength  = 3;
+
+protected:
+    ClassList msg;
 };
 
 }; // namespace ieee1905_1

--- a/framework/tlvf/src/include/tlvf/CmduMessageTx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageTx.h
@@ -24,6 +24,7 @@ public:
     std::shared_ptr<cCmduHeader> create(uint16_t id, eMessageType message_type);
     std::shared_ptr<cCmduHeader> load();
     std::shared_ptr<tlvVendorSpecific> add_vs_tlv(tlvVendorSpecific::eVendorOUI voui);
+    template <class T> std::shared_ptr<T> addClass() { return msg.addClass<T>(); }
 
     bool finalize();
 };

--- a/framework/tlvf/test/tlvf_test.cpp
+++ b/framework/tlvf/test/tlvf_test.cpp
@@ -629,7 +629,7 @@ int test_all()
         errors++;
     }
 
-    auto tlv4 = received_message.msg.getClass<tlvUnknown>()->class_cast<tlvTestVarList>();
+    auto tlv4 = received_message.getClass<tlvUnknown>()->class_cast<tlvTestVarList>();
     if (tlv4 == nullptr) {
         MAPF_ERR("TLV4 is NULL");
         errors++;

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -584,6 +584,7 @@ usage() {
     echo "  options:"
     echo "      -h|--help - show this help menu"
     echo "      -v|--verbose - verbosity on"
+    echo "      -s|--stop-on-failure - stop on failure"
     echo "      --skip-init - skip init"
     echo ""
     echo "  positional params:"
@@ -605,16 +606,17 @@ usage() {
     echo "      higher_layer_data_payload - Higher layer data payload over 1905 test"
 }
 main() {
-    OPTS=`getopt -o 'hv' --long help,verbose,skip-init -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvs' --long help,verbose,skip-init,stop-on-failure -n 'parse-options' -- "$@"`
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
     eval set -- "$OPTS"
 
     while true; do
         case "$1" in
-            -v | --verbose)     VERBOSE=true; redirect=; shift ;;
-            -h | --help)        usage; exit 0; shift ;;
-            --skip-init)        SKIP_INIT=true; shift ;;
+            -v | --verbose)         VERBOSE=true; redirect=; shift ;;
+            -h | --help)            usage; exit 0; shift ;;
+            -s | --stop-on-failure) STOP_ON_FAILURE=true; shift ;;
+            --skip-init)            SKIP_INIT=true; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
@@ -624,6 +626,7 @@ main() {
     test_init
     for test in "$@"; do
        report "test_${test}" test_${test}
+       [ "$STOP_ON_FAILURE" = "true" -a $error -gt 0 ] && exit 1
        count=$((count+1))
     done
 
@@ -651,5 +654,6 @@ main() {
 
 VERBOSE=false
 SKIP_INIT=false
+STOP_ON_FAILURE=false
 
 main "$@"

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -234,7 +234,7 @@ test_client_association_dummy(){
 
     dbg "Connect dummy STA to wlan0"
     check docker exec repeater1 sh -c \
-        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan0/EVENT"
+        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' > /tmp/$USER/beerocks/wlan0/EVENT"
     
     dbg "Send client association control request to the chosen BSSID to steer the client (UNBLOCK) "
     eval send_bml_command "client_allow \"${sta_mac} ${mac_agent1_wlan2}\"" $redirect
@@ -396,7 +396,7 @@ test_client_steering_dummy() {
 
     dbg "Connect dummy STA to wlan0"
     check docker exec repeater1 sh -c \
-        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan0/EVENT"
+        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' > /tmp/$USER/beerocks/wlan0/EVENT"
 
     dbg "Send steer request "
     eval send_bml_command "steer_client \"${sta_mac} ${mac_agent1_wlan2}\"" $redirect
@@ -432,13 +432,13 @@ test_client_steering_dummy() {
 
     dbg "Disconnect dummy STA from wlan0"
     check docker exec repeater1 sh -c \
-        "echo 'EVENT AP-STA-DISCONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan0/EVENT"
+        "echo 'EVENT AP-STA-DISCONNECTED ${sta_mac}' > /tmp/$USER/beerocks/wlan0/EVENT"
 
     #TODO// check for "disconnected after successful steering, proceeding to unblock" message 
 
     dbg "Connect dummy STA to wlan2"
     check docker exec repeater1 sh -c \
-        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' >> /tmp/$USER/beerocks/wlan2/EVENT"
+        "echo 'EVENT AP-STA-CONNECTED ${sta_mac}' > /tmp/$USER/beerocks/wlan2/EVENT"
 
     dbg "Confirm steering success by client connected"
     check docker exec gateway sh -c \

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -544,10 +544,13 @@ test_topology() {
     return $check_error
 }
 test_init() {
-    status "test initialization"    
-    eval ${scriptdir}/test_gw_repeater.sh -f -r "repeater1" -r "repeater2" -d 7 $redirect || {
-        err "start GW+Repeater failed, abort"
-        exit 1
+    status "test initialization"
+
+    [ "$SKIP_INIT" = "false" ] && {
+        eval ${scriptdir}/test_gw_repeater.sh -f -r "repeater1" -r "repeater2" -d 7 $redirect || {
+            err "start GW+Repeater failed, abort"
+            exit 1
+        }
     }
     #save bml_conn_map output into a file.
     connmap=$(mktemp)
@@ -581,6 +584,7 @@ usage() {
     echo "  options:"
     echo "      -h|--help - show this help menu"
     echo "      -v|--verbose - verbosity on"
+    echo "      --skip-init - skip init"
     echo ""
     echo "  positional params:"
     echo "      topology - Topology discovery test"
@@ -601,7 +605,7 @@ usage() {
     echo "      higher_layer_data_payload - Higher layer data payload over 1905 test"
 }
 main() {
-    OPTS=`getopt -o 'hv' --long help,verbose -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hv' --long help,verbose,skip-init -n 'parse-options' -- "$@"`
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
     eval set -- "$OPTS"
@@ -610,6 +614,7 @@ main() {
         case "$1" in
             -v | --verbose)     VERBOSE=true; redirect=; shift ;;
             -h | --help)        usage; exit 0; shift ;;
+            --skip-init)        SKIP_INIT=true; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
@@ -645,5 +650,6 @@ main() {
 }
 
 VERBOSE=false
+SKIP_INIT=false
 
 main "$@"


### PR DESCRIPTION
Prevent cases where parse is called more than once by making parse a CmduMessageTx method instead of CmduMessage. Also, make ClassList msg a protected member.