### PR TITLE
[Patch 1/2] Feature/client capability response [Test 4.6.2]

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -39,6 +39,9 @@
 #include <tlvf/wfa_map/tlvApOperationalBSS.h>
 #include <tlvf/wfa_map/tlvApRadioBasicCapabilities.h>
 #include <tlvf/wfa_map/tlvAssociatedClients.h>
+#include <tlvf/wfa_map/tlvClientCapabilityReport.h>
+#include <tlvf/wfa_map/tlvClientInfo.h>
+#include <tlvf/wfa_map/tlvErrorCode.h>
 #include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvSearchedService.h>
 #include <tlvf/wfa_map/tlvSupportedService.h>
@@ -1805,13 +1808,85 @@ bool backhaul_manager::handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx,
     case ieee1905_1::eMessageType::COMBINED_INFRASTRUCTURE_METRICS_MESSAGE: {
         return handle_1905_combined_infrastructure_metrics(cmdu_rx, src_mac);
     }
-
+    case ieee1905_1::eMessageType::CLIENT_CAPABILITY_QUERY_MESSAGE:
+        return handle_client_capability_query(cmdu_rx, src_mac);
     default: {
         // TODO add a warning once all vendor specific flows are replaced with EasyMesh
         // flows, since we won't expect a 1905 message not handled in this function
         return false;
     }
     }
