### PR TITLE
controller: client_steering_task: wait for disconnect and connect

### DIFF
--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -50,6 +50,7 @@ void client_steering_task::work()
             finish();
         }
         wait_for_event(STA_DISCONNECTED);
+        wait_for_event(STA_CONNECTED);
         set_events_timeout(steering_wait_time_ms);
         break;
     }

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -412,12 +412,14 @@ test_client_steering_dummy() {
 
     dbg "Disconnect dummy STA from wlan0"
     send_bwl_event repeater1 wlan0 "EVENT AP-STA-DISCONNECTED ${sta_mac}"
-    #TODO// check for "disconnected after successful steering, proceeding to unblock" message 
+    # Make sure that controller sees disconnect before connect by waiting a little
+    sleep 1
 
     dbg "Connect dummy STA to wlan2"
     send_bwl_event repeater1 wlan2 "EVENT AP-STA-CONNECTED ${sta_mac}"
     dbg "Confirm steering success by client connected"
     check_log gateway controller "steering successful for sta ${sta_mac}"
+    check_log gateway controller "sta ${sta_mac} disconnected after successful steering"
     return $check_error
 }
 


### PR DESCRIPTION
The steering task is considered successful when the connected event for
the STA is received. However, we were not waiting for that event, so if
the disconnected event arrives before the connected event, we would
first jump to the FINALIZE state and report that steering has failed.

Add STA_CONNECTED to the events that we're waiting for.

Add test to make sure this works.

Fixes #664