### PR TITLE
[DCS Patch 4/5] port dynamic channel selection from rdkb flow

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1409,13 +1409,50 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
     } break;
     case Event::Channel_Scan_Triggered: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION msg";
+            return false;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
     case Event::Channel_Scan_New_Results_Ready:
     case Event::Channel_Scan_Dump_Result: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION msg";
+            return false;
+        }
+
+        // If event == Channel_Scan_New_Results_Ready do nothing since is_dump's default is 0
+        if (event == Event::Channel_Scan_Dump_Result) {
+            notification->is_dump() = 1;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
     case Event::Channel_Scan_Finished: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION msg";
+            return false;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
     case Event::Channel_Scan_Abort: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION msg";
+            return false;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
 
     // Unhandled events

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -15,6 +15,7 @@
 #include <beerocks/tlvf/beerocks_message.h>
 
 #include <cmath>
+#include <vector>
 
 using namespace beerocks;
 using namespace net;
@@ -380,7 +381,6 @@ void monitor_thread::after_select(bool timeout)
                     stop_monitor_thread();
                     return;
                 }
-                LOG(DEBUG) << "proccess nl events finished ";
                 clear_ready(mon_hal_nl_events);
             }
         }
@@ -1143,6 +1143,52 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
                    << "mac=" << mac_str;
 
         mon_wlan_hal->sta_link_measurements_11k_request(mac_str);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST: {
+        auto request =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST failed";
+            return false;
+        }
+
+        auto radio_mac         = request->scan_params().radio_mac;
+        auto dwell_time_ms     = request->scan_params().dwell_time_ms;
+        auto channel_pool      = request->scan_params().channel_pool;
+        auto channel_pool_size = request->scan_params().channel_pool_size;
+        auto channel_pool_vector =
+            std::vector<unsigned int>(channel_pool, channel_pool + channel_pool_size);
+        std::string channels;
+
+        //loop for priting the channal pool
+        for (int index = 0; index < int(channel_pool_size); index++) {
+            channels += ((index != 0) ? "," : "") + std::to_string(channel_pool[index]);
+        }
+
+        //debug print incoming information:
+        LOG(DEBUG) << std::endl
+                   << "scan_params:" << std::endl
+                   << "radio_mac=" << radio_mac << std::endl
+                   << "dwell_time_ms=" << dwell_time_ms << std::endl
+                   << "channel_pool_size=" << int(channel_pool_size) << std::endl
+                   << "channel_pool=" << channels;
+
+        auto response_out = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE>(
+            cmdu_tx, beerocks_header->id());
+        if (!response_out) {
+            LOG(ERROR)
+                << "Failed building cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE message!";
+            return false;
+        }
+
+        bool result = mon_wlan_hal->channel_scan_trigger(int(dwell_time_ms), channel_pool_vector);
+        LOG_IF(!result, ERROR) << "channel_scan_trigger Failed";
+
+        response_out->success() = (result) ? 1 : 0;
+        message_com::send_cmdu(slave_socket, cmdu_tx);
         break;
     }
     default: {

--- a/agent/src/beerocks/monitor/monitor_thread.h
+++ b/agent/src/beerocks/monitor/monitor_thread.h
@@ -35,12 +35,15 @@ public:
     virtual bool init() override;
 
     enum eThreadErrors : uint32_t {
-        MONITOR_THREAD_ERROR_NO_ERROR            = 0,
-        MONITOR_THREAD_ERROR_HOSTAP_DISABLED     = 1,
-        MONITOR_THREAD_ERROR_ATTACH_FAIL         = 2,
-        MONITOR_THREAD_ERROR_SUDDEN_DETACH       = 3,
-        MONITOR_THREAD_ERROR_HAL_DISCONNECTED    = 4,
-        MONITOR_THREAD_ERROR_REPORT_PROCESS_FAIL = 5,
+        MONITOR_THREAD_ERROR_NO_ERROR                      = 0,
+        MONITOR_THREAD_ERROR_HOSTAP_DISABLED               = 1,
+        MONITOR_THREAD_ERROR_ATTACH_FAIL                   = 2,
+        MONITOR_THREAD_ERROR_SUDDEN_DETACH                 = 3,
+        MONITOR_THREAD_ERROR_HAL_DISCONNECTED              = 4,
+        MONITOR_THREAD_ERROR_REPORT_PROCESS_FAIL           = 5,
+        MONITOR_THREAD_ERROR_NL_ATTACH_FAIL                = 6,
+        MONITOR_THREAD_ERROR_NL_REPORT_PROCESS_FAIL        = 7,
+        MONITOR_THREAD_ERROR_NL_EVENTS_SOCKET_DISCONNECTED = 8,
     };
 
 protected:
@@ -80,6 +83,7 @@ private:
     Socket *slave_socket       = nullptr;
     Socket *mon_hal_ext_events = nullptr;
     Socket *mon_hal_int_events = nullptr;
+    Socket *mon_hal_nl_events  = nullptr;
     beerocks::logging &logger;
 
     typedef struct {

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1123,6 +1123,30 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
 
         break;
     }
+    case beerocks_message::ACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST: {
+        LOG(TRACE) << "ACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST";
+        auto request_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST>();
+        if (!request_in) {
+            LOG(ERROR) << "addClass cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST failed";
+            return false;
+        }
+
+        auto request_out = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST>(cmdu_tx);
+        if (!request_out) {
+            LOG(ERROR)
+                << "Failed building cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST message!";
+            return false;
+        }
+
+        request_out->scan_params() = request_in->scan_params();
+
+        LOG(DEBUG) << "send cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST";
+        message_com::send_cmdu(monitor_socket, cmdu_tx);
+        break;
+    }
     default: {
         LOG(ERROR) << "Unknown CONTROL message, action_op: " << int(beerocks_header->action_op());
         return false;
@@ -2791,6 +2815,105 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
             return false;
         }
         notification_out->params() = notification_in->params();
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE: {
+        auto response_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE>();
+        if (!response_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE failed";
+            return false;
+        }
+
+        auto response_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE>(cmdu_tx);
+        if (!response_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE";
+            return false;
+        }
+
+        response_out->success() = response_in->success();
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGERED_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_TRIGGERED_NOTIFICATION !";
+            return false;
+        }
+
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION !";
+            return false;
+        }
+
+        notification_out->scan_results() = notification_in->scan_results();
+        notification_out->is_dump()      = notification_in->is_dump();
+
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_FINISHED_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_FINISHED_NOTIFICATION !";
+            return false;
+        }
+
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_ABORT_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_ABORT_NOTIFICATION !";
+            return false;
+        }
+
         send_cmdu_to_controller(cmdu_tx);
         break;
     }

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -564,19 +564,21 @@ int bml_set_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int e
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    auto pBML = static_cast<bml_internal *>(ctx);
+    return pBML->set_dcs_continuous_scan_enable(
+        network_utils::mac_from_string(std::string(radio_mac)), enable);
 }
 
