### PR TITLE
Feature/add bml cli commands to dynamic channel selection bml apis

### DIFF
--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -507,6 +507,42 @@ void cli_bml::setFunctionsMapAndArray()
                        static_cast<pFunction>(&cli_bml::bml_rdkb_steering_client_measure_caller), 3,
                        3, INT_ARG, STRING_ARG, STRING_ARG);
 #endif
+    insertCommandToMap(
+        "bml_set_dcs_continuous_scan_enable", "<mac> <1 or 0>",
+        "Enable/Disable (1 or 0) the Dynamic-Channel-Selection for the given AP mac.",
+        static_cast<pFunction>(&cli_bml::set_dcs_continuous_scan_enable_caller), 2, 2, STRING_ARG,
+        INT_ARG);
+    insertCommandToMap("bml_get_dcs_continuous_scan_enable", "<mac>",
+                       "Get Dynamic-Channel-Selection enable configuration for the given AP mac.",
+                       static_cast<pFunction>(&cli_bml::get_dcs_continuous_scan_enable_caller), 1,
+                       1, STRING_ARG);
+    insertCommandToMap("bml_set_dcs_continuous_scan_params", "<mac> [<params>]",
+                       "Set the continuous scan params for the given AP mac: 'params' = "
+                       "(dwell_time, interval_time, channel_pool"
+                       ")=value. Params description: dwell_time - dwell time in "
+                       "milliseconds, interval_time - interval time in seconds,"
+                       " channel_pool - channels separated by commas.",
+                       static_cast<pFunction>(&cli_bml::set_dcs_continuous_scan_params_caller), 2,
+                       4, STRING_ARG, STRING_ARG, STRING_ARG, STRING_ARG);
+    insertCommandToMap("bml_get_dcs_continuous_scan_params", "<mac>",
+                       "Get Dynamic-Channel-Selection params for the given AP mac: dwell_time - "
+                       "dwell time in milliseconds, interval_time - interval time in seconds,"
+                       " channel_pool - channels seperated by commas.",
+                       static_cast<pFunction>(&cli_bml::get_dcs_continuous_scan_params_caller), 1,
+                       1, STRING_ARG);
+    insertCommandToMap(
+        "bml_start_dcs_single_scan", "<mac> <dwell_time_msec> <channel_pool>",
+        "Start a single scan, for the given AP mac, with the following scan params:"
+        " dwell_time - dwell time in milliseconds, channel_pool - channels seperated by commas.",
+        static_cast<pFunction>(&cli_bml::start_dcs_single_scan_caller), 3, 3, STRING_ARG, INT_ARG,
+        STRING_ARG);
+    insertCommandToMap(
+        "bml_get_dcs_scan_results", "<mac> <max-results-size> [<is-single-scan>]",
+        "Get Dynamic-Channel-Selection scan results for the given AP mac:"
+        " max-results-size - maximal size of the returned results,"
+        " is-single-scan - 0 for continuous-scan results (default), 1 for single scan.",
+        static_cast<pFunction>(&cli_bml::get_dcs_scan_results_caller), 2, 3, STRING_ARG, INT_ARG,
+        INT_ARG);
     //bool insertCommandToMap(std::string command, std::string help_args, std::string help,  pFunction funcPtr, uint8_t minNumOfArgs, uint8_t maxNumOfArgs,
 }
 
