### PR TITLE
[Patch 1/2] implement AP capability report test (4.6.1)

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -8,6 +8,8 @@
 
 #include "backhaul_manager_thread.h"
 
+#include "../tlvf_utils.h"
+
 #include <bcl/beerocks_utils.h>
 #include <bcl/son/son_wireless_utils.h>
 #include <easylogging++.h>
@@ -31,7 +33,9 @@
 #include <tlvf/ieee_1905_1/tlvSearchedRole.h>
 #include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
 #include <tlvf/ieee_1905_1/tlvSupportedRole.h>
+#include <tlvf/wfa_map/tlvApCapability.h>
 #include <tlvf/wfa_map/tlvApOperationalBSS.h>
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
 #include <tlvf/wfa_map/tlvAssociatedClients.h>
 #include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvSearchedService.h>
@@ -1756,6 +1760,9 @@ bool backhaul_manager::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
         return handle_1905_discovery_query(cmdu_rx, src_mac);
         //LOG(INFO) << "I got the Topology Query message!";
     }
+    case ieee1905_1::eMessageType::AP_CAPABILITY_QUERY_MESSAGE: {
+        return handle_ap_capability_query(cmdu_rx, src_mac);
+    }
     case ieee1905_1::eMessageType::HIGHER_LAYER_DATA_MESSAGE: {
         return handle_1905_higher_layer_data_message(cmdu_rx, src_mac);
     }
@@ -1765,6 +1772,39 @@ bool backhaul_manager::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
         return false;
     }
     }
