### PR TITLE
Bugfix: last Klocwork warnings in common

### DIFF
--- a/common/beerocks/bcl/include/bcl/network/socket.h
+++ b/common/beerocks/bcl/include/bcl/network/socket.h
@@ -64,11 +64,7 @@ public:
     void closeSocket();
     bool isOpen();
     SOCKET getSocketFd() { return m_socket; }
-    std::string getError()
-    {
-        return m_error;
-        m_error.clear();
-    }
+    std::string getError() { return m_error; }
     std::string getPeerIP() { return m_peer_ip; }
     int getPeerPort() { return m_peer_port; }
     std::string getUdsPath() { return m_uds_path; }

--- a/framework/common/encryption.cpp
+++ b/framework/common/encryption.cpp
@@ -90,7 +90,7 @@ diffie_hellman::diffie_hellman() : m_dh(nullptr), m_pubkey(nullptr)
 
 diffie_hellman::~diffie_hellman()
 {
-    delete m_pubkey;
+    delete[] m_pubkey;
     DH_free(m_dh);
 }
 

--- a/framework/common/include/mapf/common/encryption.h
+++ b/framework/common/include/mapf/common/encryption.h
@@ -83,6 +83,8 @@ private:
     uint8_t *m_pubkey        = nullptr;
     unsigned m_pubkey_length = 0;
     uint8_t m_nonce[16];
+
+    diffie_hellman(const diffie_hellman &) = delete;
 };
 
 /**


### PR DESCRIPTION
Fix some warnings and borderline errors found by Klocwork.
The rest of the warnings are false positives and should be updated to be ignored.