+}
+
+bool backhaul_manager::handle_client_capability_query(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                                      const std::string &src_mac)
+{
+    const auto mid = cmdu_rx.getMessageId();
+    LOG(DEBUG) << "Received CLIENT_CAPABILITY_QUERY_MESSAGE , mid=" << std::dec << int(mid);
+
+    auto client_info_tlv_r = cmdu_rx.getClass<wfa_map::tlvClientInfo>();
+    if (!client_info_tlv_r) {
+        LOG(ERROR) << "getClass wfa_map::tlvClientInfo failed";
+        return false;
+    }
+
+    //Check if it is an error scenario - if the STA specified in the Client Capability Query message is not associated
+    //with any of the BSS operated by the Multi-AP Agent [ though the TLV does contain a BSSID, the specification
+    // says that we should answer if the client is associated with any BSS on this agent.]
+    bool associated_client_found = false;
+    for (const auto &slave : m_radio_info_map) {
+        auto associated_clients_map = slave.second.associated_clients_map;
+        for (const auto &vap : associated_clients_map) {
+            if (vap.second.find(client_info_tlv_r->client_mac()) != vap.second.end()) {
+                associated_client_found = true;
+                break;
+            }
+        }
+    }
+
+    // send CLIENT_CAPABILITY_REPORT_MESSAGE back to the controller
+    if (!cmdu_tx.create(mid, ieee1905_1::eMessageType::CLIENT_CAPABILITY_REPORT_MESSAGE)) {
+        LOG(ERROR) << "cmdu creation of type CLIENT_CAPABILITY_REPORT_MESSAGE, has failed";
+        return false;
+    }
+
+    auto client_info_tlv_t = cmdu_tx.addClass<wfa_map::tlvClientInfo>();
+    if (!client_info_tlv_t) {
+        LOG(ERROR) << "addClass wfa_map::tlvClientInfo has failed";
+        return false;
+    }
+    client_info_tlv_t->bssid()      = client_info_tlv_r->bssid();
+    client_info_tlv_t->client_mac() = client_info_tlv_r->client_mac();
+
+    auto client_capability_report_tlv = cmdu_tx.addClass<wfa_map::tlvClientCapabilityReport>();
+    if (!client_capability_report_tlv) {
+        LOG(ERROR) << "addClass wfa_map::tlvClientCapabilityReport has failed";
+        return false;
+    }
+
+    //if it is an error scenario, set Success status to 0x01 = Failure and do nothing after it.
+    if (associated_client_found) {
+        client_capability_report_tlv->result_code() = wfa_map::tlvClientCapabilityReport::SUCCESS;
+        LOG(DEBUG) << "Result Code: SUCCESS";
+        //TODO: Add frame body of the most recently received (Re)Association Request frame from this client
+    } else {
+        client_capability_report_tlv->result_code() = wfa_map::tlvClientCapabilityReport::FAILURE;
+
+        LOG(DEBUG) << "Result Code: FAILURE";
+        LOG(DEBUG) << "STA specified in the Client Capability Query message is not associated with "
+                      "any of the BSS operated by the Multi-AP Agent ";
+        //Add an Error Code TLV
+        auto error_code_tlv = cmdu_tx.addClass<wfa_map::tlvErrorCode>();
+        if (!error_code_tlv) {
+            LOG(ERROR) << "addClass wfa_map::tlvErrorCode has failed";
+            return false;
+        }
+        error_code_tlv->reason_code() =
+            wfa_map::tlvErrorCode::STA_NOT_ASSOCIATED_WITH_ANY_BSS_OPERATED_BY_THE_AGENT;
+        error_code_tlv->sta_mac() = client_info_tlv_r->client_mac();
+    }
+    LOG(DEBUG) << "Send a CLIENT_CAPABILITY_REPORT_MESSAGE back to controller";
+    return send_cmdu_to_bus(cmdu_tx, src_mac, bridge_info.mac);
 }
 
 bool backhaul_manager::handle_ap_capability_query(ieee1905_1::CmduMessageRx &cmdu_rx,

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -83,6 +83,8 @@ private:
     bool handle_1905_combined_infrastructure_metrics(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                      const std::string &src_mac);
     bool handle_ap_capability_query(ieee1905_1::CmduMessageRx &cmdu_rx, const std::string &src_mac);
+    bool handle_client_capability_query(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                        const std::string &src_mac);
     //bool sta_handle_event(const std::string &iface,const std::string& event_name, void* event_obj);
     bool hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr, std::string iface);
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -385,8 +385,6 @@ bool slave_thread::handle_cmdu_control_ieee1905_1_message(Socket *sd,
         return handle_client_steering_request(sd, cmdu_rx);
     case ieee1905_1::eMessageType::ACK_MESSAGE:
         return handle_ack_message(sd, cmdu_rx);
-    case ieee1905_1::eMessageType::CLIENT_CAPABILITY_QUERY_MESSAGE:
-        return handle_client_capability_query(sd, cmdu_rx);
     case ieee1905_1::eMessageType::MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE:
         return handle_multi_ap_policy_config_request(sd, cmdu_rx);
     default:
@@ -4195,13 +4193,6 @@ bool slave_thread::parse_non_intel_join_response(Socket *sd)
 
     slave_state = STATE_UPDATE_MONITOR_SON_CONFIG;
 
-    return true;
-}
-
-bool slave_thread::handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
-{
-    const auto mid = cmdu_rx.getMessageId();
-    LOG(DEBUG) << "Received CLIENT_CAPABILITY_QUERY_MESSAGE , mid=" << std::dec << int(mid);
     return true;
 }
 

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -240,7 +240,6 @@ private:
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_multi_ap_policy_config_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool handle_client_capability_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_association_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_steering_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_ack_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -100,6 +100,7 @@ bool master_thread::init()
             ieee1905_1::eMessageType::LINK_METRIC_RESPONSE_MESSAGE,
             ieee1905_1::eMessageType::AP_METRICS_RESPONSE_MESSAGE,
             ieee1905_1::eMessageType::AP_CAPABILITY_REPORT_MESSAGE,
