### PR TITLE
Add operator<< for sMacAddr

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1389,7 +1389,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 //     << std::endl << "repeats: "              << (int)request->params.repeats
 //     << std::endl << "rand_ival: "            << (int)request->params.rand_ival
 //     << std::endl << "duration: "             << (int)request->params.duration
-//     << std::endl << "sta_mac: "              << network_utils::mac_to_string(request->params.sta_mac)
+//     << std::endl << "sta_mac: "              << request->params.sta_mac
 //     << std::endl << "parallel: "             << (int)request->params.parallel
 //     << std::endl << "enable: "               << (int)request->params.enable
 //     << std::endl << "request: "              << (int)request->params.request
@@ -1414,8 +1414,8 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 //     << std::endl << "repeats: "                          << (int)request->params.repeats
 //     << std::endl << "rand_ival: "                        << (int)request->params.rand_ival
 //     << std::endl << "duration: "                         << (int)request->params.duration
-//     << std::endl << "sta_mac: "                          << network_utils::mac_to_string(request->params.sta_mac)
-//     << std::endl << "bssid: "                            << network_utils::mac_to_string(request->params.bssid)
+//     << std::endl << "sta_mac: "                          << request->params.sta_mac
+//     << std::endl << "bssid: "                            << request->params.bssid
 //     << std::endl << "parallel: "                         << (int)request->params.parallel
 //     << std::endl << "enable: "                           << (int)request->params.enable
 //     << std::endl << "request: "                          << (int)request->params.request
@@ -1442,8 +1442,8 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 //     << std::endl << "repeats: "                                      << (int)request->params.repeats
 //     << std::endl << "rand_ival: "                                    << (int)request->params.rand_ival
 //     << std::endl << "duration: "                                     << (int)request->params.duration
-//     << std::endl << "sta_mac: "                                      << network_utils::mac_to_string(request->params.sta_mac)
-//     << std::endl << "peer_mac_addr: "                                << network_utils::mac_to_string(request->params.peer_mac_addr)
+//     << std::endl << "sta_mac: "                                      << request->params.sta_mac
+//     << std::endl << "peer_mac_addr: "                                << request->params.peer_mac_addr
 //     << std::endl << "parallel: "                                     << (int)request->params.parallel
 //     << std::endl << "enable: "                                       << (int)request->params.enable
 //     << std::endl << "request: "                                      << (int)request->params.request
@@ -1490,7 +1490,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 // void monitor_thread::debug_channel_load_11k_response(message::sACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE* event)
 // {
 //     LOG(DEBUG) << "DATA TEST:"
-//     << std::endl << "sta_mac: "              << network_utils::mac_to_string(event->params.sta_mac)
+//     << std::endl << "sta_mac: "              << event->params.sta_mac
 //     << std::endl << "measurement_rep_mode: " << (int)event->params.rep_mode
 //     << std::endl << "op_class: "             << (int)event->params.op_class
 //     << std::endl << "channel: "              << (int)event->params.channel
@@ -1507,7 +1507,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 // void monitor_thread::debug_beacon_11k_response(message::sACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE* event)
 // {
 //     LOG(DEBUG) << "DATA TEST:"
-//     << std::endl << "sta_mac: "              << network_utils::mac_to_string(event->params.sta_mac)
+//     << std::endl << "sta_mac: "              << event->params.sta_mac
 //     << std::endl << "measurement_rep_mode: " << (int)event->params.rep_mode
 //     << std::endl << "op_class: "             << (int)event->params.op_class
 //     << std::endl << "channel: "              << (int)event->params.channel
@@ -1517,7 +1517,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 //     << std::endl << "frame_type: "           << (int)event->params.frame_type
 //     << std::endl << "rcpi: "                 << (int)event->params.rcpi
 //     << std::endl << "rsni: "                 << (int)event->params.rsni
-//     << std::endl << "bssid: "                << network_utils::mac_to_string(event->params.bssid)
+//     << std::endl << "bssid: "                << event->params.bssid
 //     << std::endl << "ant_id: "               << (int)event->params.ant_id
 //     << std::endl << "tsf: "                  << (int)event->params.parent_tsf
 
@@ -1536,7 +1536,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 //     statistics_group_data.pop_back(); // deletes last comma
 
 //     LOG(DEBUG) << "DATA TEST:"
-//     << std::endl << "sta_mac: "              << network_utils::mac_to_string(event->params.sta_mac)
+//     << std::endl << "sta_mac: "              << event->params.sta_mac
 //     << std::endl << "measurement_rep_mode: " << (int)event->params.rep_mode
 //     << std::endl << "duration: "             << (int)event->params.duration
 //     << std::endl << "group_identity: "       << (int)event->params.group_identity
@@ -1551,7 +1551,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 // void monitor_thread::debug_link_measurements_11k_response(message::sACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE* event)
 // {
 //     LOG(DEBUG) << "DATA TEST:"
-//     << std::endl << "sta_mac: "          << network_utils::mac_to_string(event->params.sta_mac)
+//     << std::endl << "sta_mac: "          << event->params.sta_mac
 //     << std::endl << "transmit_power: "   << (int)event->params.transmit_power
 //     << std::endl << "link_margin: "      << (int)event->params.link_margin
 //     << std::endl << "rx_ant_id: "        << (int)event->params.rx_ant_id

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1205,7 +1205,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
         auto hal_data = static_cast<bwl::SBeaconResponse11k *>(data);
         int id        = 0;
         LOG(INFO) << "Received beacon measurement response on BSSID: "
-                  << network_utils::mac_to_string((sMacAddr &)hal_data->bssid)
+                  << (sMacAddr &)hal_data->bssid
                   << ", dialog_token: " << int(hal_data->dialog_token);
 
         // TODO: Can be changed to iterator loop?
@@ -1250,8 +1250,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
                 pending_11k_events.erase(it);
                 LOG(INFO) << "Sending beacon measurement reponse on BSSID: "
-                          << network_utils::mac_to_string(response->params().bssid)
-                          << " to task_id: " << id;
+                          << response->params().bssid << " to task_id: " << id;
 
                 message_com::send_cmdu(slave_socket, cmdu_tx);
                 break;

