### PR TITLE
[KW]: Resolve nullptr issue

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1463,6 +1463,12 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         auto register_response =
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_REGISTER_RESPONSE>(
                 cmdu_tx);
+
+        if (register_response == nullptr) {
+            LOG(ERROR) << "Failed building message!";
+            return false;
+        }
+
         message_com::send_cmdu(soc->slave, cmdu_tx);
         break;
     }
@@ -1895,6 +1901,11 @@ bool backhaul_manager::send_slaves_enable()
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_ENABLE_APS_REQUEST>(
                 cmdu_tx);
 
+        if (notification == nullptr) {
+            LOG(ERROR) << "Failed building message!";
+            return false;
+        }
+
         if (soc->sta_iface == m_sConfig.wireless_iface) {
             notification->channel() = iface_hal->get_channel();
         }
@@ -2100,6 +2111,10 @@ bool backhaul_manager::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t eve
             auto response = message_com::create_vs_message<
                 beerocks_message::cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE>(cmdu_tx);
 
+            if (response == nullptr) {
+                LOG(ERROR) << "Failed building message!";
+                break;
+            }
             std::copy_n(msg->params.result.mac.oct, sizeof(msg->params.result.mac.oct),
                         response->params().result.mac.oct);
             response->params().result.channel    = msg->params.result.channel;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3933,6 +3933,12 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
     // Notify backhaul manager that onboarding has finished (certification flow)
     auto onboarding_finished_notification = message_com::create_vs_message<
         beerocks_message::cACTION_BACKHAUL_ONBOARDING_FINISHED_NOTIFICATION>(cmdu_tx);
+
+    if (onboarding_finished_notification == nullptr) {
+        LOG(ERROR) << "Failed building message!";
+        return false;
+    }
+
     message_com::send_cmdu(backhaul_manager_socket, cmdu_tx);
 
     if (slave_state != STATE_WAIT_FOR_JOINED_RESPONSE) {

--- a/controller/src/beerocks/master/db/network_map.cpp
+++ b/controller/src/beerocks/master/db/network_map.cpp
@@ -109,6 +109,12 @@ void network_map::send_bml_network_map_message(db &database, Socket *sd,
                 response =
                     message_com::create_vs_message<beerocks_message::cACTION_BML_NW_MAP_RESPONSE>(
                         cmdu_tx, id);
+
+                if (response == nullptr) {
+                    LOG(ERROR) << "Failed building message!";
+                    return;
+                }
+
                 beerocks_header                      = message_com::get_beerocks_header(cmdu_tx);
                 beerocks_header->actionhdr()->last() = 0;
                 num_of_nodes = response->node_num(); // prepare for next message
@@ -372,6 +378,11 @@ void network_map::send_bml_nodes_statistics_message_to_listeners(
             // prepare for next message
             response =
                 message_com::create_vs_message<beerocks_message::cACTION_BML_STATS_UPDATE>(cmdu_tx);
+
+            if (response == nullptr) {
+                LOG(ERROR) << "Failed building message!";
+                return -1;
+            }
 
             beerocks_header                      = message_com::get_beerocks_header(cmdu_tx);
             beerocks_header->actionhdr()->last() = 0;


### PR DESCRIPTION
After running the klocwork script on RDKB with prplMesh, the following error was received :

" Pointer *** returned from call to function *** may be NULL and will be dereferenced at ... "

To solve this error, add a check to validate that the return value of `create_vs_message`
method is not nullptr.

Signed-off-by: CoralMalachi <coral.malachi@intel.com>