### PR TITLE
.gitlab-ci.yml: split certification job between manual and scheduled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,7 @@ test-on-netgear-rax40:
     TARGET_DEVICE_NAME: netgear-rax40-1
   needs: ["build-for-netgear-rax40"]
 
-run-certification-tests:
+.run-certification-tests:
   stage: test
   variables:
     TESTS_TO_RUN: "tools/docker/tests/certification/all_controller_tests.txt"
@@ -151,4 +151,12 @@ run-certification-tests:
   tags:
     - certs-tests
   timeout: 24h
+
+scheduled-certification-tests:
+  extends: .run-certification-tests
+  only:
+    - schedules
+
+manual-certification-tests:
+  extends: .run-certification-tests
   when: manual


### PR DESCRIPTION
I initially thought Gitlab schedules would trigger manual jobs, but it turns out it's not the case, hence this change.
Marking as dont-merge because this time I want to wait for the scheduled pipelines to actually trigger the job (next schedule is at 8PM CET).

--- 
The certification job was using "when: manual" to make sure it doesn't
run on every pipeline, and to make it possible to run it manually.

It was also intended to be run with Gitlab schedules. However, it
turns out the manual jobs are not run automatically when a pipeline is
started through Gitlab schedules.

Split run-certification-tests between a job that run only on
schedules (so that it actually gets run when a scheduled pipeline is
triggered) and another job which can only be run manually (to keep the
possibility of running the certification tests at any time through the
web interface).