### PR TITLE
Bugfix: fix topology response message 

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -25,6 +25,7 @@
 #include <tlvf/ieee_1905_1/eMessageType.h>
 #include <tlvf/ieee_1905_1/tlvAlMacAddressType.h>
 #include <tlvf/ieee_1905_1/tlvAutoconfigFreqBand.h>
+#include <tlvf/ieee_1905_1/tlvDeviceInformation.h>
 #include <tlvf/ieee_1905_1/tlvEndOfMessage.h>
 #include <tlvf/ieee_1905_1/tlvMacAddress.h>
 #include <tlvf/ieee_1905_1/tlvSearchedRole.h>
@@ -1765,6 +1766,18 @@ bool backhaul_manager::handle_1905_discovery_query(ieee1905_1::CmduMessageRx &cm
                    << (int)mid;
         return false;
     }
+
+    auto tlvDeviceInformation = cmdu_tx.addClass<ieee1905_1::tlvDeviceInformation>();
+    if (!tlvDeviceInformation) {
+        LOG(ERROR) << "addClass ieee1905_1::tlvDeviceInformation failed, mid=" << std::hex
+                   << (int)mid;
+        return false;
+    }
+    tlvDeviceInformation->mac() = network_utils::mac_from_string(bridge_info.mac);
+
+    // https://github.com/prplfoundation/prplMesh/issues/300
+    //TODO: set number of local interfaces.
+    //TODO: fill info of each of the local interfaces, according to IEEE_1905 section 6.4.5
 
     auto tlvSupportedService = cmdu_tx.addClass<wfa_map::tlvSupportedService>();
     if (!tlvSupportedService) {


### PR DESCRIPTION
### Bug description 

Currently, test 5.4.3 keeps on failing with the master version (Marvell CTT Agent 1, prplMesh DUT) with the following error: 

![image](https://user-images.githubusercontent.com/38204874/72988671-617bb300-3df5-11ea-80ff-1d8c320114b3.png)

### Reason
After exploring the root cause of this bug, it turned out that our topology response message did not match the IEEE_1905 document requirements. According to the IEEE_1905 document, section 6.4.5, the 1905 topology response message must include **One device information type TLV** (which currently is not added to the CMDU).

So when the Marvell sends a Topology Query to the prplMesh Controller, the prplMesh responds with a wrong topology response, which leads the Marvell agent to not respond to the controller Topology Query later when is triggered to.

Therefore, the required TLV is added to the Topology Response Message.
The rest of the fields of the TLV will be completed as part of the Supported Services Discovery task (#300).

Fixes #723
### Testbed status
_Test 5.4.3 passed._

Signed-off-by: Coral Malachi <coral.malachi@intel.com>