### PR TITLE
github: add workflow to assign PR to author

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,15 @@
+name: Automation on pull requests
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Assign PR to Author
+      uses: samspills/assign-pr-to-author@v1.0
+      if: github.event_name == 'pull_request' && github.event.action == 'opened'
+      with:
+        repo-token: '${{ secrets.GITHUB_TOKEN }}' 


### PR DESCRIPTION
With this workflow, supposedly every new PR should be automatically assigned to the author of the PR.

The complexity needed to make this work is staggering, but fortunately in this particular case it's handled by an external project.