### PR TITLE
.gitlab-ci.yml: remove docker images after building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,8 @@ run-tests:
   script:
     - cd tools/docker/builder/openwrt
     - ./build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee build.log | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
+  after_script:
+    - docker rmi "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID"
   artifacts:
     paths:
       - tools/docker/builder/openwrt/*.ipk


### PR DESCRIPTION
Since we now use unique names for the docker images, we have to delete
the images we create or they will be kept around forever (they are not
and should not be overridden by the next builds).
