### PR TITLE
Hotfix/findnl libs

### DIFF
--- a/cmake/Findnl-3.cmake
+++ b/cmake/Findnl-3.cmake
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Copyright (c) 2020 Tomer Eliyahu (Intel Corporation)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(NL3_LIBRARY "libnl-3.so")
+find_path(NL3_INCLUDE_DIRS netlink/netlink.h PATH_SUFFIXES libnl3)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(nl-3 DEFAULT_MSG
+    NL3_LIBRARY
+    NL3_INCLUDE_DIRS
+)
+
+if (nl-3_FOUND)
+    add_library(nl-3 UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(nl-3 PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${NL3_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(nl-3 PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${NL3_LIBRARY}"
+    )
+
+endif()

--- a/cmake/Findnl-genl-3.cmake
+++ b/cmake/Findnl-genl-3.cmake
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# Copyright (c) 2020 Tomer Eliyahu (Intel Corporation)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(NL3_GENL_LIBRARY "libnl-genl-3.so")
+find_path(NL3_INCLUDE_DIRS netlink/genl/genl.h PATH_SUFFIXES libnl3)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(nl-genl-3 DEFAULT_MSG
+    NL3_GENL_LIBRARY
+    NL3_INCLUDE_DIRS
+)
+
+if (nl-genl-3_FOUND)
+    add_library(nl-genl-3 UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(nl-genl-3 PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${NL3_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(nl-genl-3 PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${NL3_GENL_LIBRARY}"
+    )
+
+endif()

--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -45,7 +45,6 @@ if(BWL_TYPE STREQUAL "DWPAL")
     include_directories(
         ${HOSTAPD_DIR}/src/drivers
         ${PLATFORM_BUILD_DIR}/iwlwav-iw-4.14
-        ${PLATFORM_INCLUDE_DIR}/libnl3
     )
 
     file(GLOB bwl_platform_sources
@@ -54,6 +53,8 @@ if(BWL_TYPE STREQUAL "DWPAL")
     )
 
     find_package(dwpal REQUIRED)
+    find_package(nl-3 REQUIRED)
+    find_package(nl-genl-3 REQUIRED)
     list(APPEND BWL_LIBS dwpal nl-3 nl-genl-3)
 
     # safec library can come from either libsafec or slibc


### PR DESCRIPTION
In UGW, simply adding nl libraries to the list of libraries doesn't
work since the libraries are not in standard locations.
Therefore use find_package which creates an exported target and use that.

