### PR TITLE
test_flows.sh: don't dump logs on failure

### DIFF
--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -641,19 +641,6 @@ main() {
 
     if [ $error -gt 0 ]; then
         err "$error / $count tests failed"
-        if [ "$VERBOSE" = "true" ]; then
-            for dockerimage in gateway repeater1 repeater2; do
-                info "*** Dumping logs from $dockerimage ***"
-                docker exec $dockerimage sh -c '
-                    for logfile in controller agent agent_wlan0 agent_wlan2; do
-                        logpath=/tmp/$USER/beerocks/logs/beerocks_$logfile.log
-                        [ -e $logpath ] && {
-                            printf "\n\n==> %s <==\n" $logfile
-                            cat $logpath
-                        }
-                    done'
-            done
-        fi
     else
         success "$count / $count tests passed"
     fi


### PR DESCRIPTION
Previously, when there is an error, in verbose mode, we would dump all
the log files. This was because Travis has no way to store log files as
artifacts, so it was the only way to get any useful output from CI.

We now switched to gitlab CI, so this hack is no longer needed.

Remove dumping of log files in verbose mode.