### PR TITLE
common: prplmesh_utils.sh.in: exit with exit code when running status

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -268,7 +268,7 @@ status_function() {
         cat $LOGS_PATH/beerocks_agent_@BEEROCKS_WLAN2_IFACE@@BEEROCKS_LOG_FILES_SUFFIX@
     }
 
-    return $error
+    exit $error
 }
 
 usage() {


### PR DESCRIPTION
With commit ae8b6418c787d35118b602521d8ea6b20b78610e, the "return $?"
statement that was part of the "status" case, has moved to the
"roll_logs" case.

As a consequence, when running status, the script would return with an
incorrect exit code making the current CI target tests useless.

Since when running status we never need to do anything else, exit with
the corresponding exit code directly from the status function.