+}
+
+bool backhaul_manager::handle_ap_capability_query(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                                  const std::string &src_mac)
+{
+    const auto mid = cmdu_rx.getMessageId();
+    LOG(DEBUG) << "Received AP_CAPABILITY_QUERY_MESSAGE, mid=" << std::dec << int(mid);
+
+    if (!cmdu_tx.create(mid, ieee1905_1::eMessageType::AP_CAPABILITY_REPORT_MESSAGE)) {
+        LOG(ERROR) << "cmdu creation of type AP_CAPABILITY_REPORT_MESSAGE, has failed";
+        return false;
+    }
+
+    auto ap_capability_tlv = cmdu_tx.addClass<wfa_map::tlvApCapability>();
+    if (!ap_capability_tlv) {
+        LOG(ERROR) << "addClass wfa_map::tlvApCapability has failed";
+        return false;
+    }
+
+    // Capability bitmask is set to 0 because neither unassociated STA link metrics
+    // reporting or agent-initiated RCPI-based steering are supported
+
+    for (const auto &radio_info : m_radio_info_map) {
+        auto ruid               = radio_info.first;
+        auto supported_channels = radio_info.second.supported_channels;
+
+        if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, ruid, supported_channels)) {
+            return false;
+        }
+    }
+
+    LOG(DEBUG) << "Sending AP_CAPABILITY_REPORT_MESSAGE , mid: " << std::hex << (int)mid;
+    return send_cmdu_to_bus(cmdu_tx, src_mac, bridge_info.mac);
 }
 
 /**

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1697,7 +1697,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
             m_agent_ucc_listener->update_vaps_list(network_utils::mac_to_string(msg->ruid()),
                                                    msg->params());
 
-            m_vaps_map[msg->ruid()] = msg->params();
+            m_radio_info_map[msg->ruid()].vaps_list = msg->params();
         }
         break;
     }
@@ -1824,10 +1824,13 @@ bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cm
         return false;
     }
 
-    for (const auto &vaps_list : m_vaps_map) {
+    for (const auto &radio_info : m_radio_info_map) {
+        auto ruid      = radio_info.first;
+        auto vaps_list = radio_info.second.vaps_list;
+
         auto radio_list         = tlvApOperationalBSS->create_radio_list();
-        radio_list->radio_uid() = vaps_list.first;
-        for (const auto &vap : vaps_list.second.vaps) {
+        radio_list->radio_uid() = ruid;
+        for (const auto &vap : vaps_list.vaps) {
             if (vap.mac == network_utils::ZERO_MAC)
                 continue;
             auto radio_bss_list           = radio_list->create_radio_bss_list();

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1493,7 +1493,24 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
             return false;
         }
 
-        std::string mac            = network_utils::mac_to_string(request->iface_mac());
+        std::string mac = network_utils::mac_to_string(request->iface_mac());
+
+        auto tuple_supported_channels = request->supported_channels_list(0);
+        if (!std::get<0>(tuple_supported_channels)) {
+            LOG(ERROR) << "access to supported channels list failed!";
+            return false;
+        }
+
+        auto channels = &std::get<1>(tuple_supported_channels);
+
+        std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+            supported_channels;
+        for (size_t i = 0; i < supported_channels.size(); i++) {
+            supported_channels[i] = channels[i];
+        }
+
+        m_radio_info_map[request->iface_mac()].supported_channels = supported_channels;
+
         soc->radio_mac             = mac;
         soc->freq_type             = (request->iface_is_5ghz() ? beerocks::eFreqType::FREQ_5G
                                                    : beerocks::eFreqType::FREQ_24G);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -82,6 +82,8 @@ private:
     bool handle_1905_higher_layer_data_message(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                const std::string &src_mac);
 
+    bool handle_ap_capability_query(ieee1905_1::CmduMessageRx &cmdu_rx, const std::string &src_mac);
+
     //bool sta_handle_event(const std::string &iface,const std::string& event_name, void* event_obj);
     bool hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr, std::string iface);
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -228,8 +228,23 @@ private:
     std::string bssid_bridge_mac;
 
     std::unique_ptr<beerocks::agent_ucc_listener> m_agent_ucc_listener;
-    // vaps map of ruid (key) to VapsList (value)
-    std::unordered_map<sMacAddr, beerocks_message::sVapsList> m_vaps_map;
+
+    /**
+     * @brief Information gathered about a radio.
+     *
+     * Radio information is obtained from messages sent by slave threads and is used to build
+     * the TLVs to include in notification messages or responses to CDMU query messages.
+     */
+    struct sRadioInfo {
+        beerocks_message::sVapsList vaps_list; /**< List of VAPs in radio. */
+        std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+            supported_channels; /**< Array of supported channels in radio. */
+    };
+
+    /**
+     * @brief Map of radio information structures indexed by radio uid.
+     */
+    std::unordered_map<sMacAddr, sRadioInfo> m_radio_info_map;
 
     /*
  * State Machines

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -8,6 +8,7 @@
 #include "son_slave_thread.h"
 
 #include "../monitor/monitor_thread.h"
+#include "tlvf_utils.h"
 
 #include <bcl/beerocks_utils.h>
 #include <bcl/beerocks_version.h>
@@ -3347,8 +3348,14 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             return false;
         }
 
-        if (!add_radio_basic_capabilities()) {
-            LOG(ERROR) << "Failed adding WSC M1 TLV";
+        std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+            supported_channels;
+        std::copy_n(std::begin(hostap_params.supported_channels), supported_channels.size(),
+                    supported_channels.begin());
+
+        if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, hostap_params.iface_mac,
+                                                         supported_channels)) {
+            LOG(ERROR) << "Failed adding AP Radio Basic Capabilities TLV";
             return false;
         }
 
@@ -4586,57 +4593,6 @@ bool slave_thread::handle_channel_selection_request(Socket *sd, ieee1905_1::Cmdu
     operating_channel_report_tlv->current_transmit_power() = -50;
 
     return send_cmdu_to_controller(cmdu_tx);
-}
-
-bool slave_thread::add_radio_basic_capabilities()
-{
-    std::vector<uint8_t> operating_classes;
-
-    auto radio_basic_caps = cmdu_tx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
-    if (!radio_basic_caps) {
-        LOG(ERROR) << "Error creating TLV_AP_RADIO_BASIC_CAPABILITIES";
-        return false;
-    }
-    radio_basic_caps->radio_uid() = hostap_params.iface_mac;
-    //TODO get maximum supported VAPs from DWPAL
-    radio_basic_caps->maximum_number_of_bsss_supported() = 2;
-
-    operating_classes =
-        wireless_utils::get_supported_operating_classes(hostap_params.supported_channels);
-
-    for (auto op_class : operating_classes) {
-        auto operationClassesInfo = radio_basic_caps->create_operating_classes_info_list();
-        if (!operationClassesInfo) {
-            LOG(ERROR) << "Failed creating operating classes info list";
-            return false;
-        }
-
-        operationClassesInfo->operating_class() = op_class;
-        operationClassesInfo->maximum_transmit_power_dbm() =
-            wireless_utils::get_operating_class_max_tx_power(hostap_params.supported_channels,
-                                                             op_class);
-
-        std::vector<uint8_t> non_oper_channels;
-        non_oper_channels = wireless_utils::get_operating_class_non_oper_channels(
-            hostap_params.supported_channels, op_class);
-        // Create list of statically non-oper channels
-        if (!non_oper_channels.empty()) {
-            operationClassesInfo->alloc_statically_non_operable_channels_list(
-                non_oper_channels.size());
-            uint8_t idx = 0;
-            for (auto non_oper : non_oper_channels) {
-                *operationClassesInfo->statically_non_operable_channels_list(idx) = non_oper;
-                idx++;
-            }
-        }
-
-        if (!radio_basic_caps->add_operating_classes_info_list(operationClassesInfo)) {
-            LOG(ERROR) << "add_operating_classes_info_list failed";
-            return false;
-        }
-    }
-
-    return true;
 }
 
 bool slave_thread::autoconfig_wsc_add_m1()

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3214,6 +3214,15 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                                   config.backhaul_wireless_iface.c_str(),
                                   message::IFACE_NAME_LENGTH);
 
+        auto tuple_supported_channels = bh_enable->supported_channels_list(0);
+        if (!std::get<0>(tuple_supported_channels)) {
+            LOG(ERROR) << "getting supported channels has failed!";
+            break;
+        }
+
+        std::copy_n(hostap_params.supported_channels, message::SUPPORTED_CHANNELS_LENGTH,
+                    &std::get<1>(tuple_supported_channels));
+
         // Send the message
         LOG(DEBUG) << "send ACTION_BACKHAUL_ENABLE for mac " << bh_enable->iface_mac();
         if (!message_com::send_cmdu(backhaul_manager_socket, cmdu_tx)) {

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -406,8 +406,6 @@ bool slave_thread::handle_cmdu_control_ieee1905_1_message(Socket *sd,
         return handle_autoconfiguration_wsc(sd, cmdu_rx);
     case ieee1905_1::eMessageType::AP_AUTOCONFIGURATION_RENEW_MESSAGE:
         return handle_autoconfiguration_renew(sd, cmdu_rx);
-    case ieee1905_1::eMessageType::AP_CAPABILITY_QUERY_MESSAGE:
-        return handle_ap_capability_query(sd, cmdu_rx);
     case ieee1905_1::eMessageType::CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE:
         return handle_client_association_request(sd, cmdu_rx);
     case ieee1905_1::eMessageType::AP_METRICS_QUERY_MESSAGE:
@@ -4252,15 +4250,6 @@ bool slave_thread::handle_client_capability_query(Socket *sd, ieee1905_1::CmduMe
 {
     const auto mid = cmdu_rx.getMessageId();
     LOG(DEBUG) << "Received CLIENT_CAPABILITY_QUERY_MESSAGE , mid=" << std::dec << int(mid);
-    return true;
-}
-
-bool slave_thread::handle_ap_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
-{
-    //TODO - this is a stub handler for the purpose of controller certification testing,
-    //       will be implemented later on agent certification
-    const auto mid = cmdu_rx.getMessageId();
-    LOG(DEBUG) << "Received AP_CAPABILITY_QUERY_MESSAGE, mid=" << std::dec << int(mid);
     return true;
 }
 

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -250,7 +250,6 @@ private:
     bool handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_autoconfiguration_renew(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool autoconfig_wsc_add_m1();
-    bool add_radio_basic_capabilities();
     bool handle_ap_metrics_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_link_metrics_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -256,7 +256,6 @@ private:
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_multi_ap_policy_config_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool handle_ap_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_association_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_steering_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/agent/src/beerocks/slave/tlvf_utils.cpp
+++ b/agent/src/beerocks/slave/tlvf_utils.cpp
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "tlvf_utils.h"
+
+#include <bcl/son/son_wireless_utils.h>
+#include <easylogging++.h>
+
+#include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
+
+using namespace beerocks;
+
+bool tlvf_utils::add_ap_radio_basic_capabilities(
+    ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &ruid,
+    const std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+        &supported_channels)
+{
+    std::vector<uint8_t> operating_classes;
+
+    auto radio_basic_caps = cmdu_tx.addClass<wfa_map::tlvApRadioBasicCapabilities>();
+    if (!radio_basic_caps) {
+        LOG(ERROR) << "Error creating TLV_AP_RADIO_BASIC_CAPABILITIES";
+        return false;
+    }
+    radio_basic_caps->radio_uid() = ruid;
+    //TODO get maximum supported VAPs from AP Capabilities from BWL
+    radio_basic_caps->maximum_number_of_bsss_supported() = 2;
+
+    operating_classes =
+        son::wireless_utils::get_supported_operating_classes(supported_channels.data());
+
+    for (auto op_class : operating_classes) {
+        auto operationClassesInfo = radio_basic_caps->create_operating_classes_info_list();
+        if (!operationClassesInfo) {
+            LOG(ERROR) << "Failed creating operating classes info list";
+            return false;
+        }
+
+        operationClassesInfo->operating_class() = op_class;
+        operationClassesInfo->maximum_transmit_power_dbm() =
+            son::wireless_utils::get_operating_class_max_tx_power(supported_channels.data(),
+                                                                  op_class);
+
+        std::vector<uint8_t> non_oper_channels;
+        non_oper_channels = son::wireless_utils::get_operating_class_non_oper_channels(
+            supported_channels.data(), op_class);
+        // Create list of statically non-oper channels
+        if (!non_oper_channels.empty()) {
+            operationClassesInfo->alloc_statically_non_operable_channels_list(
+                non_oper_channels.size());
+            uint8_t idx = 0;
+            for (auto non_oper : non_oper_channels) {
+                *operationClassesInfo->statically_non_operable_channels_list(idx) = non_oper;
+                idx++;
+            }
+        }
+
+        if (!radio_basic_caps->add_operating_classes_info_list(operationClassesInfo)) {
+            LOG(ERROR) << "add_operating_classes_info_list failed";
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/agent/src/beerocks/slave/tlvf_utils.h
+++ b/agent/src/beerocks/slave/tlvf_utils.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef __TLVF_UTILS_H__
+#define __TLVF_UTILS_H__
+
+#include <tlvf/CmduMessageTx.h>
+
+#include <beerocks/tlvf/beerocks_message.h>
+
+namespace beerocks {
+
+class tlvf_utils {
+public:
+    /**
+     * @brief Adds a new AP Radio Basic Capabilities TLV to given message.
+     *
+     * @param[in,out] cmdu_tx CDMU message.
+     * @param[in] ruid Radio unique identifier of the radio for which capabilities are reported.
+     * @param[in] supported_channels List of channels supported by AP.
+     *
+     * @return True on success and false otherwise.
+     */
+    static bool add_ap_radio_basic_capabilities(
+        ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &ruid,
+        const std::array<beerocks::message::sWifiChannel,
+                         beerocks::message::SUPPORTED_CHANNELS_LENGTH> &supported_channels);
+};
+
+} // namespace beerocks
+
+#endif // __TLVF_UTILS_H__

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -141,15 +141,14 @@ public:
     static std::string wsc_to_bwl_encryption(WSC::eWscEncr enctype);
     static beerocks::eBssType wsc_to_bwl_bss_type(WSC::eWscVendorExtSubelementBssType bss_type);
     static std::vector<uint8_t>
