### PR TITLE
Feature/remove network before scan

### DIFF
--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
@@ -40,7 +40,7 @@ bool sta_wlan_hal_dummy::connect(const std::string &ssid, const std::string &pas
     return true;
 }
 
-bool sta_wlan_hal_dummy::disconnect() { return true; }
+bool sta_wlan_hal_dummy::disconnect(bool remove_all_networks) { return true; }
 
 bool sta_wlan_hal_dummy::roam(const std::string &bssid, uint8_t channel) { return true; }
 

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
@@ -41,7 +41,7 @@ public:
                          bool mem_only_psk, const std::string &bssid, uint8_t channel,
                          bool hidden_ssid) override;
 
-    virtual bool disconnect() override;
+    virtual bool disconnect(bool remove_all_networks = false) override;
 
     virtual bool roam(const std::string &bssid, uint8_t channel) override;
 

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
@@ -240,7 +240,7 @@ bool sta_wlan_hal_dwpal::connect(const std::string &ssid, const std::string &pas
     return true;
 }
 
-bool sta_wlan_hal_dwpal::disconnect()
+bool sta_wlan_hal_dwpal::disconnect(bool remove_all_networks)
 {
     LOG(TRACE) << __func__ << ": iface = " << get_iface_name()
                << ", m_active_network_id = " << m_active_network_id;

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
@@ -103,6 +103,12 @@ bool sta_wlan_hal_dwpal::initiate_scan()
 {
     LOG(DEBUG) << "Initiating scan on interface: " << get_iface_name();
 
+    // Remove all networks to make sure that the wpa_supplicant will not be busy
+    if (!disconnect(true)) {
+        LOG(WARNING) << "Failed disconnecting";
+        return false;
+    }
+
     // Start the scan
     if (!dwpal_send_cmd("SCAN")) {
         LOG(ERROR) << "initiate_scan - wpa_ctrl_send_msg failed for " << get_iface_name();

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.h
@@ -39,7 +39,7 @@ public:
                          bool mem_only_psk, const std::string &bssid, uint8_t channel,
                          bool hidden_ssid) override;
 
-    virtual bool disconnect() override;
+    virtual bool disconnect(bool remove_all_networks = false) override;
 
     virtual bool roam(const std::string &bssid, uint8_t channel) override;
 

--- a/common/beerocks/bwl/include/bwl/sta_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/sta_wlan_hal.h
@@ -48,7 +48,7 @@ public:
                          bool mem_only_psk, const std::string &bssid, uint8_t channel,
                          bool hidden_ssid) = 0;
 
-    virtual bool disconnect() = 0;
+    virtual bool disconnect(bool remove_all_networks = false) = 0;
 
     virtual bool roam(const std::string &bssid, uint8_t channel) = 0;
 

--- a/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.cpp
@@ -40,7 +40,7 @@ bool sta_wlan_hal_nl80211::connect(const std::string &ssid, const std::string &p
     return true;
 }
 
-bool sta_wlan_hal_nl80211::disconnect() { return true; }
+bool sta_wlan_hal_nl80211::disconnect(bool remove_all_networks) { return true; }
 
 bool sta_wlan_hal_nl80211::roam(const std::string &bssid, uint8_t channel) { return true; }
 

--- a/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.h
@@ -41,7 +41,7 @@ public:
                          bool mem_only_psk, const std::string &bssid, uint8_t channel,
                          bool hidden_ssid) override;
 
-    virtual bool disconnect() override;
+    virtual bool disconnect(bool remove_all_networks = false) override;
 
     virtual bool roam(const std::string &bssid, uint8_t channel) override;
 


### PR DESCRIPTION
Before BH-scan starts, the repeater should remove existing network configuration so STAs will not be busy in background scans.
Add removal of all existing networks before start scanning and thus make the station to be free from background scans.