### PR TITLE
Docs: add Black Duck binary analysis report on prplMesh

### DIFF
--- a/documentation/Black Duck/report-bdba-prplmesh-5fc6ccd-2020-01-12.pdf
+++ b/documentation/Black Duck/report-bdba-prplmesh-5fc6ccd-2020-01-12.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Times-Roman /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20200112114600+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20200112114600+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1876
+>>
+stream
+Gb"/)>BcPr&:XAWQq))@M5n0UhpQ>L:"QYVNSC&2HhN#@*7GaD!B3`&r<d"DHm=<afet3$[]tqVqdr<m)3>/4H][7C$NXQEiT2-a#_h4C#Y,kh4ZFL+^=\(^q_Cm.</Q8S!\#=I*GI1eic9(mYqej!ed;ZjOh-WFF*WunV7>OYo$E0[HS^YF$nb7b&iVU1:e^B[-3o26$$jMO.uaN-%>LK`p]:q+#?tqmfjdV!E[HZ@Q:'Jl<d-M5;FjJBRq,pQ>aQkC5P$Xd8)QkpcE]EOZbWnSgrW9ZGDU\Qh&GkC.!("H9Tm=c$?6,e(o1jW7k%UqT2VkTV0Ga9$%[mWSN=o66(&FWC#PNK1mq*69fbHL,>WWWO1kkJ28j?V>U&FZ!j?/?7M4#ef1Y]C+V>m-E'dQs634_UH82lEUE.:`f#.T4CP\hXGU_hS)r#gY^V$nVc^fRb[;Gm]#$o:%hR\9BV#`$BW"?34Bq\)#E0Ur:nqfCq@>'nHTEW3V@1'k_)mSPC=Kori7ea4-lS*2%(oPP8]Gucp6Te#:ls$&\3`r4>Q%>dA9n8,Ff.Y9lPTSX:a"*T7M1j<)7Irqe+Ue\$AE@?sHeID$7"-IRV&.=1XU$=Z.\+\j;F#N5ftD4,`n:o,!cLt>\'^P]$nigS6*`QK2HmSD3Hl#L\\qCQ%Jjsl!(V[jZU+W$5<N;0mO]*\N"RDE36/`T:l[B1JjK`2C)b0[<>m6(rZJ5f*6HJ_0'mV?CN1&Ddl9*[QEI4VUI[dN<%L'\GRk.s[K(F>c@pGPH>)G;4([uMif!j]>[U(bnk24+*H&/;aggCe?a]6M@c2ea=md.hKdkE^81NGVZUpa80.(:LSuL`:`A9"OiAEb0AV;K:Lca8O=g6ceFa,,i#`;$4S+kkGJIusZ'jcQ=$s-;R*Pp@<5CuIg"_N8C;FTK$;c_CP&!us(Lc?:f/'uV,rHD&-kNr5=r?")tgLSOYQL+WaJ+0EJ+$]Do^M`oJpdg=sEt-Kr#'_(lNh:([f5niN/ZH%bE;<ClRlTEsZN$ooK3@spF1l^IUU<geJE5Jh,kh=Rj8sW(."^g)"d1)R\J:^Bm`!e)Z[W^'0D8c#jK;[EBn\Ole)=)%CHXmrH*4OrXk",1Xi7`u>.p,pj8SlEY?P]5!ma9kF+s:n<EMc]oO_Q%fi,#YIYh\gB-o'NB"m^%;:khQC&L<%qhUNgS$Ut8/@DP]n9cs"Ot1?5"j?oa3C%)MV'LFA%T(m-f7`&$5nZtW^gq>'ZSt*J!VbT/'odC%]K<Pe\KWq;i8$JbS1ctZ\W*,#(_o-=4m;l_bo0:(]=24:KC)(<h=b,+X(sUb,uABL`THM>B!c)LOjb<r_.=1g',Uld'=jgiacUObCZP1spY)(%q:;gZRCMtB"P\LQh]<F"`l>V_f5@7jC=F:q?3oY>gA%+7i]%aG.p_%D7Ok)Pbq;Ib)GDb9C:(oDkVPh_mgZq\!er\U&TISm6hmh+X)4+Kg!9Atfme#?Ic5>\NT,e7YO7Dm6;!(2KF_cOR1DNQ_j.c(?T!Y,2Y)&n\X"or/I875@;)qln/Cn9"&m70kZ[Fn(O-q^CM*a\XeaRsD6kL8Gi*:)[Z0WWZ<Z3mi5o+HY&-Rj3j*>*a%>K$)XuS,D*kcB6EPN)Mcb4J53Tm3ErfEkAYMYkD?EhXgM%65K>UhMDU,d%6lfjh-KC03A-1d6c!jnq2IYDGV2hrs&L1q+RU4$khh5neq/q'fMZ>c+=o3sI0'(H.K@%kZM:I9*)lVK_f-3]@%Yn]m%lVHTao]o6JiIM0\KBJfpD8%"GQb2<-RMQW)>bQomjbLp6UEcn[`"XO<_ag[hPW!pgWE$d$mQ!],8,]LnS#PEe'-E`o!4],T^s7b)HT]~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000330 00000 n 
+0000000533 00000 n 
+0000000601 00000 n 
+0000000884 00000 n 
+0000000943 00000 n 
+trailer
+<<
+/ID 
+[<af667cb687da2773dd7ddc5eebbc5c77><af667cb687da2773dd7ddc5eebbc5c77>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2910
+%%EOF


### PR DESCRIPTION
Add a report generated by a [Black Duck](https://www.synopsys.com/content/dam/synopsys/sig-assets/datasheets/blackduck-binaryanalysis-ds-ul.pdf) binary analysis scan ran on the linux build of latest version of prplMesh as of Jan 12th, 2020 - 5fc6ccdd843b359dee676dd0263618359e2588c9.
The report shows no vulnerabilities or intellectual property violations.

You can compare the checksum by building 5fc6ccdd843b359dee676dd0263618359e2588c9 and zipping the files in `prplMesh/build/out/bin` into a `.zip`.