### PR TITLE
Agent UCC listener: support BSSID option

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -109,7 +109,7 @@ void agent_ucc_listener::update_vaps_list(std::string ruid, beerocks_message::sV
 bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
                                               std::string &value)
 {
-    if (params["parameter"] == "macaddr") {
+    if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
         if (params.find("ruid") == params.end()) {
             value = "missing ruid";
             return false;
@@ -132,7 +132,7 @@ bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, st
                 return true;
             }
         }
-        value = "macaddr not found for ruid " + ruid + " ssid " + ssid;
+        value = "macaddr/bssid not found for ruid " + ruid + " ssid " + ssid;
         return false;
     }
     value = "parameter " + params["parameter"] + " not supported";


### PR DESCRIPTION
### Description

currently, test 4.6.2 keeps on failing on step 9, which is the topology response message, with the following error message:

![image](https://user-images.githubusercontent.com/38204874/73264795-438ac580-41dc-11ea-8e99-169ee817171f.png)

The reason for this error is that our dev_get_parameter does not support a `bssid` as an option.
Therefore, since the `bssid` is equal to the MAC address, add an or logic to support this option exactly the same way we do with the `macaddr` option.

### Testbed status
passed this step.









Signed-off-by: Coral Malachi <coral.malachi@intel.com>