### PR TITLE
gitlab-ci.yml: improve clang-format check output

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,8 +14,16 @@ clang-format:
     # `diff-index` doesn't update the index so doesn't actually see changes. Need to manually update index.
     - git update-index -q --refresh
     # Use `diff-index` instead of `status` or `diff` because it gives more predictable output and exit code.
-    # `-p` shows the differences as patch on stdout. This is handy to copy&paste from CI to fix mistakes.
-    - git diff-index -p --exit-code HEAD
+    - |
+      git diff-index --exit-code HEAD || {
+        ret=$?
+        echo "Inconsistent formatting, please apply patch from artifacts"
+        git diff > correct-formatting.patch
+        exit $?
+      }
+  artifacts:
+    paths:
+      - correct-formatting.patch
 
 build-in-docker:
   extends: .in-prplmesh-builder


### PR DESCRIPTION
The clang-format check prints a patch to stdout, but it's not very clear
what the problem is and how to fix it. In addition, if the output is
downloaded as raw, there's an additional space added to every line so it
doesn't apply as is.

Improve this by:
 - printing an explicit error message;
 - generating the patch with 'git diff' instead of 'git diff-index';
 - saving the diff in a file and export it as an artifact;
 - still returning the original exit code from 'git diff-index'.