### PR TITLE
Feature/move sta ifaces from beerocks agent conf to platform db

### DIFF
--- a/agent/config/beerocks_agent.conf.in
+++ b/agent/config/beerocks_agent.conf.in
@@ -30,7 +30,6 @@ radio_identifier=00:00:00:00:00:00
 hostap_iface_type=WIFI_INTEL
 hostap_iface=@BEEROCKS_WLAN1_IFACE@
 hostap_ant_gain=0
-sta_iface=#wlan1  <-- 2.4G station has been disabled due to GEN4 instability 
 enable_repeater_mode=@BEEROCKS_REPEATER_MODE@
 
 [agent1]
@@ -38,14 +37,12 @@ radio_identifier=00:00:00:00:00:02
 hostap_iface_type=WIFI_INTEL
 hostap_iface=@BEEROCKS_WLAN2_IFACE@
 hostap_ant_gain=0
-sta_iface=#wlan3
 enable_repeater_mode=0
 
 #[agent2]
 #hostap_iface_type=WIFI_INTEL
 #hostap_iface=@BEEROCKS_WLAN3_IFACE@
 #hostap_ant_gain=0
-#sta_iface=wlan5
 #enable_repeater_mode=0
 #sta_iface_filter_low=1
 

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -297,14 +297,6 @@ static int run_beerocks_slave(beerocks::config_file::sConfigSlave &beerocks_slav
     std::string pid_file_path =
         beerocks_slave_conf.temp_path + "pid/" + base_slave_name; // for file touching
 
-    // Threads
-    std::set<std::string> slave_sta_ifaces;
-    for (int slave_num = 0; slave_num < beerocks::IRE_MAX_SLAVES; slave_num++) {
-        if (!beerocks_slave_conf.sta_iface[slave_num].empty()) {
-            slave_sta_ifaces.insert(beerocks_slave_conf.sta_iface[slave_num]);
-        }
-    }
-
     std::set<std::string> slave_ap_ifaces;
     for (int slave_num = 0; slave_num < beerocks::IRE_MAX_SLAVES; slave_num++) {
         if (!beerocks_slave_conf.hostap_iface[slave_num].empty()) {
@@ -318,6 +310,14 @@ static int run_beerocks_slave(beerocks::config_file::sConfigSlave &beerocks_slav
     if (platform_mgr.init()) {
         // read the number of failures allowed before stopping agent from platform configuration
         int stop_on_failure_attempts = beerocks::bpl::cfg_get_stop_on_failure_attempts();
+
+        // The platform manager updates the beerocks_slave_conf.sta_iface in the init stage
+        std::set<std::string> slave_sta_ifaces;
+        for (int slave_num = 0; slave_num < beerocks::IRE_MAX_SLAVES; slave_num++) {
+            if (!beerocks_slave_conf.sta_iface[slave_num].empty()) {
+                slave_sta_ifaces.insert(beerocks_slave_conf.sta_iface[slave_num]);
+            }
+        }
 
         beerocks::backhaul_manager backhaul_mgr(beerocks_slave_conf, slave_ap_ifaces,
                                                 slave_sta_ifaces, stop_on_failure_attempts);

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -125,6 +125,25 @@ static bool parse_arguments(int argc, char *argv[])
     return true;
 }
 
+static std::string get_sta_iface_from_hostap_iface(const std::string &hostap_iface)
+{
+    // read the sta_iface from bpl and verify it is available
+    char sta_iface_str[BPL_IFNAME_LEN];
+    std::string sta_iface;
+
+    if (beerocks::bpl::cfg_get_sta_iface(hostap_iface.c_str(), sta_iface_str) < 0) {
+        LOG(ERROR) << "failed to read sta_iface for slave ";
+        return std::string();
+    } else {
+        sta_iface = std::string(sta_iface_str);
+        if (!beerocks::net::network_utils::linux_iface_exists(sta_iface)) {
+            LOG(DEBUG) << "sta iface " << sta_iface << " does not exist, clearing it from config";
+            sta_iface.clear();
+        }
+    }
+    return sta_iface;
+}
+
 static void fill_son_slave_config(beerocks::config_file::sConfigSlave &beerocks_slave_conf,
                                   son::slave_thread::sSlaveConfig &son_slave_conf, int slave_num)
 {
@@ -149,8 +168,9 @@ static void fill_son_slave_config(beerocks::config_file::sConfigSlave &beerocks_
     son_slave_conf.hostap_iface = beerocks_slave_conf.hostap_iface[slave_num];
     son_slave_conf.hostap_ant_gain =
         beerocks::string_utils::stoi(beerocks_slave_conf.hostap_ant_gain[slave_num]);
-    son_slave_conf.radio_identifier        = beerocks_slave_conf.radio_identifier[slave_num];
-    son_slave_conf.backhaul_wireless_iface = beerocks_slave_conf.sta_iface[slave_num];
+    son_slave_conf.radio_identifier = beerocks_slave_conf.radio_identifier[slave_num];
+    son_slave_conf.backhaul_wireless_iface =
+        get_sta_iface_from_hostap_iface(son_slave_conf.hostap_iface);
     son_slave_conf.backhaul_wireless_iface_filter_low =
         beerocks::string_utils::stoi(beerocks_slave_conf.sta_iface_filter_low[slave_num]);
     son_slave_conf.backhaul_wireless_iface_type = son_slave_conf.hostap_iface_type;
@@ -482,14 +502,6 @@ int main(int argc, char *argv[])
                 LOG(DEBUG) << "hostap iface " << beerocks_slave_conf.hostap_iface[slave_num]
                            << " does not exist, clearing it from config";
                 beerocks_slave_conf.hostap_iface[slave_num].clear();
-            }
-        }
-        if (!beerocks_slave_conf.sta_iface[slave_num].empty()) {
-            if (!beerocks::net::network_utils::linux_iface_exists(
-                    beerocks_slave_conf.sta_iface[slave_num])) {
-                LOG(DEBUG) << "sta iface " << beerocks_slave_conf.sta_iface[slave_num]
-                           << " does not exist, clearing it from config";
-                beerocks_slave_conf.sta_iface[slave_num].clear();
             }
         }
     }

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -282,6 +282,21 @@ std::string extern_query_db(std::string parameter)
     return ret;
 }
 
+static std::string get_sta_iface(const std::string &hostap_iface)
+{
+    char sta_iface_str[BPL_IFNAME_LEN];
+    if (bpl::cfg_get_sta_iface(hostap_iface.c_str(), sta_iface_str) < 0) {
+        LOG(DEBUG) << "failed to read sta_iface for slave ";
+        return std::string();
+    }
+    auto sta_iface = std::string(sta_iface_str);
+    if (!network_utils::linux_iface_exists(sta_iface)) {
+        LOG(DEBUG) << "sta iface " << sta_iface << " does not exist, clearing it from config";
+        return std::string();
+    }
+    return sta_iface;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/common/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/common/beerocks/bcl/source/beerocks_config_file.cpp
@@ -197,7 +197,6 @@ bool config_file::read_slave_config_file(std::string config_file_path, sConfigSl
                             mandatory_slave),
             std::make_tuple("hostap_iface=", &conf.hostap_iface[slave_num], mandatory_slave),
             std::make_tuple("hostap_ant_gain=", &conf.hostap_ant_gain[slave_num], mandatory_slave),
-            std::make_tuple("sta_iface=", &conf.sta_iface[slave_num], 0),
             std::make_tuple("sta_iface_filter_low=", &conf.sta_iface_filter_low[slave_num], 0),
         };
         std::string config_type = "agent" + std::to_string(slave_num);

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -456,6 +456,17 @@ int cfg_notify_iface_status(const BPL_INTERFACE_STATUS_NOTIFICATION *status_noti
  */
 int cfg_get_administrator_credentials(char pass[BPL_USER_PASS_LEN]);
 
+/**
+ * Returns the STA interface for the specified radio id.
+ *
+ * @param [in] iface Interface name for the requested parameters.
+ * @param [out] sta_iface name of STA interface (up to 32 bytes in length).
+ *
+ * @return 0 Success.
+ * @return -1 Error, or no sta_iface is configured.
+ */
+int cfg_get_sta_iface(const char iface[BPL_IFNAME_LEN], char sta_iface[BPL_IFNAME_LEN]);
+
 } // namespace bpl
 } // namespace beerocks
 

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -220,5 +220,17 @@ int cfg_notify_iface_status(const BPL_INTERFACE_STATUS_NOTIFICATION *status_noti
 
 int cfg_get_administrator_credentials(char pass[BPL_PASS_LEN]) { return RETURN_ERR; }
 
+int cfg_get_sta_iface(const char iface[BPL_IFNAME_LEN], char sta_iface[BPL_IFNAME_LEN])
+{
+    if (iface == NULL || sta_iface == NULL) {
+        MAPF_ERR("cfg_get_sta_iface: invalid input: iface or sta_iface are NULL");
+        return RETURN_ERR;
+    }
+
+    // return empty STA interface name
+    sta_iface[0] = '\0';
+    return RETURN_OK;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -274,5 +274,21 @@ int cfg_notify_iface_status(const BPL_INTERFACE_STATUS_NOTIFICATION *status_noti
 
 int cfg_get_administrator_credentials(char pass[BPL_PASS_LEN]) { return 0; }
 
+int cfg_get_sta_iface(const char iface[BPL_IFNAME_LEN], char sta_iface[BPL_IFNAME_LEN])
+{
+    if (iface == NULL || sta_iface == NULL) {
+        MAPF_ERR("cfg_get_sta_iface: invalid input: iface or sta_iface are NULL");
+        return RETURN_ERR;
+    }
+
+    int index = -1;
+    if (cfg_get_index_from_interface(iface, &index) == RETURN_ERR) {
+        MAPF_ERR("cfg_get_sta_iface: Failed to get radio index from iface\n");
+        return RETURN_ERR;
+    }
+
+    return cfg_get_prplmesh_radio_param(index, "sta_iface", sta_iface, BPL_IFNAME_LEN);
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
@@ -49,6 +49,23 @@ int cfg_get_prplmesh_param(const std::string &param, char *buf, size_t buf_len)
     return cfg_uci_get(path, buf, buf_len);
 }
 
+int cfg_get_prplmesh_radio_param(int radio_id, const std::string &radio_param, char *buf,
+                                 size_t buf_len)
+{
+    char path[MAX_UCI_BUF_LEN] = {0};
+
+    if (buf_len > MAX_UCI_BUF_LEN) {
+        buf_len = MAX_UCI_BUF_LEN;
+    }
+
+    if (snprintf_s(path, MAX_UCI_BUF_LEN, "prplmesh.radio%d.%s", radio_id, radio_param.c_str()) <=
+        0) {
+        return RETURN_ERR;
+    }
+
+    return cfg_uci_get(path, buf, buf_len);
+}
+
 int cfg_get_prplmesh_param_int(const std::string &param, int *buf)
 {
     int status;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.h
@@ -38,6 +38,19 @@ int cfg_get_index_from_interface(const std::string &inputIfName, int *nIndex);
 int cfg_get_prplmesh_param(const std::string &param, char *buf, size_t buf_len);
 
 /**
+ * Returns the value of requested param from DB for the specified radio
+ *
+ * @param [in] radio_id prplmesh radio id
+ * @param [in] param prplmesh param key string
+ * @param [out] buf buffer to get value of requested param
+ * @param [in]  buf_len buffer length.
+ *
+ * @return 0 on success or -1 on error.
+ **/
+int cfg_get_prplmesh_radio_param(int radio_id, const std::string &radio_param, char *buf,
+                                 size_t buf_len);
+
+/**
  * Returns the value of requested integer type param from DB
  *
  * @param [in] param prplmesh param key string


### PR DESCRIPTION
The following changes are contained in this PR:
- add generic BPL API to read prplmesh radio param from UCI
- add BPL APIs to read sta_iface from BPL (the UGW utilizes the API above)
- change sta_iface reads from beerocks_agent.conf to read using BPL
- platform_mgr is now responsible to read the sta_ifaces and update the config struct
- configurations that depend on sta_iface have moved to a later stage (after BPL is initialized and sta_ifaces are read from BPL)
- sta_iface was removed from beerocks_agent.conf and the sta_iface was removed from the config_file::read_slave_config_file().