### PR TITLE
Hotfix/dont stop monitor if netlink fails

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1417,13 +1417,50 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
 
     } break;
     case Event::Channel_Scan_Triggered: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION msg";
+            return false;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
     case Event::Channel_Scan_New_Results_Ready:
     case Event::Channel_Scan_Dump_Result: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION msg";
+            return false;
+        }
+
+        // If event == Channel_Scan_New_Results_Ready do nothing since is_dump's default is 0
+        if (event == Event::Channel_Scan_Dump_Result) {
+            notification->is_dump() = 1;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
     case Event::Channel_Scan_Finished: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION msg";
+            return false;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
     case Event::Channel_Scan_Abort: {
+        auto notification = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION>(cmdu_tx);
+        if (!notification) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION msg";
+            return false;
+        }
+
+        message_com::send_cmdu(slave_socket, cmdu_tx);
     } break;
 
     // Unhandled events

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -286,7 +286,6 @@ void monitor_thread::after_select(bool timeout)
             } else {
                 LOG(ERROR) << "Couldn't get NL socket ";
                 thread_last_error_code = MONITOR_THREAD_ERROR_NL_ATTACH_FAIL;
-                stop_monitor_thread();
                 return;
             }
 
@@ -390,7 +389,6 @@ void monitor_thread::after_select(bool timeout)
             // There is no socket for external events
             LOG(ERROR) << "no socket exists for mon_hal_nl_events";
             thread_last_error_code = MONITOR_THREAD_ERROR_NL_ATTACH_FAIL;
-            stop_monitor_thread();
             return;
         }
 

--- a/agent/src/beerocks/monitor/monitor_thread.h
+++ b/agent/src/beerocks/monitor/monitor_thread.h
@@ -35,12 +35,14 @@ public:
     virtual bool init() override;
 
     enum eThreadErrors : uint32_t {
-        MONITOR_THREAD_ERROR_NO_ERROR            = 0,
-        MONITOR_THREAD_ERROR_HOSTAP_DISABLED     = 1,
-        MONITOR_THREAD_ERROR_ATTACH_FAIL         = 2,
-        MONITOR_THREAD_ERROR_SUDDEN_DETACH       = 3,
-        MONITOR_THREAD_ERROR_HAL_DISCONNECTED    = 4,
-        MONITOR_THREAD_ERROR_REPORT_PROCESS_FAIL = 5,
+        MONITOR_THREAD_ERROR_NO_ERROR               = 0,
+        MONITOR_THREAD_ERROR_HOSTAP_DISABLED        = 1,
+        MONITOR_THREAD_ERROR_ATTACH_FAIL            = 2,
+        MONITOR_THREAD_ERROR_SUDDEN_DETACH          = 3,
+        MONITOR_THREAD_ERROR_HAL_DISCONNECTED       = 4,
+        MONITOR_THREAD_ERROR_REPORT_PROCESS_FAIL    = 5,
+        MONITOR_THREAD_ERROR_NL_ATTACH_FAIL         = 6,
+        MONITOR_THREAD_ERROR_NL_REPORT_PROCESS_FAIL = 7,
     };
 
 protected:
@@ -80,6 +82,7 @@ private:
     Socket *slave_socket       = nullptr;
     Socket *mon_hal_ext_events = nullptr;
     Socket *mon_hal_int_events = nullptr;
+    Socket *mon_hal_nl_events  = nullptr;
     beerocks::logging &logger;
 
     typedef struct {

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1124,6 +1124,30 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
 
         break;
     }
+    case beerocks_message::ACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST: {
+        LOG(TRACE) << "ACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST";
+        auto request_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST>();
+        if (!request_in) {
+            LOG(ERROR) << "addClass cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST failed";
+            return false;
+        }
+
+        auto request_out = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST>(cmdu_tx);
+        if (!request_out) {
+            LOG(ERROR)
+                << "Failed building cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST message!";
+            return false;
+        }
+
+        request_out->scan_params() = request_in->scan_params();
+
+        LOG(DEBUG) << "send cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST";
+        message_com::send_cmdu(monitor_socket, cmdu_tx);
+        break;
+    }
     default: {
         LOG(ERROR) << "Unknown CONTROL message, action_op: " << int(beerocks_header->action_op());
         return false;
@@ -2785,6 +2809,105 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
             return false;
         }
         notification_out->params() = notification_in->params();
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE: {
+        auto response_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE>();
+        if (!response_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE failed";
+            return false;
+        }
+
+        auto response_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE>(cmdu_tx);
+        if (!response_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE";
+            return false;
+        }
+
+        response_out->success() = response_in->success();
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGERED_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_TRIGGERED_NOTIFICATION !";
+            return false;
+        }
+
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION !";
+            return false;
+        }
+
+        notification_out->scan_results() = notification_in->scan_results();
+        notification_out->is_dump()      = notification_in->is_dump();
+
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_FINISHED_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_FINISHED_NOTIFICATION !";
+            return false;
+        }
+
+        send_cmdu_to_controller(cmdu_tx);
+        break;
+    }
+    case beerocks_message::ACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION: {
+        auto notification_in =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION>();
+        if (!notification_in) {
+            LOG(ERROR) << "addClass cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION failed";
+            return false;
+        }
+
+        auto notification_out = message_com::create_vs_message<
+            beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_ABORT_NOTIFICATION>(cmdu_tx);
+        if (!notification_out) {
+            LOG(ERROR) << "Failed building cACTION_CONTROL_CHANNEL_SCAN_ABORT_NOTIFICATION !";
+            return false;
+        }
+
         send_cmdu_to_controller(cmdu_tx);
         break;
     }

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -629,6 +629,6 @@ int bml_start_dcs_single_scan(BML_CTX ctx, const char *radio_mac, int dwell_time
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    bml_internal *pBML = (bml_internal *)ctx;
+    return pBML->start_dcs_single_scan(radio_mac, dwell_time, channel_pool_size, channel_pool);
 }

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -588,8 +588,9 @@ int bml_set_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int d
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    bml_internal *pBML = (bml_internal *)ctx;
+    return pBML->set_dcs_continuous_scan_params(radio_mac, dwell_time, interval_time, channel_pool,
+                                                channel_pool_size);
 }
 
 int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *output_dwell_time,