-int bml_get_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int *output_enable)
+int bml_get_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int *enable)
 {
     // Validate input parameters
     if (!ctx) {
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    auto pBML = static_cast<bml_internal *>(ctx);
+    return pBML->get_dcs_continuous_scan_enable(
+        network_utils::mac_from_string(std::string(radio_mac)), *enable);
 }
 
 int bml_set_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int dwell_time,

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -633,6 +633,7 @@ int bml_start_dcs_single_scan(BML_CTX ctx, const char *radio_mac, int dwell_time
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    auto pBML = static_cast<bml_internal *>(ctx);
+    return pBML->start_dcs_single_scan(network_utils::mac_from_string(std::string(radio_mac)),
+                                       dwell_time, channel_pool, channel_pool_size);
 }

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -590,8 +590,10 @@ int bml_set_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int d
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    auto pBML = static_cast<bml_internal *>(ctx);
+    return pBML->set_dcs_continuous_scan_params(
+        network_utils::mac_from_string(std::string(radio_mac)), dwell_time, interval_time,
+        channel_pool, channel_pool_size);
 }
 
 int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *output_dwell_time,
@@ -603,8 +605,10 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    auto pBML = static_cast<bml_internal *>(ctx);
+    return pBML->get_dcs_continuous_scan_params(
+        network_utils::mac_from_string(std::string(radio_mac)), output_dwell_time,
+        output_interval_time, output_channel_pool, output_channel_pool_size);
 }
 
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -612,7 +612,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
 }
 
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_DCS_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP **output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan)
 {
@@ -621,8 +621,10 @@ int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    auto pBML = static_cast<bml_internal *>(ctx);
+    return pBML->get_dcs_scan_results(network_utils::mac_from_string(std::string(radio_mac)),
+                                      output_results, *output_results_size, *output_results_size,
+                                      *output_result_status, is_single_scan);
 }
 
 int bml_start_dcs_single_scan(BML_CTX ctx, const char *radio_mac, int dwell_time,

--- a/controller/src/beerocks/bml/bml.h
+++ b/controller/src/beerocks/bml/bml.h
@@ -554,7 +554,7 @@ int bml_set_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int e
  *
  * @return BML_RET_OK on success.
  */
-int bml_get_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int *output_enable);
+int bml_get_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int *enable);
 
 /**
  * set DCS continuous scan params.
@@ -601,7 +601,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
  * @return BML_RET_OK on success.
  */
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_DCS_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP **output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan);
 

