### PR TITLE
github: issue_template: correctly set project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 title: "[BUG] <component>: <headline>"
 labels: bug
 assignees: ''
-projects: prplMesh
+projects: prplfoundation/prplMesh/1
 ---
 
 **Describe the bug** -

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-projects: prplMesh
+projects: prplfoundation/prplMesh/1
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -4,7 +4,7 @@ about: Feature currently being developed / reviewed
 title: "[TASK]"
 labels: enhancement
 assignees: ''
-projects: prplMesh
+projects: prplfoundation/prplMesh/1
 
 ---
 


### PR DESCRIPTION
We set the project field in the issue templates, but it didn't work.
Probably that's because it in fact needs the full path to the project
ID. Let's try that now.