-    get_supported_operating_classes(beerocks::message::sWifiChannel supported_channels[]);
+    get_supported_operating_classes(const beerocks::message::sWifiChannel supported_channels[]);
     static uint8_t
-    get_operating_class_max_tx_power(beerocks::message::sWifiChannel supported_channels[],
+    get_operating_class_max_tx_power(const beerocks::message::sWifiChannel supported_channels[],
                                      uint8_t operating_class);
-    static std::vector<uint8_t>
-    get_operating_class_non_oper_channels(beerocks::message::sWifiChannel supported_channels[],
-                                          uint8_t operating_class);
+    static std::vector<uint8_t> get_operating_class_non_oper_channels(
+        const beerocks::message::sWifiChannel supported_channels[], uint8_t operating_class);
     static std::list<sChannelPreference>
-    get_channel_preferences(beerocks::message::sWifiChannel supported_channels[]);
+    get_channel_preferences(const beerocks::message::sWifiChannel supported_channels[]);
 
 private:
     enum eAntennaFactor {

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -575,7 +575,7 @@ std::vector<uint8_t> wireless_utils::calc_5g_20MHz_subband_channels(
  *         list of channels> as value
  */
 std::list<wireless_utils::sChannelPreference>
-wireless_utils::get_channel_preferences(beerocks::message::sWifiChannel supported_channels[])
+wireless_utils::get_channel_preferences(const beerocks::message::sWifiChannel supported_channels[])
 {
     std::list<sChannelPreference> preferences;
 
@@ -607,7 +607,7 @@ wireless_utils::get_channel_preferences(beerocks::message::sWifiChannel supporte
  * @return std::vector<uint8_t> vector of supported operating classes
  */
 std::vector<uint8_t> wireless_utils::get_supported_operating_classes(
-    beerocks::message::sWifiChannel supported_channels[])
+    const beerocks::message::sWifiChannel supported_channels[])
 {
     std::vector<uint8_t> operating_classes;
     //TODO handle regulatory domain operating classes
@@ -631,7 +631,7 @@ std::vector<uint8_t> wireless_utils::get_supported_operating_classes(
  * @return max tx power for requested operating class
  */
 uint8_t wireless_utils::get_operating_class_max_tx_power(
-    beerocks::message::sWifiChannel supported_channels[], uint8_t operating_class)
+    const beerocks::message::sWifiChannel supported_channels[], uint8_t operating_class)
 {
     uint8_t max_tx_power = 0;
     auto oper_class      = operating_classes_list.at(operating_class);
@@ -652,7 +652,7 @@ uint8_t wireless_utils::get_operating_class_max_tx_power(
  * @return std::vector<uint8_t> vector of non operable channels
  */
 std::vector<uint8_t> wireless_utils::get_operating_class_non_oper_channels(
-    beerocks::message::sWifiChannel supported_channels[], uint8_t operating_class)
+    const beerocks::message::sWifiChannel supported_channels[], uint8_t operating_class)
 {
     std::vector<uint8_t> non_oper_channels;
     auto oper_class = operating_classes_list.at(operating_class);

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -149,6 +149,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint8_t& wireless_iface_type();
         uint8_t& mem_only_psk();
         uint8_t& backhaul_preferred_radio_band();
+        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -175,6 +176,8 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint8_t* m_wireless_iface_type = nullptr;
         uint8_t* m_mem_only_psk = nullptr;
         uint8_t* m_backhaul_preferred_radio_band = nullptr;
+        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
+        size_t m_supported_channels_list_idx__ = 0;
 };
 
 class cACTION_BACKHAUL_CONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -503,11 +503,23 @@ uint8_t& cACTION_BACKHAUL_ENABLE::backhaul_preferred_radio_band() {
     return (uint8_t&)(*m_backhaul_preferred_radio_band);
 }
 
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::supported_channels_list(size_t idx) {
+    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+}
+
 void cACTION_BACKHAUL_ENABLE::class_swap()
 {
     m_iface_mac->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_security_type));
     m_preferred_bssid->struct_swap();
+    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+        m_supported_channels_list[i].struct_swap();
+    }
 }
 
 bool cACTION_BACKHAUL_ENABLE::finalize()
@@ -553,6 +565,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
     class_size += sizeof(uint8_t); // wireless_iface_type
     class_size += sizeof(uint8_t); // mem_only_psk
     class_size += sizeof(uint8_t); // backhaul_preferred_radio_band
+    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
     return class_size;
 }
 
@@ -633,6 +646,15 @@ bool cACTION_BACKHAUL_ENABLE::init()
     if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
+    }
+    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+        return false;
+    }
+    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    if (!m_parse__) {
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -59,6 +59,9 @@ cACTION_BACKHAUL_ENABLE:
   wireless_iface_type: uint8_t  
   mem_only_psk: uint8_t
   backhaul_preferred_radio_band: uint8_t
+  supported_channels_list:
+    _type: beerocks::message::sWifiChannel 
+    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
 
 cACTION_BACKHAUL_CONNECTED_NOTIFICATION:
   _type: class

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -99,6 +99,7 @@ bool master_thread::init()
             ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE,
             ieee1905_1::eMessageType::LINK_METRIC_RESPONSE_MESSAGE,
             ieee1905_1::eMessageType::AP_METRICS_RESPONSE_MESSAGE,
+            ieee1905_1::eMessageType::AP_CAPABILITY_REPORT_MESSAGE,
             ieee1905_1::eMessageType::ACK_MESSAGE,
 
         })) {
@@ -288,6 +289,8 @@ bool master_thread::handle_cmdu_1905_1_message(const std::string &src_mac,
         return handle_cmdu_1905_link_metric_response(src_mac, cmdu_rx);
     case ieee1905_1::eMessageType::AP_METRICS_RESPONSE_MESSAGE:
         return handle_cmdu_1905_ap_metric_response(src_mac, cmdu_rx);
+    case ieee1905_1::eMessageType::AP_CAPABILITY_REPORT_MESSAGE:
+        return handle_cmdu_1905_ap_capability_report(src_mac, cmdu_rx);
     default:
         break;
     }
@@ -1328,6 +1331,15 @@ bool master_thread::handle_cmdu_1905_ap_metric_response(const std::string &src_m
     }
 
     print_ap_metric_map(ap_metric_data);
+
+    return true;
+}
+
+bool master_thread::handle_cmdu_1905_ap_capability_report(const std::string &src_mac,
+                                                          ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    auto mid = cmdu_rx.getMessageId();
+    LOG(INFO) << "Received AP_CAPABILITY_REPORT_MESSAGE, mid=" << std::dec << int(mid);
 
     return true;
 }

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -77,6 +77,8 @@ private:
                                                ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_ap_metric_response(const std::string &src_mac,
                                              ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_ap_capability_report(const std::string &src_mac,
+                                               ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_preference_report(const std::string &src_mac,
                                                     ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_channel_selection_response(const std::string &src_mac,

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApHeCapabilities.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApHeCapabilities.h
@@ -1,0 +1,114 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVAPHECAPABILITIES_H_
+#define _TLVF_WFA_MAP_TLVAPHECAPABILITIES_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+#include <tuple>
+#include <asm/byteorder.h>
+
+namespace wfa_map {
+
+
+class tlvApHeCapabilities : public BaseClass
+{
+    public:
+        tlvApHeCapabilities(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApHeCapabilities(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvApHeCapabilities();
+
+        typedef struct sFlags1 {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t he_support_160mhz : 1;
+            uint8_t he_support_80_80mhz : 1;
+            uint8_t max_num_of_supported_rx_spatial_streams : 3;
+            uint8_t max_num_of_supported_tx_spatial_streams : 3;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t max_num_of_supported_tx_spatial_streams : 3;
+            uint8_t max_num_of_supported_rx_spatial_streams : 3;
+            uint8_t he_support_80_80mhz : 1;
+            uint8_t he_support_160mhz : 1;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+            }
+        } __attribute__((packed)) sFlags1;
+        
+        typedef struct sFlags2 {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t reserved : 1;
+            uint8_t dl_ofdm_capable : 1;
+            uint8_t ul_ofdm_capable : 1;
+            uint8_t dl_mu_mimo_and_ofdm_capable : 1;
+            uint8_t ul_mu_mimo_and_ofdm_capable : 1;
+            uint8_t ul_mu_mimo_capable : 1;
+            uint8_t mu_beamformer_capable : 1;
+            uint8_t su_beamformer_capable : 1;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t su_beamformer_capable : 1;
+            uint8_t mu_beamformer_capable : 1;
+            uint8_t ul_mu_mimo_capable : 1;
+            uint8_t ul_mu_mimo_and_ofdm_capable : 1;
+            uint8_t dl_mu_mimo_and_ofdm_capable : 1;
+            uint8_t ul_ofdm_capable : 1;
+            uint8_t dl_ofdm_capable : 1;
+            uint8_t reserved : 1;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+                reserved = 0x0;
+            }
+        } __attribute__((packed)) sFlags2;
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& radio_uid();
+        uint8_t& supported_he_mcs_length();
+        uint8_t* supported_he_mcs(size_t idx = 0);
+        bool alloc_supported_he_mcs(size_t count = 1);
+        sFlags1& flags1();
+        sFlags2& flags2();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_radio_uid = nullptr;
+        uint8_t* m_supported_he_mcs_length = nullptr;
+        uint8_t* m_supported_he_mcs = nullptr;
+        size_t m_supported_he_mcs_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+        sFlags1* m_flags1 = nullptr;
+        sFlags2* m_flags2 = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVAPHECAPABILITIES_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApHtCapabilities.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApHtCapabilities.h
@@ -1,0 +1,79 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVAPHTCAPABILITIES_H_
+#define _TLVF_WFA_MAP_TLVAPHTCAPABILITIES_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+#include <asm/byteorder.h>
+
+namespace wfa_map {
+
+
+class tlvApHtCapabilities : public BaseClass
+{
+    public:
+        tlvApHtCapabilities(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApHtCapabilities(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvApHtCapabilities();
+
+        typedef struct sFalgs {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t reserved : 1;
+            uint8_t ht_support_40mhz : 1;
+            uint8_t short_gi_support_40mhz : 1;
+            uint8_t short_gi_support_20mhz : 1;
+            uint8_t max_num_of_supported_rx_spatial_streams : 2;
+            uint8_t max_num_of_supported_tx_spatial_streams : 2;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t max_num_of_supported_tx_spatial_streams : 2;
+            uint8_t max_num_of_supported_rx_spatial_streams : 2;
+            uint8_t short_gi_support_20mhz : 1;
+            uint8_t short_gi_support_40mhz : 1;
+            uint8_t ht_support_40mhz : 1;
+            uint8_t reserved : 1;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+            }
+        } __attribute__((packed)) sFalgs;
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& radio_uid();
+        sFalgs& flags();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_radio_uid = nullptr;
+        sFalgs* m_flags = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVAPHTCAPABILITIES_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApVhtCapabilities.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvApVhtCapabilities.h
@@ -1,0 +1,104 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVAPVHTCAPABILITIES_H_
+#define _TLVF_WFA_MAP_TLVAPVHTCAPABILITIES_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+#include <asm/byteorder.h>
+
+namespace wfa_map {
+
+
+class tlvApVhtCapabilities : public BaseClass
+{
+    public:
+        tlvApVhtCapabilities(uint8_t* buff, size_t buff_len, bool parse = false);
+        tlvApVhtCapabilities(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvApVhtCapabilities();
+
+        typedef struct sFlags1 {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t short_gi_support_160mhz_and_80_80mhz : 1;
+            uint8_t short_gi_support_80mhz : 1;
+            uint8_t max_num_of_supported_rx_spatial_streams : 3;
+            uint8_t max_num_of_supported_tx_spatial_streams : 3;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t max_num_of_supported_tx_spatial_streams : 3;
+            uint8_t max_num_of_supported_rx_spatial_streams : 3;
+            uint8_t short_gi_support_80mhz : 1;
+            uint8_t short_gi_support_160mhz_and_80_80mhz : 1;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+            }
+        } __attribute__((packed)) sFlags1;
+        
+        typedef struct sFlags2 {
+            #if defined(__LITTLE_ENDIAN_BITFIELD)
+            uint8_t reserved : 4;
+            uint8_t mu_beamformer_capable : 1;
+            uint8_t su_beamformer_capable : 1;
+            uint8_t vht_support_160mhz : 1;
+            uint8_t vht_support_80_80mhz : 1;
+            #elif defined(__BIG_ENDIAN_BITFIELD)
+            uint8_t vht_support_80_80mhz : 1;
+            uint8_t vht_support_160mhz : 1;
+            uint8_t su_beamformer_capable : 1;
+            uint8_t mu_beamformer_capable : 1;
+            uint8_t reserved : 4;
+            #else
+            #error "Bitfield macros are not defined"
+            #endif
+            void struct_swap(){
+            }
+            void struct_init(){
+                reserved = 0x0;
+            }
+        } __attribute__((packed)) sFlags2;
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& radio_uid();
+        uint16_t& supported_vht_tx_mcs();
+        uint16_t& supported_vht_rx_mcs();
+        sFlags1& flags1();
+        sFlags2& flags2();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_radio_uid = nullptr;
+        uint16_t* m_supported_vht_tx_mcs = nullptr;
+        uint16_t* m_supported_vht_rx_mcs = nullptr;
+        sFlags1* m_flags1 = nullptr;
+        sFlags2* m_flags2 = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVAPVHTCAPABILITIES_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApHeCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApHeCapabilities.cpp
@@ -1,0 +1,204 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvApHeCapabilities.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvApHeCapabilities::tlvApHeCapabilities(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvApHeCapabilities::tlvApHeCapabilities(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvApHeCapabilities::~tlvApHeCapabilities() {
+}
+const eTlvTypeMap& tlvApHeCapabilities::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvApHeCapabilities::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvApHeCapabilities::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
+}
+
+uint8_t& tlvApHeCapabilities::supported_he_mcs_length() {
+    return (uint8_t&)(*m_supported_he_mcs_length);
+}
+
+uint8_t* tlvApHeCapabilities::supported_he_mcs(size_t idx) {
+    if ( (m_supported_he_mcs_idx__ <= 0) || (m_supported_he_mcs_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_supported_he_mcs[idx]);
+}
+
+bool tlvApHeCapabilities::alloc_supported_he_mcs(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list supported_he_mcs, abort!";
+        return false;
+    }
+    if (count == 0) {
+        TLVF_LOG(WARNING) << "can't allocate 0 bytes";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_supported_he_mcs[*m_supported_he_mcs_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_flags1 = (sFlags1 *)((uint8_t *)(m_flags1) + len);
+    m_flags2 = (sFlags2 *)((uint8_t *)(m_flags2) + len);
+    m_supported_he_mcs_idx__ += count;
+    *m_supported_he_mcs_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+tlvApHeCapabilities::sFlags1& tlvApHeCapabilities::flags1() {
+    return (sFlags1&)(*m_flags1);
+}
+
+tlvApHeCapabilities::sFlags2& tlvApHeCapabilities::flags2() {
+    return (sFlags2&)(*m_flags2);
+}
+
+void tlvApHeCapabilities::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_radio_uid->struct_swap();
+    m_flags1->struct_swap();
+    m_flags2->struct_swap();
+}
+
+bool tlvApHeCapabilities::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvApHeCapabilities::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // radio_uid
+    class_size += sizeof(uint8_t); // supported_he_mcs_length
+    class_size += sizeof(sFlags1); // flags1
+    class_size += sizeof(sFlags2); // flags2
+    return class_size;
+}
+
+bool tlvApHeCapabilities::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_HE_CAPABILITIES;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_radio_uid->struct_init(); }
+    m_supported_he_mcs_length = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_supported_he_mcs_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_supported_he_mcs = (uint8_t*)m_buff_ptr__;
+    uint8_t supported_he_mcs_length = *m_supported_he_mcs_length;
+    m_supported_he_mcs_idx__ = supported_he_mcs_length;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (supported_he_mcs_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (supported_he_mcs_length) << ") Failed!";
+        return false;
+    }
+    m_flags1 = (sFlags1*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sFlags1))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFlags1) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sFlags1); }
+    if (!m_parse__) { m_flags1->struct_init(); }
+    m_flags2 = (sFlags2*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sFlags2))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFlags2) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sFlags2); }
+    if (!m_parse__) { m_flags2->struct_init(); }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_HE_CAPABILITIES) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_HE_CAPABILITIES) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApHtCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApHtCapabilities.cpp
@@ -1,0 +1,131 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvApHtCapabilities.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvApHtCapabilities::tlvApHtCapabilities(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvApHtCapabilities::tlvApHtCapabilities(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvApHtCapabilities::~tlvApHtCapabilities() {
+}
+const eTlvTypeMap& tlvApHtCapabilities::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvApHtCapabilities::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvApHtCapabilities::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
+}
+
+tlvApHtCapabilities::sFalgs& tlvApHtCapabilities::flags() {
+    return (sFalgs&)(*m_flags);
+}
+
+void tlvApHtCapabilities::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_radio_uid->struct_swap();
+    m_flags->struct_swap();
+}
+
+bool tlvApHtCapabilities::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvApHtCapabilities::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // radio_uid
+    class_size += sizeof(sFalgs); // flags
+    return class_size;
+}
+
+bool tlvApHtCapabilities::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_HT_CAPABILITIES;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_radio_uid->struct_init(); }
+    m_flags = (sFalgs*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sFalgs))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFalgs) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sFalgs); }
+    if (!m_parse__) { m_flags->struct_init(); }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_HT_CAPABILITIES) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_HT_CAPABILITIES) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApVhtCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApVhtCapabilities.cpp
@@ -1,0 +1,168 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvApVhtCapabilities.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvApVhtCapabilities::tlvApVhtCapabilities(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvApVhtCapabilities::tlvApVhtCapabilities(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvApVhtCapabilities::~tlvApVhtCapabilities() {
+}
+const eTlvTypeMap& tlvApVhtCapabilities::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvApVhtCapabilities::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvApVhtCapabilities::radio_uid() {
+    return (sMacAddr&)(*m_radio_uid);
+}
+
+uint16_t& tlvApVhtCapabilities::supported_vht_tx_mcs() {
+    return (uint16_t&)(*m_supported_vht_tx_mcs);
+}
+
+uint16_t& tlvApVhtCapabilities::supported_vht_rx_mcs() {
+    return (uint16_t&)(*m_supported_vht_rx_mcs);
+}
+
+tlvApVhtCapabilities::sFlags1& tlvApVhtCapabilities::flags1() {
+    return (sFlags1&)(*m_flags1);
+}
+
+tlvApVhtCapabilities::sFlags2& tlvApVhtCapabilities::flags2() {
+    return (sFlags2&)(*m_flags2);
+}
+
+void tlvApVhtCapabilities::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_radio_uid->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_supported_vht_tx_mcs));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_supported_vht_rx_mcs));
+    m_flags1->struct_swap();
+    m_flags2->struct_swap();
+}
+
+bool tlvApVhtCapabilities::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvApVhtCapabilities::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // radio_uid
+    class_size += sizeof(uint16_t); // supported_vht_tx_mcs
+    class_size += sizeof(uint16_t); // supported_vht_rx_mcs
+    class_size += sizeof(sFlags1); // flags1
+    class_size += sizeof(sFlags2); // flags2
+    return class_size;
+}
+
+bool tlvApVhtCapabilities::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_AP_VHT_CAPABILITIES;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_radio_uid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_radio_uid->struct_init(); }
+    m_supported_vht_tx_mcs = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_supported_vht_rx_mcs = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint16_t); }
+    m_flags1 = (sFlags1*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sFlags1))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFlags1) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sFlags1); }
+    if (!m_parse__) { m_flags1->struct_init(); }
+    m_flags2 = (sFlags2*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sFlags2))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sFlags2) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sFlags2); }
+    if (!m_parse__) { m_flags2->struct_init(); }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_AP_VHT_CAPABILITIES) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_AP_VHT_CAPABILITIES) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -28,6 +28,9 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvApMetricQuery.yaml",
   "tlvf/wfa_map/tlvClientAssociationEvent.yaml",
   "tlvf/wfa_map/tlvClientAssociationControlRequest.yaml",