@@ -601,8 +602,9 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    bml_internal *pBML = (bml_internal *)ctx;
+    return pBML->get_dcs_continuous_scan_params(radio_mac, output_dwell_time, output_interval_time,
+                                                output_channel_pool, output_channel_pool_size);
 }
 
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -608,7 +608,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
 }
 
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_DCS_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP **output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan)
 {
@@ -617,8 +617,9 @@ int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    bml_internal *pBML = (bml_internal *)ctx;
+    return pBML->get_dcs_scan_results(radio_mac, output_results, output_results_size,
+                                      *output_results_size, output_result_status, is_single_scan);
 }
 
 int bml_start_dcs_single_scan(BML_CTX ctx, const char *radio_mac, int dwell_time,

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -564,8 +564,8 @@ int bml_set_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int e
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    bml_internal *pBML = (bml_internal *)ctx;
+    return pBML->set_dcs_continuous_scan_enable(radio_mac, enable);
 }
 
 int bml_get_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int *output_enable)
@@ -575,8 +575,8 @@ int bml_get_dcs_continuous_scan_enable(BML_CTX ctx, const char *radio_mac, int *
         return (-BML_RET_INVALID_ARGS);
     }
 
-    // TODO: call suitable bml api
-    return BML_RET_OP_FAILED;
+    bml_internal *pBML = (bml_internal *)ctx;
+    return pBML->get_dcs_continuous_scan_enable(radio_mac, output_enable);
 }
 
 int bml_set_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int dwell_time,

--- a/controller/src/beerocks/bml/bml.h
+++ b/controller/src/beerocks/bml/bml.h
@@ -601,7 +601,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
  * @return BML_RET_OK on success.
  */
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_DCS_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP **output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan);
 

