### PR TITLE
[KW] convert non value returning functions to void

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3641,12 +3641,9 @@ bool slave_thread::autoconfig_wsc_calculate_keys(WSC::m2 &m2, uint8_t authkey[32
         return false;
     }
     auto mac = network_utils::mac_from_string(backhaul_params.bridge_mac);
-    if (!mapf::encryption::wps_calculate_keys(*dh, m2.public_key(),
-                                              WSC::eWscLengths::WSC_PUBLIC_KEY_LENGTH, dh->nonce(),
-                                              mac.oct, m2.registrar_nonce(), authkey, keywrapkey)) {
-        LOG(ERROR) << "Failed to calculate WPS keys";
-        return false;
-    }
+    mapf::encryption::wps_calculate_keys(*dh, m2.public_key(),
+                                         WSC::eWscLengths::WSC_PUBLIC_KEY_LENGTH, dh->nonce(),
+                                         mac.oct, m2.registrar_nonce(), authkey, keywrapkey);
 
     return true;
 }

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -506,7 +506,7 @@ bool master_thread::autoconfig_wsc_add_m2_encrypted_settings(WSC::config &m2_cfg
  * @return true on success
  * @return false on failure
  */
-bool master_thread::autoconfig_wsc_calculate_keys(WSC::m1 &m1, WSC::config &m2,
+void master_thread::autoconfig_wsc_calculate_keys(WSC::m1 &m1, WSC::config &m2,
                                                   const mapf::encryption::diffie_hellman &dh,
                                                   uint8_t authkey[32], uint8_t keywrapkey[16])
 {
@@ -516,8 +516,6 @@ bool master_thread::autoconfig_wsc_calculate_keys(WSC::m1 &m1, WSC::config &m2,
         dh, m1.public_key(), WSC::eWscLengths::WSC_PUBLIC_KEY_LENGTH, m1.enrollee_nonce(),
         m1.mac_addr().oct, m2.registrar_nonce, authkey, keywrapkey);
     std::copy(dh.pubkey(), dh.pubkey() + dh.pubkey_length(), m2.pub_key);
-
-    return true;
 }
 
 /**
@@ -623,8 +621,7 @@ bool master_thread::autoconfig_wsc_add_m2(WSC::m1 &m1,
     mapf::encryption::diffie_hellman dh;
     uint8_t authkey[32];
     uint8_t keywrapkey[16];
-    if (!autoconfig_wsc_calculate_keys(m1, m2_cfg, dh, authkey, keywrapkey))
-        return false;
+    autoconfig_wsc_calculate_keys(m1, m2_cfg, dh, authkey, keywrapkey);
 
     // Encrypted settings
     // Encrypted settings are the ConfigData + IV. First create the ConfigData,

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -512,12 +512,9 @@ bool master_thread::autoconfig_wsc_calculate_keys(WSC::m1 &m1, WSC::config &m2,
 {
     std::copy_n(m1.enrollee_nonce(), WSC::eWscLengths::WSC_NONCE_LENGTH, m2.enrollee_nonce);
     std::copy_n(dh.nonce(), dh.nonce_length(), m2.registrar_nonce);
-    if (!mapf::encryption::wps_calculate_keys(
-            dh, m1.public_key(), WSC::eWscLengths::WSC_PUBLIC_KEY_LENGTH, m1.enrollee_nonce(),
-            m1.mac_addr().oct, m2.registrar_nonce, authkey, keywrapkey)) {
-        LOG(ERROR) << "Failed to calculate WPS keys";
-        return false;
-    }
+    mapf::encryption::wps_calculate_keys(
+        dh, m1.public_key(), WSC::eWscLengths::WSC_PUBLIC_KEY_LENGTH, m1.enrollee_nonce(),
+        m1.mac_addr().oct, m2.registrar_nonce, authkey, keywrapkey);
     std::copy(dh.pubkey(), dh.pubkey() + dh.pubkey_length(), m2.pub_key);
 
     return true;

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -103,7 +103,7 @@ private:
                                                   WSC::cConfigData &config_data,
                                                   uint8_t authkey[32], uint8_t keywrapkey[16]);
     bool autoconfig_wsc_authentication(WSC::m1 &m1, WSC::m2 &m2, uint8_t authkey[32]);
-    bool autoconfig_wsc_calculate_keys(WSC::m1 &m1, WSC::config &m2_cfg,
+    void autoconfig_wsc_calculate_keys(WSC::m1 &m1, WSC::config &m2_cfg,
                                        const mapf::encryption::diffie_hellman &dh,
                                        uint8_t authkey[32], uint8_t keywrapkey[16]);
 

--- a/framework/common/encryption.cpp
+++ b/framework/common/encryption.cpp
@@ -330,7 +330,7 @@ bool aes_decrypt(const uint8_t *key, const uint8_t *iv, uint8_t *ciphertext, int
     return true;
 }
 
-bool wps_calculate_keys(const diffie_hellman &dh, const uint8_t *remote_pubkey,
+void wps_calculate_keys(const diffie_hellman &dh, const uint8_t *remote_pubkey,
                         unsigned remote_pubkey_length, const uint8_t *m1_nonce, const uint8_t *mac,
                         const uint8_t *m2_nonce, uint8_t *authkey, uint8_t *keywrapkey)
 {
@@ -396,7 +396,6 @@ bool wps_calculate_keys(const diffie_hellman &dh, const uint8_t *remote_pubkey,
     std::copy(keys.keys.authkey, keys.keys.authkey + sizeof(keys.keys.authkey), authkey);
     std::copy(keys.keys.keywrapkey, keys.keys.keywrapkey + sizeof(keys.keys.keywrapkey),
               keywrapkey);
-    return true;
 }
 
 bool kwa_compute(const uint8_t *authkey, uint8_t *data, uint32_t data_len, uint8_t *kwa)

--- a/framework/common/include/mapf/common/encryption.h
+++ b/framework/common/include/mapf/common/encryption.h
@@ -178,7 +178,7 @@ bool aes_decrypt(const uint8_t *key, const uint8_t *iv, uint8_t *ciphertext, int
  * @param[out] keywrapkey calculated 128 bit keywrapkey
  * @return true on success, false on error
  */
-bool wps_calculate_keys(const diffie_hellman &dh, const uint8_t *remote_pubkey,
+void wps_calculate_keys(const diffie_hellman &dh, const uint8_t *remote_pubkey,
                         unsigned remote_pubkey_length, const uint8_t *m1_nonce, const uint8_t *mac,
                         const uint8_t *m2_nonce, uint8_t *authkey, uint8_t *keywrapkey);
 

--- a/framework/common/test/encryption_test.cpp
+++ b/framework/common/test/encryption_test.cpp
@@ -46,16 +46,13 @@ int main()
     uint8_t mac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     uint8_t authkey1[32];
     uint8_t keywrapkey1[16];
-    check(errors,
-          wps_calculate_keys(m1, m2.pubkey(), m2.pubkey_length(), m1.nonce(), mac, m2.nonce(),
-                             authkey1, keywrapkey1),
-          "WPS calculate keys");
+    wps_calculate_keys(m1, m2.pubkey(), m2.pubkey_length(), m1.nonce(), mac, m2.nonce(), authkey1,
+                       keywrapkey1);
     uint8_t authkey2[32];
     uint8_t keywrapkey2[16];
-    check(errors,
-          wps_calculate_keys(m2, m1.pubkey(), m1.pubkey_length(), m1.nonce(), mac, m2.nonce(),
-                             authkey2, keywrapkey2),
-          "WPS calculate keys");
+
+    wps_calculate_keys(m2, m1.pubkey(), m1.pubkey_length(), m1.nonce(), mac, m2.nonce(), authkey2,
+                       keywrapkey2);
     check(errors, std::equal(authkey1, authkey1 + sizeof(authkey1), authkey2),
           "authkeys should be equal");
     check(errors, std::equal(keywrapkey1, keywrapkey1 + sizeof(keywrapkey1), keywrapkey2),


### PR DESCRIPTION
After running the klocwork script on RDKB with prplMesh, the following
error was received :

" Code is unreachable "

The reason for this is that the `wps_calculate_keys` method always
returns true, so the check that validates the success of this function
 is completely unnecessary.

Therefore, change `wps_calculate_keys` method to be a void method, and
update all the calls to this method accordingly.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>