+  "tlvf/wfa_map/tlvApHtCapabilities.yaml",
+  "tlvf/wfa_map/tlvApHeCapabilities.yaml",  
+  "tlvf/wfa_map/tlvApVhtCapabilities.yaml",  
 }
 
 # Relative to tlvf.py src_path variable

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApHeCapabilities.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApHeCapabilities.yaml
@@ -19,7 +19,7 @@ tlvApHeCapabilities:
   flags1: sFlags1
   flags2: sFlags2
 
-sFalgs1:
+sFlags1:
   _type: struct
   _bit_field: uint8_t
   max_num_of_supported_tx_spatial_streams:
@@ -31,7 +31,7 @@ sFalgs1:
   he_support_160mhz:
     _bit_range: [0,0]
 
-sFalgs2:
+sFlags2:
   _type: struct
   _bit_field: uint8_t
   su_beamformer_capable:

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvApVhtCapabilities.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvApVhtCapabilities.yaml
@@ -15,7 +15,7 @@ tlvApVhtCapabilities:
   flags1: sFlags1
   flags2: sFlags2
 
-sFalgs1:
+sFlags1:
   _type: struct
   _bit_field: uint8_t
   max_num_of_supported_tx_spatial_streams:
@@ -27,7 +27,7 @@ sFalgs1:
   short_gi_support_160mhz_and_80_80mhz:
     _bit_range: [0,0]
 
