### PR TITLE
Bugfix/get actual ssid2

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1694,6 +1694,8 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
 
             m_agent_ucc_listener->update_vaps_list(network_utils::mac_to_string(msg->ruid()),
                                                    msg->params());
+
+            m_vaps_map[msg->ruid()] = msg->params();
         }
         break;
     }

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1809,15 +1809,22 @@ bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cm
         LOG(ERROR) << "addClass wfa_map::tlvApOperationalBSS failed, mid=" << std::hex << (int)mid;
         return false;
     }
-    //add dummy data
-    auto radio_list     = tlvApOperationalBSS->create_radio_list();
-    auto radio_bss_list = radio_list->create_radio_bss_list();
-    radio_bss_list->set_ssid("wlan_0");
-    radio_list->add_radio_bss_list(radio_bss_list);
-    radio_bss_list = radio_list->create_radio_bss_list();
-    radio_bss_list->set_ssid("wlan_2");
-    radio_list->add_radio_bss_list(radio_bss_list);
-    tlvApOperationalBSS->add_radio_list(radio_list);
+
+    for (const auto &vaps_list : m_vaps_map) {
+        auto radio_list         = tlvApOperationalBSS->create_radio_list();
+        radio_list->radio_uid() = vaps_list.first;
+        for (const auto &vap : vaps_list.second.vaps) {
+            if (vap.mac == network_utils::ZERO_MAC)
+                continue;
+            auto radio_bss_list           = radio_list->create_radio_bss_list();
+            radio_bss_list->radio_bssid() = vap.mac;
+            auto ssid =
+                std::string(vap.ssid, strnlen(vap.ssid, beerocks::message::WIFI_SSID_MAX_LENGTH));
+            radio_bss_list->set_ssid(ssid);
+            radio_list->add_radio_bss_list(radio_bss_list);
+        }
+        tlvApOperationalBSS->add_radio_list(radio_list);
+    }
 
     auto tlvAssociatedClients = cmdu_tx.addClass<wfa_map::tlvAssociatedClients>();
     if (!tlvAssociatedClients) {

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -228,6 +228,8 @@ private:
     std::string bssid_bridge_mac;
 
     std::unique_ptr<beerocks::agent_ucc_listener> m_agent_ucc_listener;
+    // vaps map of ruid (key) to VapsList (value)
+    std::unordered_map<sMacAddr, beerocks_message::sVapsList> m_vaps_map;
 
     /*
  * State Machines


### PR DESCRIPTION
The topology response contains an AP Operational BSS TLV which contains
a radio info list, where each radio contains a radio bss list which
contains the radui bssid and bssid.

The current implementation used dummy values, which causes a failure in
the agent certification since the UCC compares these values to the
reported mac addresses and ssids recieved via dev_get_parameter.

This commit adds implementation in the backhaul manager to fetch this
data from the VAP list map and prepare the AP Operational BSS TLV with
correct data as received from BWL.

Fixes #672

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>