### PR TITLE
.gitlab-ci.yml: remove TESTS_TO_RUN

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,7 +141,7 @@ test-on-netgear-rax40:
 .run-certification-tests:
   stage: test
   variables:
-    TESTS_TO_RUN: "tools/docker/tests/certification/all_controller_tests.txt"
+    # TESTS_TO_RUN needs to be set by the user (or the pipeline schedule)
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplMesh/"
   script:
       - /easymesh_cert/run_test_file.sh -o logs $TESTS_TO_RUN


### PR DESCRIPTION
Due to a number of issues with setting variables manually using
Gitlab's web UI, setting TESTS_TO_RUN to run all the controller tests
can accidentally trigger more tests to be run than what was intended.
For example: when a job is retried all manually set variables are
ignored and take back their default value.

Remove TESTS_TO_RUN to force the user to specify the tests to run. If
TESTS_TO_RUN is not set for any reason, the test will fail.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>