### PR TITLE
[DCS Patch 3/5] port dynamic channel selection from rdkb task

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -3320,6 +3320,29 @@ bool db::assign_rdkb_wlan_task_id(int new_task_id)
 
 int db::get_rdkb_wlan_task_id() { return rdkb_wlan_task_id; }
 
+bool db::assign_dynamic_channel_selection_task_id(const sMacAddr &mac, int new_task_id)
+{
+    auto n = get_node(mac);
+    if (!n) {
+        LOG(WARNING) << __FUNCTION__ << " - node " << network_utils::mac_to_string(mac)
+                     << " does not exist!";
+        return false;
+    }
+    n->dynamic_channel_selection_task_id = new_task_id;
+    return true;
+}
+
+int db::get_dynamic_channel_selection_task_id(const sMacAddr &mac)
+{
+    auto n = get_node(mac);
+    if (!n) {
+        LOG(WARNING) << __FUNCTION__ << " - node " << network_utils::mac_to_string(mac)
+                     << " does not exist!";
+        return -1;
+    }
+    return n->dynamic_channel_selection_task_id;
+}
+
 void db::lock() { db_mutex.lock(); }
 
 void db::unlock() { db_mutex.unlock(); }

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -714,6 +714,9 @@ public:
     bool assign_channel_selection_task_id(int new_task_id);
     int get_channel_selection_task_id();
 
+    bool assign_dynamic_channel_selection_task_id(const sMacAddr &mac, int new_task_id);
+    int get_dynamic_channel_selection_task_id(const sMacAddr &mac);
+
     void lock();
     void unlock();
 

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -101,6 +101,7 @@ public:
     int load_balancer_task_id                    = -1;
     int client_locating_task_id_new_connection   = -1;
     int client_locating_task_id_exist_connection = -1;