--- a/controller/src/beerocks/bml/bml_defs.h
+++ b/controller/src/beerocks/bml/bml_defs.h
@@ -117,9 +117,10 @@ extern "C" {
 #define BML_WLAN_ENC_TKIP 1      /* Temporal Key Integrity Protocol */
 #define BML_WLAN_ENC_AES 2       /* Advanced Encryption Standart */
 
-/* DCS Parameters Placeholders */
-#define BML_DCS_INVALID_PARAM -1         /* Invalid parameter placeholder */
-#define BML_DCS_MAX_CHANNEL_POOL_SIZE 32 /* Maximal size of the channel pool */
+/* Channel Scan Parameters Placeholders */
+#define BML_CHANNEL_SCAN_INVALID_PARAM -1         /* Invalid parameter placeholder */
+#define BML_CHANNEL_SCAN_MAX_CHANNEL_POOL_SIZE 32 /* Maximal size of the channel pool */
+#define BML_CHANNEL_SCAN_ENUM_LIST_SIZE 16
 
 /****************************************************************************/
 /******************************* General Types ******************************/
@@ -553,43 +554,41 @@ struct BML_STATS_ITER {
     struct BML_STATS *(*get_node)();
 };
 
-struct BML_DCS_NEIGHBOR_AP {
-    //char  ap_Radio[64];
-    //The Radio that detected the neighboring WiFi SSID.
-    char ap_SSID[64];
-    //The current service set identifier in use by the neighboring WiFi SSID.
-    char ap_BSSID[64];
-    //[MACAddress] The BSSID used for the neighboring WiFi SSID.
-    char ap_Mode[64];
-    //The mode the neighboring WiFi radio is operating in.
-    unsigned int ap_Channel;
+struct BML_NEIGHBOR_AP {
+    char ap_SSID[BML_SSID_MAX_LENGTH];
+    //The current service set identifier in use by the neighboring WiFi SSID. The value MAY be empty for hidden SSIDs.
+    unsigned char ap_BSSID[BML_MAC_ADDR_LEN];
+    //The BSSID used for the neighboring WiFi SSID.
+    uint8_t ap_Mode;
+    //The mode the neighboring WiFi radio is operating in. Enumerate
+    uint32_t ap_Channel;
     //The current radio channel used by the neighboring WiFi radio.
-    int ap_SignalStrength;
-    //An indicator of radio signal strength (RSSI) of the neighboring WiFi radio measured indBm.
-    char ap_SecurityModeEnabled[64];
-    //The type of encryption the neighboring WiFi SSID advertises.
-    char ap_EncryptionMode[64];
-    //The type of encryption the neighboring WiFi SSID advertises.
-    char ap_OperatingFrequencyBand[16];
-    //Indicates the frequency band at which the radio this SSID instance is operating.
-    char ap_SupportedStandards[64];
-    //List items indicate which IEEE 802.11 standards thisResultinstance can support simultaneously.
-    char ap_OperatingStandards[16];
-    //Each list item MUST be a member of the list reported by theSupportedStandardsparameter.
-    char ap_OperatingChannelBandwidth[16];
-    //Indicates the bandwidth at which the channel is operating. Enumeration of:
-    unsigned int ap_BeaconPeriod;
+    int32_t ap_SignalStrength;
+    //An indicator of radio signal strength (RSSI) of the neighboring WiFi radio measured in dBm, as an average of the last 100 packets received.
+    uint8_t ap_SecurityModeEnabled[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
+    uint8_t ap_EncryptionMode[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
+    uint8_t ap_OperatingFrequencyBand;
+    //Indicates the frequency band at which the radio this SSID instance is operating. Enumerate
+    uint8_t ap_SupportedStandards[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //List items indicate which IEEE 802.11 standards thisResultinstance can support simultaneously, in the frequency band specified byOperatingFrequencyBand. Enumerate List
+    uint8_t ap_OperatingStandards;
+    //Indicates which IEEE 802.11 standard that is detected for this Result. Enumerate
+    uint8_t ap_OperatingChannelBandwidth;
+    //Indicates the bandwidth at which the channel is operating. Enumerate
+    uint32_t ap_BeaconPeriod;
     //Time interval (inms) between transmitting beacons.
-    int ap_Noise;
+    int32_t ap_Noise;
     //Indicator of average noise strength (indBm) received from the neighboring WiFi radio.
-    char ap_BasicDataTransferRates[256];
-    //Basic data transmit rates (in Mbps) for the SSID.
-    char ap_SupportedDataTransferRates[256];
-    //Data transmit rates for unicast frames at which the SSID will permit a station to connect.
-    unsigned int ap_DTIMPeriod;
-    //The number of beacon intervals that elapse between transmission of Beacon frames.
-    unsigned int ap_ChannelUtilization;
-    //Indicates the fraction of the time AP senses that the channel is in use by the neighboring AP.
+    uint32_t ap_BasicDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //Basic data transmit rates (in Kbps) for the SSID.
+    uint32_t ap_SupportedDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //Data transmit rates (in Kbps) for unicast frames at which the SSID will permit a station to connect.
+    uint32_t ap_DTIMPeriod;
+    //The number of beacon intervals that elapse between transmission of Beacon frames containing a TIM element whose DTIM count field is 0. This value is transmitted in the DTIM Period field of beacon frames. [802.11-2012]
+    uint32_t ap_ChannelUtilization;
+    //Indicates the fraction of the time AP senses that the channel is in use by the neighboring AP for transmissions.
 };
 
 /****************************************************************************/

--- a/controller/src/beerocks/bml/bml_defs.h
+++ b/controller/src/beerocks/bml/bml_defs.h
@@ -120,7 +120,7 @@ extern "C" {
 /* Channel Scan Parameters Placeholders */
 #define BML_CHANNEL_SCAN_INVALID_PARAM -1         /* Invalid parameter placeholder */
 #define BML_CHANNEL_SCAN_MAX_CHANNEL_POOL_SIZE 32 /* Maximal size of the channel pool */
-#define BML_CHANNEL_SCAN_ENUM_LIST_SIZE 16
+#define BML_CHANNEL_SCAN_ENUM_LIST_SIZE 8
 
 /****************************************************************************/
 /******************************* General Types ******************************/

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -27,8 +27,12 @@ INITIALIZE_EASYLOGGINGPP
 ////////////////////////// Local Module Definitions //////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-#define SELECT_TIMEOUT (500)    // 500 milliseconds
-#define RESPONSE_TIMEOUT (5000) // 5 seconds
+//These timeout definitions used throughout the code.
+//Usually used for setting wait periods for promises,
+//and sleeping until a partial or complete response arrives.
+#define SELECT_TIMEOUT (500)             // equivelent of 0.5 seconds
+#define RESPONSE_TIMEOUT (5000)          // equivelent of 5 seconds
+#define DELAYED_RESPONSE_TIMEOUT (30000) // equivelent of 30 seconds
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Static Members Initialization ///////////////////////
@@ -883,6 +887,18 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             }
             *m_pvaps_list_size = i;
 
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE: {
         } break;
         default: {
             LOG(WARNING) << "unhandled header BML action type 0x" << std::hex

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -152,6 +152,38 @@ public:
     int bml_set_vap_list_credentials(const BML_VAP_INFO *vaps, const uint8_t vaps_num);
     int bml_get_vap_list_credentials(BML_VAP_INFO *vaps, uint8_t &vaps_num);
 
+    /**
+    * @brief Enables or disables beerocks DCS continuous scans.
+    *
+    * @param [in] radio_mac Radio MAC of selected radio
+    * @param [in] enable    Value of 1 to enable or 0 to disable.
+    *
+    * @return BML_RET_OK on success.
+    */
+    int set_dcs_continuous_scan_enable(const sMacAddr &mac, int enable);
+    /**
+    * @brief Get DCS continuous scans param.
+    *
+    * @param [in] mac     Radio MAC of selected radio
+    * @param [out] enable A reference for the result to be stored in.
+    *
+    * @return BML_RET_OK on success.
+    */
+    int get_dcs_continuous_scan_enable(const sMacAddr &mac, int &enable);
+    int set_dcs_continuous_scan_params(const sMacAddr &mac, int dwell_time, int interval_time,
+                                       unsigned int *channel_pool, int channel_pool_size);
+    int get_dcs_continuous_scan_params(const sMacAddr &mac, int *output_dwell_time,
+                                       int *output_interval_time, unsigned int *output_channel_pool,
+                                       int *output_channel_pool_size);
+
+    //get channel scan results
+    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **output_results,
+                             unsigned int *output_results_size, const unsigned int max_results_size,
+                             uint8_t *output_result_status, bool is_single_scan);
+
+    //trigger single channel scan
+    int start_dcs_single_scan(const sMacAddr &mac, int dwell_time_ms, int channel_pool_size,
+                              unsigned int *channel_pool);
     /*
  * Public static methods:
  */

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -170,20 +170,35 @@ public:
     * @return BML_RET_OK on success.
     */
     int get_dcs_continuous_scan_enable(const sMacAddr &mac, int &enable);
+
+    /**
+    * @brief Set DCS continuous scan params.
+    *
+    * @param [in] mac               Radio MAC of selected radio
+    * @param [in] dwell_time        Set the dwell time in milliseconds.
+    * @param [in] interval_time     Set the interval time in seconds.
+    * @param [in] channel_pool      Set the channel pool for the DCS.
+    * @param [in] channel_pool_size Set the DCS channel pool size.
+    *
+    * @return BML_RET_OK on success.
+    */
     int set_dcs_continuous_scan_params(const sMacAddr &mac, int dwell_time, int interval_time,
                                        unsigned int *channel_pool, int channel_pool_size);
-    int get_dcs_continuous_scan_params(const sMacAddr &mac, int *output_dwell_time,
-                                       int *output_interval_time, unsigned int *output_channel_pool,
-                                       int *output_channel_pool_size);
 
-    //get channel scan results
-    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **output_results,
-                             unsigned int *output_results_size, const unsigned int max_results_size,
-                             uint8_t *output_result_status, bool is_single_scan);
+    /**
+    * @brief Get DCS continuous scan params.
+    *
+    * @param [in] mac                Radio MAC of selected radio
+    * @param [out] dwell_time        Get the dwell time in milliseconds.
+    * @param [out] interval_time     Get the interval time in seconds.
+    * @param [out] channel_pool      Get the channel pool for the DCS.
+    * @param [out] channel_pool_size Get the DCS channel pool size.
+    *
+    * @return BML_RET_OK on success.
+    */
+    int get_dcs_continuous_scan_params(const sMacAddr &mac, int *dwell_time, int *interval_time,
+                                       unsigned int *channel_pool, int *channel_pool_size);
 
-    //trigger single channel scan
-    int start_dcs_single_scan(const sMacAddr &mac, int dwell_time_ms, int channel_pool_size,
-                              unsigned int *channel_pool);
     /*
  * Public static methods:
  */
@@ -248,6 +263,8 @@ private:
     beerocks::promise<bool> *m_prmLocalMasterGet        = nullptr;
     beerocks::promise<bool> *m_prmRestrictedChannelsGet = nullptr;
     beerocks::promise<int> *m_prmRdkbWlan               = nullptr;
+    //Promise used to indicate the GetParams response was received
+    beerocks::promise<bool> *m_prmChannelScanParamsGet = nullptr;
 
     std::map<uint8_t, beerocks::promise<int> *> m_prmCliResponses;
 
@@ -262,9 +279,11 @@ private:
     beerocks_message::sAdminCredentials *m_admin_credentials     = nullptr;
     beerocks_message::sVersions *m_master_slave_versions         = nullptr;
     beerocks_message::sRestrictedChannels *m_Restricted_channels = nullptr;
-    BML_VAP_INFO *m_vaps                                         = nullptr;
-    uint8_t *m_pvaps_list_size                                   = nullptr;
-    uint16_t id                                                  = 0;
+    //m_scan_params is used when receiving the channel scan parameters
+    beerocks_message::sChannelScanRequestParams *m_scan_params = nullptr;
+    BML_VAP_INFO *m_vaps                                       = nullptr;
+    uint8_t *m_pvaps_list_size                                 = nullptr;
+    uint16_t id                                                = 0;
     static bool s_fExtLogContext;
 };
 

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -199,6 +199,18 @@ public:
     int get_dcs_continuous_scan_params(const sMacAddr &mac, int *dwell_time, int *interval_time,
                                        unsigned int *channel_pool, int *channel_pool_size);
 
+    /**
+    * Start a single DCS scan with parameters.
+    *
+    * @param [in] mac                  Radio MAC of selected radio
+    * @param [in] dwell_time_ms        Set the dwell time in milliseconds.
+    * @param [in] channel_pool         Set the channel pool for the DCS.
+    * @param [in] channel_pool_size    Set the DCS channel pool size.
+    *
+    * @return BML_RET_OK on success.
+    */
+    int start_dcs_single_scan(const sMacAddr &mac, int dwell_time_ms, unsigned int *channel_pool,
+                              int channel_pool_size);
     /*
  * Public static methods:
  */

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -200,6 +200,22 @@ public:
                                        unsigned int *channel_pool, int *channel_pool_size);
 
     /**
+    * @brief Get DCS channel scan results.
+    *
+    * @param [in] mac              Radio MAC of selected radio
+    * @param [out] results         Returning results.
+    * @param [out] results_size    Returning results size.
+    * @param [in] max_results_size Max requested results
+    * @param [out] result_status   Returning status of results
+    * @param [in] is_single_scan   Flag, if the results should be from a single scan or continuous
+    * 
+    * @return BML_RET_OK on success.
+    */
+    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **results,
+                             unsigned int &results_size, const unsigned int max_results_size,
+                             uint8_t &result_status, bool is_single_scan);
+
+    /**
     * Start a single DCS scan with parameters.
     *
     * @param [in] mac                  Radio MAC of selected radio
@@ -277,6 +293,8 @@ private:
     beerocks::promise<int> *m_prmRdkbWlan               = nullptr;
     //Promise used to indicate the GetParams response was received
     beerocks::promise<bool> *m_prmChannelScanParamsGet = nullptr;
+    //Promise used to indicate the GetResults response was received
+    beerocks::promise<int> *m_prmChannelScanResultsGet = nullptr;
 
     std::map<uint8_t, beerocks::promise<int> *> m_prmCliResponses;
 
@@ -293,9 +311,15 @@ private:
     beerocks_message::sRestrictedChannels *m_Restricted_channels = nullptr;
     //m_scan_params is used when receiving the channel scan parameters
     beerocks_message::sChannelScanRequestParams *m_scan_params = nullptr;
-    BML_VAP_INFO *m_vaps                                       = nullptr;
-    uint8_t *m_pvaps_list_size                                 = nullptr;
-    uint16_t id                                                = 0;
+    //m_scan_results is used when receiving channel scan results
+    std::list<beerocks_message::sChannelScanResults> *m_scan_results = nullptr;
+    //m_scan_results_status is used to store the results' latest status
+    uint8_t *m_scan_results_status = nullptr;
+    //m_scan_results_maxsize is used to indicate the maximum capacity of the requested results
+    uint32_t *m_scan_results_maxsize = nullptr;
+    BML_VAP_INFO *m_vaps             = nullptr;
+    uint8_t *m_pvaps_list_size       = nullptr;
+    uint16_t id                      = 0;
     static bool s_fExtLogContext;
 };
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2329,8 +2329,7 @@ bool db::clear_channel_scan_results(const sMacAddr &mac, bool single_scan)
         return false;
     }
 
-    (single_scan ? hostap->single_scan_config : hostap->continuous_scan_config)
-        .channel_pool.clear();
+    (single_scan ? hostap->single_scan_results : hostap->continuous_scan_results).clear();
 
     return true;
 }

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "db/network_map.h"
 #include "tasks/channel_selection_task.h"
+#include "tasks/dynamic_channel_selection_task.h"
 #include "tasks/ire_network_optimization_task.h"
 #include "tasks/load_balancer_task.h"
 
@@ -1798,6 +1799,34 @@ void son_management::handle_bml_message(Socket *sd,
         }
 
         son_actions::send_cmdu_to_agent(agent_mac, cmdu_tx, database);
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST";
+       break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST";
         break;
     }
     default: {

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -29,8 +29,6 @@ dynamic_channel_selection_task::dynamic_channel_selection_task(db &database_,
 
 void dynamic_channel_selection_task::work()
 {
-    TASK_LOG(DEBUG) << "FSM current state: " << s_ar_states[int(m_fsm_state)];
-
     switch (m_fsm_state) {
     case eState::INIT: {
         database.assign_dynamic_channel_selection_task_id(m_radio_mac, id);
@@ -57,7 +55,7 @@ void dynamic_channel_selection_task::work()
         break;
     }
     case eState::TRIGGER_SCAN: {
-        LOG(TRACE) << "TRIGGER_SCAN, mac=" << m_radio_mac << "scan_type is "
+        LOG(TRACE) << "TRIGGER_SCAN, mac=" << m_radio_mac << ", scan_type is "
                    << ((m_is_single_scan) ? "single-scan" : "continuous-scan");
 
         // When a scan is requested send the scan parameters Channel pool & Dwell time
@@ -180,7 +178,6 @@ void dynamic_channel_selection_task::work()
         break;
     }
     }
-    TASK_LOG(DEBUG) << "FSM next state: " << s_ar_states[int(m_fsm_state)];
 }
 
 void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
@@ -389,3 +386,11 @@ void dynamic_channel_selection_task::dcs_wait_for_event(eEvent dcs_event)
     m_dcs_waiting_for_event = dcs_event;
     wait_for_event((int)dcs_event);
 }
+
+void dynamic_channel_selection_task::fsm_move_state(eState new_state)
+{
+    TASK_LOG(TRACE) << "FSM: " << s_ar_states[int(m_fsm_state)] << " --> "
+                    << s_ar_states[int(new_state)];
+    m_fsm_state = new_state;
+}
+bool dynamic_channel_selection_task::fsm_in_state(eState state) { return m_fsm_state == state; }

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -69,6 +69,8 @@ protected:
 
 private:
     void dcs_wait_for_event(eEvent cs_event);
+    void fsm_move_state(eState new_state);
+    bool fsm_in_state(eState state);
 
     eState m_fsm_state;
 
@@ -85,9 +87,6 @@ private:
 
     bool m_is_single_scan_pending = false;
     bool m_is_single_scan         = false;
-
-    void fsm_move_state(eState new_state) { (m_fsm_state = new_state); }
-    bool fsm_in_state(eState state) { return (m_fsm_state == state); }
 };
 } //namespace son
 #endif


### PR DESCRIPTION
> The Dynamic Channel Selection as a feature can provide information on the supported channels which can be utilized by the management system to provide better availability and user experience.
#562

The Dynamic Channel Selection feature is divided into several pull request, this is the forth out of 5
### Dynamic channel selection message flow & actions
Changes in this PR include the following:
- agent: monitor_thread: proccess nl events
- agent: monitor_thread: handle channel scan events
- agent: monitor_thread: handle channel scan trigger CMDU
- controller & agent: master & slave: DCS channel scan
- controller: son_managment: DCS channel scan stubs
- controller: son_managment: DCS channel scan
- controller: bml: DCS channel scan setup
- controller: bml: DCS channel scan, set/get enable
- controller: bml: DCS channel scan, set/get params
- controller: bml: DCS channel scan, start single scan
- controller: bml: DCS channel scan, get results

**Before merging this PR please merge hotfix #695**