### PR TITLE
[KW]: Resolve uninitialized class member issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ analyzer-venv
 /*.ipk
 /build/
 /logs/
+_GO_KW
+.kwlp
+.kwps
+kw_reports

--- a/common/beerocks/bcl/include/bcl/beerocks_logging.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_logging.h
@@ -119,14 +119,14 @@ private:
     std::string m_module_name;
 
     size_t m_logfile_size;
-    bool m_log_files_enabled;
+    bool m_log_files_enabled = true;
     std::string m_log_files_path;
     std::string m_log_filename;
-    bool m_log_files_auto_roll;
+    bool m_log_files_auto_roll = true;
     log_levels m_levels;
     log_levels m_syslog_levels;
-    bool m_stdout_enabled;
-    bool m_syslog_enabled;
+    bool m_stdout_enabled = true;
+    bool m_syslog_enabled = false;
 
     settings_t m_settings_map;
 };

--- a/common/beerocks/bcl/include/bcl/beerocks_promise.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_promise.h
@@ -16,7 +16,7 @@ namespace beerocks {
 
 template <class T> class promise {
 public:
-    promise(){};
+    promise() : m_value(T()), m_signal(false){};
     ~promise(){};
 
     // Set value for waiting threads
@@ -78,7 +78,7 @@ private:
     pthread_cond_t m_cond = PTHREAD_COND_INITIALIZER;
     pthread_mutex_t m_mut = PTHREAD_MUTEX_INITIALIZER;
     T m_value;
-    bool m_signal = 0;
+    bool m_signal;
 };
 } //  namespace beerocks
 

--- a/common/beerocks/bcl/source/beerocks_logging.cpp
+++ b/common/beerocks/bcl/source/beerocks_logging.cpp
@@ -292,8 +292,7 @@ const std::string logging::syslogFormat("<%thread> %fbase[%line] --> %msg");
 
 logging::logging(const std::string config_path, std::string module_name)
     : m_module_name(module_name), m_logfile_size(LOGGING_DEFAULT_MAX_SIZE),
-      m_levels(LOG_LEVELS_GLOBAL_DEFAULT), m_syslog_levels(LOG_LEVELS_SYSLOG_DEFAULT),
-      m_stdout_enabled("true"), m_syslog_enabled("false")
+      m_levels(LOG_LEVELS_GLOBAL_DEFAULT), m_syslog_levels(LOG_LEVELS_SYSLOG_DEFAULT)
 {
     bool found_settings = false;
 
@@ -313,8 +312,8 @@ logging::logging(const std::string config_path, std::string module_name)
 
 logging::logging(const settings_t &settings, bool cache_settings, std::string module_name)
     : m_module_name(module_name), m_logfile_size(LOGGING_DEFAULT_MAX_SIZE),
-      m_levels(LOG_LEVELS_GLOBAL_DEFAULT), m_syslog_levels(LOG_LEVELS_SYSLOG_DEFAULT),
-      m_stdout_enabled(true), m_syslog_enabled(false)
+      m_levels(LOG_LEVELS_GLOBAL_DEFAULT), m_syslog_levels(LOG_LEVELS_SYSLOG_DEFAULT)
+
 {
     for (auto &setting : settings) {
         if (0 == setting.first.find("log_")) {
@@ -332,8 +331,7 @@ logging::logging(const settings_t &settings, bool cache_settings, std::string mo
 logging::logging(const beerocks::config_file::SConfigLog &settings, std::string module_name,
                  bool cache_settings)
     : m_module_name(module_name), m_logfile_size(LOGGING_DEFAULT_MAX_SIZE),
-      m_levels(LOG_LEVELS_GLOBAL_DEFAULT), m_syslog_levels(LOG_LEVELS_SYSLOG_DEFAULT),
-      m_stdout_enabled(true), m_syslog_enabled(false)
+      m_levels(LOG_LEVELS_GLOBAL_DEFAULT), m_syslog_levels(LOG_LEVELS_SYSLOG_DEFAULT)
 {
     m_settings_map.insert(
         {"log_files_enabled", settings.files_enabled.empty() ? "true" : settings.files_enabled});

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -747,7 +747,7 @@ private:
     std::shared_ptr<uint8_t> certification_tx_buffer;
     std::unordered_map<sMacAddr, std::list<wireless_utils::sBssInfoConf>> bss_infos; // key=al_mac
 
-    master_thread *m_master_thread_ctx;
+    master_thread *m_master_thread_ctx = nullptr;
     const std::string m_local_bridge_mac;
 };
 

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -207,8 +207,8 @@ public:
         ~ap_metrics_data(){};
 
         sMacAddr bssid;
-        uint8_t channel_utilization;
-        uint16_t number_of_stas_currently_associated;
+        uint8_t channel_utilization                  = 0;
+        uint16_t number_of_stas_currently_associated = 0;
         std::vector<uint8_t> estimated_service_info_fields;
         bool include_ac_vo = false;
         bool include_ac_bk = false;

--- a/framework/common/include/mapf/common/encryption.h
+++ b/framework/common/include/mapf/common/encryption.h
@@ -80,8 +80,8 @@ private:
     /**
      * If keypair generation failed in the constructor, this will be @a nullptr.
      */
-    uint8_t *m_pubkey = nullptr;
-    unsigned m_pubkey_length;
+    uint8_t *m_pubkey        = nullptr;
+    unsigned m_pubkey_length = 0;
     uint8_t m_nonce[16];
 };
 


### PR DESCRIPTION
After running the klocwork script on RDKB with prplMesh, the following error was received : 

" 'this->***' is not initialized in this constructor. "

This KW error indicates that there is a class member possibly unassigned.
This PR fixes all occurrences of this issue by updating each of those constructors to assign its uninitialized member a default value.

In addition, update .gitignore to ignore KW files irrelevant to the GitHub repo.