### PR TITLE
easylogging++: bug - access attempt to released memory

### DIFF
--- a/framework/external/easylogging/easylogging++.cc
+++ b/framework/external/easylogging/easylogging++.cc
@@ -603,7 +603,7 @@ void LogBuilder::convertToColoredOutput(base::type::string_t* logLine, Level lev
 
 // Logger
 
-Logger::Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsReference) :
+Logger::Logger(const std::string& id, base::LogStreamsReferenceMapPtr logStreamsReference) :
   m_id(id),
   m_typedConfigurations(nullptr),
   m_parentApplicationName(std::string()),
@@ -613,7 +613,7 @@ Logger::Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsRe
 }
 
 Logger::Logger(const std::string& id, const Configurations& configurations,
-               base::LogStreamsReferenceMap* logStreamsReference) :
+               base::LogStreamsReferenceMapPtr logStreamsReference) :
   m_id(id),
   m_typedConfigurations(nullptr),
   m_parentApplicationName(std::string()),
@@ -1620,7 +1620,7 @@ void LogFormat::updateFormatSpec(void) {
 // TypedConfigurations
 
 TypedConfigurations::TypedConfigurations(Configurations* configurations,
-    base::LogStreamsReferenceMap* logStreamsReference) {
+    LogStreamsReferenceMapPtr logStreamsReference) {
   m_configurations = configurations;
   m_logStreamsReference = logStreamsReference;
   build(m_configurations);
@@ -1901,6 +1901,7 @@ bool RegisteredHitCounters::validateNTimes(const char* filename, base::type::Lin
 RegisteredLoggers::RegisteredLoggers(const LogBuilderPtr& defaultLogBuilder) :
   m_defaultLogBuilder(defaultLogBuilder) {
   m_defaultConfigurations.setToDefault();
+  m_logStreamsReference = std::make_shared<base::LogStreamsReferenceMap>();
 }
 
 Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
@@ -1912,7 +1913,7 @@ Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
       ELPP_ASSERT(validId, "Invalid logger ID [" << id << "]. Not registering this logger.");
       return nullptr;
     }
-    logger_ = new Logger(id, m_defaultConfigurations, &m_logStreamsReference);
+    logger_ = new Logger(id, m_defaultConfigurations, m_logStreamsReference);
     logger_->m_logBuilder = m_defaultLogBuilder;
     registerNew(id, logger_);
     LoggerRegistrationCallback* callback = nullptr;
@@ -1942,8 +1943,8 @@ bool RegisteredLoggers::remove(const std::string& id) {
 
 void RegisteredLoggers::unsafeFlushAll(void) {
   ELPP_INTERNAL_INFO(1, "Flushing all log files");
-  for (base::LogStreamsReferenceMap::iterator it = m_logStreamsReference.begin();
-       it != m_logStreamsReference.end(); ++it) {
+  for (base::LogStreamsReferenceMap::iterator it = m_logStreamsReference->begin();
+       it != m_logStreamsReference->end(); ++it) {
     if (it->second.get() == nullptr) continue;
     it->second->flush();
   }
@@ -3038,7 +3039,7 @@ const Configurations* Loggers::defaultConfigurations(void) {
   return ELPP->registeredLoggers()->defaultConfigurations();
 }
 
-const base::LogStreamsReferenceMap* Loggers::logStreamsReference(void) {
+const base::LogStreamsReferenceMapPtr Loggers::logStreamsReference(void) {
   return ELPP->registeredLoggers()->logStreamsReference();
 }
 

--- a/framework/external/easylogging/easylogging++.h
+++ b/framework/external/easylogging/easylogging++.h
@@ -1896,6 +1896,7 @@ class Configurations : public base::utils::RegistryWithPred<Configuration, Confi
 namespace base {
 typedef std::shared_ptr<base::type::fstream_t> FileStreamPtr;
 typedef std::unordered_map<std::string, FileStreamPtr> LogStreamsReferenceMap;
+typedef std::shared_ptr<base::LogStreamsReferenceMap> LogStreamsReferenceMapPtr;
 /// @brief Configurations with data types.
 ///
 /// @detail el::Configurations have string based values. This is whats used internally in order to read correct configurations.
@@ -1907,7 +1908,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   /// @brief Constructor to initialize (construct) the object off el::Configurations
   /// @param configurations Configurations pointer/reference to base this typed configurations off.
   /// @param logStreamsReference Use ELPP->registeredLoggers()->logStreamsReference()
-  TypedConfigurations(Configurations* configurations, base::LogStreamsReferenceMap* logStreamsReference);
+  TypedConfigurations(Configurations* configurations, LogStreamsReferenceMapPtr logStreamsReference);
 
   TypedConfigurations(const TypedConfigurations& other);
 
@@ -1947,7 +1948,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   std::unordered_map<Level, base::FileStreamPtr> m_fileStreamMap;
   std::unordered_map<Level, std::size_t> m_maxLogFileSizeMap;
   std::unordered_map<Level, std::size_t> m_logFlushThresholdMap;
-  base::LogStreamsReferenceMap* m_logStreamsReference;
+  LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
 
   friend class el::Helpers;
   friend class el::base::MessageBuilder;
@@ -2218,8 +2219,8 @@ typedef std::shared_ptr<LogBuilder> LogBuilderPtr;
 /// @detail This class does not write logs itself instead its used by writer to read configuations from.
 class Logger : public base::threading::ThreadSafe, public Loggable {
  public:
-  Logger(const std::string& id, base::LogStreamsReferenceMap* logStreamsReference);
-  Logger(const std::string& id, const Configurations& configurations, base::LogStreamsReferenceMap* logStreamsReference);
+  Logger(const std::string& id, base::LogStreamsReferenceMapPtr logStreamsReference);
+  Logger(const std::string& id, const Configurations& configurations, base::LogStreamsReferenceMapPtr logStreamsReference);
   Logger(const Logger& logger);
   Logger& operator=(const Logger& logger);
 
@@ -2309,7 +2310,7 @@ inline void FUNCTION_NAME(const T&);
   bool m_isConfigured;
   Configurations m_configurations;
   std::unordered_map<Level, unsigned int> m_unflushedCount;
-  base::LogStreamsReferenceMap* m_logStreamsReference;
+  base::LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
   LogBuilderPtr m_logBuilder;
 
   friend class el::LogMessage;
@@ -2396,8 +2397,8 @@ class RegisteredLoggers : public base::utils::Registry<Logger, std::string> {
     base::utils::Registry<Logger, std::string>::unregister(logger->id());
   }
 
-  inline base::LogStreamsReferenceMap* logStreamsReference(void) {
-    return &m_logStreamsReference;
+  inline LogStreamsReferenceMapPtr logStreamsReference(void) {
+    return m_logStreamsReference;
   }
 
   inline void flushAll(void) {
@@ -2413,7 +2414,7 @@ class RegisteredLoggers : public base::utils::Registry<Logger, std::string> {
  private:
   LogBuilderPtr m_defaultLogBuilder;
   Configurations m_defaultConfigurations;
-  base::LogStreamsReferenceMap m_logStreamsReference;
+  base::LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
   std::unordered_map<std::string, base::type::LoggerRegistrationCallbackPtr> m_loggerRegistrationCallbacks;
   friend class el::base::Storage;
 
@@ -3837,7 +3838,7 @@ class Loggers : base::StaticClass {
   /// @brief Returns current default
   static const Configurations* defaultConfigurations(void);
   /// @brief Returns log stream reference pointer if needed by user
-  static const base::LogStreamsReferenceMap* logStreamsReference(void);
+  static const base::LogStreamsReferenceMapPtr logStreamsReference(void);
   /// @brief Default typed configuration based on existing defaultConf
   static base::TypedConfigurations defaultTypedConfigurations(void);
   /// @brief Populates all logger IDs in current repository.
@@ -3848,7 +3849,7 @@ class Loggers : base::StaticClass {
   /// @brief Configures loggers using command line arg. Ensure you have already set command line args,
   /// @return False if invalid argument or argument with no value provided, true if attempted to configure logger.
   ///         If true is returned that does not mean it has been configured successfully, it only means that it
-  ///         has attempeted to configure logger using configuration file provided in argument
+  ///         has attempted to configure logger using configuration file provided in argument
   static bool configureFromArg(const char* argKey);
   /// @brief Flushes all loggers for all levels - Be careful if you dont know how many loggers are registered
   static void flushAll(void);


### PR DESCRIPTION
On the UGW platform, a SIGSEGV event is sent to the APM application
that utilizes the easylogging++ library. The event is sent due to an
access attempt to a released memory. The released memory is a pointer
to the "LogStreamsReferenceMap m_logStreamsReference" which is defined
statically in RegisteredLoggers class.

The RegisteredLoggers object is released in UGW before the release of
other Class objects that make use of the pointer, and thus - the pointer
is accessed after the map is already released.

The issue may be seen in other platforms and is dependent on the difference in object release order.

After this change, the map is defined as a shared-pointer in the
RegisteredLoggers class and is set to a shared-pointer of type
LogStreamsReferenceMap in the RegisteredLoggers CTOR. Even if the
RegisteredLoggers object is released, the map resource will be
available to the rest of the objects until all are destructed.

Signed-off-by: Adam Dov <adamx.dov@intel.com>