### PR TITLE
[KW] - solve lost resource issue

### DIFF
--- a/common/beerocks/bcl/source/beerocks_os_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_os_utils.cpp
@@ -189,6 +189,7 @@ int os_utils::redirect_console_std(std::string log_file_name)
         dup2(fd_log_file_std, STDOUT_FILENO);
         dup2(fd_log_file_std, STDERR_FILENO);
     }
+    close_file(fd_log_file_std);
     return fd_log_file_std;
 }
 


### PR DESCRIPTION
After running the klocwork script on RDKB with prplMesh, the following error was received :

" Resource acquired to ***  may be lost here. "

The reason for this bug is that we do not close the file after opening it
in `os_utils::redirect_console_std` method.

The close() function deallocates the given file descriptor, which means
that it will be available for other functions that allocate file descriptors.

This KW error indicates that the resource may be lost, which means that
if the resource isn't properly released, it will be unavailable at the
next access attempt.

Signed-off-by: CoralMalachi <coral.malachi@intel.com>