### PR TITLE
controller: fix encrypted_settings length bug

### DIFF
--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -453,8 +453,7 @@ bool master_thread::autoconfig_wsc_add_m2_encrypted_settings(WSC::m2::config &m2
     // attribute type, 2 bytes attribute length, 8 bytes data), but check it anyway
     // to be on the safe side. Then, we add keywrapauth at its end.
     uint8_t *plaintext = config_data.getMessageBuff();
-    int plaintextlen =
-        config_data.getMessageBuffLength() + sizeof(WSC::sWscAttrKeyWrapAuthenticator);
+    int plaintextlen   = config_data.getMessageLength() + sizeof(WSC::sWscAttrKeyWrapAuthenticator);
     WSC::sWscAttrKeyWrapAuthenticator *keywrapauth =
         reinterpret_cast<WSC::sWscAttrKeyWrapAuthenticator *>(
             &plaintext[config_data.getMessageLength()]);


### PR DESCRIPTION
Commit a35edf81532bc5d081e1ad26bc41719b482aa26d converted the son master
thread to use configData class based on AttrList for creating the config
data in the M2 message.

This commit introduced a bug which caused the plaintextlen to be larger
than the actual size of the config data contents, causing a huge
encrypted settings of over 1000 bytes to be add to the CMDU.

Due to this , the CMDU gets fragmented. As we know from agent
tests, the testbed devices don't necessarily work correctly with
fragmented CMDUs, which explains the tests failure.

Fix the bug by using the getMessageLength() instead of the wrong
getMessageBufLength() for getting the config data actual length.

Fixes #681

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>