### PR TITLE
Hotfix/enable statistics polling task

### DIFF
--- a/controller/config/beerocks_controller.conf.in
+++ b/controller/config/beerocks_controller.conf.in
@@ -30,7 +30,7 @@ load_ire_roaming=1
 load_load_balancing=0
 
 #   Measurement feature:  
-load_diagnostics_measurements=0
+load_diagnostics_measurements=1
 load_backhaul_measurements=0
 load_front_measurements=1
 load_monitor_on_vaps=1

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -104,6 +104,7 @@ bool master_thread::init()
         LOG(ERROR) << "Failed subscribing to the Bus";
     }
 
+#ifndef BEEROCKS_LINUX
     auto new_statistics_polling_task =
         std::make_shared<statistics_polling_task>(database, cmdu_tx, tasks);
     if (!new_statistics_polling_task) {
@@ -111,6 +112,7 @@ bool master_thread::init()
         return false;
     }
     tasks.add_task(new_statistics_polling_task);
+#endif
 
     auto new_bml_task = std::make_shared<bml_task>(database, cmdu_tx, tasks);
     if (!new_bml_task) {


### PR DESCRIPTION
Enable diagnostics_measurements on the controller configuration file
to initiate the statistics polling task.
This task is responsible for client RSSI updates on the CLI and required
by QA test flow.

Tested on RDKB and I didn't see any timeout error message like mentioned in #527 .

Fixes #527 