### PR TITLE
Hotfix/fix start monitor with empty ip

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -184,7 +184,7 @@ bool db::set_local_slave_mac(std::string mac)
 
 std::string db::get_local_slave_mac() { return local_slave_mac; }
 
-bool db::set_node_ipv4(std::string mac, std::string ipv4)
+bool db::set_node_ipv4(const std::string &mac, const std::string &ipv4)
 {
     auto n = get_node(mac);
     if (!n) {
@@ -194,7 +194,7 @@ bool db::set_node_ipv4(std::string mac, std::string ipv4)
     return true;
 }
 
-std::string db::get_node_ipv4(std::string mac)
+std::string db::get_node_ipv4(const std::string &mac)
 {
     auto n = get_node(mac);
     if (!n) {

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -175,8 +175,8 @@ public:
     bool set_local_slave_mac(std::string mac);
     std::string get_local_slave_mac();
 
-    bool set_node_ipv4(std::string mac, std::string ipv4);
-    std::string get_node_ipv4(std::string mac);
+    bool set_node_ipv4(const std::string &mac, const std::string &ipv4 = std::string());
+    std::string get_node_ipv4(const std::string &mac);
 
     bool set_node_manufacturer(std::string mac, std::string manufacturer);
     std::string get_node_manufacturer(std::string mac);

--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -312,6 +312,10 @@ void son_actions::handle_dead_node(std::string mac, std::string hostap_mac, db &
     if (parent_hostap_mac == hostap_mac) {
         if (mac_type == beerocks::TYPE_IRE_BACKHAUL || mac_type == beerocks::TYPE_CLIENT) {
             database.set_node_state(mac, beerocks::STATE_DISCONNECTED);
+
+            // Clear node ipv4
+            database.set_node_ipv4(mac);
+
             // Notify steering task, if any, of disconnect.
             int steering_task = database.get_steering_task_id(mac);
             if (tasks.is_task_running(steering_task))

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -41,8 +41,13 @@ void association_handling_task::work()
 {
     switch (state) {
     case START: {
+        // If this task already has been created by another event, let it finish and finish the new
+        // instance of it.
         int prev_task_id = database.get_association_handling_task_id(sta_mac);
-        tasks.kill_task(prev_task_id);
+        if (tasks.is_task_running(prev_task_id)) {
+            finish();
+            return;
+        }
         database.assign_association_handling_task_id(sta_mac, id);
 
         original_parent_mac = database.get_node_parent(sta_mac);


### PR DESCRIPTION
Currently, when a client connects, an association handling task is triggered
on topology notification. The task may reach to a point when it needs to
send START_MONITORING_REQUEST, before the client ipv4 has been updated
(from DHCP notification), and send the request with previous and not updated IP.
This causes a bug in the measurements, since the arp to the client
which used to measure the client will be sent to the wrong IP and the
measurement will fail.

Discovered by QA on RDKB, when the client connected and the statistics polling task was disabled,
a measurement was supposed to be performed by the START_MONITORING_REQUEST, but the RSSI in the CLI remained "-127"