--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -91,8 +91,7 @@ typedef struct {
 } sVapElement;
 void agent_ucc_listener::update_vaps_list(std::string ruid, beerocks_message::sVapsList &vaps)
 {
-    LOG(INFO) << "Update VAP map for ruid " << ruid << " bssid "
-              << network_utils::mac_to_string(vaps.vaps->mac) << " ssid "
+    LOG(INFO) << "Update VAP map for ruid " << ruid << " bssid " << vaps.vaps->mac << " ssid "
               << std::string(vaps.vaps->ssid, 36);
     vaps_map[ruid] = vaps;
 }

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1172,7 +1172,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         //TODO EasyMesh SteeringBTMReport should contain source BSSID and target BSSID
         auto msg = static_cast<bwl::sACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE *>(data);
-        LOG(INFO) << "BSS_STEER_RESPONSE client " << network_utils::mac_to_string(msg->params.mac)
+        LOG(INFO) << "BSS_STEER_RESPONSE client " << msg->params.mac
                   << " status_code=" << int(msg->params.status_code);
 
         auto response = message_com::create_vs_message<
@@ -1200,8 +1200,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         auto msg = static_cast<bwl::sACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE *>(data);
 
-        LOG(INFO) << "CLIENT_RX_RSSI_MEASUREMENT_RESPONSE for mac "
-                  << network_utils::mac_to_string(msg->params.result.mac)
+        LOG(INFO) << "CLIENT_RX_RSSI_MEASUREMENT_RESPONSE for mac " << msg->params.result.mac
                   << " id=" << sta_unassociated_rssi_measurement_header_id;
 
         if (sta_unassociated_rssi_measurement_header_id > -1) {
@@ -1244,8 +1243,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         auto msg =
             static_cast<bwl::sACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION *>(data);
 
-        LOG(INFO) << "CLIENT_SOFTBLOCK_NOTIFICATION for client mac "
-                  << network_utils::mac_to_string(msg->params.client_mac);
+        LOG(INFO) << "CLIENT_SOFTBLOCK_NOTIFICATION for client mac " << msg->params.client_mac;
 
         // Build the response message
         auto notification = message_com::create_vs_message<
@@ -1275,8 +1273,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         auto msg =
             static_cast<bwl::sACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION *>(data);
 
-        LOG(INFO) << "CLIENT_SOFTBLOCK_NOTIFICATION for client mac "
-                  << network_utils::mac_to_string(msg->params.client_mac);
+        LOG(INFO) << "CLIENT_SOFTBLOCK_NOTIFICATION for client mac " << msg->params.client_mac;
 
         // Build the response message
         auto notification = message_com::create_vs_message<

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2201,8 +2201,7 @@ bool backhaul_manager::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t eve
         auto msg = static_cast<bwl::sACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE *>(data);
 
         LOG(DEBUG) << "ACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE for mac "
-                   << network_utils::mac_to_string(msg->params.result.mac)
-                   << " id = " << unassociated_rssi_measurement_header_id;
+                   << msg->params.result.mac << " id = " << unassociated_rssi_measurement_header_id;
 
         if (unassociated_rssi_measurement_header_id > -1) {
             auto response = message_com::create_vs_message<

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -1279,7 +1279,7 @@ bool main_thread::handle_arp_monitor()
 
         // LOG(DEBUG) << "Ignoring ARP from: "
         //            << network_utils::ipv4_to_string(entry.ip) << " ("
-        //            << network_utils::mac_to_string(entry.mac) << ")"
+        //            << entry.mac << ")"
         //            << ", state: " << int(entry.state)
         //            << ", type: " << int(entry.type);
 

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -838,8 +838,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             // LOG(DEBUG) << "UINT64 --> MAC: " << network_utils::mac_to_string(
             //     (const uint8_t*)pArpEntry->ip);
 
-            LOG(DEBUG) << "Adding MAC " << network_utils::mac_to_string(request->params().mac)
-                       << " to the ARP list...";
+            LOG(DEBUG) << "Adding MAC " << request->params().mac << " to the ARP list...";
 
             m_mapArpEntries[request->params().mac] = pArpEntry;
         }
@@ -1449,8 +1448,8 @@ bool main_thread::handle_arp_raw()
             : "FRONT";
 
     LOG(DEBUG) << "Discovered IP: " << network_utils::ipv4_to_string(arp_resp->params().ipv4)
-               << " (" << network_utils::mac_to_string(arp_resp->params().mac) << ") on '"
-               << strIface << "' (" << strSource << ")";
+               << " (" << arp_resp->params().mac << ") on '" << strIface << "' (" << strSource
+               << ")";
 
     // Update ARP entry parameters
     auto pArpEntry = m_mapArpEntries.find(arp_resp->params().mac);
@@ -1461,7 +1460,7 @@ bool main_thread::handle_arp_raw()
         pArpEntry->second->last_seen   = std::chrono::steady_clock::now();
     } else {
         // This should not happen since the client is added to the list on query request...
-        LOG(WARNING) << "MAC " << network_utils::mac_to_string(arp_resp->params().mac)
+        LOG(WARNING) << "MAC " << arp_resp->params().mac
                      << " was NOT found in the ARP entries list...";
     }
 
@@ -1469,8 +1468,7 @@ bool main_thread::handle_arp_raw()
     Socket *sd = get_backhaul_socket();
 
     if (sd) {
-        LOG(TRACE) << "ACTION_PLATFORM_ARP_QUERY_RESPONSE mac="
-                   << network_utils::mac_to_string(arp_resp->params().mac)
+        LOG(TRACE) << "ACTION_PLATFORM_ARP_QUERY_RESPONSE mac=" << arp_resp->params().mac
                    << " task_id=" << task_id;
         send_cmdu_safe(sd, cmdu_tx);
     }
