### PR TITLE
add deploy script to tools

### DIFF
--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -35,8 +35,10 @@ deploy() {
 # we don't want opkg to stay locked with a previous failed invocation.
 # when using this, make sure no one is using opkg in the meantime!
 pgrep opkg | xargs kill -SIGINT
-# remove any previously installed prplmesh:
-opkg remove prplmesh prplmesh-dwpal prplmesh-nl80211
+# remove any previously installed prplmesh. Use force-depends in case
+# there are packages depending on prplmesh which will cause opkg remove
+# to fail without this:
+opkg remove --force-depends prplmesh prplmesh-dwpal prplmesh-nl80211
 # currently opkg remove does not remove everything from /opt/prplmesh:
 rm -rf /opt/prplmesh
 opkg install -V2 "$DEST_FOLDER/$IPK_FILENAME"
@@ -77,6 +79,6 @@ main() {
     deploy "$@"
 }
 
-SSH_OPTIONS="\"-oBatchMode yes\""
+SSH_OPTIONS="\"-oBatchMode yes\" \"-oStrictHostKeyChecking no\""
 
 main "$@"

--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -1,16 +1,22 @@
 #!/bin/sh -e
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2019 Raphaël Mélotte
+# Copyright (c) 2020 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
 
 usage() {
-    echo "usage: $(basename "$0") [-h]"
+    echo "usage: $(basename "$0") <user>@<target> <ipk> [-h]"
     echo "  options:"
     echo "      -h|--help - show this help menu"
     echo "      --certification-mode - enable certification-mode on the target"
+    echo "      --proxy - use ssh proxy <user>@<proxy>"
 }
 
 deploy() {
-    SSH_OPTIONS="-oBatchMode=yes"
-
-    if ! ssh "$SSH_OPTIONS" "$1" /bin/true ; then
+    if ! eval ssh "$SSH_OPTIONS" "$1" /bin/true ; then
         echo "Error: $1 unreachable via ssh"
         exit 1
     fi
@@ -21,11 +27,11 @@ deploy() {
     DEST_FOLDER=/tmp/prplmesh_ipks
 
     echo "Removing previous ipks"
-    ssh "$TARGET" "rm -rf \"$DEST_FOLDER\" ; mkdir -p \"$DEST_FOLDER\""
+    eval ssh "$SSH_OPTIONS" "$TARGET" \""rm -rf \"$DEST_FOLDER\" ; mkdir -p \"$DEST_FOLDER\"\""
     echo "Copying $IPK to $TARGET:$DEST_FOLDER/$IPK_FILENAME"
-    scp "$IPK" "$TARGET:$DEST_FOLDER/$IPK_FILENAME"
+    eval scp "$SSH_OPTIONS" "$IPK" "$TARGET:$DEST_FOLDER/$IPK_FILENAME"
 
-    ssh "$TARGET" <<EOF
+    eval ssh "$SSH_OPTIONS" "$TARGET" <<EOF
 # we don't want opkg to stay locked with a previous failed invocation.
 # when using this, make sure no one is using opkg in the meantime!
 pgrep opkg | xargs kill -SIGINT
@@ -38,16 +44,18 @@ EOF
 
     if [ "$CERTIFICATION_MODE" = true ] ; then
         echo "Certification mode will be enabled on the target"
-        ssh "$TARGET" "uci set prplmesh.config.certification_mode=1 && uci commit"
+        eval ssh "$SSH_OPTIONS" "$TARGET" "uci set prplmesh.config.certification_mode=1 && uci commit"
         echo "Certification mode enabled on the target."
     fi
     echo "Done"
 }
 
 main() {
-        OPTS=$(getopt -o 'h' --long help,certification-mode -n 'parse-options' -- "$@")
-
-    if [ "$?" != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
+    if ! OPTS=$(getopt -o 'h' --long help,certification-mode,proxy: -n 'parse-options' -- "$@"); then
+        err "Failed parsing options." >&2
+        usage
+        exit 1
+    fi
 
     eval set -- "$OPTS"
 
@@ -57,6 +65,10 @@ main() {
                 CERTIFICATION_MODE=true
                 shift
                 ;;
+            --proxy)
+                SSH_OPTIONS="$SSH_OPTIONS \"-oProxyJump \"$2\"\""
+                shift 2
+                ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
@@ -64,5 +76,7 @@ main() {
 
     deploy "$@"
 }
+
+SSH_OPTIONS="\"-oBatchMode yes\""
 
 main "$@"

--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -54,7 +54,7 @@ EOF
 
 main() {
     if ! OPTS=$(getopt -o 'h' --long help,certification-mode,proxy: -n 'parse-options' -- "$@"); then
-        err "Failed parsing options." >&2
+        echo "Failed parsing options." >&2
         usage
         exit 1
     fi

--- a/tools/scripts/deploy.sh
+++ b/tools/scripts/deploy.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2020 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+scriptdir="$(cd "${0%/*}" && pwd)"
+rootdir="${scriptdir%/*/*}"
+
+dbg() {
+    [ "$VERBOSE" = "true" ] && echo "$@"
+}
+
+err() {
+    printf "\033[1;31m%s\n\033[0m" "$@"
+}
+
+success() {
+    printf "\033[1;32m%s\n\033[0m" "$@"
+}
+
+run() {
+    dbg "$*"
+    "$@" || exit $?
+}
+
+
+usage() {
+    echo "usage: $(basename "$0") [-hvdb] [--target <user@target>] [--proxy <user@proxy>]"
+}
+
+main() {
+
+    if ! OPTS=$(getopt -o 'hvdb:' --long help,verbose,deploy,build-dir:,target:,proxy: -n 'parse-options' -- "$@"); then
+        err "Failed parsing options." >&2
+        usage
+        exit 1 
+    fi
+
+    eval set -- "$OPTS"
+
+    while true; do
+        case "$1" in
+            -v | --verbose)       VERBOSE=true; shift ;;
+            -h | --help)          usage; exit 0 ;;
+            -d | --deploy)        DEPLOY=true; shift ;;
+            -b | --build-dir)     BUILD_DIR="$2"; shift; shift ;;
+            --proxy)              SSH_OPTIONS="$SSH_OPTIONS \"-oProxyJump $2\""; shift 2 ;;
+            --target)             TARGET="$2"; shift 2 ;;
+            --keep-conf)          KEEP_CONF=true; shift ;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1 ;;
+        esac
+    done
+
+    echo "Start"
+    tmpdir=$(mktemp -d)
+    mkdir -p "${tmpdir}"/opt/prplmesh
+    mkdir -p "${tmpdir}"/usr
+
+    cp -r "${BUILD_DIR}"/install/bin "${tmpdir}"/opt/prplmesh
+    cp -r "${BUILD_DIR}"/install/config "${tmpdir}"/opt/prplmesh
+    cp -r "${BUILD_DIR}"/install/lib "${tmpdir}"/usr/
+    cp -r "${BUILD_DIR}"/install/scripts "${tmpdir}"/opt/prplmesh
+    cp -r "${BUILD_DIR}"/install/share "${tmpdir}"/opt/prplmesh
+
+    dbg "create prplmesh.tar.gz..."
+    tar czvf "${BUILD_DIR}"/prplmesh.tar.gz -C "${tmpdir}"/ .
+    rm -rf "${tmpdir}"
+
+    [ "$DEPLOY" = "true" ] && {
+
+        echo "local md5sum"
+        run md5sum "${BUILD_DIR}"/prplmesh.tar.gz
+
+        echo "scp ${BUILD_DIR}/prplmesh.tar.gz to ${TARGET}"
+        eval scp "${SSH_OPTIONS} ${BUILD_DIR}/prplmesh.tar.gz ${TARGET}:/tmp/"
+
+        if [ "$KEEP_CONF" = "true" ]; then
+            echo "backaup /opt/prplmesh/beerocks_agent.conf on target"
+            eval ssh "${SSH_OPTIONS} ${TARGET} cp /opt/prplmesh/config/beerocks_agent.conf /tmp/"
+        fi
+
+        echo "untar /tmp/prplmesh.tar.gz on target"
+        eval ssh "${SSH_OPTIONS} ${TARGET} tar -C / -xzvf /tmp/prplmesh.tar.gz"
+
+        if [ "$KEEP_CONF" = "true" ]; then
+            echo "restore /opt/prplmesh/beerocks_agent.conf on target"
+            eval ssh "${SSH_OPTIONS} ${TARGET} mv /tmp/beerocks_agent.conf /opt/prplmesh/config/"
+        fi
+    
+    }
+
+    success "Done! Run /etc/init.d/prplmesh.sh restart on target to apply new settings."
+}
+
+VERBOSE=false
+BUILD_DIR=${rootdir}/build
+DEPLOY=false
+KEEP_CONF=false
+TARGET=
+SSH_OPTIONS="\"-oBatchMode yes\" \"-oStrictHostKeyChecking no\""
+
+main "$@"


### PR DESCRIPTION
Add a deploy script to make the operation of updating the current prplMesh version that running on the RAX40 (or any other board) much 
easier.

currently, each change in the prplMesh source code needs to be updated on the board itself so we can test it. Therefore, add the following script, which accepts the details of the desired board you want to update 
the prplMesh version on.

currently, the way we do it is with a "proxy" between the local machine and the desired board. An option to do the same process without a proxy will be added soon.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>

