### PR TITLE
docker: multiple users support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ run-tests:
     - cd tools/docker
     # Try to pull from dockerhub, build the container images if that fails
     - ./image-pull.sh || ./image-build.sh
-    - ./tests/test_flows.sh -v
+    - ./tests/test_flows.sh -v -u $RANDOM
 
   artifacts:
     paths:

--- a/tools/docker/tests/test_flows.sh
+++ b/tools/docker/tests/test_flows.sh
@@ -28,7 +28,7 @@ error=0
 bridge_name=br-lan
 
 get_host_bridge_name() {
-    docker network inspect prplMesh-net --format="br-{{ printf \"%.12s\" .Id }}"
+    docker network inspect prplMesh-net-${UNIQUE_ID} --format="br-{{ printf \"%.12s\" .Id }}"
 }
 
 start_tcpdump() {
@@ -57,15 +57,15 @@ container_CAPI_port() {
     # get the CAPI port based on the container name.
     # For test_flows, we always consider the gateway to be a controller-only
     # device (i.e. the agent on the gateway is not addressed by CAPI).
-    if [ "$1" = "gateway" ]; then
-        docker exec -t "$1" grep ucc_listener_port ${installdir}/config/beerocks_controller.conf  | cut -f2 -d= | cut -f1 -d' '
+    if [ "$1" = "${GATEWAY}" ]; then
+        docker exec -t "${GATEWAY}" grep ucc_listener_port ${installdir}/config/beerocks_controller.conf  | cut -f2 -d= | cut -f1 -d' '
     else
-        docker exec -t "$1" grep ucc_listener_port ${installdir}/config/beerocks_agent.conf  | cut -f2 -d= | cut -f1 -d' '
+        docker exec -t "${GATEWAY}" grep ucc_listener_port ${installdir}/config/beerocks_agent.conf  | cut -f2 -d= | cut -f1 -d' '
     fi
 }
 
 send_bml_command() {
-    docker exec gateway ${installdir}/bin/beerocks_cli -c "$*"
+    docker exec ${GATEWAY} ${installdir}/bin/beerocks_cli -c "$*"
 }
 
 send_CAPI_command() {
@@ -80,7 +80,7 @@ send_CAPI_command() {
 
 check_log() {
     # Check for a certain message in a log file
-    # $1: device to check (gateway, repeater1, repeater2)
+    # $1: device to check (${GATEWAY}, ${REPEATER1}, ${REPEATER2})
     # $2: program to check (controller, agent, agent_wlan0, ...)
     # rest: arguments to grep. -q is always added.
     device="$1"; shift
@@ -90,7 +90,7 @@ check_log() {
 
 send_bwl_event() {
     # Send an event to a dummy bwl
-    # $1: device to send to (gateway, repeater1, repeater2)
+    # $1: device to send to (${GATEWAY}, ${REPEATER1}, ${REPEATER2})
     # $2: radio to send to (wlan0, wlan2)
     # $3: event string
     check docker exec $1 sh -c 'echo '"$3"' > /tmp/$USER/beerocks/'$2'/EVENT'
@@ -100,12 +100,12 @@ test_initial_ap_config() {
     status "test initial autoconfig"
 
     check_error=0
-    check_log repeater1 agent_wlan0 "WSC Global authentication success"
-    check_log repeater1 agent_wlan2 "WSC Global authentication success"
-    check_log repeater1 agent_wlan0 "KWA (Key Wrap Auth) success"
-    check_log repeater1 agent_wlan2 "KWA (Key Wrap Auth) success"
-    check_log repeater1 agent_wlan0 "Controller configuration (WSC M2 Encrypted Settings)"
-    check_log repeater1 agent_wlan2 "Controller configuration (WSC M2 Encrypted Settings)"
+    check_log ${REPEATER1} agent_wlan0 "WSC Global authentication success"
+    check_log ${REPEATER1} agent_wlan2 "WSC Global authentication success"
+    check_log ${REPEATER1} agent_wlan0 "KWA (Key Wrap Auth) success"
+    check_log ${REPEATER1} agent_wlan2 "KWA (Key Wrap Auth) success"
+    check_log ${REPEATER1} agent_wlan0 "Controller configuration (WSC M2 Encrypted Settings)"
+    check_log ${REPEATER1} agent_wlan2 "Controller configuration (WSC M2 Encrypted Settings)"
 
     return $check_error
 }
@@ -116,20 +116,20 @@ test_ap_config_renew() {
     # Regression test: MAC address should be case insensitive
     MAC_AGENT1=$(echo $mac_agent1 | tr a-z A-Z)
     # Configure the controller and send renew
-    send_CAPI_command gateway "DEV_RESET_DEFAULT" $redirect
-    send_CAPI_command gateway "DEV_SET_CONFIG,bss_info1,$MAC_AGENT1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1,bss_info2,$mac_agent1 8x Multi-AP-24G-2 0x0020 0x0008 maprocks2 1 0" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_RESET_DEFAULT" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SET_CONFIG,bss_info1,$MAC_AGENT1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1,bss_info2,$mac_agent1 8x Multi-AP-24G-2 0x0020 0x0008 maprocks2 1 0" $redirect
     gw_mac_without_colons="$(printf $mac_gateway | tr -d :)"
-    send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}" $redirect
 
     # Wait a bit for the renew to complete
     sleep 3
 
-    check_log repeater1 agent_wlan0 "Received credentials for ssid: Multi-AP-24G-1 .* bss_type: 2"
-    check_log repeater1 agent_wlan0 "Received credentials for ssid: Multi-AP-24G-2 .* bss_type: 1"
-    check_log repeater1 agent_wlan2 "ssid: .* teardown"
+    check_log ${REPEATER1} agent_wlan0 "Received credentials for ssid: Multi-AP-24G-1 .* bss_type: 2"
+    check_log ${REPEATER1} agent_wlan0 "Received credentials for ssid: Multi-AP-24G-2 .* bss_type: 1"
+    check_log ${REPEATER1} agent_wlan2 "ssid: .* teardown"
 
     mac_agent1_wlan0_hex=0x$(echo $mac_agent1_wlan0 | tr -d :)
-    send_CAPI_command repeater1 "dev_get_parameter,program,map,ruid,${mac_agent1_wlan0_hex},ssid,Multi-AP-24G-1,parameter,macaddr"
+    send_CAPI_command ${REPEATER1} "dev_get_parameter,program,map,ruid,${mac_agent1_wlan0_hex},ssid,Multi-AP-24G-1,parameter,macaddr"
     check [ "$capi_command_reply" = "status,COMPLETE,macaddr,$mac_agent1_wlan0" ];
 
     return $check_error
@@ -140,23 +140,23 @@ test_ap_config_bss_tear_down() {
     # Regression test: MAC address should be case insensitive
     MAC_AGENT1=$(echo $mac_agent1 | tr a-z A-Z)
     # Configure the controller and send renew
-    send_CAPI_command gateway "DEV_RESET_DEFAULT" $redirect
-    send_CAPI_command gateway "DEV_SET_CONFIG,bss_info1,$mac_agent1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_RESET_DEFAULT" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SET_CONFIG,bss_info1,$mac_agent1 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1" $redirect
 
     gw_mac_without_colons="$(printf $mac_gateway | tr -d :)"
-    send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}" $redirect
 
     sleep 3
-    check_log repeater1 agent_wlan0 "ssid: Multi-AP-24G-1, .* fronthaul"
-    check_log repeater1 agent_wlan2 "ssid: .* teardown"
+    check_log ${REPEATER1} agent_wlan0 "ssid: Multi-AP-24G-1, .* fronthaul"
+    check_log ${REPEATER1} agent_wlan2 "ssid: .* teardown"
 
     # SSIDs have been removed for the CTT Agent1's front radio
-    send_CAPI_command gateway "DEV_SET_CONFIG,bss_info1,$MAC_AGENT1 8x" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SET_CONFIG,bss_info1,$MAC_AGENT1 8x" $redirect
     # Send renew message
-    send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x000A,tlv_type1,0x01,tlv_length1,0x0006,tlv_value1,0x${gw_mac_without_colons},tlv_type2,0x0F,tlv_length2,0x0001,tlv_value2,{0x00},tlv_type3,0x10,tlv_length3,0x0001,tlv_value3,{0x00}}" $redirect
 
     sleep 3
-    check_log repeater1 agent_wlan0 "ssid: .* teardown"
+    check_log ${REPEATER1} agent_wlan0 "ssid: .* teardown"
     
     return $check_error
 }
@@ -166,23 +166,23 @@ test_channel_selection() {
     
     check_error=0
     dbg "Send channel preference query"
-    send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8004" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8004" $redirect
     sleep 1
     dbg "Confirming channel preference query has been received on agent"
-    check_log repeater1 agent_wlan0 "CHANNEL_PREFERENCE_QUERY_MESSAGE"
-    check_log repeater1 agent_wlan2 "CHANNEL_PREFERENCE_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "CHANNEL_PREFERENCE_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent_wlan2 "CHANNEL_PREFERENCE_QUERY_MESSAGE"
     
     dbg "Send channel selection request"
-    send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8006" $redirect
+    send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8006" $redirect
     sleep 1
     dbg "Confirming channel selection request has been received on agent"
-    check_log repeater1 agent_wlan0 "CHANNEL_SELECTION_REQUEST_MESSAGE"
-    check_log repeater1 agent_wlan2 "CHANNEL_SELECTION_REQUEST_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "CHANNEL_SELECTION_REQUEST_MESSAGE"
+    check_log ${REPEATER1} agent_wlan2 "CHANNEL_SELECTION_REQUEST_MESSAGE"
     
     dbg "Confirming 1905.1 Ack Message request was received on agent"
     # TODO: When creating handler for the ACK message on the agent, replace lookup of this string
-    check_log repeater1 agent_wlan0 "ACK_MESSAGE"
-    check_log repeater1 agent_wlan2 "ACK_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "ACK_MESSAGE"
+    check_log ${REPEATER1} agent_wlan2 "ACK_MESSAGE"
 
     return $check_error
 }
@@ -190,21 +190,21 @@ test_client_capability_query() {
     status "test client capability"
 
     check_error=0
-    send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8009,tlv_type,0x90,tlv_length,\
+    send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8009,tlv_type,0x90,tlv_length,\
 0x000C,tlv_value,{$mac_agent1_wlan0 0x000000110022}" $redirect
     sleep 1
     dbg "Confirming client capability query has been received on agent"
     # check that both radio agents received it,in the future we'll add a check to verify which radio the query was intended for.
-    check_log repeater1 agent_wlan0 "CLIENT_CAPABILITY_QUERY_MESSAGE"
-    check_log repeater1 agent_wlan2 "CLIENT_CAPABILITY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "CLIENT_CAPABILITY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent_wlan2 "CLIENT_CAPABILITY_QUERY_MESSAGE"
 }
 test_ap_capability_query() {
     status "test ap capability query"
     check_error=0
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8001" $redirect
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8001" $redirect
     sleep 1
     dbg "Confirming ap capability query has been received on agent"
-    check_log repeater1 agent_wlan0 "AP_CAPABILITY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "AP_CAPABILITY_QUERY_MESSAGE"
     return $check_error
 }
 test_combined_infra_metrics() {
@@ -216,44 +216,44 @@ test_client_steering_mandate() {
     check_error=0
 
     dbg "Send topology request to agent 1"
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x0002" $redirect
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x0002" $redirect
     sleep 1
     dbg "Confirming topology query was received"
-    check_log repeater1 agent "TOPOLOGY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent "TOPOLOGY_QUERY_MESSAGE"
 
     dbg "Send topology request to agent 2"
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent2,MessageTypeValue,0x0002" $redirect
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent2,MessageTypeValue,0x0002" $redirect
     sleep 1
     dbg "Confirming topology query was received"
-    check_log repeater2 agent "TOPOLOGY_QUERY_MESSAGE"
+    check_log ${REPEATER2} agent "TOPOLOGY_QUERY_MESSAGE"
 
     dbg "Send Client Steering Request message for Steering Mandate to CTT Agent1"
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8014,tlv_type,0x9B,tlv_length,\
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8014,tlv_type,0x9B,tlv_length,\
 0x001b,tlv_value,{$mac_agent1_wlan0 0xe0 0x0000 0x1388 0x01 {0x000000110022} 0x01 {$mac_agent2_wlan0 0x73 0x24}}" $redirect
     sleep 1
     dbg "Confirming Client Steering Request message was received - mandate"
-    check_log repeater1 agent_wlan0 "Got steer request"
+    check_log ${REPEATER1} agent_wlan0 "Got steer request"
     
     dbg "Confirming BTM Report message was received"
-    check_log gateway controller "CLIENT_STEERING_BTM_REPORT_MESSAGE"
+    check_log ${GATEWAY} controller "CLIENT_STEERING_BTM_REPORT_MESSAGE"
 
     dbg "Confirming ACK message was received"
-    check_log repeater1 agent_wlan0 "ACK_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "ACK_MESSAGE"
 
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8014,tlv_type,0x9B,tlv_length,\
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8014,tlv_type,0x9B,tlv_length,\
 0x000C,tlv_value,{$mac_agent1_wlan0 0x00 0x000A 0x0000 0x00}" $redirect
     sleep 1
     dbg "Confirming Client Steering Request message was received - Opportunity"
-    check_log repeater1 agent_wlan0 "CLIENT_STEERING_REQUEST_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "CLIENT_STEERING_REQUEST_MESSAGE"
 
     dbg "Confirming ACK message was received"
-    check_log gateway controller "ACK_MESSAGE"
+    check_log ${GATEWAY} controller "ACK_MESSAGE"
 
     dbg "Confirming steering completed message was received"
-    check_log gateway controller "STEERING_COMPLETED_MESSAGE"
+    check_log ${GATEWAY} controller "STEERING_COMPLETED_MESSAGE"
 
     dbg "Confirming ACK message was received"
-    check_log repeater1 agent_wlan0 "ACK_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "ACK_MESSAGE"
     return $check_error
 }
 
@@ -263,20 +263,20 @@ test_client_association_dummy(){
     sta_mac=11:11:33:44:55:66
 
     dbg "Connect dummy STA to wlan0"
-    send_bwl_event repeater1 wlan0 "EVENT AP-STA-CONNECTED ${sta_mac}"
+    send_bwl_event ${REPEATER1} wlan0 "EVENT AP-STA-CONNECTED ${sta_mac}"
     dbg "Send client association control request to the chosen BSSID to steer the client (UNBLOCK) "
     eval send_bml_command "client_allow \"${sta_mac} ${mac_agent1_wlan2}\"" $redirect
     sleep 1
 
     dbg "Confirming Client Association Control Request message was received (UNBLOCK)"
-    check_log repeater1 agent_wlan2 "Got client allow request for ${sta_mac}"
+    check_log ${REPEATER1} agent_wlan2 "Got client allow request for ${sta_mac}"
 
     dbg "Send client association control request to all other (BLOCK) "
     eval send_bml_command "client_disallow \"${sta_mac} ${mac_agent1_wlan0}\"" $redirect
     sleep 1
 
     dbg "Confirming Client Association Control Request message was received (BLOCK)"
-    check_log repeater1 agent_wlan0 "Got client disallow request for ${sta_mac}"
+    check_log ${REPEATER1} agent_wlan0 "Got client disallow request for ${sta_mac}"
     return $check_error
 }
 
@@ -306,77 +306,77 @@ test_optimal_path_dummy() {
     check_error=0
 
     dbg "Connect dummy STA to wlan0"
-    send_bwl_event repeater1 wlan0 "EVENT AP-STA-CONNECTED 11:22:33:44:55:66"
+    send_bwl_event ${REPEATER1} wlan0 "EVENT AP-STA-CONNECTED 11:22:33:44:55:66"
     dbg "Pre-prepare RRM Beacon Response for association handling task"
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-40 rsni=40 bssid=aa:bb:cc:00:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-40 rsni=40 bssid=aa:bb:cc:00:00:10"
     dbg "Confirming 11k request is done by association handling task"
-    wait_for_message 2 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:00:00:10 channel 1"
+    wait_for_message 2 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:00:00:10 channel 1"
 
     dbg "Update Stats"
-    send_bwl_event repeater1 wlan0 "DATA STA-UPDATE-STATS 11:22:33:44:55:66 rssi=-38,-39,-40,-41 snr=38,39,40,41 uplink=1000 downlink=800"
+    send_bwl_event ${REPEATER1} wlan0 "DATA STA-UPDATE-STATS 11:22:33:44:55:66 rssi=-38,-39,-40,-41 snr=38,39,40,41 uplink=1000 downlink=800"
     dbg "Pre-prepare RRM Beacon Responses for optimal path task"
     #Response for IRE1, BSSID of wlan0.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:11:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:11:00:10"
     #Response for IRE1, BSSID of wlan2.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:11:00:20"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:11:00:20"
     #Response for IRE2, BSSID of wlan0.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-40 rsni=40 bssid=aa:bb:cc:00:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-40 rsni=40 bssid=aa:bb:cc:00:00:10"
     #Response for IRE2, BSSID of wlan2.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:00:00:20"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:00:00:20"
     #Response for GW, BSSID of wlan0.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=00:11:22:33:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=00:11:22:33:00:10"
     #Response for GW, BSSID of wlan2.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=00:11:22:33:00:20"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=00:11:22:33:00:20"
     dbg "Confirming 11k request is done by optimal path task"
-    wait_for_message 20 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:11:00:20 channel 149"
+    wait_for_message 20 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:11:00:20 channel 149"
 
     dbg "Confirming 11k request is done by optimal path task"
-    wait_for_message 20 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:00:00:20 channel 149"
+    wait_for_message 20 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:00:00:20 channel 149"
 
     dbg "Confirming 11k request is done by optimal path task"
-    wait_for_message 20 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:11:00:10 channel 1"
+    wait_for_message 20 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:11:00:10 channel 1"
 
     dbg "Confirming 11k request is done by optimal path task"
-    wait_for_message 20 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid 00:11:22:33:00:20 channel 149"
+    wait_for_message 20 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid 00:11:22:33:00:20 channel 149"
 
     dbg "Confirming 11k request is done by optimal path task"
-    wait_for_message 20 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid 00:11:22:33:00:10 channel 1"
+    wait_for_message 20 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:66 on bssid 00:11:22:33:00:10 channel 1"
 
     dbg "Confirming no steer is done"
-    wait_for_message 20 gateway "beerocks_controller.log" "could not find a better path for sta 11:22:33:44:55:66"
+    wait_for_message 20 ${GATEWAY} "beerocks_controller.log" "could not find a better path for sta 11:22:33:44:55:66"
 
     # Steer scenario
     dbg "Update Stats"
-    send_bwl_event repeater1 wlan0 "DATA STA-UPDATE-STATS 11:22:33:44:55:66 rssi=-58,-59,-60,-61 snr=18,19,20,21 uplink=100 downlink=80"
+    send_bwl_event ${REPEATER1} wlan0 "DATA STA-UPDATE-STATS 11:22:33:44:55:66 rssi=-58,-59,-60,-61 snr=18,19,20,21 uplink=100 downlink=80"
     dbg "Pre-prepare RRM Beacon Responses for optimal path task"
     #Response for IRE1, BSSID of wlan0.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:11:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:11:00:10"
     #Response for IRE1, BSSID of wlan2.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:11:00:20"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:11:00:20"
     #Response for IRE2, BSSID of wlan0.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-60 rsni=20 bssid=aa:bb:cc:00:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-60 rsni=20 bssid=aa:bb:cc:00:00:10"
     #Response for IRE2, BSSID of wlan2.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:00:00:20"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:00:00:20"
     #Response for GW, BSSID of wlan0.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=00:11:22:33:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=00:11:22:33:00:10"
     #Response for GW, BSSID of wlan2.0
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=00:11:22:33:00:20"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=00:11:22:33:00:20"
     dbg "Confirming steering is requested by optimal path task"
-    wait_for_message 20 gateway "beerocks_controller.log" "optimal_path_task: steering"
+    wait_for_message 20 ${GATEWAY} "beerocks_controller.log" "optimal_path_task: steering"
 
     # Error scenario, sta doesn't support 11k
     dbg "Connect dummy STA to wlan0"
-    send_bwl_event repeater1 wlan0 "EVENT AP-STA-CONNECTED 11:22:33:44:55:77"
+    send_bwl_event ${REPEATER1} wlan0 "EVENT AP-STA-CONNECTED 11:22:33:44:55:77"
     dbg "Pre-prepare RRM Beacon Response with error for association handling task"
-    send_bwl_event repeater1 wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:77 channel=0 dialog_token=0 measurement_rep_mode=4 op_class=0 duration=0 rcpi=0 rsni=0 bssid=aa:bb:cc:00:00:10"
+    send_bwl_event ${REPEATER1} wlan0 "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:77 channel=0 dialog_token=0 measurement_rep_mode=4 op_class=0 duration=0 rcpi=0 rsni=0 bssid=aa:bb:cc:00:00:10"
     dbg "Confirming 11k request is done by association handling task"
-    wait_for_message 20 repeater1 "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:77 on bssid aa:bb:cc:00:00:10 channel 1"
+    wait_for_message 20 ${REPEATER1} "beerocks_monitor_wlan0.log" "Beacon 11k request to sta 11:22:33:44:55:77 on bssid aa:bb:cc:00:00:10 channel 1"
 
     dbg "Confirming STA doesn't support beacon measurement"
-    wait_for_message 20 gateway "beerocks_controller.log" "setting sta 11:22:33:44:55:77 as beacon measurement unsupported"
+    wait_for_message 20 ${GATEWAY} "beerocks_controller.log" "setting sta 11:22:33:44:55:77 as beacon measurement unsupported"
 
     dbg "Confirming optimal path falls back to RSSI measurements"
-    wait_for_message 20 gateway "beerocks_controller.log" "requesting rssi measurements for 11:22:33:44:55:77"
+    wait_for_message 20 ${GATEWAY} "beerocks_controller.log" "requesting rssi measurements for 11:22:33:44:55:77"
 }
 
 test_client_steering_dummy() {
@@ -385,42 +385,42 @@ test_client_steering_dummy() {
     sta_mac=11:22:33:44:55:66
 
     dbg "Connect dummy STA to wlan0"
-    send_bwl_event repeater1 wlan0 "EVENT AP-STA-CONNECTED ${sta_mac}"
+    send_bwl_event ${REPEATER1} wlan0 "EVENT AP-STA-CONNECTED ${sta_mac}"
     dbg "Send steer request "
     eval send_bml_command "steer_client \"${sta_mac} ${mac_agent1_wlan2}\"" $redirect
     sleep 1
 
     dbg "Confirming Client Association Control Request message was received (UNBLOCK)"
-    check_log repeater1 agent_wlan2 "Got client allow request"
+    check_log ${REPEATER1} agent_wlan2 "Got client allow request"
 
     dbg "Confirming Client Association Control Request message was received (BLOCK)"
-    check_log repeater1 agent_wlan0 "Got client disallow request"
+    check_log ${REPEATER1} agent_wlan0 "Got client disallow request"
 
     dbg "Confirming Client Association Control Request message was received (BLOCK)"
-    check_log repeater2 agent_wlan0 "Got client disallow request"
+    check_log ${REPEATER2} agent_wlan0 "Got client disallow request"
 
     dbg "Confirming Client Association Control Request message was received (BLOCK)"
-    check_log repeater2 agent_wlan2 "Got client disallow request"
+    check_log ${REPEATER2} agent_wlan2 "Got client disallow request"
 
     dbg "Confirming Client Steering Request message was received - mandate"
-    check_log repeater1 agent_wlan0 "Got steer request"
+    check_log ${REPEATER1} agent_wlan0 "Got steer request"
 
     dbg "Confirming BTM Report message was received"
-    check_log gateway controller "CLIENT_STEERING_BTM_REPORT_MESSAGE"
+    check_log ${GATEWAY} controller "CLIENT_STEERING_BTM_REPORT_MESSAGE"
 
     dbg "Confirming ACK message was received"
-    check_log repeater1 agent_wlan0 "ACK_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "ACK_MESSAGE"
 
     dbg "Disconnect dummy STA from wlan0"
-    send_bwl_event repeater1 wlan0 "EVENT AP-STA-DISCONNECTED ${sta_mac}"
+    send_bwl_event ${REPEATER1} wlan0 "EVENT AP-STA-DISCONNECTED ${sta_mac}"
     # Make sure that controller sees disconnect before connect by waiting a little
     sleep 1
 
     dbg "Connect dummy STA to wlan2"
-    send_bwl_event repeater1 wlan2 "EVENT AP-STA-CONNECTED ${sta_mac}"
+    send_bwl_event ${REPEATER1} wlan2 "EVENT AP-STA-CONNECTED ${sta_mac}"
     dbg "Confirm steering success by client connected"
-    check_log gateway controller "steering successful for sta ${sta_mac}"
-    check_log gateway controller "sta ${sta_mac} disconnected after successful steering"
+    check_log ${GATEWAY} controller "steering successful for sta ${sta_mac}"
+    check_log ${GATEWAY} controller "sta ${sta_mac} disconnected after successful steering"
     return $check_error
 }
 
@@ -429,16 +429,16 @@ test_client_steering_policy() {
     check_error=0
 
     dbg "Send client steering policy to agent 1"
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8003,tlv_type,0x89,tlv_length\
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8003,tlv_type,0x89,tlv_length\
 ,0x000C,tlv_value,{0x00 0x00 0x01 {0x112233445566 0x01 0xFF 0x14}}" $redirect
     sleep 1
     MID1_STR=$(echo "$capi_command_reply" | grep -Po "(?<=mid,0x).*[^\s]")
     dbg "Confirming client steering policy has been received on agent"
     
-    check_log repeater1 agent_wlan0 "MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE"
     sleep 1
     dbg "Confirming client steering policy ack message has been received on the controller"
-    check_log gateway controller "ACK_MESSAGE, mid=$MID1_STR"
+    check_log ${GATEWAY} controller "ACK_MESSAGE, mid=$MID1_STR"
 
     return $check_error
 }
@@ -447,21 +447,21 @@ test_client_association() {
     status "test client association"
     check_error=0
     dbg "Send topology request to agent 1"
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x0002" $redirect
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x0002" $redirect
     dbg "Confirming topology query was received"
-    check_log repeater1 agent "TOPOLOGY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent "TOPOLOGY_QUERY_MESSAGE"
 
     dbg "Send client association control message"
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8016,tlv_type,0x9D,tlv_length,\
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8016,tlv_type,0x9D,tlv_length,\
 0x000f,tlv_value,{$mac_agent1_wlan0 0x00 0x1E 0x01 {0x000000110022}}" $redirect
 
     dbg "Confirming client association control message has been received on agent"
     # check that both radio agents received it,in the future we'll add a check to verify which radio the query was intended for.
-    check_log repeater1 agent_wlan0 "CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE"
-    check_log repeater1 agent_wlan2 "CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE"
+    check_log ${REPEATER1} agent_wlan0 "CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE"
+    check_log ${REPEATER1} agent_wlan2 "CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE"
 
     dbg "Confirming ACK message was received on controller"
-    check_log gateway controller "ACK_MESSAGE"
+    check_log ${GATEWAY} controller "ACK_MESSAGE"
     return $check_error
 }
 
@@ -481,29 +481,29 @@ test_higher_layer_data_payload_trigger() {
     # MCUT sends Higher Layer Data message to CTT Agent1 by providing:
     # Higher layer protocol = "0x00"
     # Higher layer payload = 200 concatenated copies of the ALID of the MCUT (1200 octets)
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8018,tlv_type,0xA0,tlv_length,\
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x8018,tlv_type,0xA0,tlv_length,\
 0x04b1,tlv_value,{0x00 $payload}" $redirect
 
     dbg "Confirming higher layer data message was received in the agent" 
     
-    check_log repeater1 agent "HIGHER_LAYER_DATA_MESSAGE"
+    check_log ${REPEATER1} agent "HIGHER_LAYER_DATA_MESSAGE"
 
     dbg "Confirming matching protocol and payload length"
 
-    check_log repeater1 agent "protocol: 0"
-    check_log repeater1 agent "payload_length: 4b0"
+    check_log ${REPEATER1} agent "protocol: 0"
+    check_log ${REPEATER1} agent "payload_length: 4b0"
 
     dbg "Confirming ACK message was received in the controller"
-    check_log gateway controller "ACK_MESSAGE"
+    check_log ${GATEWAY} controller "ACK_MESSAGE"
     return $check_error
 }
 
 test_topology() {
     status "test topology query"
     check_error=0
-    check send_CAPI_command gateway "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x0002" $redirect
+    check send_CAPI_command ${GATEWAY} "DEV_SEND_1905,DestALid,$mac_agent1,MessageTypeValue,0x0002" $redirect
     dbg "Confirming topology query was received"
-    check_log repeater1 agent "TOPOLOGY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent "TOPOLOGY_QUERY_MESSAGE"
     return $check_error
 }
 
@@ -513,7 +513,7 @@ test_init() {
     start_tcpdump init
 
     [ "$SKIP_INIT" = "false" ] && {
-        eval ${scriptdir}/test_gw_repeater.sh -f -r "repeater1" -r "repeater2" -d 7 $redirect || {
+        eval ${scriptdir}/test_gw_repeater.sh -f -u ${UNIQUE_ID} -g ${GATEWAY} -r "${REPEATER1}" -r "${REPEATER2}" -d 7 $redirect || {
             err "start GW+Repeater failed, abort"
             exit 1
         }
@@ -524,7 +524,7 @@ test_init() {
     connmap=$(mktemp)
     [ -z "$connmap" ] && { err "Failed to create temp file"; exit 1; }
     trap "rm -f $connmap" EXIT
-    docker exec gateway ${installdir}/bin/beerocks_cli -c bml_conn_map > "$connmap"
+    docker exec ${GATEWAY} ${installdir}/bin/beerocks_cli -c bml_conn_map > "$connmap"
 
     mac_gateway=$(grep "GW_BRIDGE" "$connmap" | head -1 | awk '{print $5}' | cut -d ',' -f 1)
     dbg "mac_gateway = ${mac_gateway}"
@@ -534,16 +534,16 @@ test_init() {
     mac_agent2=$(grep "IRE_BRIDGE" "$connmap" | sed -n 2p | awk '{print $5}' | cut -d ',' -f 1)
     dbg "mac_agent2 = ${mac_agent2}"
 
-    mac_agent1_wlan0=$(docker exec repeater1 ip -o l list dev wlan0 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
+    mac_agent1_wlan0=$(docker exec ${REPEATER1} ip -o l list dev wlan0 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
     dbg "mac_agent1_wlan0 = ${mac_agent1_wlan0}"
 
-    mac_agent2_wlan0=$(docker exec repeater2 ip -o l list dev wlan0 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
+    mac_agent2_wlan0=$(docker exec ${REPEATER2} ip -o l list dev wlan0 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
     dbg "mac_agent2_wlan0 = ${mac_agent2_wlan0}"
 
-    mac_agent1_wlan2=$(docker exec repeater1 ip -o l list dev wlan2 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
+    mac_agent1_wlan2=$(docker exec ${REPEATER1} ip -o l list dev wlan2 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
     dbg "mac_agent1_wlan2 = ${mac_agent1_wlan2}"
 
-    mac_agent2_wlan2=$(docker exec repeater2 ip -o l list dev wlan2 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
+    mac_agent2_wlan2=$(docker exec ${REPEATER2} ip -o l list dev wlan2 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')
     dbg "mac_agent2_wlan2 = ${mac_agent2_wlan2}"
 
 }
@@ -554,6 +554,7 @@ usage() {
     echo "      -t|--tcpdump - Capture the results with tcpdump (requires root (sudo) or special permission/capability management of interfaces)"
     echo "      -v|--verbose - verbosity on"
     echo "      -s|--stop-on-failure - stop on failure"
+    echo "      -u|--unique-id - unique id to add as suffix to container and network names"
     echo "      --skip-init - skip init"
     echo ""
     echo "  positional params:"
@@ -574,7 +575,7 @@ usage() {
     echo "      higher_layer_data_payload_trigger - Higher layer data payload over 1905 trigger test"
 }
 main() {
-    OPTS=`getopt -o 'htvs' --long help,tcpdump,verbose,skip-init,stop-on-failure -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'htvsu:' --long help,tcpdump,verbose,skip-init,stop-on-failure,unique-id: -n 'parse-options' -- "$@"`
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
     eval set -- "$OPTS"
@@ -585,11 +586,17 @@ main() {
             -v | --verbose)         VERBOSE=true; redirect=; shift ;;
             -h | --help)            usage; exit 0; shift ;;
             -s | --stop-on-failure) STOP_ON_FAILURE=true; shift ;;
+            -u | --unique-id)       UNIQUE_ID="$2"; shift; shift ;;
             --skip-init)            SKIP_INIT=true; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
     done
+
+    REPEATER1=repeater1-${UNIQUE_ID}
+    REPEATER2=repeater2-${UNIQUE_ID}
+    GATEWAY=gateway-${UNIQUE_ID}
+
     [ -z "$*" ] && set ${ALL_TESTS}
     info "Tests to run: $*"
     trap kill_tcpdump EXIT
@@ -615,5 +622,5 @@ VERBOSE=false
 SKIP_INIT=false
 STOP_ON_FAILURE=false
 TCPDUMP=false
-
+UNIQUE_ID=${SUDO_USER:-${USER}}
 main "$@"

--- a/tools/docker/tests/test_gw_repeater.sh
+++ b/tools/docker/tests/test_gw_repeater.sh
@@ -19,6 +19,7 @@ usage() {
     echo "      -d|--delay - delay between starting the containers
     and testing their status (default %DELAY seconds"
     echo "      -f|--force - kill any running containers before starting"
+    echo "      -u|--unique-id - unique id to add as suffix to container and network names"
     echo "      -g|--gateway - gateway container name"
     echo "      -r|--repeater - repeater container name"
     echo "      --rm - remove containers after test completes"
@@ -27,7 +28,7 @@ usage() {
 }
 
 main() {
-    OPTS=`getopt -o 'hvd:fg:r:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater: -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvd:fg:r:u:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater:,unique-id: -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -39,6 +40,7 @@ main() {
             -h | --help)          usage; exit 0; shift ;;
             -d | --delay)         DELAY="$2"; shift; shift ;;
             -f | --force)         FORCE_OPT="-f"; shift ;;
+            -u | --unique-id)     UNIQUE_ID="$2"; shift; shift ;;
             -g | --gateway)       GW_NAME="$2"; shift; shift ;;
             -r | --repeater)      REPEATER_NAMES="$REPEATER_NAMES $2"; shift; shift ;;
             --rm)                 REMOVE=true; shift ;;
@@ -52,8 +54,8 @@ main() {
     status "Starting GW+Repeater test"
 
     # default values for gateway and repeater[s] names
-    REPEATER_NAMES=${REPEATER_NAMES-repeater}
-    GW_NAME=${GW_NAME-gateway}
+    REPEATER_NAMES=${REPEATER_NAMES-repeater-${UNIQUE_ID}}
+    GW_NAME=${GW_NAME-gateway-${UNIQUE_ID}}
 
     dbg REMOVE=$REMOVE
     dbg GW_NAME=$GW_NAME
@@ -61,10 +63,11 @@ main() {
     dbg START_GATEWAY=$START_GATEWAY
     dbg START_REPEATER=$START_REPEATER
     dbg DELAY=$DELAY
+    dbg UNIQUE_ID=$UNIQUE_ID
 
     [ "$START_GATEWAY" = "true" ] && {
         status "Start GW (Controller + local Agent)"
-        ${scriptdir}/../run.sh ${VERBOSE_OPT} ${FORCE_OPT} start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 -- "$@"
+        ${scriptdir}/../run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 -- "$@"
     }
 
     [ "$START_GATEWAY" = "true" -a "$START_REPEATER" = "true" ] && {
@@ -77,7 +80,7 @@ main() {
         no_vendor="-n"
         for repeater in $REPEATER_NAMES; do
             status "Start Repeater (Remote Agent): $repeater"
-            ${scriptdir}/../run.sh ${VERBOSE_OPT} ${FORCE_OPT} start-agent -d -n ${repeater} -m aa:bb:cc:$index$index -- $no_vendor "$@"
+            ${scriptdir}/../run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} start-agent -d -n ${repeater} -m aa:bb:cc:$index$index -- $no_vendor "$@"
             index=$((index+1))
             no_vendor=
         done
@@ -111,6 +114,7 @@ VERBOSE=false
 REMOVE=false
 START_GATEWAY=true
 START_REPEATER=true
+UNIQUE_ID=${SUDO_USER:-${USER}}
 DELAY=5
 
 main $@


### PR DESCRIPTION
Add multiple users support for docker scripts so that multiple users on
the same server can work in parallel running test_flows.sh.

This requires basically renaming all containers to include the username
of the current user.
In addition, we also add the current user prefix to the docker network
which is used for the test, for obvious reasons.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>