-sFalgs2:
+sFlags2:
   _type: struct
   _bit_field: uint8_t
   vht_support_80_80mhz:

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -203,8 +203,13 @@ test_ap_capability_query() {
     check_error=0
     check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8001" $redirect
     sleep 1
+    
     dbg "Confirming ap capability query has been received on agent"
-    check_log ${REPEATER1} agent_wlan0 "AP_CAPABILITY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent "AP_CAPABILITY_QUERY_MESSAGE"
+    
+    dbg "Confirming ap capability report has been received on controller"
+    check_log ${GATEWAY} controller "AP_CAPABILITY_REPORT_MESSAGE"
+    
     return $check_error
 }
 test_combined_infra_metrics() {


### PR DESCRIPTION
## Description

According to the Wi-Fi CERTIFIED EasyMesh™ Test Plan v1.0, test 4.6.1, which is the AP capability report test, the MAUT is triggered by the CTT controller with an AP Capability Query message, and the MAUT should reply with AP Capability Report message.

According to Multi-AP-Spesification, when a Multi-AP Agent receives an AP
Capability Query message, it shall respond within one second with an AP
Capability Report message which includes one AP Capability TLV, and one AP Radio Basic Capabilities TLV for each AP radio.

Currently, the handling of the AP Capability Query message is in the responsibility of the son slave thread, which makes no sense, since one slave has no way to know the AP capabilities of the other slaves (and should not).

The handling of the AP Capability Query message should be part of the backhaul manager, and for that reason, the following changes were made:

- Each one of the radios sends its supported channels list as part of the cACTION_BACKHAUL_ENABLE
VS CMDU to the backhaul manager.

- The backhaul manager saves for each radio its supported channels list

- When the AP Capability Query message is received in the backhaul manager, an AP Capability Report message is created, which contains one AP Capability TLV, and one AP Radio Basic Capabilities TLV for each AP radio.


## Testbed status

_Those changes were checked on the testbed with the excepted results._



