### PR TITLE
Hotfix/channel scan trigger

### DIFF
--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
@@ -150,6 +150,13 @@ bool mon_wlan_hal_dummy::sta_link_measurements_11k_request(const std::string &st
     return true;
 }
 
+bool mon_wlan_hal_dummy::channel_scan_trigger(int dwell_time_msec,
+                                              const std::vector<unsigned int> &channel_pool)
+{
+    LOG(TRACE) << __func__ << " - NOT IMPLEMENTED";
+    return false;
+}
+
 bool mon_wlan_hal_dummy::process_dummy_data(parsed_obj_map_t &parsed_obj)
 {
     char *tmp_str;

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -43,7 +43,8 @@ public:
     virtual bool sta_beacon_11k_request(const SBeaconRequest11k &req, int &dialog_token) override;
     virtual bool sta_statistics_11k_request(const SStatisticsRequest11k &req) override;
     virtual bool sta_link_measurements_11k_request(const std::string &sta_mac) override;
-
+    virtual bool channel_scan_trigger(int dwell_time_msec,
+                                      const std::vector<unsigned int> &channel_pool) override;
     // Protected methods:
 protected:
     virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
@@ -41,7 +41,7 @@ public:
     virtual bool sta_statistics_11k_request(const SStatisticsRequest11k &req) override;
     virtual bool sta_link_measurements_11k_request(const std::string &sta_mac) override;
     virtual bool channel_scan_trigger(int dwell_time_msec,
-                                      const std::vector<unsigned int> &channel_pool);
+                                      const std::vector<unsigned int> &channel_pool) override;
     virtual bool channel_scan_dump_results();
     // Protected methods:
 protected:

--- a/common/beerocks/bwl/include/bwl/mon_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/mon_wlan_hal.h
@@ -55,6 +55,8 @@ public:
     virtual bool sta_beacon_11k_request(const SBeaconRequest11k &req, int &dialog_token) = 0;
     virtual bool sta_statistics_11k_request(const SStatisticsRequest11k &req)            = 0;
     virtual bool sta_link_measurements_11k_request(const std::string &sta_mac)           = 0;
+    virtual bool channel_scan_trigger(int dwell_time_msec,
+                                      const std::vector<unsigned int> &channel_pool)     = 0;
 };
 
 // mon HAL factory types

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
@@ -385,6 +385,13 @@ bool mon_wlan_hal_nl80211::sta_link_measurements_11k_request(const std::string &
     return true;
 }
 
+bool mon_wlan_hal_nl80211::channel_scan_trigger(int dwell_time_msec,
+                                                const std::vector<unsigned int> &channel_pool)
+{
+    LOG(TRACE) << __func__ << " - NOT IMPLEMENTED!";
+    return false;
+}
+
 bool mon_wlan_hal_nl80211::process_nl80211_event(parsed_obj_map_t &parsed_obj)
 {
     // Filter out empty events

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.h
@@ -40,7 +40,8 @@ public:
     virtual bool sta_beacon_11k_request(const SBeaconRequest11k &req, int &dialog_token) override;
     virtual bool sta_statistics_11k_request(const SStatisticsRequest11k &req) override;
     virtual bool sta_link_measurements_11k_request(const std::string &sta_mac) override;
-
+    virtual bool channel_scan_trigger(int dwell_time_msec,
+                                      const std::vector<unsigned int> &channel_pool) override;
     // Protected methods:
 protected:
     virtual bool process_nl80211_event(parsed_obj_map_t &parsed_obj) override;


### PR DESCRIPTION
Hot fix for channel scan
the function channel_scan_trigger in mon_wlan_hal_dwpal
needs to be inherited from mon_wlan_hal in order to be accessible from monitor_thread

This PR needs to merged after #643 