+            ieee1905_1::eMessageType::CLIENT_CAPABILITY_REPORT_MESSAGE,
             ieee1905_1::eMessageType::ACK_MESSAGE,
 
         })) {

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -95,6 +95,8 @@ private:
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_client_steering_btm_report_message(const std::string &src_mac,
                                                              ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_1905_client_capability_report_message(const std::string &src_mac,
+                                                           ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_topology_notification(const std::string &src_mac,
                                                 ieee1905_1::CmduMessageRx &cmdu_rx);
 

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientCapabilityReport.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientCapabilityReport.h
@@ -1,0 +1,64 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVCLIENTCAPABILITYREPORT_H_
+#define _TLVF_WFA_MAP_TLVCLIENTCAPABILITYREPORT_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include <tuple>
+
+namespace wfa_map {
+
+
+class tlvClientCapabilityReport : public BaseClass
+{
+    public:
+        tlvClientCapabilityReport(uint8_t* buff, size_t buff_len, bool parse = false);
+        explicit tlvClientCapabilityReport(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvClientCapabilityReport();
+
+        enum eResultCode: uint8_t {
+            SUCCESS = 0x0,
+            FAILURE = 0x1,
+        };
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        eResultCode& result_code();
+        uint8_t& association_frame_length();
+        uint8_t* association_frame(size_t idx = 0);
+        bool alloc_association_frame(size_t count = 1);
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eResultCode* m_result_code = nullptr;
+        uint8_t* m_association_frame_length = nullptr;
+        uint8_t* m_association_frame = nullptr;
+        size_t m_association_frame_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVCLIENTCAPABILITYREPORT_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientInfo.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientInfo.h
@@ -1,0 +1,54 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVCLIENTINFO_H_
+#define _TLVF_WFA_MAP_TLVCLIENTINFO_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+
+namespace wfa_map {
+
+
+class tlvClientInfo : public BaseClass
+{
+    public:
+        tlvClientInfo(uint8_t* buff, size_t buff_len, bool parse = false);
+        explicit tlvClientInfo(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvClientInfo();
+
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        sMacAddr& bssid();
+        sMacAddr& client_mac();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        sMacAddr* m_client_mac = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVCLIENTINFO_H_

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvErrorCode.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvErrorCode.h
@@ -1,0 +1,64 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _TLVF_WFA_MAP_TLVERRORCODE_H_
+#define _TLVF_WFA_MAP_TLVERRORCODE_H_
+
+#include <cstddef>
+#include <stdint.h>
+#include <tlvf/swap.h>
+#include <string.h>
+#include <memory>
+#include <tlvf/BaseClass.h>
+#include <tlvf/ClassList.h>
+#include "tlvf/wfa_map/eTlvTypeMap.h"
+#include "tlvf/common/sMacAddr.h"
+
+namespace wfa_map {
+
+
+class tlvErrorCode : public BaseClass
+{
+    public:
+        tlvErrorCode(uint8_t* buff, size_t buff_len, bool parse = false);
+        explicit tlvErrorCode(std::shared_ptr<BaseClass> base, bool parse = false);
+        ~tlvErrorCode();
+
+        enum eReasonCode: uint8_t {
+            RESERVED = 0x0,
+            STA_ASSOCIATED_WITH_A_BSS_OPERATED_BY_THE_AGENT = 0x1,
+            STA_NOT_ASSOCIATED_WITH_ANY_BSS_OPERATED_BY_THE_AGENT = 0x2,
+            CLIENT_CAPABILITY_REPORT_UNSPECIFIED_FAILURE = 0x3,
+            BACKHAUL_STEERING_REQUEST_REJECTED_CANNOT_OPERATE_ON_CHANNEL_SPECIFIED = 0x4,
+            BACKHAUL_STEERING_REQUEST_REJECTED_TARGET_BSS_SIGNAL_NOT_SUITABLE = 0x5,
+            BACKHAUL_STEERING_REQUEST_AUTHENTICATION_OR_ASSOCIATION_REJECTED = 0x6,
+        };
+        
+        const eTlvTypeMap& type();
+        const uint16_t& length();
+        eReasonCode& reason_code();
+        sMacAddr& sta_mac();
+        void class_swap() override;
+        bool finalize() override;
+        static size_t get_initial_size();
+
+    private:
+        bool init();
+        eTlvTypeMap* m_type = nullptr;
+        uint16_t* m_length = nullptr;
+        eReasonCode* m_reason_code = nullptr;
+        sMacAddr* m_sta_mac = nullptr;
+};
+
+}; // close namespace: wfa_map
+
+#endif //_TLVF/WFA_MAP_TLVERRORCODE_H_

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientCapabilityReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientCapabilityReport.cpp
@@ -1,0 +1,171 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvClientCapabilityReport.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvClientCapabilityReport::tlvClientCapabilityReport(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvClientCapabilityReport::tlvClientCapabilityReport(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvClientCapabilityReport::~tlvClientCapabilityReport() {
+}
+const eTlvTypeMap& tlvClientCapabilityReport::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvClientCapabilityReport::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+tlvClientCapabilityReport::eResultCode& tlvClientCapabilityReport::result_code() {
+    return (eResultCode&)(*m_result_code);
+}
+
+uint8_t& tlvClientCapabilityReport::association_frame_length() {
+    return (uint8_t&)(*m_association_frame_length);
+}
+
+uint8_t* tlvClientCapabilityReport::association_frame(size_t idx) {
+    if ( (m_association_frame_idx__ == 0) || (m_association_frame_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_association_frame[idx]);
+}
+
+bool tlvClientCapabilityReport::alloc_association_frame(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list association_frame, abort!";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_association_frame[*m_association_frame_length];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_association_frame_idx__ += count;
+    *m_association_frame_length += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if(m_length){ (*m_length) += len; }
+    return true;
+}
+
+void tlvClientCapabilityReport::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eResultCode), reinterpret_cast<uint8_t*>(m_result_code));
+}
+
+bool tlvClientCapabilityReport::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvClientCapabilityReport::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eResultCode); // result_code
+    class_size += sizeof(uint8_t); // association_frame_length
+    return class_size;
+}
+
+bool tlvClientCapabilityReport::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_CLIENT_CAPABILITY_REPORT;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_result_code = (eResultCode*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(eResultCode))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eResultCode) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eResultCode); }
+    m_association_frame_length = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_association_frame_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
+    m_association_frame = (uint8_t*)m_buff_ptr__;
+    uint8_t association_frame_length = *m_association_frame_length;
+    m_association_frame_idx__ = association_frame_length;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (association_frame_length))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (association_frame_length) << ") Failed!";
+        return false;
+    }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_CLIENT_CAPABILITY_REPORT) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CLIENT_CAPABILITY_REPORT) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientInfo.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientInfo.cpp
@@ -1,0 +1,131 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvClientInfo.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvClientInfo::tlvClientInfo(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvClientInfo::tlvClientInfo(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvClientInfo::~tlvClientInfo() {
+}
+const eTlvTypeMap& tlvClientInfo::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvClientInfo::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+sMacAddr& tlvClientInfo::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
+sMacAddr& tlvClientInfo::client_mac() {
+    return (sMacAddr&)(*m_client_mac);
+}
+
+void tlvClientInfo::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    m_bssid->struct_swap();
+    m_client_mac->struct_swap();
+}
+
+bool tlvClientInfo::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvClientInfo::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(sMacAddr); // client_mac
+    return class_size;
+}
+
+bool tlvClientInfo::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_CLIENT_INFO;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_bssid->struct_init(); }
+    m_client_mac = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_client_mac->struct_init(); }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_CLIENT_INFO) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_CLIENT_INFO) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvErrorCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvErrorCode.cpp
@@ -1,0 +1,130 @@
+///////////////////////////////////////
+// AUTO GENERATED FILE - DO NOT EDIT //
+///////////////////////////////////////
+
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2016-2019 Intel Corporation
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <tlvf/wfa_map/tlvErrorCode.h>
+#include <tlvf/tlvflogging.h>
+
+using namespace wfa_map;
+
+tlvErrorCode::tlvErrorCode(uint8_t* buff, size_t buff_len, bool parse) :
+    BaseClass(buff, buff_len, parse) {
+    m_init_succeeded = init();
+}
+tlvErrorCode::tlvErrorCode(std::shared_ptr<BaseClass> base, bool parse) :
+BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
+    m_init_succeeded = init();
+}
+tlvErrorCode::~tlvErrorCode() {
+}
+const eTlvTypeMap& tlvErrorCode::type() {
+    return (const eTlvTypeMap&)(*m_type);
+}
+
+const uint16_t& tlvErrorCode::length() {
+    return (const uint16_t&)(*m_length);
+}
+
+tlvErrorCode::eReasonCode& tlvErrorCode::reason_code() {
+    return (eReasonCode&)(*m_reason_code);
+}
+
+sMacAddr& tlvErrorCode::sta_mac() {
+    return (sMacAddr&)(*m_sta_mac);
+}
+
+void tlvErrorCode::class_swap()
+{
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eReasonCode), reinterpret_cast<uint8_t*>(m_reason_code));
+    m_sta_mac->struct_swap();
+}
+
+bool tlvErrorCode::finalize()
+{
+    if (m_parse__) {
+        TLVF_LOG(DEBUG) << "finalize() called but m_parse__ is set";
+        return true;
+    }
+    if (m_finalized__) {
+        TLVF_LOG(DEBUG) << "finalize() called for already finalized class";
+        return true;
+    }
+    if (!isPostInitSucceeded()) {
+        TLVF_LOG(ERROR) << "post init check failed";
+        return false;
+    }
+    if (m_inner__) {
+        if (!m_inner__->finalize()) {
+            TLVF_LOG(ERROR) << "m_inner__->finalize() failed";
+            return false;
+        }
+        auto tailroom = m_inner__->getMessageBuffLength() - m_inner__->getMessageLength();
+        m_buff_ptr__ -= tailroom;
+        *m_length -= tailroom;
+    }
+    class_swap();
+    m_finalized__ = true;
+    return true;
+}
+
+size_t tlvErrorCode::get_initial_size()
+{
+    size_t class_size = 0;
+    class_size += sizeof(eTlvTypeMap); // type
+    class_size += sizeof(uint16_t); // length
+    class_size += sizeof(eReasonCode); // reason_code
+    class_size += sizeof(sMacAddr); // sta_mac
+    return class_size;
+}
+
+bool tlvErrorCode::init()
+{
+    if (getBuffRemainingBytes() < get_initial_size()) {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
+        return false;
+    }
+    m_type = (eTlvTypeMap*)m_buff_ptr__;
+    if (!m_parse__) *m_type = eTlvTypeMap::TLV_ERROR_CODE;
+    if (!buffPtrIncrementSafe(sizeof(eTlvTypeMap))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eTlvTypeMap) << ") Failed!";
+        return false;
+    }
+    m_length = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_length = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_reason_code = (eReasonCode*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(eReasonCode))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(eReasonCode) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(eReasonCode); }
+    m_sta_mac = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(sMacAddr); }
+    if (!m_parse__) { m_sta_mac->struct_init(); }
+    if (m_parse__) { class_swap(); }
+    if (m_parse__) {
+        if (*m_type != eTlvTypeMap::TLV_ERROR_CODE) {
+            TLVF_LOG(ERROR) << "TLV type mismatch. Expected value: " << int(eTlvTypeMap::TLV_ERROR_CODE) << ", received value: " << int(*m_type);
+            return false;
+        }
+    }
+    return true;
+}
+
+