--- a/controller/src/beerocks/bml/bml_defs.h
+++ b/controller/src/beerocks/bml/bml_defs.h
@@ -117,9 +117,10 @@ extern "C" {
 #define BML_WLAN_ENC_TKIP 1      /* Temporal Key Integrity Protocol */
 #define BML_WLAN_ENC_AES 2       /* Advanced Encryption Standart */
 
-/* DCS Parameters Placeholders */
-#define BML_DCS_INVALID_PARAM -1         /* Invalid parameter placeholder */
-#define BML_DCS_MAX_CHANNEL_POOL_SIZE 32 /* Maximal size of the channel pool */
+/* Channel Scan Parameters Placeholders */
+#define BML_CHANNEL_SCAN_INVALID_PARAM -1         /* Invalid parameter placeholder */
+#define BML_CHANNEL_SCAN_MAX_CHANNEL_POOL_SIZE 32 /* Maximal size of the channel pool */
+#define BML_CHANNEL_SCAN_ENUM_LIST_SIZE 16
 
 /****************************************************************************/
 /******************************* General Types ******************************/
@@ -553,43 +554,41 @@ struct BML_STATS_ITER {
     struct BML_STATS *(*get_node)();
 };
 
-struct BML_DCS_NEIGHBOR_AP {
-    //char  ap_Radio[64];
-    //The Radio that detected the neighboring WiFi SSID.
-    char ap_SSID[64];
-    //The current service set identifier in use by the neighboring WiFi SSID.
-    char ap_BSSID[64];
-    //[MACAddress] The BSSID used for the neighboring WiFi SSID.
-    char ap_Mode[64];
-    //The mode the neighboring WiFi radio is operating in.
-    unsigned int ap_Channel;
+struct BML_NEIGHBOR_AP {
+    char ap_SSID[BML_SSID_MAX_LENGTH];
+    //The current service set identifier in use by the neighboring WiFi SSID. The value MAY be empty for hidden SSIDs.
+    unsigned char ap_BSSID[BML_MAC_ADDR_LEN];
+    //The BSSID used for the neighboring WiFi SSID.
+    uint8_t ap_Mode;
+    //The mode the neighboring WiFi radio is operating in. Enumerate
+    uint32_t ap_Channel;
     //The current radio channel used by the neighboring WiFi radio.
-    int ap_SignalStrength;
-    //An indicator of radio signal strength (RSSI) of the neighboring WiFi radio measured indBm.
-    char ap_SecurityModeEnabled[64];
-    //The type of encryption the neighboring WiFi SSID advertises.
-    char ap_EncryptionMode[64];
-    //The type of encryption the neighboring WiFi SSID advertises.
-    char ap_OperatingFrequencyBand[16];
-    //Indicates the frequency band at which the radio this SSID instance is operating.
-    char ap_SupportedStandards[64];
-    //List items indicate which IEEE 802.11 standards thisResultinstance can support simultaneously.
-    char ap_OperatingStandards[16];
-    //Each list item MUST be a member of the list reported by theSupportedStandardsparameter.
-    char ap_OperatingChannelBandwidth[16];
-    //Indicates the bandwidth at which the channel is operating. Enumeration of:
-    unsigned int ap_BeaconPeriod;
+    int32_t ap_SignalStrength;
+    //An indicator of radio signal strength (RSSI) of the neighboring WiFi radio measured in dBm, as an average of the last 100 packets received.
+    uint8_t ap_SecurityModeEnabled[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
+    uint8_t ap_EncryptionMode[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
+    uint8_t ap_OperatingFrequencyBand;
+    //Indicates the frequency band at which the radio this SSID instance is operating. Enumerate
+    uint8_t ap_SupportedStandards[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //List items indicate which IEEE 802.11 standards thisResultinstance can support simultaneously, in the frequency band specified byOperatingFrequencyBand. Enumerate List
+    uint8_t ap_OperatingStandards;
+    //Indicates which IEEE 802.11 standard that is detected for this Result. Enumerate
+    uint8_t ap_OperatingChannelBandwidth;
+    //Indicates the bandwidth at which the channel is operating. Enumerate
+    uint32_t ap_BeaconPeriod;
     //Time interval (inms) between transmitting beacons.
-    int ap_Noise;
+    int32_t ap_Noise;
     //Indicator of average noise strength (indBm) received from the neighboring WiFi radio.
-    char ap_BasicDataTransferRates[256];
-    //Basic data transmit rates (in Mbps) for the SSID.
-    char ap_SupportedDataTransferRates[256];
-    //Data transmit rates for unicast frames at which the SSID will permit a station to connect.
-    unsigned int ap_DTIMPeriod;
-    //The number of beacon intervals that elapse between transmission of Beacon frames.
-    unsigned int ap_ChannelUtilization;
-    //Indicates the fraction of the time AP senses that the channel is in use by the neighboring AP.
+    uint32_t ap_BasicDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //Basic data transmit rates (in Kbps) for the SSID.
+    uint32_t ap_SupportedDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    //Data transmit rates (in Kbps) for unicast frames at which the SSID will permit a station to connect.
+    uint32_t ap_DTIMPeriod;
+    //The number of beacon intervals that elapse between transmission of Beacon frames containing a TIM element whose DTIM count field is 0. This value is transmitted in the DTIM Period field of beacon frames. [802.11-2012]
+    uint32_t ap_ChannelUtilization;
+    //Indicates the fraction of the time AP senses that the channel is in use by the neighboring AP for transmissions.
 };
 
 /****************************************************************************/

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -1219,6 +1219,53 @@ int bml_internal::bml_get_vap_list_credentials(BML_VAP_INFO *vaps, uint8_t &vaps
     return (iRet);
 }
 
+int bml_internal::set_dcs_continuous_scan_enable(const std::string &mac, int enable)
+{
+    //CMDU message
+    auto request = message_com::create_vs_message<
+        beerocks_message::cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST>(cmdu_tx);
+
+    if (!request) {
+        LOG(ERROR)
+            << "Failed building cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST message!";
+        return (-BML_RET_OP_FAILED);
+    }
+
+    request->radio_mac() = network_utils::mac_from_string(mac);
+    request->isEnable()  = enable;
+
+    int result = 0;
+    if (send_bml_cmdu(result, request->get_action_op()) != BML_RET_OK) {
+        LOG(ERROR) << "Send ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST failed";
+        return (-BML_RET_OP_FAILED);
+    }
+
+    if (result > 0) {
+        LOG(ERROR) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST returned error code:"
+                   << result;
+        return result;
+    }
+
+    return BML_RET_OK;
+}
+
+int bml_internal::get_dcs_continuous_scan_enable(const std::string &mac, int *output_enable)
+{
+    //CMDU message
+    auto request = message_com::create_vs_message<
+        beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST>(cmdu_tx);
+
+    if (!request) {
+        LOG(ERROR)
+            << "Failed building ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST message!";
+        return (-BML_RET_OP_FAILED);
+    }
+
+    request->radio_mac() = network_utils::mac_from_string(mac);
+
+    return send_bml_cmdu(*output_enable, request->get_action_op());
+}
+
 int bml_internal::ping()
 {
     // Command supported only on local master

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -64,6 +64,38 @@ static void config_logger(const std::string log_file = std::string())
 
 #endif // BEEROCKS_DEBUG
 
+static void translate_channel_scan_results(const beerocks_message::sChannelScanResults &res_in,
+                                           BML_NEIGHBOR_AP *res_out)
+{
+    if (!res_out) {
+        LOG(ERROR) << "Failed translating results, res_out==NULL";
+        return;
+    }
+
+    string_utils::copy_string(res_out->ap_SSID, res_in.ssid, 36);
+    std::copy_n(res_in.bssid.oct, BML_MAC_ADDR_LEN, res_out->ap_BSSID);
+    std::copy_n(res_in.security_mode_enabled, BML_CHANNEL_SCAN_ENUM_LIST_SIZE,
+                res_out->ap_SecurityModeEnabled);
+    std::copy_n(res_in.encryption_mode, BML_CHANNEL_SCAN_ENUM_LIST_SIZE,
+                res_out->ap_EncryptionMode);
+    std::copy_n(res_in.supported_standards, BML_CHANNEL_SCAN_ENUM_LIST_SIZE,
+                res_out->ap_SupportedStandards);
+    std::copy_n(res_in.basic_data_transfer_rates_kbps, BML_CHANNEL_SCAN_ENUM_LIST_SIZE,
+                res_out->ap_BasicDataTransferRates);
+    std::copy_n(res_in.supported_data_transfer_rates_kbps, BML_CHANNEL_SCAN_ENUM_LIST_SIZE,
+                res_out->ap_SupportedDataTransferRates);
+
+    res_out->ap_Channel                   = res_in.channel;
+    res_out->ap_SignalStrength            = res_in.signal_strength_dBm;
+    res_out->ap_OperatingFrequencyBand    = res_in.operating_frequency_band;
+    res_out->ap_OperatingStandards        = res_in.operating_standards;
+    res_out->ap_OperatingChannelBandwidth = res_in.operating_channel_bandwidth;
+    res_out->ap_BeaconPeriod              = res_in.beacon_period_ms;
+    res_out->ap_Noise                     = res_in.noise_dBm;
+    res_out->ap_DTIMPeriod                = res_in.dtim_period;
+    res_out->ap_ChannelUtilization        = res_in.channel_utilization;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1399,6 +1431,90 @@ int bml_internal::get_dcs_continuous_scan_params(const std::string &mac, int *ou
     }
 
     return (iRet);
+}
+
+int bml_internal::get_dcs_scan_results(const std::string &mac, BML_NEIGHBOR_AP **output_results,
+                                       unsigned int *output_results_size,
+                                       const unsigned int max_results_size,
+                                       uint8_t *output_result_status, bool is_single_scan)
+{
+    if (m_sockPlatform == nullptr && !connect_to_platform()) {
+        return (-BML_RET_CONNECT_FAIL);
+    }
+
+    // Initialize the promise for receiving the response
+    beerocks::promise<int> prmChannelScanResultsGet;
+    m_prmChannelScanResultsGet    = &prmChannelScanResultsGet;
+    int iOpTimeout                = DELAYED_RESPONSE_TIMEOUT; // Default timeout
+    auto scan_results             = std::list<beerocks_message::sChannelScanResults>();
+    uint32_t scan_results_size    = 0;
+    uint32_t scan_results_maxsize = uint32_t(max_results_size);
+
+    m_scan_results         = &scan_results;
+    m_scan_results_size    = &scan_results_size;
+    m_scan_results_maxsize = &scan_results_maxsize;
+    m_scan_results_status  = output_result_status;
+
+    //CMDU message
+    auto request = message_com::create_vs_message<
+        beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST>(cmdu_tx);
+
+    if (!request) {
+        LOG(ERROR) << "Failed building cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST message!";
+        return (-BML_RET_OP_FAILED);
+    }
+
+    request->radio_mac() = network_utils::mac_from_string(mac);
+    request->scan_mode() = (is_single_scan) ? 1 : 0;
+    // Build and send the message
+    if (!message_com::send_cmdu(m_sockMaster, cmdu_tx)) {
+        LOG(ERROR) << "Failed sending param get message!";
+        m_prmChannelScanResultsGet = nullptr;
+        m_scan_results             = nullptr;
+        m_scan_results_size        = nullptr;
+        m_scan_results_maxsize     = nullptr;
+        m_scan_results_status      = nullptr;
+        return (-BML_RET_OP_FAILED);
+    }
+    LOG(DEBUG) << "ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST sent";
+
+    int iRet = BML_RET_OK;
+
+    if (!m_prmChannelScanResultsGet->wait_for(iOpTimeout)) {
+        LOG(WARNING) << "Timeout while waiting for results get response...";
+        iRet = -BML_RET_TIMEOUT;
+    }
+
+    // Clear the scan results members
+    m_scan_results         = nullptr;
+    m_scan_results_size    = nullptr;
+    m_scan_results_maxsize = nullptr;
+    m_scan_results_status  = nullptr;
+
+    // Clear the promise holder
+    m_prmChannelScanResultsGet = nullptr;
+
+    if (iRet != BML_RET_OK) {
+        LOG(ERROR) << "Results get failed!";
+        return (iRet);
+    }
+
+    iRet = prmChannelScanResultsGet.get_value();
+    if (iRet != int(eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS) &&
+        iRet != int(eChannelScanOpErrCode::CHANNEL_SCAN_OP_SCAN_RESULTS_EMPTY)) {
+        LOG(ERROR) << "Results returned with error code:" << iRet << ". Aborting!";
+        return iRet;
+    }
+
+    //output_results_size will be set to the number of actual returning results
+    *output_results_size = 0;
+    for (auto res : scan_results) {
+        auto out = &((*output_results)[*output_results_size]);
+        translate_channel_scan_results(res, out);
+        *output_results_size += 1;
+    }
+
+    return BML_RET_OK;
 }
 
 int bml_internal::start_dcs_single_scan(const std::string &mac, int dwell_time_ms,

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -27,8 +27,9 @@ INITIALIZE_EASYLOGGINGPP
 ////////////////////////// Local Module Definitions //////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-#define SELECT_TIMEOUT (500)    // 500 milliseconds
-#define RESPONSE_TIMEOUT (5000) // 5 seconds
+#define SELECT_TIMEOUT (500)             // 500 milliseconds
+#define RESPONSE_TIMEOUT (5000)          // 5 seconds
+#define DELAYED_RESPONSE_TIMEOUT (30000) // 30 seconds
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Static Members Initialization ///////////////////////
@@ -1029,6 +1030,18 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
                 LOG(WARNING)
                     << "Received MASTER_SLAVE_VERSIONS_RESPONSE response, but no one is waiting...";
             }
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE: {
+        } break;
+        case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE: {
         } break;
         default: {
             LOG(WARNING) << "unhandled header platform action type 0x" << std::hex

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -152,6 +152,9 @@ public:
     int bml_set_vap_list_credentials(const BML_VAP_INFO *vaps, const uint8_t vaps_num);
     int bml_get_vap_list_credentials(BML_VAP_INFO *vaps, uint8_t &vaps_num);
 
+    //set and get channel scan enable flag
+    int set_dcs_continuous_scan_enable(const std::string &mac, int enable);
+    int get_dcs_continuous_scan_enable(const std::string &mac, int *output_enable);
     /*
  * Public static methods:
  */

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -163,6 +163,11 @@ public:
                                        int *output_interval_time, unsigned int *output_channel_pool,
                                        int *output_channel_pool_size);
 
+    //get channel scan results
+    int get_dcs_scan_results(const std::string &mac, BML_NEIGHBOR_AP **output_results,
+                             unsigned int *output_results_size, const unsigned int max_results_size,
+                             uint8_t *output_result_status, bool is_single_scan);
+
     //trigger single channel scan
     int start_dcs_single_scan(const std::string &mac, int dwell_time_ms, int channel_pool_size,
                               unsigned int *channel_pool);
@@ -231,6 +236,7 @@ private:
     beerocks::promise<bool> *m_prmRestrictedChannelsGet = nullptr;
     beerocks::promise<int> *m_prmRdkbWlan               = nullptr;
     beerocks::promise<bool> *m_prmChannelScanParamsGet  = nullptr;
+    beerocks::promise<int> *m_prmChannelScanResultsGet  = nullptr;
 
     std::map<uint8_t, beerocks::promise<int> *> m_prmCliResponses;
 
@@ -240,15 +246,19 @@ private:
     BML_STATS_UPDATE_CB m_cbStatsUpdate  = nullptr;
     BML_EVENT_CB m_cbEvent               = nullptr;
 
-    beerocks_message::sDeviceInfo *m_device_info                 = nullptr;
-    beerocks_message::sWifiCredentials *m_wifi_credentials       = nullptr;
-    beerocks_message::sAdminCredentials *m_admin_credentials     = nullptr;
-    beerocks_message::sVersions *m_master_slave_versions         = nullptr;
-    beerocks_message::sRestrictedChannels *m_Restricted_channels = nullptr;
-    beerocks_message::sChannelScanRequestParams *m_scan_params   = nullptr;
-    BML_VAP_INFO *m_vaps                                         = nullptr;
-    uint8_t *m_pvaps_list_size                                   = nullptr;
-    uint16_t id                                                  = 0;
+    beerocks_message::sDeviceInfo *m_device_info                     = nullptr;
+    beerocks_message::sWifiCredentials *m_wifi_credentials           = nullptr;
+    beerocks_message::sAdminCredentials *m_admin_credentials         = nullptr;
+    beerocks_message::sVersions *m_master_slave_versions             = nullptr;
+    beerocks_message::sRestrictedChannels *m_Restricted_channels     = nullptr;
+    beerocks_message::sChannelScanRequestParams *m_scan_params       = nullptr;
+    std::list<beerocks_message::sChannelScanResults> *m_scan_results = nullptr;
+    uint8_t *m_scan_results_status                                   = nullptr;
+    uint32_t *m_scan_results_size                                    = nullptr;
+    uint32_t *m_scan_results_maxsize                                 = nullptr;
+    BML_VAP_INFO *m_vaps                                             = nullptr;
+    uint8_t *m_pvaps_list_size                                       = nullptr;
+    uint16_t id                                                      = 0;
     static bool s_fExtLogContext;
 };
 

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -155,6 +155,13 @@ public:
     //set and get channel scan enable flag
     int set_dcs_continuous_scan_enable(const std::string &mac, int enable);
     int get_dcs_continuous_scan_enable(const std::string &mac, int *output_enable);
+
+    //set and get channel scan params
+    int set_dcs_continuous_scan_params(const std::string &mac, int dwell_time, int interval_time,
+                                       unsigned int *channel_pool, int channel_pool_size);
+    int get_dcs_continuous_scan_params(const std::string &mac, int *output_dwell_time,
+                                       int *output_interval_time, unsigned int *output_channel_pool,
+                                       int *output_channel_pool_size);
     /*
  * Public static methods:
  */
@@ -219,6 +226,7 @@ private:
     beerocks::promise<bool> *m_prmLocalMasterGet        = nullptr;
     beerocks::promise<bool> *m_prmRestrictedChannelsGet = nullptr;
     beerocks::promise<int> *m_prmRdkbWlan               = nullptr;
+    beerocks::promise<bool> *m_prmChannelScanParamsGet  = nullptr;
 
     std::map<uint8_t, beerocks::promise<int> *> m_prmCliResponses;
 
@@ -233,6 +241,7 @@ private:
     beerocks_message::sAdminCredentials *m_admin_credentials     = nullptr;
     beerocks_message::sVersions *m_master_slave_versions         = nullptr;
     beerocks_message::sRestrictedChannels *m_Restricted_channels = nullptr;
+    beerocks_message::sChannelScanRequestParams *m_scan_params   = nullptr;
     BML_VAP_INFO *m_vaps                                         = nullptr;
     uint8_t *m_pvaps_list_size                                   = nullptr;
     uint16_t id                                                  = 0;

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -162,6 +162,10 @@ public:
     int get_dcs_continuous_scan_params(const std::string &mac, int *output_dwell_time,
                                        int *output_interval_time, unsigned int *output_channel_pool,
                                        int *output_channel_pool_size);
+
+    //trigger single channel scan
+    int start_dcs_single_scan(const std::string &mac, int dwell_time_ms, int channel_pool_size,
+                              unsigned int *channel_pool);
     /*
  * Public static methods:
  */

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -1803,26 +1803,355 @@ void son_management::handle_bml_message(Socket *sd,
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST: {
         LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST";
-       break;
+
+        auto request = beerocks_header->addClass<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST failed";
+            break;
+        }
+
+        auto response = message_com::create_vs_message<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE>(
+            cmdu_tx, beerocks_header->id());
+        if (!response) {
+            LOG(ERROR) << "Failed building cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE";
+        }
+
+        auto radio_mac         = request->radio_mac();
+        auto dwell_time_ms     = request->params().dwell_time_ms;
+        auto interval_time_sec = request->params().interval_time_sec;
+        auto channel_pool      = request->params().channel_pool;
+        auto channel_pool_size = request->params().channel_pool_size;
+
+        LOG(DEBUG) << "request radio_mac:" << radio_mac;
+        auto op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS;
+
+        if (dwell_time_ms != CHANNEL_SCAN_INVALID_PARAM &&
+            op_error_code == eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS) {
+            op_error_code =
+                database.set_channel_scan_dwell_time_msec(radio_mac, dwell_time_ms, false)
+                    ? op_error_code
+                    : eChannelScanOpErrCode::CHANNEL_SCAN_OP_INVALID_PARAMS_DWELLTIME;
+        }
+        if (interval_time_sec != CHANNEL_SCAN_INVALID_PARAM &&
+            op_error_code == eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS) {
+            op_error_code = database.set_channel_scan_interval_sec(radio_mac, interval_time_sec)
+                                ? op_error_code
+                                : eChannelScanOpErrCode::CHANNEL_SCAN_OP_INVALID_PARAMS_SCANTIME;
+        }
+        if (channel_pool != nullptr && channel_pool_size != CHANNEL_SCAN_INVALID_PARAM &&
+            op_error_code == eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS) {
+            auto channel_pool_set =
+                std::unordered_set<uint8_t>(channel_pool, channel_pool + channel_pool_size);
+            op_error_code = database.set_channel_scan_pool(radio_mac, channel_pool_set, false)
+                                ? op_error_code
+                                : eChannelScanOpErrCode::CHANNEL_SCAN_OP_INVALID_PARAMS_CHANNELPOOL;
+        }
+        response->op_error_code() = uint8_t(op_error_code);
+        //send response to bml
+        message_com::send_cmdu(sd, cmdu_tx);
+        break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST: {
         LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST";
+
+        auto request = beerocks_header->addClass<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST failed";
+            break;
+        }
+
+        auto response = message_com::create_vs_message<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_RESPONSE>(
+            cmdu_tx, beerocks_header->id());
+        if (!response) {
+            LOG(ERROR) << "Failed building message "
+                          "cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_RESPONSE !";
+        }
+
+        auto radio_mac = request->radio_mac();
+        response->params().dwell_time_ms =
+            database.get_channel_scan_dwell_time_msec(radio_mac, false);
+        response->params().interval_time_sec = database.get_channel_scan_interval_sec(radio_mac);
+        auto &channel_pool                   = database.get_channel_scan_pool(radio_mac, false);
+        std::copy(channel_pool.begin(), channel_pool.end(), response->params().channel_pool);
+        response->params().channel_pool_size = channel_pool.size();
+        LOG(DEBUG) << "request radio_mac:" << radio_mac;
+        message_com::send_cmdu(sd, cmdu_tx);
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST: {
         LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST";
+
+        auto request = beerocks_header->addClass<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST failed";
+            break;
+        }
+
+        auto response = message_com::create_vs_message<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE>(
+            cmdu_tx, beerocks_header->id());
+        if (!response) {
+            LOG(ERROR) << "Failed building message "
+                          "cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE !";
+            return;
+        }
+
+        auto radio_mac = request->radio_mac();
+        auto enable    = (request->isEnable() == 1);
+        LOG(DEBUG) << "request radio_mac:" << radio_mac;
+        bool success = database.set_channel_scan_is_enabled(radio_mac, enable);
+        response->op_error_code() =
+            uint8_t((success) ? eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS
+                              : eChannelScanOpErrCode::CHANNEL_SCAN_OP_INVALID_PARAMS_ENABLE);
+
+        // on DCS enable - "reset" the interval wait of the task
+        // (will perform scan right after change to enable)
+        if (enable && success) {
+            dynamic_channel_selection_task::sScanEvent new_event;
+            new_event.radio_mac = request->radio_mac();
+
+            tasks.push_event(database.get_dynamic_channel_selection_task_id(radio_mac),
+                             (int)dynamic_channel_selection_task::eEvent::SCAN_ENABLE_CHANGE,
+                             (void *)&new_event);
+        }
+        //send response to bml
+        message_com::send_cmdu(sd, cmdu_tx);
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST: {
         LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST";
+
+        auto request = beerocks_header->addClass<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST failed";
+            break;
+        }
+
+        auto response = message_com::create_vs_message<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE>(
+            cmdu_tx, beerocks_header->id());
+        if (!response) {
+            LOG(ERROR) << "Failed building message "
+                          "cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE !";
+            return;
+        }
+
+        auto radio_mac = request->radio_mac();
+        LOG(DEBUG) << "request radio_mac:" << radio_mac;
+        response->isEnable() = (database.get_channel_scan_is_enabled(radio_mac)) ? 1 : 0;
+
+        //send response to bml
+        message_com::send_cmdu(sd, cmdu_tx);
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST: {
         LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST";
+
+        auto request =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST failed";
+            break;
+        }
+
+        // Get information from request
+        auto radio_mac      = request->radio_mac();
+        auto is_single_scan = request->scan_mode() == 1;
+        LOG(DEBUG) << "request radio_mac:" << radio_mac << ", "
+                   << ((is_single_scan) ? "single-scan" : "continuous-scan");
+
+        // Clear flags
+        auto result_status = eChannelScanErrCode::CHANNEL_SCAN_SUCCESS;
+        auto op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS;
+        uint8_t last       = 0;
+
+        // Get scan statuses
+        auto scan_in_progress = database.get_channel_scan_in_progress(radio_mac, is_single_scan);
+        if (scan_in_progress) {
+            LOG(ERROR) << "Scan is still running!";
+            op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SCAN_IN_PROGRESS;
+        }
+
+        auto last_scan_success =
+            database.get_channel_scan_results_status(radio_mac, is_single_scan);
+        if (last_scan_success != eChannelScanErrCode::CHANNEL_SCAN_SUCCESS) {
+            LOG(ERROR) << "Last scan did not finish successfully!";
+            result_status = last_scan_success;
+        }
+
+        // Get results
+        auto scan_results      = database.get_channel_scan_results(radio_mac, is_single_scan);
+        auto scan_results_size = scan_results.size();
+
+        LOG(DEBUG) << "scan_results received for hostap_mac= " << radio_mac << std::endl
+                   << "scan_results_size= " << scan_results_size;
+
+        //Results avaliablity check
+        if (scan_results_size == 0) {
+            LOG(DEBUG) << "no scan results are available";
+            //op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SCAN_RESULTS_EMPTY;
+        }
+
+        auto response = message_com::create_vs_message<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>(cmdu_tx,
+                                                                             beerocks_header->id());
+
+        // If there was an error before, send the results with a failed status
+        if (op_error_code != eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS ||
+            result_status != eChannelScanErrCode::CHANNEL_SCAN_SUCCESS) {
+            LOG(ERROR) << "Something went wrong, sending CMDU with error code: ["
+                       << (int)op_error_code << "] & result status [" << (int)result_status << "].";
+            response->result_status() = uint8_t(result_status);
+            response->op_error_code() = uint8_t(op_error_code);
+            response->last()          = 1;
+            message_com::send_cmdu(sd, cmdu_tx);
+
+            break;
+        }
+
+        // Set const sized for message building
+        const size_t tlvEndSize    = ieee1905_1::tlvEndOfMessage::get_initial_size();
+        const size_t result_size   = sizeof(beerocks_message::sChannelScanResults);
+        const size_t ext_data_size = sizeof(result_status) + sizeof(op_error_code) + sizeof(last);
+        int remaining_results      = scan_results_size;
+        int response_result_index  = 0;
+        beerocks_message::sChannelScanResults *results = nullptr;
+
+        for (auto dump : scan_results) {
+
+            if (results == nullptr) {
+                LOG(DEBUG) << "Creating new ACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE !";
+                response = message_com::create_vs_message<
+                    beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>(
+                    cmdu_tx, beerocks_header->id());
+                if (!response) {
+                    LOG(ERROR) << "Failed building message "
+                                  "cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE !";
+                    return;
+                }
+
+                //reset message flags
+                result_status = eChannelScanErrCode::CHANNEL_SCAN_SUCCESS;
+                op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS;
+                last          = 0;
+
+                // Need to find how much results we can allocate before running out of room
+                int size_left = cmdu_tx.getMessageBuffLength() - cmdu_tx.getMessageLength() -
+                                tlvEndSize - ext_data_size;
+                int cmdu_max_avaliable_result_count = size_left / result_size;
+                int cmdu_max_result_count = cmdu_max_avaliable_result_count > remaining_results
+                                                ? remaining_results
+                                                : cmdu_max_avaliable_result_count;
+
+                LOG(DEBUG) << "Allocating space for " << cmdu_max_result_count << " results";
+                if (response->alloc_results(cmdu_max_result_count) == false) {
+                    LOG(ERROR) << "Failed buffer allocation to size = "
+                               << int(cmdu_max_result_count);
+                    op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
+                    break;
+                }
+
+                // Getting response results' pointer
+                auto results_tuple = response->results(0);
+                if (std::get<0>(results_tuple) == false) {
+                    LOG(ERROR) << "response->results access fail!";
+                    op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
+                    break;
+                }
+                results               = &std::get<1>(results_tuple);
+                response_result_index = 0;
+            }
+            LOG(DEBUG) << "Adding result to CMDU";
+
+            results[response_result_index++] = dump;
+            remaining_results--;
+
+            if (remaining_results <= 0) {
+                LOG(DEBUG) << "reached end of results";
+                last = 1;
+            }
+            if (response_result_index >= (int)response->results_size() || remaining_results <= 0) {
+                LOG(DEBUG) << "reached CMDU capacity";
+
+                response->result_status() = uint8_t(result_status);
+                response->op_error_code() = uint8_t(op_error_code);
+                response->last()          = last;
+                message_com::send_cmdu(sd, cmdu_tx);
+
+                //clears result, this will cause another response to be created
+                if (remaining_results > 0) {
+                    results = nullptr;
+                }
+            }
+        }
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST: {
         LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST";
+
+        auto request =
+            beerocks_header
+                ->addClass<beerocks_message::cACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST>();
+        if (!request) {
+            LOG(ERROR) << "addClass cACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST failed";
+            break;
+        }
+
+        auto response = message_com::create_vs_message<
+            beerocks_message::cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE>(cmdu_tx,
+                                                                            beerocks_header->id());
+        if (!response) {
+            LOG(ERROR) << "Failed building message cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE !";
+            return;
+        }
+        auto radio_mac         = request->scan_params().radio_mac;
+        auto dwell_time_ms     = request->scan_params().dwell_time_ms;
+        auto channel_pool_size = request->scan_params().channel_pool_size;
+        auto channel_pool      = request->scan_params().channel_pool;
+        auto channel_pool_set =
+            std::unordered_set<uint8_t>(channel_pool, channel_pool + channel_pool_size);
+
+        LOG(DEBUG) << "set_channel_scan_dwell_time_msec " << dwell_time_ms;
+        if (!database.set_channel_scan_dwell_time_msec(radio_mac, dwell_time_ms, true)) {
+            LOG(ERROR) << "set_channel_scan_dwell_time_msec failed";
+            response->op_error_code() =
+                uint8_t(eChannelScanOpErrCode::CHANNEL_SCAN_OP_INVALID_PARAMS_DWELLTIME);
+            message_com::send_cmdu(sd, cmdu_tx);
+            break;
+        }
+
+        LOG(DEBUG) << "set_channel_scan_pool " << channel_pool_size;
+        if (!database.set_channel_scan_pool(radio_mac, channel_pool_set, true)) {
+            LOG(ERROR) << "set_channel_scan_pool failed";
+            response->op_error_code() =
+                uint8_t(eChannelScanOpErrCode::CHANNEL_SCAN_OP_INVALID_PARAMS_CHANNELPOOL);
+            message_com::send_cmdu(sd, cmdu_tx);
+            break;
+        }
+
+        LOG(DEBUG) << "Clearing DB results for a single scan";
+        if (!database.clear_channel_scan_results(radio_mac, true)) {
+            LOG(ERROR) << "failed to clear scan results";
+            response->op_error_code() = uint8_t(eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR);
+            message_com::send_cmdu(sd, cmdu_tx);
+            break;
+        }
+
+        LOG(DEBUG) << "Triggering Scan in task";
+        dynamic_channel_selection_task::sScanEvent new_event;
+        new_event.radio_mac = radio_mac;
+        tasks.push_event(database.get_dynamic_channel_selection_task_id(radio_mac),
+                         (int)dynamic_channel_selection_task::eEvent::TRIGGER_SINGLE_SCAN,
+                         (void *)&new_event);
+        response->op_error_code() = uint8_t(eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS);
+        message_com::send_cmdu(sd, cmdu_tx);
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST: {

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "db/network_map.h"
 #include "tasks/channel_selection_task.h"
+#include "tasks/dynamic_channel_selection_task.h"
 #include "tasks/ire_network_optimization_task.h"
 #include "tasks/load_balancer_task.h"
 
@@ -1798,6 +1799,34 @@ void son_management::handle_bml_message(Socket *sd,
         }
 
         son_actions::send_cmdu_to_agent(agent_mac, cmdu_tx, database);
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST";
+       break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST";
+        break;
+    }
+    case beerocks_message::ACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST: {
+        LOG(TRACE) << "ACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST";
         break;
     }
     default: {


### PR DESCRIPTION
monitor thread: dont stop if netlink not supported

In case platform does not support netlink
commands  or dummy mode no need to stop monitor.

print only error and continue.