@@ -1212,7 +1248,7 @@ int cli_bml::get_dcs_continuous_scan_params_caller(int numOfArgs)
  */
 int cli_bml::start_dcs_single_scan_caller(int numOfArgs)
 {
-    if (numOfArgs == 4) {
+    if (numOfArgs == 3) {
         return start_dcs_single_scan(args.stringArgs[0], args.intArgs[1], args.stringArgs[2]);
     }
     return -1;

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -1123,6 +1123,119 @@ int cli_bml::bml_rdkb_steering_client_measure_caller(int numOfArgs)
 }
 #endif //BEEROCKS_RDKB
 
+/**
+ * caller function for set_dcs_continuous_scan_enable
+ *
+ * @param [in] numOfArgs Num of received arguments
+ *
+ * @return 0 on success.
+ */
+int cli_bml::set_dcs_continuous_scan_enable_caller(int numOfArgs)
+{
+    if (numOfArgs == 2) {
+        return set_dcs_continuous_scan_enable(args.stringArgs[0], args.intArgs[1]);
+    }
+    return -1;
+}
+
+/**
+ * caller function for get_dcs_continuous_scan_enable
+ *
+ * @param [in] numOfArgs Num of received arguments
+ *
+ * @return 0 on success.
+ */
+int cli_bml::get_dcs_continuous_scan_enable_caller(int numOfArgs)
+{
+    if (numOfArgs == 1) {
+        return get_dcs_continuous_scan_enable(args.stringArgs[0]);
+    }
+    return -1;
+}
+
+/**
+ * caller function for set_dcs_continuous_scan_params
+ *
+ * @param [in] numOfArgs Num of received arguments
+ *
+ * @return 0 on success.
+ */
+int cli_bml::set_dcs_continuous_scan_params_caller(int numOfArgs)
+{
+    std::string radio_mac(network_utils::WILD_MAC_STRING);
+    int32_t dwell_time    = BML_CHANNEL_SCAN_INVALID_PARAM;
+    int32_t interval_time = BML_CHANNEL_SCAN_INVALID_PARAM;
+    std::string channel_pool;
+
+    std::string::size_type pos;
+    //[radio_mac=<radio_mac> dwell_time=<dwell_time> interval_time='<interval_time>']"
+    for (int i = 1; i < numOfArgs; i++) { //first optional arg
+        if ((pos = args.stringArgs[i].find("radio_mac=")) != std::string::npos) {
+            radio_mac = args.stringArgs[i].substr(pos + sizeof("radio_mac"));
+        } else if ((pos = args.stringArgs[i].find("dwell_time=")) != std::string::npos) {
+            dwell_time = string_utils::stoi(args.stringArgs[i].substr(pos + sizeof("dwell_time")));
+        } else if ((pos = args.stringArgs[i].find("interval_time=")) != std::string::npos) {
+            interval_time =
+                string_utils::stoi(args.stringArgs[i].substr(pos + sizeof("interval_time")));
+        } else if ((pos = args.stringArgs[i].find("channel_pool=")) != std::string::npos) {
+            channel_pool = args.stringArgs[i].substr(pos + sizeof("channel_pool"));
+        }
+    }
+
+    if (numOfArgs > 1) {
+        return set_dcs_continuous_scan_params(radio_mac, dwell_time, interval_time, channel_pool);
+    }
+    return -1;
+}
+
+/**
+ * caller function for get_dcs_continuous_scan_params
+ *
+ * @param [in] numOfArgs Num of received arguments
+ *
+ * @return 0 on success.
+ */
+int cli_bml::get_dcs_continuous_scan_params_caller(int numOfArgs)
+{
+    if (numOfArgs == 1) {
+        return get_dcs_continuous_scan_params(args.stringArgs[0]);
+    }
+    return -1;
+}
+
+/**
+ * caller function for start_dcs_single_scan
+ *
+ * @param [in] numOfArgs Num of received arguments
+ *
+ * @return 0 on success.
+ */
+int cli_bml::start_dcs_single_scan_caller(int numOfArgs)
+{
+    if (numOfArgs == 4) {
+        return start_dcs_single_scan(args.stringArgs[0], args.intArgs[1], args.stringArgs[2]);
+    }
+    return -1;
+}
+
+/**
+ * caller function for get_dcs_scan_results
+ *
+ * @param [in] numOfArgs Num of received arguments
+ *
+ * @return 0 on success.
+ */
+int cli_bml::get_dcs_scan_results_caller(int numOfArgs)
+{
+    if (numOfArgs == 2) {
+        return get_dcs_scan_results(args.stringArgs[0], args.intArgs[1]);
+    } else if (numOfArgs == 3) {
+        bool single_scan = (args.intArgs[2] == 1);
+        return get_dcs_scan_results(args.stringArgs[0], args.intArgs[1], single_scan);
+    }
+    return -1;
+}
+
 //
 // Functions
 //

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -1661,3 +1661,102 @@ int cli_bml::steering_client_measure(uint32_t steeringGroupIndex, const std::str
     return 0;
 }
 #endif //BEEROCKS_RDKB
+
+/**
+ * Enables or disables beerocks DCS continuous scans.
+ *
+ * @param [in] radio_mac Radio MAC of selected radio
+ * @param [in] enable Value of 1 to enable or 0 to disable.
+ *
+ * @return 0 on success.
+ */
+int cli_bml::set_dcs_continuous_scan_enable(const std::string &radio_mac, int8_t enable)
+{
+    std::cout << "set_dcs_continuous_scan_enable" << std::endl;
+
+    return 0;
+}
+
+/**
+ * get DCS continuous scans param. Value is printed to the console.
+ *
+ * @param [in] radio_mac Radio MAC of selected radio
+ *
+ * @return 0 on success.
+ */
+int cli_bml::get_dcs_continuous_scan_enable(const std::string &radio_mac)
+{
+    std::cout << __func__ << ", mac=" << radio_mac << std::endl;
+
+    return 0;
+}
+
+/**
+ * set DCS continuous scan params.
+ *
+ * @param [in] radio_mac Radio MAC of selected radio
+ * @param [in] dwell_time Set the dwell time in milliseconds.
+ * @param [in] interval_time Set the interval time in seconds.
+ * @param [in] channel_pool Set the channel pool for the DCS.
+ *
+ * @return 0 on success.
+ */
+int cli_bml::set_dcs_continuous_scan_params(const std::string &radio_mac, int32_t dwell_time,
+                                            int32_t interval_time, const std::string &channel_pool)
+{
+    std::cout << __func__ << ", mac=" << radio_mac << ", dwell_time=" << dwell_time
+              << ", interval_time=" << interval_time << ", channel_pool=" << channel_pool
+              << std::endl;
+
+    return 0;
+}
+
+/**
+ * get DCS continuous scan params. Values are printed to the console.
+ *
+ * @param [in] radio_mac Radio MAC of selected radio
+ *
+ * @return 0 on success.
+ */
+int cli_bml::get_dcs_continuous_scan_params(const std::string &radio_mac)
+{
+    std::cout << __func__ << ", mac=" << radio_mac << std::endl;
+
+    return 0;
+}
+
+/**
+ * Start a single DCS scan with parameters.
+ *
+ * @param [in] radio_mac radio MAC of selected radio
+ * @param [in] dwell_time Set the dwell time in milliseconds.
+ * @param [in] channel_pool Set the channel pool for the DCS.
+ *
+ * @return 0 on success.
+ */
+int cli_bml::start_dcs_single_scan(const std::string &radio_mac, int32_t dwell_time,
+                                   const std::string &channel_pool)
+{
+    std::cout << "start_dcs_single_scan, mac=" << radio_mac << ", dwell_time=" << dwell_time
+              << ", channel_pool=" << channel_pool << std::endl;
+
+    return 0;
+}
+
+/**
+ * get DCS continuous scan params.
+ *
+ * @param [in] radio_mac radio MAC of selected radio
+ * @param [in] max_results_size Max number of the returned results
+ * @param [in] is_single_scan Flag indicating if the results belong to a single scan or not
+ * 
+ * @return 0 on success.
+ */
+int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_results_size,
+                                  bool is_single_scan)
+{
+    std::cout << __func__ << ", mac=" << radio_mac << ", max_results_size=" << max_results_size
+              << ", is_single_scan=" << string_utils::bool_str(is_single_scan) << std::endl;
+
+    return 0;
+}

