### PR TITLE
cmake: Disable auto-roll on RDKB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ elseif (TARGET_PLATFORM STREQUAL "rdkb")
     # Disable file and enable syslog logging
     set(BEEROCKS_LOG_FILES_ENABLED "false")
     set(BEEROCKS_LOG_SYSLOG_ENABLED "true")
+    set(BEEROCKS_LOG_FILES_AUTO_ROLL "false")
     set(BEEROCKS_LOG_FILES_PATH "/rdklogs/logs")
     set(BEEROCKS_LOG_FILES_SUFFIX ".txt.0")
     set(CMAKE_SKIP_RPATH TRUE)


### PR DESCRIPTION
RDKB uses syslog-ng which has an internal mechanism to perform log roll.
When the auto roll definition is set on the CMake, we use Beerocks internal,
roll mechanism.
If it is set on RDKB, it causes the logs to be empty after the
automatic beerocks roll.
Disable the Beerocks auto-roll on RDKB to fix it.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>