--- a/framework/tlvf/src/src/CmduMessageRx.cpp
+++ b/framework/tlvf/src/src/CmduMessageRx.cpp
@@ -36,6 +36,8 @@
 #include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
 #include <tlvf/wfa_map/tlvClientAssociationControlRequest.h>
 #include <tlvf/wfa_map/tlvClientAssociationEvent.h>
+#include <tlvf/wfa_map/tlvClientCapabilityReport.h>
+#include <tlvf/wfa_map/tlvClientInfo.h>
 #include <tlvf/wfa_map/tlvHigherLayerData.h>
 #include <tlvf/wfa_map/tlvOperatingChannelReport.h>
 #include <tlvf/wfa_map/tlvRadioOperationRestriction.h>
@@ -135,6 +137,12 @@ std::shared_ptr<BaseClass> CmduMessageRx::parseNextTlv()
     }
     case (143): {
         return msg.addClass<wfa_map::tlvOperatingChannelReport>();
+    }
+    case (144): {
+        return msg.addClass<wfa_map::tlvClientInfo>();
+    }
+    case (145): {
+        return msg.addClass<wfa_map::tlvClientCapabilityReport>();
     }
     case (146): {
         return msg.addClass<wfa_map::tlvClientAssociationEvent>();

--- a/framework/tlvf/tlvf_conf.yaml
+++ b/framework/tlvf/tlvf_conf.yaml
@@ -31,6 +31,9 @@ include_yaml_path: {
   "tlvf/wfa_map/tlvApHtCapabilities.yaml",
   "tlvf/wfa_map/tlvApHeCapabilities.yaml",  
   "tlvf/wfa_map/tlvApVhtCapabilities.yaml",  
+  "tlvf/wfa_map/tlvClientInfo.yaml",
+  "tlvf/wfa_map/tlvClientCapabilityReport.yaml",  
+  "tlvf/wfa_map/tlvErrorCode.yaml",  
 }
 
 # Relative to tlvf.py src_path variable

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -211,15 +211,32 @@ test_channel_selection() {
 }
 test_client_capability_query() { 
     status "test client capability"
+    sta_mac1=00:00:00:11:00:22
+    sta_mac2=00:00:00:11:00:33
 
     check_error=0
-    send_CAPI_1905 ${GATEWAY} $mac_agent1 0x8009 "tlv_type,0x90,tlv_length,\
-0x000C,tlv_value,{$mac_agent1_wlan0 0x000000110022}"
+    check send_CAPI_1905 ${GATEWAY} $mac_agent1 0x8009 "tlv_type,0x90,tlv_length,\
+0x000C,tlv_value,{$mac_agent1_wlan0 ${sta_mac1}}"
     sleep 1
     dbg "Confirming client capability query has been received on agent"
     # check that both radio agents received it,in the future we'll add a check to verify which radio the query was intended for.
-    check_log ${REPEATER1} agent_wlan0 "CLIENT_CAPABILITY_QUERY_MESSAGE"
-    check_log ${REPEATER1} agent_wlan2 "CLIENT_CAPABILITY_QUERY_MESSAGE"
+    check_log ${REPEATER1} agent "CLIENT_CAPABILITY_QUERY_MESSAGE"
+    
+    dbg "Confirming client capability report message has been received on controller"
+    check_log ${GATEWAY} controller "Received CLIENT_CAPABILITY_REPORT_MESSAGE"
+    check_log ${GATEWAY} controller "Result Code= FAILURE, client MAC= ${sta_mac1}, BSSID= ${mac_agent1_wlan0}"
+
+    dbg "Connect dummy STA to wlan0"
+    send_bwl_event ${REPEATER1} wlan0 "EVENT AP-STA-CONNECTED ${sta_mac2}"
+
+    check send_CAPI_1905 ${GATEWAY} $mac_agent1 0x8009 "tlv_type,0x90,tlv_length,\
+0x000C,tlv_value,{$mac_agent1_wlan0 ${sta_mac2}}" 
+    sleep 1
+
+    dbg "Confirming client capability report message has been received on controller"
+    check_log ${GATEWAY} controller "Received CLIENT_CAPABILITY_REPORT_MESSAGE"
+    check_log ${GATEWAY} controller "Result Code= SUCCESS, client MAC= ${sta_mac2}, BSSID= ${mac_agent1_wlan0}"
+    return $check_error
 }
 test_ap_capability_query() {
     status "test ap capability query"


### PR DESCRIPTION
### Description
According to Multi-AP Specification, If a Multi-AP Agent receives a
Client Capability Query message, then within one second it shall respond
with a Client Capability Report message.

If the STA specified in the Client Capability Query message is not
associated with any of the BSS operated by the Multi-AP Agent (an error
scenario), the Multi-AP Agent shall set the result code in the Client
Capability Report TLV to 0x01  and include an Error Code TLV.

### Changes
Therefore, the following changes were made:

- Create a Client Capability Report message CMDU.

- Add the Client Info TLV.

- Add a Client Capability Report TLV.

- Check that the Multi-AP Agent has the BSSID that was specified in the Client Info TLV, and that the client is associated with that BSS. If not, this is an error scenario, so set the result code in the Client
Capability Report TLV to 0x01, and include an Error Code TLV with the reason code set to 0x02.

### Testbed status
This branch was tested on testbed while using Qualcomm as CTT Controller, Marvell STA as client and prplMesh as MAUT.
Currently, there is an issue with the Marvell STA, which can not connect to the prplMesh agent.
Since the client was not connected to the agent, the Client Capability Report contained an Error Code TLV as it should.

_Status update: test 4.6.2 **passed** the test on the testbed._

### Next steps

- [x] After solving the issue with the Marvell STA, run the test again and verify that in case of success the Client Capability Report does not contain an Error Code TLV.


- [ ] Client Capability Report TLV  should include the frame body of the most recently received (Re)Association Request frame from this client (if it is an error scenario this field is omitted).
This part will be done in a separate PR.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>