+    int dynamic_channel_selection_task_id        = -1;
 
     std::chrono::steady_clock::time_point measurement_sent_timestamp;
     int measurement_recv_delta  = 0;

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019-2020 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "dynamic_channel_selection_task.h"
+#include "../son_actions.h"
+#include <bcl/beerocks_defines.h>
+#include <bcl/network/network_utils.h>
+#include <easylogging++.h>
+
+#define SCAN_TRIGGERED_WAIT_TIME_MSEC 20000
+#define SCAN_RESULTS_DUMP_WAIT_TIME_MSEC 40000
+
+std::string s_ar_states[] = {FOREACH_DCS_STATE(GENERATE_STRING)};
+std::string s_ar_events[] = {FOREACH_DCS_EVENT(GENERATE_STRING)};
+
+dynamic_channel_selection_task::dynamic_channel_selection_task(db &database_,
+                                                               ieee1905_1::CmduMessageTx &cmdu_tx_,
+                                                               task_pool &tasks_,
+                                                               sMacAddr radio_mac_)
+    : database(database_), cmdu_tx(cmdu_tx_), tasks(tasks_), m_radio_mac(radio_mac_)
+{
+    m_fsm_state = eState::INIT;
+}
+
+void dynamic_channel_selection_task::work()
+{
+    TASK_LOG(DEBUG) << "FSM current state: " << s_ar_states[int(m_fsm_state)];
+
+    switch (m_fsm_state) {
+    case eState::INIT:
+    case eState::IDLE:
+    case eState::TRIGGER_SCAN:
+    case eState::WAIT_FOR_SCAN_TRIGGERED:
+    case eState::WAIT_FOR_RESULTS_READY:
+    case eState::WAIT_FOR_RESULTS_DUMP:
+    case eState::SCAN_DONE:
+    case eState::ABORT_SCAN:
+    default: {
+        break;
+    }
+    }
+    TASK_LOG(DEBUG) << "FSM next state: " << s_ar_states[int(m_fsm_state)];
+}
+
+void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
+{
+    if (obj == nullptr) {
+        TASK_LOG(ERROR) << "obj == nullptr";
+        return;
+    }
+
+    auto event_radio_mac = *reinterpret_cast<sMacAddr *>(obj);
+    if (m_radio_mac != event_radio_mac) {
+        TASK_LOG(ERROR) << "event : " << s_ar_events[int(eEvent(event_type))]
+                        << " in state: " << s_ar_states[int(m_fsm_state)]
+                        << " for mac: " << event_radio_mac;
+        if (m_dcs_waiting_for_event != eEvent::INVALID_EVENT) {
+            TASK_LOG(DEBUG) << "calling wait_for_event for "
+                            << s_ar_events[int(m_dcs_waiting_for_event)];
+            wait_for_event(int(m_dcs_waiting_for_event));
+        }
+        return;
+    }
+
+    // This flag (event_handled) indicate if event has arived in the correct fsm state.
+    bool event_handled = false;
+    switch (eEvent(event_type)) {
+    case eEvent::TRIGGER_SINGLE_SCAN:
+    case eEvent::SCAN_TRIGGERED:
+    case eEvent::SCAN_RESULTS_READY:
+    case eEvent::SCAN_RESULTS_DUMP:
+    case eEvent::SCAN_FINISHED:
+    case eEvent::SCAN_ABORTED:
+    case eEvent::SCAN_ENABLE_CHANGE:
+    default: {
+        break;
+    }
+    }
+
+    if (!event_handled) {
+        TASK_LOG(ERROR) << "unexpected event: " << s_ar_events[int(eEvent(event_type))]
+                        << " in state: " << s_ar_states[int(m_fsm_state)];
+    } else {
+        m_dcs_waiting_for_event = eEvent::INVALID_EVENT;
+    }
+}
+
+void dynamic_channel_selection_task::handle_events_timeout(std::multiset<int> pending_events)
+{
+    // only one event is expected
+    for (std::multiset<int>::iterator it = pending_events.begin(); it != pending_events.end();
+         ++it) {
+        TASK_LOG(ERROR) << "event " << *it << " timed out on " << m_radio_mac
+                        << ", going to abort-scan state -> handle_nl_dead_node";
+
+        switch (m_fsm_state) {
+        case eState::WAIT_FOR_SCAN_TRIGGERED:
+        case eState::WAIT_FOR_RESULTS_READY:
+        case eState::WAIT_FOR_RESULTS_DUMP:
+        case eState::SCAN_DONE:
+        case eState::IDLE:
+        case eState::ABORT_SCAN: {
+            break;
+        }
+        default: {
+            TASK_LOG(ERROR) << "Unexpected event timeout!";
+            break;
+        }
+        }
+    }
+    m_dcs_waiting_for_event = eEvent::INVALID_EVENT;
+}
+
+void dynamic_channel_selection_task::dcs_wait_for_event(eEvent dcs_event)
+{
+    m_dcs_waiting_for_event = dcs_event;
+    wait_for_event((int)dcs_event);
+}

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -206,13 +206,130 @@ void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
     // This flag (event_handled) indicate if event has arived in the correct fsm state.
     bool event_handled = false;
     switch (eEvent(event_type)) {
-    case eEvent::TRIGGER_SINGLE_SCAN:
-    case eEvent::SCAN_TRIGGERED:
-    case eEvent::SCAN_RESULTS_READY:
-    case eEvent::SCAN_RESULTS_DUMP:
-    case eEvent::SCAN_FINISHED:
-    case eEvent::SCAN_ABORTED:
-    case eEvent::SCAN_ENABLE_CHANGE:
+    case eEvent::TRIGGER_SINGLE_SCAN: {
+        TASK_LOG(DEBUG) << "TRIGGER_SINGLE_SCAN received";
+        auto single_scan_event = reinterpret_cast<sScanEvent *>(obj);
+        event_handled          = true;
+        TASK_LOG(DEBUG) << "TRIGGER_SINGLE_SCAN handled on:" << single_scan_event->radio_mac.oct;
+        m_is_single_scan_pending = true;
+        break;
+    }
+    case eEvent::SCAN_TRIGGERED: {
+        TASK_LOG(DEBUG) << "SCAN_TRIGGERED received";
+        if (fsm_in_state(eState::WAIT_FOR_SCAN_TRIGGERED)) {
+            auto scan_triggered_event = reinterpret_cast<sScanEvent *>(obj);
+            event_handled             = true;
+            TASK_LOG(DEBUG) << "SCAN_TRIGGERED handled on:" << scan_triggered_event->radio_mac.oct;
+
+            set_events_timeout(SCAN_RESULTS_DUMP_WAIT_TIME_MSEC);
+            dcs_wait_for_event(eEvent::SCAN_RESULTS_DUMP);
+
+            fsm_move_state(eState::WAIT_FOR_RESULTS_READY);
+        } else {
+            TASK_LOG(DEBUG) << "ignoring SCAN_TRIGERRED event,"
+                            << " not in state WAIT_FOR_SCAN_TRIGGERED";
+        }
+        break;
+    }
+    case eEvent::SCAN_RESULTS_READY: {
+        TASK_LOG(DEBUG) << "SCAN_RESULTS_READY received";
+        if (fsm_in_state(eState::WAIT_FOR_RESULTS_READY)) {
+            auto scan_results_ready_event = reinterpret_cast<sScanEvent *>(obj);
+            event_handled                 = true;
+            TASK_LOG(DEBUG) << "SCAN_RESULTS_READY handled on:"
+                            << scan_results_ready_event->radio_mac.oct;
+
+            if (!database.clear_channel_scan_results(m_radio_mac, m_is_single_scan)) {
+                TASK_LOG(ERROR) << "failed to clear scan results";
+                m_last_scan_error_code =
+                    beerocks::eChannelScanErrCode::CHANNEL_SCAN_INTERNAL_FAILURE;
+                fsm_move_state(eState::ABORT_SCAN);
+                break;
+            }
+
+            set_events_timeout(SCAN_RESULTS_DUMP_WAIT_TIME_MSEC);
+            dcs_wait_for_event(eEvent::SCAN_RESULTS_DUMP);
+
+            fsm_move_state(eState::WAIT_FOR_RESULTS_DUMP);
+        } else {
+            TASK_LOG(DEBUG) << "ignoring SCAN_RESULTS_READY event,"
+                            << " not in state WAIT_FOR_RESULTS_READY";
+        }
+        break;
+    }
+    case eEvent::SCAN_RESULTS_DUMP: {
+        TASK_LOG(DEBUG) << "SCAN_RESULTS_DUMP received";
+        if (fsm_in_state(eState::WAIT_FOR_RESULTS_DUMP)) {
+            auto scan_results_dump_event = reinterpret_cast<sScanEvent *>(obj);
+            event_handled                = true;
+            TASK_LOG(DEBUG) << "SCAN_RESULTS_DUMP handled on:"
+                            << scan_results_dump_event->radio_mac.oct;
+            auto channel = scan_results_dump_event->udata.scan_results.channel;
+
+            if (!database.is_channel_in_pool(m_radio_mac, channel, m_is_single_scan)) {
+                LOG(DEBUG) << "channel is not in channel pool - ignoring results";
+            } else if (!database.add_channel_scan_results(
+                           m_radio_mac, scan_results_dump_event->udata.scan_results,
+                           m_is_single_scan)) {
+                TASK_LOG(ERROR) << "failed to save scan results";
+                m_last_scan_error_code =
+                    beerocks::eChannelScanErrCode::CHANNEL_SCAN_INTERNAL_FAILURE;
+                fsm_move_state(eState::ABORT_SCAN);
+                break;
+            } else {
+                TASK_LOG(DEBUG) << "results for channel=" << int(channel)
+                                << " saved successfully to DB";
+            }
+
+            set_events_timeout(SCAN_RESULTS_DUMP_WAIT_TIME_MSEC);
+            dcs_wait_for_event(eEvent::SCAN_RESULTS_DUMP);
+        } else {
+            TASK_LOG(DEBUG) << "ignoring SCAN_RESULTS_DUMP event,"
+                            << " not in state WAIT_FOR_RESULTS_DUMP";
+        }
+        break;
+    }
+    case eEvent::SCAN_FINISHED: {
+        TASK_LOG(DEBUG) << "SCAN_FINISHED received";
+        if (fsm_in_state(eState::WAIT_FOR_RESULTS_DUMP)) {
+            auto scan_finished_event = reinterpret_cast<sScanEvent *>(obj);
+            event_handled            = true;
+            TASK_LOG(DEBUG) << "SCAN_FINISHED handled on:" << scan_finished_event->radio_mac.oct;
+
+            //clear any pending events. for example SCAN_RESULTS_DUMP
+            clear_pending_events();
+
+            fsm_move_state(eState::SCAN_DONE);
+        } else {
+            TASK_LOG(DEBUG) << "ignoring SCAN_FINISHED event,"
+                            << " not in state WAIT_FOR_RESULTS_DUMP";
+        }
+        break;
+    }
+    case eEvent::SCAN_ABORTED: {
+        TASK_LOG(DEBUG) << "SCAN_ABORTED received";
+        auto scan_abort_event = reinterpret_cast<sScanEvent *>(obj);
+        event_handled         = true;
+        TASK_LOG(DEBUG) << "SCAN_FINISHED handled on:" << scan_abort_event->radio_mac.oct;
+
+        m_last_scan_error_code = beerocks::eChannelScanErrCode::CHANNEL_SCAN_ABORTED_BY_DRIVER;
+
+        clear_pending_events();
+        fsm_move_state(eState::ABORT_SCAN);
+        break;
+    }
+    case eEvent::SCAN_ENABLE_CHANGE: {
+        TASK_LOG(DEBUG) << "SCAN_ENABLE_CHANGE received";
+        auto scan_enable_change_event = reinterpret_cast<sScanEvent *>(obj);
+        event_handled                 = true;
+        TASK_LOG(DEBUG) << "SCAN_FINISHED handled on:" << scan_enable_change_event->radio_mac.oct;
+
+        if (fsm_in_state(eState::IDLE)) {
+            TASK_LOG(DEBUG) << "current state:IDLE, resetting interval wait";
+            m_next_scan_timestamp_interval = std::chrono::steady_clock::now();
+        }
+        break;
+    }
     default: {
         break;
     }
@@ -235,9 +352,24 @@ void dynamic_channel_selection_task::handle_events_timeout(std::multiset<int> pe
                         << ", going to abort-scan state -> handle_nl_dead_node";
 
         switch (m_fsm_state) {
-        case eState::WAIT_FOR_SCAN_TRIGGERED:
-        case eState::WAIT_FOR_RESULTS_READY:
-        case eState::WAIT_FOR_RESULTS_DUMP:
+        case eState::WAIT_FOR_SCAN_TRIGGERED: {
+            m_last_scan_error_code =
+                beerocks::eChannelScanErrCode::CHANNEL_SCAN_TRIGGERED_EVENT_TIMEOUT;
+            fsm_move_state(eState::ABORT_SCAN);
+            break;
+        }
+        case eState::WAIT_FOR_RESULTS_READY: {
+            m_last_scan_error_code =
+                beerocks::eChannelScanErrCode::CHANNEL_SCAN_RESULTS_READY_EVENT_TIMEOUT;
+            fsm_move_state(eState::ABORT_SCAN);
+            break;
+        }
+        case eState::WAIT_FOR_RESULTS_DUMP: {
+            m_last_scan_error_code =
+                beerocks::eChannelScanErrCode::CHANNEL_SCAN_RESULTS_DUMP_EVENT_TIMEOUT;
+            fsm_move_state(eState::ABORT_SCAN);
+            break;
+        }
         case eState::SCAN_DONE:
         case eState::IDLE:
         case eState::ABORT_SCAN: {

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2019-2020 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _DYNAMIC_CHANNEL_SELECTION_TASK_H_
+#define _DYNAMIC_CHANNEL_SELECTION_TASK_H_
+
+#include "../db/db.h"
+#include "task.h"
+#include "task_pool.h"
+
+#include <beerocks/tlvf/beerocks_message.h>
+
+#include <chrono>
+
+// Helper MACROs for Enum/String generation
+#define GENERATE_ENUM(ENUM) ENUM,
+#define GENERATE_STRING(STRING) #STRING,
+
+namespace son {
+
+class dynamic_channel_selection_task : public task, public std::enable_shared_from_this<task> {
+public:
+    dynamic_channel_selection_task(db &database, ieee1905_1::CmduMessageTx &cmdu_tx_,
+                                   task_pool &tasks_, sMacAddr radio_mac_);
+    virtual ~dynamic_channel_selection_task() {}
+
+    struct sScanEvent {
+        sMacAddr radio_mac;
+        union {
+            beerocks_message::sChannelScanResults scan_results;
+        } udata;
+    };
+
+#define FOREACH_DCS_EVENT(EVENT)                                                                   \
+    EVENT(INVALID_EVENT)                                                                           \
+    EVENT(TRIGGER_SINGLE_SCAN)                                                                     \
+    EVENT(SCAN_TRIGGERED)                                                                          \
+    EVENT(SCAN_RESULTS_READY)                                                                      \
+    EVENT(SCAN_RESULTS_DUMP)                                                                       \
+    EVENT(SCAN_FINISHED)                                                                           \
+    EVENT(SCAN_ABORTED)                                                                            \
+    EVENT(SCAN_ENABLE_CHANGE)
+
+    // Event ENUM
+    enum class eEvent { FOREACH_DCS_EVENT(GENERATE_ENUM) };
+
+#define FOREACH_DCS_STATE(STATE)                                                                   \
+    STATE(INIT)                                                                                    \
+    STATE(IDLE)                                                                                    \
+    STATE(TRIGGER_SCAN)                                                                            \
+    STATE(WAIT_FOR_SCAN_TRIGGERED)                                                                 \
+    STATE(WAIT_FOR_RESULTS_READY)                                                                  \
+    STATE(WAIT_FOR_RESULTS_DUMP)                                                                   \
+    STATE(SCAN_DONE)                                                                               \
+    STATE(ABORT_SCAN)
+
+    // State ENUM
+    enum class eState { FOREACH_DCS_STATE(GENERATE_ENUM) };
+
+protected:
+    virtual void work() override;
+    virtual void handle_event(int event_type, void *obj) override;
+    virtual void handle_events_timeout(std::multiset<int> pending_events) override;
+
+private:
+    void dcs_wait_for_event(eEvent cs_event);
+
+    eState m_fsm_state;
+
+    db &database;
+    ieee1905_1::CmduMessageTx &cmdu_tx;
+    task_pool &tasks;
+    sMacAddr m_radio_mac;
+    std::chrono::steady_clock::time_point m_next_scan_timestamp_interval;
+    std::chrono::steady_clock::time_point m_last_scan_try_timestamp;
+
+    beerocks::eChannelScanErrCode m_last_scan_error_code =
+        beerocks::eChannelScanErrCode::CHANNEL_SCAN_INVALID_PARAMS;
+    eEvent m_dcs_waiting_for_event = eEvent::INVALID_EVENT;
+
+    bool m_is_single_scan_pending = false;
+    bool m_is_single_scan         = false;
+
+    void fsm_move_state(eState new_state) { (m_fsm_state = new_state); }
+    bool fsm_in_state(eState state) { return (m_fsm_state == state); }
+};
+} //namespace son
+#endif

--- a/controller/src/beerocks/master/tasks/task.cpp
+++ b/controller/src/beerocks/master/tasks/task.cpp
@@ -89,6 +89,7 @@ void task::wait_for_task_end(int task_id, int ms)
     waiting                  = true;
     pending_task_id          = task_id;
 }
+void task::clear_pending_events() { pending_events.clear(); }
 
 void task::finish()
 {

--- a/controller/src/beerocks/master/tasks/task.h
+++ b/controller/src/beerocks/master/tasks/task.h
@@ -51,6 +51,7 @@ protected:
     void set_events_timeout(int ms);
     void wait_for_event(int event);
     void wait_for_task_end(int id, int ms);
+    void clear_pending_events();
     void finish();
 
     virtual void work() = 0;


### PR DESCRIPTION
> The Dynamic Channel Selection as a feature can provide information on the supported channels which can be utilized by the management system to provide better availability and user experience.
#562

The Dynamic Channel Selection feature is divided into several pull request, this is the third out of 5
start review from 676ac83
### Dynamic Channel Selection Task:
Changes in this PR include the following:
- controller: task: add clear pending events
- controller: dymanic channel selection task intro
- controller: DCS task: FSM
- controller: DCS task: events
- controller: DCS task: node & DB