### PR TITLE
test_flows.sh: test_client_steering_policy: check for any ack with mid

### DIFF
--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -461,10 +461,8 @@ test_client_steering_policy() {
     check docker exec repeater1 sh -c 'grep -i -q "MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_agent_wlan0.log > /tmp/catch'
     sleep 1
     dbg "Confirming client steering policy ack message has been received on the controller"
-    TMP="$(docker exec gateway sh -c 'grep -i "ACK_MESSAGE" /tmp/$USER/beerocks/logs/beerocks_controller.log')"
-    MID2_STR="$(echo "$TMP" | tr ' ' '\n' | grep -Po "(?<=mid=).*[^\s]" | tail -n 1)"
+    check docker exec gateway "grep" "-q" "ACK_MESSAGE, mid=$MID1_STR" "/tmp/$USER/beerocks/logs/beerocks_controller.log"
 
-    check [ "$MID1_STR" = "$MID2_STR" ]
     return $check_error
 }
 


### PR DESCRIPTION
The test_client_steering_policy test first sends a steering policy to
the gateway, saves a mid, then later compare it to the mid of the
latest ACK_MESSAGE received by the controller.

However, it can happen that the ACK is present, but is not the latest
one. An example of such a situation is if the client gets unblocked
from the network, and son_master_thread receives an ACK_MESSAGE for
allow requests before test_flows.sh could check the ACK for the
steering.

Instead of comparing only the last mid, check if the controller
received any ACK_MESSAGE with the corresponding mid.

