### PR TITLE
.gitlab-ci.yml: do the alpine build on schedules only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,8 @@ build-in-docker:
 build-in-docker-alpine:
   extends: build-in-docker
   image: prplfoundationinc/prplmesh-builder:alpine-3.11.3
+  only:
+    - schedules
 
 .run-test-in-docker:
   stage: test


### PR DESCRIPTION
It turns out that the Gitlab runners we have cannot cope with the
number of builds they have to do.
For every pushed branch, 2 new docker builds must be done, and the 2
builds alone prevent the OpenWrt builds from being built in a
reasonable time.

Build only with alpine when scheduled jobs are run, which at the
moment means it will be built nightly.
This still allows us to detect issues with more recent/different
versions of GCC for instance, without the cost of building twice at
every push.
