### PR TITLE
tools: tests-runner: add tcpdump

### DIFF
--- a/tools/docker/tests/tests-runner/Dockerfile
+++ b/tools/docker/tests/tests-runner/Dockerfile
@@ -3,7 +3,8 @@ FROM docker:18.09.7-dind
 RUN apk add --update --no-cache \
     python3 \
     grep \
-    coreutils
+    coreutils \
+    tcpdump
 
 COPY entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
We would like to add support for saving pcap files when running the
tests, so add tcpdump to the tests-runner image.
