### PR TITLE
Bugfix/remove unnecessary return statement

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -50,8 +50,6 @@ std::string agent_ucc_listener::fill_version_reply_string()
 {
     return std::string("vendor,") + m_vendor + std::string(",model,") + m_model +
            std::string(",version,") + BEEROCKS_VERSION;
-
-    return std::string();
 }
 
 /**


### PR DESCRIPTION
After running the klocwork script on RDKB with prplMesh, the following error was received :

" Code is unreachable "

The reason for this specific error is that there is an unnecessary return
statement at `fill_version_reply_string()` method.

Therefore, remove the second return statement, which of course we will
never get to this line since we already got out from the function after
the first return statement.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>