@@ -1500,8 +1498,7 @@ void main_thread::arp_entries_cleanup()
 
         // If the client wasn't seen --> erase it
         if (last_seen_duration >= ARP_NOTIF_INTERVAL) {
-            LOG(INFO) << "Removing client with MAC "
-                      << network_utils::mac_to_string((const uint8_t *)&it->first)
+            LOG(INFO) << "Removing client with MAC " << (const uint8_t *)&it->first
                       << " due to inactivity of " << last_seen_duration << " milliseconds.";
 
             it = m_mapArpEntries.erase(it);

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -835,9 +835,6 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             pArpEntry->iface_index = -1;
             pArpEntry->last_seen   = std::chrono::steady_clock::now();
 
-            // LOG(DEBUG) << "UINT64 --> MAC: " << network_utils::mac_to_string(
-            //     (const uint8_t*)pArpEntry->ip);
-
             LOG(DEBUG) << "Adding MAC " << request->params().mac << " to the ARP list...";
 
             m_mapArpEntries[request->params().mac] = pArpEntry;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1237,9 +1237,7 @@ bool slave_thread::handle_cmdu_backhaul_manager_message(
 
             for (unsigned int i = 0; i < message::BACKHAUL_SCAN_MEASUREMENT_MAX_LENGTH; i++) {
                 if (backhaul_params.backhaul_scan_measurement_list[i].channel > 0) {
-                    LOG(DEBUG) << "mac = "
-                               << network_utils::mac_to_string(
-                                      backhaul_params.backhaul_scan_measurement_list[i].mac)
+                    LOG(DEBUG) << "mac = " << backhaul_params.backhaul_scan_measurement_list[i].mac
                                << " channel = "
                                << int(backhaul_params.backhaul_scan_measurement_list[i].channel)
                                << " rssi = "
@@ -3275,9 +3273,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             if (notification->backhaul_params().backhaul_scan_measurement_list[i].channel > 0) {
                 LOG(DEBUG)
                     << "mac = "
-                    << network_utils::mac_to_string(notification->backhaul_params()
-                                                        .backhaul_scan_measurement_list[i]
-                                                        .mac.oct)
+                    << notification->backhaul_params().backhaul_scan_measurement_list[i].mac.oct
                     << " channel = "
                     << int(notification->backhaul_params()
                                .backhaul_scan_measurement_list[i]
@@ -3868,8 +3864,7 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
     }
     // Check if the message is for this radio agent by comparing the ruid
     if (network_utils::mac_from_string(config.radio_identifier) != ruid->radio_uid()) {
-        LOG(DEBUG) << "not to me - ruid " << config.radio_identifier
-                   << " != " << ruid->radio_uid();
+        LOG(DEBUG) << "not to me - ruid " << config.radio_identifier << " != " << ruid->radio_uid();
         return true;
     }
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -438,7 +438,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
                                                std::shared_ptr<beerocks_header> beerocks_header)
 {
     // LOG(DEBUG) << "handle_cmdu_control_message(), INTEL_VS: action=" + std::to_string(beerocks_header->action()) + ", action_op=" + std::to_string(beerocks_header->action_op());
-    // LOG(DEBUG) << "received radio_mac=" << network_utils::mac_to_string(beerocks_header->radio_mac()) << ", local radio_mac=" << network_utils::mac_to_string(hostap_params.iface_mac);
+    // LOG(DEBUG) << "received radio_mac=" << network_utils::mac_to_string(beerocks_header->radio_mac()) << ", local radio_mac=" << hostap_params.iface_mac;
 
     // to me or not to me, this is the question...
     if (beerocks_header->actionhdr()->radio_mac() != hostap_params.iface_mac) {
@@ -4323,8 +4323,7 @@ bool slave_thread::handle_channel_selection_request(Socket *sd, ieee1905_1::Cmdu
 
         const auto &ruid = channel_preference_tlv->radio_uid();
         if (network_utils::mac_to_string(ruid) != config.radio_identifier) {
-            LOG(DEBUG) << "ruid_rx=" << network_utils::mac_to_string(ruid)
-                       << ", son_slave_ruid=" << config.radio_identifier;
+            LOG(DEBUG) << "ruid_rx=" << ruid << ", son_slave_ruid=" << config.radio_identifier;
             continue;
         }
 

--- a/common/beerocks/bcl/include/bcl/network/network_utils.h
+++ b/common/beerocks/bcl/include/bcl/network/network_utils.h
@@ -14,6 +14,7 @@
 
 #include "net_struct.h"
 #include <cstdint>
+#include <easylogging++.h>
 #include <string>
 #include <vector>
 
@@ -124,5 +125,15 @@ public:
 };
 } // namespace net
 } // namespace beerocks
+
+inline std::ostream &operator<<(std::ostream &os, const sMacAddr &addr)
+{
+    return os << beerocks::net::network_utils::mac_to_string(addr);
+}
+
+inline el::base::MessageBuilder &operator<<(el::base::MessageBuilder &log, const sMacAddr &addr)
+{
+    return log << beerocks::net::network_utils::mac_to_string(addr);
+}
 
 #endif //_NETWORK_UTILS_H_

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -939,7 +939,7 @@ bool network_utils::arp_send(const std::string &iface, const std::string &dst_ip
 
     // Send ethernet frame to socket.
     for (int i = 0; i < count; i++) {
-        //LOG_MONITOR(DEBUG) << "ARP to ip=" << dest_ip << " mac=" <<network_utils::mac_to_string(dest_mac);
+        //LOG_MONITOR(DEBUG) << "ARP to ip=" << dest_ip << " mac=" << dest_mac;
         if (sendto(arp_socket, packet_buffer, tx_len, 0, (struct sockaddr *)&sock, sizeof(sock)) <=
             0) {
             LOG(ERROR) << "sendto() failed";

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
@@ -507,8 +507,7 @@ bool mon_wlan_hal_nl80211::process_nl80211_event(parsed_obj_map_t &parsed_obj)
                    << "  phy_type = " << int(resp->phy_type) << std::endl
                    << "  rcpi = " << int(resp->rcpi) << std::endl
                    << "  rsni = " << int(resp->rsni) << std::endl
-                   << "  bssid = " << beerocks::net::network_utils::mac_to_string(resp->bssid.oct)
-                   << std::endl
+                   << "  bssid = " << resp->bssid.oct << std::endl
                    << "  ant_id = " << int(resp->ant_id) << std::endl
                    << "  parent_tfs = " << int(resp->parent_tsf);
 

--- a/controller/src/beerocks/bml/bml_utils.cpp
+++ b/controller/src/beerocks/bml/bml_utils.cpp
@@ -89,11 +89,10 @@ int bml_utils_node_to_string(const struct BML_NODE *node, char *buffer, int buff
     ss << ", Type: " << node_type_to_string(node->type) << " (" << std::to_string(node->type) << ")"
        << ", State: " << node_state_to_string(node->state) << " (" << std::to_string(node->state)
        << ")"
-       << ", MAC: " << network_utils::mac_to_string(node->mac)
-       << ", IP: " << network_utils::ipv4_to_string(node->ip_v4);
+       << ", MAC: " << node->mac << ", IP: " << network_utils::ipv4_to_string(node->ip_v4);
 
     if (node->type != BML_NODE_TYPE_CLIENT) {
-        ss << ", Backhaul: " << network_utils::mac_to_string(node->data.gw_ire.backhaul_mac);
+        ss << ", Backhaul: " << node->data.gw_ire.backhaul_mac;
     }
 
     if (node->channel) {
@@ -101,8 +100,8 @@ int bml_utils_node_to_string(const struct BML_NODE *node, char *buffer, int buff
     }
 
     if (node->parent_bridge[0]) {
-        ss << ", Parent Bridge: " << network_utils::mac_to_string(node->parent_bridge)
-           << ", Parent BSSID: " << network_utils::mac_to_string(node->parent_bssid);
+        ss << ", Parent Bridge: " << node->parent_bridge
+           << ", Parent BSSID: " << node->parent_bssid;
     }
 
     // New line
@@ -166,7 +165,7 @@ int bml_utils_stats_to_string(const struct BML_STATS *stats, char *buffer, int b
     ss << "Type: " << node_type_to_string(stats->type) << " (" << int(stats->type)
        << ")"
           ", MAC: "
-       << network_utils::mac_to_string(stats->mac)
+       << stats->mac
        << ", measurement_window_msec: " << std::to_string(stats->measurement_window_msec);
 
     if (stats->type == BML_STAT_TYPE_RADIO) {
@@ -266,7 +265,7 @@ int bml_utils_stats_to_string_raw(const struct BML_STATS *stats, char *buffer, i
 {
     std::stringstream ss;
 
-    ss << "Type: " << int(stats->type) << ", mac: " << network_utils::mac_to_string(stats->mac)
+    ss << "Type: " << int(stats->type) << ", mac: " << stats->mac
        << ", measurement_window_msec: " << std::to_string(stats->measurement_window_msec);
 
     if (stats->type == BML_STAT_TYPE_RADIO) {
@@ -331,42 +330,42 @@ int bml_utils_event_to_string(const struct BML_EVENT *event, char *buffer, int b
     case BML_EVENT_TYPE_BSS_TM_REQ: {
         ss << "BML_EVENT_TYPE_BSS_TM_REQ";
         auto event_data = (BML_EVENT_BSS_TM_REQ *)(event->data);
-        ss << ", target bssid: " << network_utils::mac_to_string(event_data->target_bssid) << ", "
+        ss << ", target bssid: " << event_data->target_bssid << ", "
            << "disassoc imminent: " << std::to_string(event_data->disassoc_imminent) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_BH_ROAM_REQ: {
         ss << "BML_EVENT_TYPE_BH_ROAM_REQ";
         auto event_data = (BML_EVENT_BH_ROAM_REQ *)(event->data);
-        ss << ", bssid: " << network_utils::mac_to_string(event_data->bssid) << ", "
+        ss << ", bssid: " << event_data->bssid << ", "
            << "channel: " << std::to_string(event_data->channel) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_CLIENT_ALLOW_REQ: {
         ss << "BML_EVENT_TYPE_CLIENT_ALLOW_REQ";
         auto event_data = (BML_EVENT_CLIENT_ALLOW_REQ *)(event->data);
-        ss << ", hostap_mac: " << network_utils::mac_to_string(event_data->hostap_mac) << ", "
-           << "sta_mac: " << network_utils::mac_to_string(event_data->sta_mac) << ", "
+        ss << ", hostap_mac: " << event_data->hostap_mac << ", "
+           << "sta_mac: " << event_data->sta_mac << ", "
            << "ip: " << network_utils::ipv4_to_string(event_data->ip) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_CLIENT_DISALLOW_REQ: {
         ss << "BML_EVENT_TYPE_CLIENT_DISALLOW_REQ";
         auto event_data = (BML_EVENT_CLIENT_ALLOW_REQ *)(event->data);
-        ss << ", hostap_mac: " << network_utils::mac_to_string(event_data->hostap_mac)
-           << ", sta_mac: " << network_utils::mac_to_string(event_data->sta_mac) << std::endl;
+        ss << ", hostap_mac: " << event_data->hostap_mac << ", sta_mac: " << event_data->sta_mac
+           << std::endl;
         break;
     }
     case BML_EVENT_TYPE_ACS_START: {
         ss << "BML_EVENT_TYPE_ACS_START";
         auto event_data = (BML_EVENT_ACS_START *)(event->data);
-        ss << ", hostap_mac: " << network_utils::mac_to_string(event_data->hostap_mac) << std::endl;
+        ss << ", hostap_mac: " << event_data->hostap_mac << std::endl;
         break;
     }
     case BML_EVENT_TYPE_CSA_NOTIFICATION: {
         ss << "BML_EVENT_TYPE_CSA_NOTIFICATION";
         auto event_data = (BML_EVENT_CSA_NOTIFICATION *)(event->data);
-        ss << ", hostap_mac: " << network_utils::mac_to_string(event_data->hostap_mac)
+        ss << ", hostap_mac: " << event_data->hostap_mac
            << ", bandwidth: " << std::to_string(event_data->bandwidth)
            << ", channel: " << std::to_string(event_data->channel)
            << ", channel_ext_above_primary: "
@@ -378,7 +377,7 @@ int bml_utils_event_to_string(const struct BML_EVENT *event, char *buffer, int b
     case BML_EVENT_TYPE_CAC_STATUS_CHANGED_NOTIFICATION: {
         ss << "BML_EVENT_TYPE_CAC_STATUS_CHANGED_NOTIFICATION";
         auto event_data = (BML_EVENT_CAC_STATUS_CHANGED_NOTIFICATION *)(event->data);
-        ss << ", hostap_mac: " << network_utils::mac_to_string(event_data->hostap_mac)
+        ss << ", hostap_mac: " << event_data->hostap_mac
            << ", cac_completed: " << std::to_string(event_data->cac_completed) << std::endl;
         break;
     }

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -130,7 +130,7 @@ static void bml_utils_dump_conn_map(
     for (auto it = range.first; it != range.second; it++) {
         auto node = it->second;
 
-        // ss << "***" << " node mac: " << network_utils::mac_to_string(node->mac) << "***" << std::endl;
+        // ss << "***" << " node mac: " << node->mac << "***" << std::endl;
 
         // CLIENT
         if (node->type == BML_NODE_TYPE_CLIENT) {
@@ -246,13 +246,13 @@ static void steering_set_group_string_to_struct(const std::string &str_cfg_2,
     std::copy_n(cfg2.bssid, sizeof(sMacAddr::oct), bssid2.oct);
     std::copy_n(cfg5.bssid, sizeof(sMacAddr::oct), bssid5.oct);
 
-    std::cout << "cfg2.bssid = " << network_utils::mac_to_string(bssid2) << std::endl
+    std::cout << "cfg2.bssid = " << bssid2 << std::endl
               << "cfg2.utilCheckIntervalSec = " << cfg2.utilCheckIntervalSec << std::endl
               << "cfg2.utilAvgCount = " << cfg2.utilAvgCount << std::endl
               << "cfg2.inactCheckIntervalSec = " << cfg2.inactCheckIntervalSec << std::endl
               << "cfg2.inactCheckThresholdSec = " << cfg2.inactCheckThresholdSec << std::endl
               << "___________________________________________________" << std::endl
-              << "cfg5.bssid = " << network_utils::mac_to_string(bssid5) << std::endl
+              << "cfg5.bssid = " << bssid5 << std::endl
               << "cfg5.utilCheckIntervalSec = " << cfg5.utilCheckIntervalSec << std::endl
               << "cfg5.utilAvgCount = " << cfg5.utilAvgCount << std::endl
               << "cfg5.inactCheckIntervalSec = " << cfg5.inactCheckIntervalSec << std::endl

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -42,7 +42,7 @@ bool db::add_virtual_node(sMacAddr mac, sMacAddr real_node_mac)
     auto real_node = get_node(real_node_mac);
 
     if (!real_node) {
-        LOG(ERROR) << "node " << network_utils::mac_to_string(real_node_mac) << " does not exist";
+        LOG(ERROR) << "node " << real_node_mac << " does not exist";
         return false;
     }
 
@@ -70,14 +70,13 @@ bool db::add_node(const sMacAddr &mac, const sMacAddr &parent_mac, beerocks::eTy
     // if parent node does not exist, new_hierarchy will be equal to 0
     int new_hierarchy = get_node_hierarchy(parent_node) + 1;
     if (new_hierarchy >= HIERARCHY_MAX) {
-        LOG(ERROR) << "hierarchy too high for node " << network_utils::mac_to_string(mac);
+        LOG(ERROR) << "hierarchy too high for node " << mac;
         return false;
     }
 
     auto n = get_node(mac);
     if (n) { // n is not nullptr
-        LOG(DEBUG) << "node with mac " << network_utils::mac_to_string(mac)
-                   << " already exists, updating";
+        LOG(DEBUG) << "node with mac " << mac << " already exists, updating";
         n->set_type(type);
         if (n->parent_mac != network_utils::mac_to_string(parent_mac)) {
             n->previous_parent_mac = n->parent_mac;
@@ -87,15 +86,14 @@ bool db::add_node(const sMacAddr &mac, const sMacAddr &parent_mac, beerocks::eTy
         if (old_hierarchy >= 0 && old_hierarchy < HIERARCHY_MAX) {
             nodes[old_hierarchy].erase(network_utils::mac_to_string(mac));
         } else {
-            LOG(ERROR) << "old hierarchy " << old_hierarchy << " for node "
-                       << network_utils::mac_to_string(mac) << " is invalid!!!";
+            LOG(ERROR) << "old hierarchy " << old_hierarchy << " for node " << mac
+                       << " is invalid!!!";
         }
         auto subtree = get_node_subtree(n);
         int offset   = new_hierarchy - old_hierarchy;
         adjust_subtree_hierarchy(subtree, offset);
     } else {
-        LOG(DEBUG) << "node with mac " << network_utils::mac_to_string(mac)
-                   << " being created, the type is " << type;
+        LOG(DEBUG) << "node with mac " << mac << " being created, the type is " << type;
         n             = std::make_shared<node>(type, network_utils::mac_to_string(mac));
         n->parent_mac = network_utils::mac_to_string(parent_mac);
     }

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -47,7 +47,7 @@ bool db::add_virtual_node(sMacAddr mac, sMacAddr real_node_mac)
     }
 
     /*
-     * TODO 
+     * TODO
      * the regular add_node() function should take care of a situation where the real node
      * already exists and is moved to a different hierarchy
      * it should be able to find its virtual nodes and move them to the appropriate hierarchy as well
@@ -1231,7 +1231,7 @@ std::string db::get_hostap_supported_channels_string(const std::string &radio_ma
  * Currently this function is a wrapper which converts the operating
  * class to a set of supported channels and updates the list of currently
  * supported channels.
- * 
+ *
  * @param mac radio mac
  * @param operating class operating class to add
  * @tx_power transmit power

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -876,7 +876,7 @@ bool master_thread::handle_cmdu_1905_channel_preference_report(const std::string
                 continue;
             }
 
-            LOG(INFO) << "ruid=" << network_utils::mac_to_string(ruid);
+            LOG(INFO) << "ruid=" << ruid;
             LOG(INFO) << "selected_operating_class=" << std::dec << int(operating_class);
             LOG(INFO) << "selected_channel=" << int(*channel_rx);
 
@@ -1026,8 +1026,7 @@ bool master_thread::handle_cmdu_1905_channel_selection_response(const std::strin
         auto response_code = channel_selection_response_tlv->response_code();
 
         LOG(DEBUG)
-            << "channel selection response from ruid=" << network_utils::mac_to_string(ruid)
-            << ", response_code="
+            << "channel selection response from ruid=" << ruid << ", response_code="
             << ([](const wfa_map::tlvChannelSelectionResponse::eResponseCode &response_code) {
                    std::string ret_str;
                    switch (response_code) {
@@ -1063,29 +1062,25 @@ static void print_link_metric_map(
 {
     LOG(DEBUG) << "Printing Link Metrics data map";
     for (auto const &pair_agent : link_metric_data) {
-        LOG(DEBUG) << "  sent from al_mac= " << network_utils::mac_to_string(pair_agent.first)
-                   << std::endl;
+        LOG(DEBUG) << "  sent from al_mac= " << pair_agent.first << std::endl;
 
         for (auto const &pair_neighbor : pair_agent.second) {
-            LOG(DEBUG) << "  reporting neighbor al_mac= "
-                       << network_utils::mac_to_string(pair_neighbor.first) << std::endl;
+            LOG(DEBUG) << "  reporting neighbor al_mac= " << pair_neighbor.first << std::endl;
 
             auto &vrx = pair_neighbor.second.receiverLinkMetrics;
             for (unsigned int i = 0; i < vrx.size(); ++i) {
-                LOG(DEBUG) << "  rx interface metric data # " << i << "  neighbor interface MAC:"
-                           << network_utils::mac_to_string(vrx[i].neighbor_interface_mac)
-                           << "  receiving al_mac:"
-                           << network_utils::mac_to_string(vrx[i].rc_interface_mac)
+                LOG(DEBUG) << "  rx interface metric data # " << i
+                           << "  neighbor interface MAC:" << vrx[i].neighbor_interface_mac
+                           << "  receiving al_mac:" << vrx[i].rc_interface_mac
                            << "  rssi= " << std::hex << int(vrx[i].link_metric_info.rssi_db)
                            << std::endl;
             }
 
             auto &vtx = pair_neighbor.second.transmitterLinkMetrics;
             for (unsigned int i = 0; i < vtx.size(); i++) {
-                LOG(DEBUG) << "  tx interface metric data # " << i << "  neighbor interface MAC:"
-                           << network_utils::mac_to_string(vtx[i].neighbor_interface_mac)
-                           << "  receiving al_mac:"
-                           << network_utils::mac_to_string(vtx[i].rc_interface_mac)
+                LOG(DEBUG) << "  tx interface metric data # " << i
+                           << "  neighbor interface MAC:" << vtx[i].neighbor_interface_mac
+                           << "  receiving al_mac:" << vtx[i].rc_interface_mac
                            << "  phy_rate= " << std::hex << int(vtx[i].link_metric_info.phy_rate)
                            << std::endl;
             }
@@ -1100,8 +1095,7 @@ print_ap_metric_map(std::unordered_map<sMacAddr, son::node::ap_metrics_data> &ap
     for (auto const &pair_agent : ap_metric_data) {
         auto len = pair_agent.second.estimated_service_info_fields.size();
         LOG(DEBUG) << std::endl
-                   << "  Ap Metrics from agent with bssid= "
-                   << network_utils::mac_to_string(pair_agent.first) << std::endl
+                   << "  Ap Metrics from agent with bssid= " << pair_agent.first << std::endl
                    << "  channel_utilization =" << int(pair_agent.second.channel_utilization)
                    << std::endl
                    << "  number_of_stas_currently_associated="
@@ -1159,8 +1153,8 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
             old_link_metrics_removed = true;
         }
 
-        LOG(DEBUG) << "recieved  tlvTransmitterLinkMetric from al_mac ="
-                   << network_utils::mac_to_string(reporting_agent_al_mac) << std::endl
+        LOG(DEBUG) << "recieved  tlvTransmitterLinkMetric from al_mac =" << reporting_agent_al_mac
+                   << std::endl
                    << "reported  al_mac ="
                    << network_utils::mac_to_string(TxLinkMetricData->neighbor_al_mac())
                    << std::endl;
@@ -1180,8 +1174,8 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
 
     if (reporting_agent_al_mac != network_utils::ZERO_MAC) {
         if (reporting_agent_al_mac != RxLinkMetricData->reporter_al_mac()) {
-            LOG(ERROR) << "TLV_RECEIVER_LINK_METRIC reporter al_mac ="
-                       << network_utils::mac_to_string(reporting_agent_al_mac) << std::endl
+            LOG(ERROR) << "TLV_RECEIVER_LINK_METRIC reporter al_mac =" << reporting_agent_al_mac
+                       << std::endl
                        << " and TLV_TRANSMITTER_LINK_METRIC reporter al_mac ="
                        << network_utils::mac_to_string(RxLinkMetricData->reporter_al_mac())
                        << std::endl
@@ -1190,8 +1184,8 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
         }
     }
 
-    LOG(DEBUG) << "recieved tlvReceiverLinkMetric from al_mac="
-               << network_utils::mac_to_string(reporting_agent_al_mac) << std::endl
+    LOG(DEBUG) << "recieved tlvReceiverLinkMetric from al_mac=" << reporting_agent_al_mac
+               << std::endl
                << "reported  al_mac ="
                << network_utils::mac_to_string(RxLinkMetricData->neighbor_al_mac()) << std::endl;
 
@@ -1204,7 +1198,7 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
     link_metric_data[reporting_agent_al_mac][reporting_agent_al_mac] = new_link_metric_data;
 
     LOG(DEBUG) << " Added metric data from "
-               << " al_mac = " << network_utils::mac_to_string(reporting_agent_al_mac) << std::endl
+               << " al_mac = " << reporting_agent_al_mac << std::endl
                << std::endl;
 
     print_link_metric_map(link_metric_data);
@@ -1335,8 +1329,7 @@ bool master_thread::handle_cmdu_1905_ap_metric_response(const std::string &src_m
         //parse tx_ap_metric_data
         sMacAddr reporting_agent_bssid = ap_metric_tlv->bssid();
 
-        LOG(DEBUG) << "recieved tlvApMetric from BSSID ="
-                   << network_utils::mac_to_string(reporting_agent_bssid);
+        LOG(DEBUG) << "recieved tlvApMetric from BSSID =" << reporting_agent_bssid;
 
         //fill tx data from TLV
         if (!ap_metric_data[reporting_agent_bssid].add_ap_metric_data(ap_metric_tlv)) {
@@ -1361,8 +1354,8 @@ bool master_thread::handle_cmdu_1905_operating_channel_report(const std::string 
         auto &ruid    = operating_channel_report_tlv->radio_uid();
         auto tx_power = operating_channel_report_tlv->current_transmit_power();
 
-        LOG(INFO) << "operating channel report, ruid=" << network_utils::mac_to_string(ruid)
-                  << ", tx_power=" << std::dec << int(tx_power);
+        LOG(INFO) << "operating channel report, ruid=" << ruid << ", tx_power=" << std::dec
+                  << int(tx_power);
 
         auto operating_classes_list_length =
             operating_channel_report_tlv->operating_classes_list_length();

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1155,9 +1155,7 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
 
         LOG(DEBUG) << "recieved  tlvTransmitterLinkMetric from al_mac =" << reporting_agent_al_mac
                    << std::endl
-                   << "reported  al_mac ="
-                   << network_utils::mac_to_string(TxLinkMetricData->neighbor_al_mac())
-                   << std::endl;
+                   << "reported  al_mac =" << TxLinkMetricData->neighbor_al_mac() << std::endl;
 
         //fill tx data from TLV
         if (!new_link_metric_data.add_transmitter_link_metric(TxLinkMetricData)) {
@@ -1177,8 +1175,7 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
             LOG(ERROR) << "TLV_RECEIVER_LINK_METRIC reporter al_mac =" << reporting_agent_al_mac
                        << std::endl
                        << " and TLV_TRANSMITTER_LINK_METRIC reporter al_mac ="
-                       << network_utils::mac_to_string(RxLinkMetricData->reporter_al_mac())
-                       << std::endl
+                       << RxLinkMetricData->reporter_al_mac() << std::endl
                        << " not the same";
             return false;
         }
@@ -1186,8 +1183,7 @@ bool master_thread::handle_cmdu_1905_link_metric_response(const std::string &src
 
     LOG(DEBUG) << "recieved tlvReceiverLinkMetric from al_mac=" << reporting_agent_al_mac
                << std::endl
-               << "reported  al_mac ="
-               << network_utils::mac_to_string(RxLinkMetricData->neighbor_al_mac()) << std::endl;
+               << "reported  al_mac =" << RxLinkMetricData->neighbor_al_mac() << std::endl;
 
     //fill rx data from TLV
     if (!new_link_metric_data.add_receiver_link_metric(RxLinkMetricData)) {
@@ -3013,8 +3009,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             DEBUG,
             "beacon response , ID: "
                 << beerocks_header->id() << std::endl
-                << "sta_mac: " << network_utils::mac_to_string(response->params().sta_mac)
-                << std::endl
+                << "sta_mac: " << response->params().sta_mac << std::endl
                 << "measurement_rep_mode: " << (int)response->params().rep_mode << std::endl
                 << "op_class: " << (int)response->params().op_class << std::endl
                 << "channel: "
@@ -3028,7 +3023,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
                 << std::endl
                 << "rcpi: " << (int)response->params().rcpi << std::endl
                 << "rsni: " << (int)response->params().rsni << std::endl
-                << "bssid: " << network_utils::mac_to_string(response->params().bssid)
+                << "bssid: " << response->params().bssid
             //<< std::endl << "ant_id: "               << (int)response->params.ant_id
             //<< std::endl << "tsf: "                  << (int)response->params.parent_tsf
             //<< std::endl << "new_ch_width: "                         << (int)response->params.new_ch_width
@@ -3045,24 +3040,23 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             LOG(ERROR) << "addClass ACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE failed";
             return false;
         }
-        LOG_CLI(DEBUG,
-                "sta channel load response:"
-                    << std::endl
-                    << "sta_mac: " << network_utils::mac_to_string(response->params().sta_mac)
-                    << std::endl
-                    << "measurement_rep_mode: " << (int)response->params().rep_mode << std::endl
-                    << "op_class: " << (int)response->params().op_class << std::endl
-                    << "channel: " << (int)response->params().channel << std::endl
-                    << "start_time: " << (int)response->params().start_time << std::endl
-                    << "duration: " << (int)response->params().duration << std::endl
-                    << "channel_load: " << (int)response->params().channel_load
+        LOG_CLI(DEBUG, "sta channel load response:"
+                           << std::endl
+                           << "sta_mac: " << response->params().sta_mac << std::endl
+                           << "measurement_rep_mode: " << (int)response->params().rep_mode
+                           << std::endl
+                           << "op_class: " << (int)response->params().op_class << std::endl
+                           << "channel: " << (int)response->params().channel << std::endl
+                           << "start_time: " << (int)response->params().start_time << std::endl
+                           << "duration: " << (int)response->params().duration << std::endl
+                           << "channel_load: " << (int)response->params().channel_load
 
-                    << std::endl
-                    << "new_ch_width: " << (int)response->params().new_ch_width << std::endl
-                    << "new_ch_center_freq_seg_0: "
-                    << (int)response->params().new_ch_center_freq_seg_0 << std::endl
-                    << "new_ch_center_freq_seg_1: "
-                    << (int)response->params().new_ch_center_freq_seg_1);
+                           << std::endl
+                           << "new_ch_width: " << (int)response->params().new_ch_width << std::endl
+                           << "new_ch_center_freq_seg_0: "
+                           << (int)response->params().new_ch_center_freq_seg_0 << std::endl
+                           << "new_ch_center_freq_seg_1: "
+                           << (int)response->params().new_ch_center_freq_seg_1);
         break;
     }
     case beerocks_message::ACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE: {
@@ -3082,8 +3076,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         LOG_CLI(DEBUG,
                 "statistics response: "
                     << std::endl
-                    << "sta_mac: " << network_utils::mac_to_string(response->params().sta_mac)
-                    << std::endl
+                    << "sta_mac: " << response->params().sta_mac << std::endl
                     << "measurement_rep_mode: " << (int)response->params().rep_mode << std::endl
                     << "duration: " << (int)response->params().duration << std::endl
                     << "group_identity: " << (int)response->params().group_identity << std::endl
@@ -3106,8 +3099,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         LOG_CLI(DEBUG,
                 "link measurements response: "
                     << std::endl
-                    << "sta_mac: " << network_utils::mac_to_string(response->params().sta_mac)
-                    << std::endl
+                    << "sta_mac: " << response->params().sta_mac << std::endl
                     << "transmit_power: " << (int)response->params().transmit_power << std::endl
                     << "link_margin: " << (int)response->params().link_margin << std::endl
                     << "rx_ant_id: " << (int)response->params().rx_ant_id << std::endl

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1977,9 +1977,7 @@ bool master_thread::handle_intel_slave_join(
 
         for (unsigned int i = 0; i < message::BACKHAUL_SCAN_MEASUREMENT_MAX_LENGTH; i++) {
             if (cs_new_event->backhaul_scan_measurement_list[i].channel > 0) {
-                LOG(DEBUG) << "mac = "
-                           << network_utils::mac_to_string(
-                                  cs_new_event->backhaul_scan_measurement_list[i].mac)
+                LOG(DEBUG) << "mac = " << cs_new_event->backhaul_scan_measurement_list[i].mac
                            << " channel = "
                            << int(cs_new_event->backhaul_scan_measurement_list[i].channel)
                            << " rssi = "

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -259,8 +259,7 @@ void association_handling_task::handle_response(std::string mac,
         }
 
         LOG(DEBUG) << "beacon response , ID: " << id << std::endl
-                   << "sta_mac: " << network_utils::mac_to_string(response->params().sta_mac)
-                   << std::endl
+                   << "sta_mac: " << response->params().sta_mac << std::endl
                    << "measurement_rep_mode: " << (int)response->params().rep_mode << std::endl
                    << "op_class: " << (int)response->params().op_class << std::endl
                    << "channel: "
@@ -274,7 +273,7 @@ void association_handling_task::handle_response(std::string mac,
                    << std::endl
                    << "rcpi: " << (int)response->params().rcpi << std::endl
                    << "rsni: " << (int)response->params().rsni << std::endl
-                   << "bssid: " << network_utils::mac_to_string(response->params().bssid)
+                   << "bssid: " << response->params().bssid
             //<< std::endl << "ant_id: "               << (int)response->params.ant_id
             //<< std::endl << "tsf: "                  << (int)response->params.parent_tsf
 

--- a/controller/src/beerocks/master/tasks/channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.cpp
@@ -359,9 +359,7 @@ void channel_selection_task::work()
         for (int i = 0; i < beerocks::message::BACKHAUL_SCAN_MEASUREMENT_MAX_LENGTH; i++) {
             if (slave_joined_event->backhaul_scan_measurement_list[i].channel > 0) {
                 TASK_LOG(DEBUG)
-                    << "mac = "
-                    << network_utils::mac_to_string(
-                           slave_joined_event->backhaul_scan_measurement_list[i].mac)
+                    << "mac = " << slave_joined_event->backhaul_scan_measurement_list[i].mac
                     << " channel = "
                     << int(slave_joined_event->backhaul_scan_measurement_list[i].channel)
                     << " rssi = "

--- a/controller/src/beerocks/master/tasks/channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.cpp
@@ -353,8 +353,7 @@ void channel_selection_task::work()
         }
         TASK_LOG(DEBUG) << "vht_center_frequency = " << uint16_t(vht_center_frequency);
 
-        TASK_LOG(DEBUG) << "hostap_mac = "
-                        << network_utils::mac_to_string(slave_joined_event->hostap_mac)
+        TASK_LOG(DEBUG) << "hostap_mac = " << slave_joined_event->hostap_mac
                         << " channel_ext_above_primary = "
                         << int(slave_joined_event->cs_params.channel_ext_above_primary);
         for (int i = 0; i < beerocks::message::BACKHAUL_SCAN_MEASUREMENT_MAX_LENGTH; i++) {

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
@@ -299,7 +299,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
         if (obj) {
             auto event_obj = (steering_rssi_measurement_request_event *)obj;
             TASK_LOG(INFO) << "STEERING_RSSI_MEASUREMENT_REQUEST event was received for client_mac "
-                           << net::network_utils::mac_to_string(event_obj->params.mac);
+                           << event_obj->params.mac;
 
             auto update = message_com::create_vs_message<
                 beerocks_message::cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST>(cmdu_tx, id);

--- a/framework/platform/bpl/uci/arp/monitor/arp_monitor.cpp
+++ b/framework/platform/bpl/uci/arp/monitor/arp_monitor.cpp
@@ -188,7 +188,7 @@ static bool send_arp(std::string iface, std::string dst_ip, std::string src_ip, 
 
     // Send ethernet frame to socket.
     for (int i = 0; i < count; i++) {
-        //LOG_MONITOR(DEBUG) << "ARP to ip=" << dest_ip << " mac=" <<network_utils::mac_to_string(dest_mac);
+        //LOG_MONITOR(DEBUG) << "ARP to ip=" << dest_ip << " mac=" << dest_mac;
         if (sendto(arp_socket, packet_buffer, tx_len, 0, (struct sockaddr *)&sock, sizeof(sock)) <=
             0) {
             LOG(ERROR) << "sendto() failed";

--- a/framework/platform/bpl/uci/arp/monitor/arp_monitor.cpp
+++ b/framework/platform/bpl/uci/arp/monitor/arp_monitor.cpp
@@ -516,7 +516,7 @@ int arp_monitor::process_arp(BPL_ARP_MON_ENTRY &sArpMonData)
     std::copy_n(pArpHeader->sender_ip, sizeof(sArpMonData.ip), sArpMonData.ip);
 
     //LOG(DEBUG) << "ARP Response - IP: " << network_utils::ipv4_to_string(sArpMonData.ipv4)
-    //           << ", MAC: " << network_utils::mac_to_string(sArpMonData.mac) << " task_id:" << iTaskID;
+    //           << ", MAC: " << sArpMonData.mac << " task_id:" << iTaskID;
 
     return iTaskID;
 }
@@ -658,11 +658,11 @@ void arp_monitor::print_arp_table()
         // uint8_t mac[6];
         // get_mac_for_ip(neigh.ip, mac);
         // LOG(DEBUG) << "MAC for IP: " << network_utils::ipv4_to_string(neigh.ip)
-        //            << " --> " << network_utils::mac_to_string(mac);
+        //            << " --> " << mac;
 
         // uint8_t ip[4];
         // get_ip_for_mac(neigh.mac, ip);
-        // LOG(DEBUG) << "IP for MAC: " << network_utils::mac_to_string(neigh.mac)
+        // LOG(DEBUG) << "IP for MAC: " << neigh.mac
         //            << " --> " << network_utils::ipv4_to_string(ip);
     }
 }


### PR DESCRIPTION
We very often need to log a MAC address. Instead of calling 
`network_utils::mac_to_string` all the time, it's much easier to define an 
additional operator<< for elpp that handles sMacAddr.

This PR adds that operator, and also replaces all the instances of `network_utils::mac_to_string` that have become redundant.

This is a spin-off of #431. They are kind of independent though: the first commit is shared between the two PRs, the others are not. When one is merged, the other
will have to be rebased.