### PR TITLE
Feature/dev get param

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -97,6 +97,22 @@ void agent_ucc_listener::update_vaps_list(std::string ruid, beerocks_message::sV
 }
 
 /**
+ * @brief get parameter command
+ *
+ * get agent parameter
+ *
+ * @param[in] params command parsed parameter map
+ * @param[out] value returned parameter or error on failure
+ * @return true on success
+ * @return false on failure
+ */
+bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
+                                              std::string &value)
+{
+    value = "parameter " + params["parameter"] + " not supported";
+    return false;
+}
+/**
  * @brief Validate if the 'dest_alid` MAC address matches the controllers MAC address.
  * 
  * @param[in] dest_alid Agent bridge MAC address.

--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -109,6 +109,32 @@ void agent_ucc_listener::update_vaps_list(std::string ruid, beerocks_message::sV
 bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
                                               std::string &value)
 {
+    if (params["parameter"] == "macaddr") {
+        if (params.find("ruid") == params.end()) {
+            value = "missing ruid";
+            return false;
+        }
+        if (params.find("ssid") == params.end()) {
+            value = "missing ssid";
+            return false;
+        }
+        auto ruid = network_utils::mac_to_string(std::stoull(params["ruid"], nullptr, 16));
+        auto ssid = params["ssid"];
+
+        auto it = vaps_map.find(ruid);
+        if (it == vaps_map.end()) {
+            value = "ruid " + ruid + " not found";
+            return false;
+        }
+        for (const auto &vap : it->second.vaps) {
+            if (std::string(vap.ssid) == ssid) {
+                value = network_utils::mac_to_string(vap.mac);
+                return true;
+            }
+        }
+        value = "macaddr not found for ruid " + ruid + " ssid " + ssid;
+        return false;
+    }
     value = "parameter " + params["parameter"] + " not supported";
     return false;
 }

--- a/agent/src/beerocks/slave/agent_ucc_listener.h
+++ b/agent/src/beerocks/slave/agent_ucc_listener.h
@@ -58,6 +58,8 @@ private:
                                   const std::string &dest_mac = std::string()) override;
     bool handle_dev_set_config(std::unordered_map<std::string, std::string> &params,
                                std::string &err_string) override;
+    bool handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
+                              std::string &value) override;
 
     backhaul_manager &m_backhaul_manager_ctx;
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1668,7 +1668,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         LOG(DEBUG) << "ACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION received from iface "
                    << soc->hostap_iface;
         if (m_agent_ucc_listener) {
-            auto msg = cmdu_rx.getClass<
+            auto msg = beerocks_header->addClass<
                 beerocks_message::cACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
             if (!msg) {
                 LOG(ERROR)

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -989,7 +989,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 
     case beerocks_message::ACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION: {
         LOG(DEBUG) << "ACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION";
-        auto notification = cmdu_rx.getClass<
+        auto notification = beerocks_header->addClass<
             beerocks_message::
                 cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION>();
         if (notification == nullptr) {

--- a/common/beerocks/bcl/include/bcl/beerocks_ucc_listener.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_ucc_listener.h
@@ -46,6 +46,8 @@ protected:
                                           const std::string &dest_mac = std::string()) = 0;
     virtual bool handle_dev_set_config(std::unordered_map<std::string, std::string> &params,
                                        std::string &err_string)                        = 0;
+    virtual bool handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
+                                      std::string &value)                              = 0;
 
     enum class eUccListenerRunOn : uint8_t {
         CONTROLLER,

--- a/common/beerocks/bcl/include/bcl/network/network_utils.h
+++ b/common/beerocks/bcl/include/bcl/network/network_utils.h
@@ -78,6 +78,7 @@ public:
         struct in_addr nmask;
     } raw_iface_info;
 
+    static std::string mac_to_string(const uint64_t mac);
     static std::string mac_to_string(const sMacAddr &mac);
     static std::string mac_to_string(const uint8_t *mac_address);
 

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -13,6 +13,7 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <linux/if_bridge.h>
 #include <linux/if_ether.h>  // ETH_P_ARP = 0x0806
 #include <linux/if_packet.h> // struct sockaddr_ll (see man 7 packet)
@@ -76,6 +77,18 @@ const std::string network_utils::WILD_MAC_STRING("ff:ff:ff:ff:ff:ff");
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
+
+// Converts uint64_t mac address to string format
+std::string network_utils::mac_to_string(const uint64_t mac)
+{
+    uint8_t mac_address[MAC_ADDR_LEN];
+    int8_t i;
+    uint8_t *p = mac_address;
+    for (i = 5; i >= 0; i--) {
+        *p++ = mac >> (CHAR_BIT * i);
+    }
+    return mac_to_string(mac_address);
+}
 
 // Converts a mac address in a human-readable format
 std::string network_utils::mac_to_string(const uint8_t *mac_address)

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -176,6 +176,8 @@ bool ap_wlan_hal_dummy::sta_bss_steer(const std::string &mac, const std::string 
 bool ap_wlan_hal_dummy::update_vap_credentials(
     std::list<son::wireless_utils::sBssInfoConf> &bss_info_conf_list)
 {
+    int vap_id = beerocks::IFACE_VAP_ID_MIN;
+
     for (auto bss_info_conf : bss_info_conf_list) {
         auto auth_type =
             son::wireless_utils::wsc_to_bwl_authentication(bss_info_conf.authentication_type);
@@ -196,6 +198,7 @@ bool ap_wlan_hal_dummy::update_vap_credentials(
         LOG(DEBUG) << "Received credentials for ssid: " << bss_info_conf.ssid
                    << " auth_type: " << auth_type << " encr_type: " << enc_type
                    << " network_key: " << bss_info_conf.network_key << " bss_type: " << bss_type;
+        m_radio_info.available_vaps[vap_id++].ssid = bss_info_conf.ssid;
     }
 
     return true;

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -289,8 +289,13 @@ bool base_wlan_hal_dummy::refresh_radio_info()
     if (get_iface_name() == "wlan2") {
         m_radio_info.is_5ghz = true;
     }
-    beerocks::net::network_utils::linux_iface_get_mac(
-        m_radio_info.iface_name, m_radio_info.available_vaps[beerocks::IFACE_VAP_ID_MIN].mac);
+    std::string radio_mac;
+    beerocks::net::network_utils::linux_iface_get_mac(m_radio_info.iface_name, radio_mac);
+    for (int vap_id = 0; vap_id < 4; vap_id++) {
+        auto mac = beerocks::net::network_utils::mac_from_string(radio_mac);
+        mac.oct[5] += vap_id;
+        m_radio_info.available_vaps[vap_id].mac = beerocks::net::network_utils::mac_to_string(mac);
+    }
     return true;
 }
 

--- a/controller/src/beerocks/master/controller_ucc_listener.cpp
+++ b/controller/src/beerocks/master/controller_ucc_listener.cpp
@@ -37,6 +37,23 @@ std::string controller_ucc_listener::fill_version_reply_string()
 void controller_ucc_listener::clear_configuration() { m_database.clear_bss_info_configuration(); }
 
 /**
+ * @brief get parameter command
+ *
+ * get controller parameter
+ *
+ * @param[in] params command parsed parameter map
+ * @param[out] value returned parameter or error on failure
+ * @return true on success
+ * @return false on failure
+ */
+bool controller_ucc_listener::handle_dev_get_param(
+    std::unordered_map<std::string, std::string> &params, std::string &value)
+{
+    value = "parameter " + params["parameter"] + " not supported";
+    return false;
+}
+
+/**
  * @brief Validate if the 'dest_alid` MAC address matches one of known Agents MAC addresses.
  * 
  * @param[in] dest_alid Agent bridge MAC address.

--- a/controller/src/beerocks/master/controller_ucc_listener.h
+++ b/controller/src/beerocks/master/controller_ucc_listener.h
@@ -32,7 +32,8 @@ private:
                                   const std::string &dest_mac = std::string()) override;
     bool handle_dev_set_config(std::unordered_map<std::string, std::string> &params,
                                std::string &err_string) override;
-
+    bool handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
+                              std::string &value) override;
     static std::string parse_bss_info(const std::string &bss_info_str,
                                       son::wireless_utils::sBssInfoConf &bss_info_conf,
                                       std::string &err_string);

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -26,7 +26,13 @@ container_ip() {
 
 container_CAPI_port() {
     # get the CAPI port based on the container name.
-    docker exec -t "$1" grep ucc_listener_port ${installdir}/config/beerocks_controller.conf  | cut -f2 -d= | cut -f1 -d' '
+    # For test_flows, we always consider the gateway to be a controller-only
+    # device (i.e. the agent on the gateway is not addressed by CAPI).
+    if [ "$1" = "gateway" ]; then
+        docker exec -t "$1" grep ucc_listener_port ${installdir}/config/beerocks_controller.conf  | cut -f2 -d= | cut -f1 -d' '
+    else
+        docker exec -t "$1" grep ucc_listener_port ${installdir}/config/beerocks_agent.conf  | cut -f2 -d= | cut -f1 -d' '
+    fi
 }
 
 send_bml_command() {


### PR DESCRIPTION
For controller certification, dev_get_parameter is always ALid which is why it is hard-coded in prplMesh.
When the request is for the agent, it can either be ALid or macaddr, so this needs to be fixed.

When the parameter is macaddr, it includes the ruid and ssid, so the UCC agent listener should fetch the information from the VAPs configuration MAP - see attached card.

This PR adds generic dev_get_parameter support to both the controller and agent, with identical implementation for the case where `parameter=ALid`, and implements the case where `parameter=macaddr` in the agent ucc listener.

In addition, this PR fixes several minor bugs preventing the VAPs to be updated in the UCC agent, and finally adds a test in `test_flows.sh` which will make sure that `dev_get_parameter` will not be broken easily in the future by using and checking it in ap_config_renew test.

Fixes #336 