### PR TITLE
Hotfix/ci move ipks to builddir

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ run-tests:
   stage: build
   script:
     - mkdir -p "build/$TARGET_DEVICE"
-    - tools/docker/builder/openwrt/build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log" | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
+    - tools/docker/builder/openwrt/build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log" | grep -E '^[[:blank:]]?make\[[12]\]|^Step|^ --->' --color=never --line-buffered
   after_script:
     # if we're on master, tag the docker image with a persistant tag:
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,8 +83,8 @@ run-tests:
 .build-for-openwrt:
   stage: build
   script:
-    - cd tools/docker/builder/openwrt
-    - ./build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee build.log | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
+    - mkdir -p "build/$TARGET_DEVICE"
+    - tools/docker/builder/openwrt/build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log" | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
   after_script:
     # if we're on master, tag the docker image with a persistant tag:
     - |
@@ -96,8 +96,8 @@ run-tests:
     - docker rmi "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID"
   artifacts:
     paths:
-      - tools/docker/builder/openwrt/*.ipk
-      - tools/docker/builder/openwrt/build.log
+      - "build/$TARGET_DEVICE/*.ipk"
+      - "build/$TARGET_DEVICE/openwrt-build.log"
     when: always
   tags:
     - shell
@@ -111,7 +111,7 @@ run-tests:
     # kill prplmesh on each target to make sure they don't interfere with the test
     - for i in $ALL_TARGETS ; do ssh "$i" 'pgrep -f beerocks | xargs kill -9 2>/dev/null' || true ; done
   script:
-    - tools/deploy_ipk.sh $TARGET_DEVICE_NAME tools/docker/builder/openwrt/*.ipk
+    - tools/deploy_ipk.sh $TARGET_DEVICE_NAME "build/$TARGET_DEVICE/"*.ipk
     - tests/openwrt/test_status.sh $TARGET_DEVICE_NAME
   artifacts:
     paths:
@@ -139,18 +139,21 @@ build-for-netgear-rax40:
 test-on-turris-omnia:
   extends: .test-on-target
   variables:
+    TARGET_DEVICE: turris-omnia
     TARGET_DEVICE_NAME: turris-omnia-1
   needs: ["build-for-turris-omnia"]
 
 test-on-glinet-b1300:
   extends: .test-on-target
   variables:
+    TARGET_DEVICE: glinet-b1300
     TARGET_DEVICE_NAME: glinet-b1300-1
   needs: ["build-for-glinet-b1300"]
 
 test-on-netgear-rax40:
   extends: .test-on-target
   variables:
+    TARGET_DEVICE: netgear-rax40
     TARGET_DEVICE_NAME: netgear-rax40-1
   needs: ["build-for-netgear-rax40"]
 

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -68,7 +68,7 @@ main() {
 
     eval set -- "$OPTS"
 
-    SUPPORTED_TARGETS="turris-omnia glinet-b1300"
+    SUPPORTED_TARGETS="turris-omnia glinet-b1300 netgear-rax40"
 
     while true; do
         case "$1" in

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -56,6 +56,12 @@ build_prplmesh() {
 }
 
 main() {
+
+    if ! command -v uuidgen > /dev/null ; then
+        err "You need uuidgen to use this script. Please install it and try again."
+        exit 1
+    fi
+
     OPTS=`getopt -o 'hb:d:io:r:t:v' --long help,build-options:,device:,image,openwrt-version:,openwrt-repository:,tag:,verbose -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -39,6 +39,7 @@ build_image() {
 }
 
 build_prplmesh() {
+    build_dir="$1"
     container_name="prplmesh-builder-${TARGET_DEVICE}-$(uuidgen)"
     dbg "Container name will be $container_name"
     trap 'docker rm -f $container_name' EXIT
@@ -51,8 +52,8 @@ build_prplmesh() {
            -v "${rootdir}:/home/openwrt/prplMesh_source:ro" \
            "$image_tag" \
            ./build_scripts/build.sh
-
-    docker cp "${container_name}:/home/openwrt/openwrt_sdk/prplmesh-${TARGET}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" .
+    mkdir -p "$build_dir"
+    docker cp "${container_name}:/home/openwrt/openwrt_sdk/prplmesh-${TARGET}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" "$build_dir"
 }
 
 main() {
@@ -145,7 +146,7 @@ main() {
     fi
 
     build_image
-    build_prplmesh
+    build_prplmesh "$rootdir/build/$TARGET_DEVICE"
 
 }
 


### PR DESCRIPTION
Various small CI improvements:
- check if `uuidgen` is available before running the whole docker build
- add netgear-rax40 to the list of supported targets
- build the ipk in ./build/TARGET_DEVICE to make it target specific
- slightly improve the CI output