--- a/controller/src/beerocks/cli/beerocks_cli_bml.h
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.h
@@ -190,6 +190,15 @@ private:
     int steering_client_measure(uint32_t steeringGroupIndex, const std::string &str_bssid,
                                 const std::string &str_client_mac);
 #endif
+    int set_dcs_continuous_scan_enable(const std::string &radio_mac, int8_t enable);
+    int get_dcs_continuous_scan_enable(const std::string &radio_mac);
+    int set_dcs_continuous_scan_params(const std::string &radio_mac, int32_t dwell_time,
+                                       int32_t interval_time, const std::string &channel_pool);
+    int get_dcs_continuous_scan_params(const std::string &radio_mac);
+    int start_dcs_single_scan(const std::string &radio_mac, int32_t dwell_time,
+                              const std::string &channel_pool);
+    int get_dcs_scan_results(const std::string &radio_mac, uint32_t max_results_size,
+                             bool is_single_scan = false);
     // Variable
     std::string beerocks_conf_path;
     BML_CTX ctx = nullptr;

--- a/controller/src/beerocks/cli/beerocks_cli_bml.h
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.h
@@ -140,6 +140,12 @@ private:
     int bml_rdkb_steering_event_register_caller(int numOfArgs);
     int bml_rdkb_steering_client_measure_caller(int numOfArgs);
 #endif
+    int set_dcs_continuous_scan_enable_caller(int numOfArgs);
+    int get_dcs_continuous_scan_enable_caller(int numOfArgs);
+    int set_dcs_continuous_scan_params_caller(int numOfArgs);
+    int get_dcs_continuous_scan_params_caller(int numOfArgs);
+    int start_dcs_single_scan_caller(int numOfArgs);
+    int get_dcs_scan_results_caller(int numOfArgs);
     // Functions
     int onboard_status();
     int ping();


### PR DESCRIPTION
This PR adds CLI BML commands to the beerocks_cli for the following DCS BML APIS:
bml_set_dcs_continuous_scan_enable
bml_get_dcs_continuous_scan_enable
bml_set_dcs_continuous_scan_params
bml_get_dcs_continuous_scan_params
bml_start_dcs_single_scan
bml_get_dcs_scan_results

The commands naming are aligned to the called APIs without the 'bml_' initial:
set_dcs_continuous_scan_enable
get_dcs_continuous_scan_enable
set_dcs_continuous_scan_params
get_dcs_continuous_scan_params
start_dcs_single_scan
get_dcs_scan_results

The command's description is available in the beerocks_cli help menu