### PR TITLE
gitlab-ci.yml: create a persistent docker image tag on master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,13 @@ run-tests:
     - cd tools/docker/builder/openwrt
     - ./build.sh -v -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee build.log | grep '^make\[[12]\]\|^Step\|^ --->' --color=never --line-buffered
   after_script:
+    # if we're on master, tag the docker image with a persistant tag:
+    - |
+      if [ $CI_COMMIT_REF_NAME == "master" ] ; then
+          echo "Keeping tag prplmesh-builder-$TARGET_DEVICE"
+          docker tag prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID prplmesh-builder-$TARGET_DEVICE
+      fi
+    # always delete the unique tag:
     - docker rmi "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID"
   artifacts:
     paths:


### PR DESCRIPTION
Since commit 36c676aafd6fd5cf0a8b76e930c0d430f6df357a, we're always
deleting the unique docker image tag we create. Because no other tags
use the same image, it actually also gets deleted from the cache.
Because of this, the next pipeline will have to rebuild the entirety
of the last stage.

It was not a problem until now because the shell runner we had did
keep tags from back when we didn't delete them automatically. Now that
we want to add other runners however, the issue shows up.

If we're on the master branch, add a docker image tag per target
device, so that at least one image is kept in cache (the latest one
from master).

close #744 