### PR TITLE
Hotfix/agent run ucc listener on backhaul register handler

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3048,6 +3048,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         request->sta_iface_filter_low() = config.backhaul_wireless_iface_filter_low;
         request->onboarding()           = platform_settings.onboarding;
         request->ruid()                 = hostap_params.iface_mac;
+        request->certification_mode()   = platform_settings.certification_mode;  
 
         LOG(INFO) << "ACTION_BACKHAUL_REGISTER_REQUEST local_master="
                   << int(platform_settings.local_master)

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -50,6 +50,7 @@ class cACTION_BACKHAUL_REGISTER_REQUEST : public BaseClass
         uint8_t& sta_iface_filter_low();
         uint8_t& onboarding();
         sMacAddr& ruid();
+        uint8_t& certification_mode();
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -67,6 +68,7 @@ class cACTION_BACKHAUL_REGISTER_REQUEST : public BaseClass
         uint8_t* m_sta_iface_filter_low = nullptr;
         uint8_t* m_onboarding = nullptr;
         sMacAddr* m_ruid = nullptr;
+        uint8_t* m_certification_mode = nullptr;
 };
 
 class cACTION_BACKHAUL_REGISTER_RESPONSE : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -99,6 +99,10 @@ sMacAddr& cACTION_BACKHAUL_REGISTER_REQUEST::ruid() {
     return (sMacAddr&)(*m_ruid);
 }
 
+uint8_t& cACTION_BACKHAUL_REGISTER_REQUEST::certification_mode() {
+    return (uint8_t&)(*m_certification_mode);
+}
+
 void cACTION_BACKHAUL_REGISTER_REQUEST::class_swap()
 {
     m_ruid->struct_swap();
@@ -141,6 +145,7 @@ size_t cACTION_BACKHAUL_REGISTER_REQUEST::get_initial_size()
     class_size += sizeof(uint8_t); // sta_iface_filter_low
     class_size += sizeof(uint8_t); // onboarding
     class_size += sizeof(sMacAddr); // ruid
+    class_size += sizeof(uint8_t); // certification_mode
     return class_size;
 }
 
@@ -188,6 +193,11 @@ bool cACTION_BACKHAUL_REGISTER_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_ruid->struct_init(); }
+    m_certification_mode = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -25,6 +25,7 @@ cACTION_BACKHAUL_REGISTER_REQUEST:
   sta_iface_filter_low: uint8_t
   onboarding: uint8_t
   ruid: sMacAddr
+  certification_mode: uint8_t
 
 cACTION_BACKHAUL_REGISTER_RESPONSE:
   _type: class


### PR DESCRIPTION
Currently, the UCC Listener has been initiated on the backhaul_manager  init function.
This has caused to the UCC Listener to bind to the port from the configuration
file.
The problem is that on some platforms, the port that we are using is used by other
applications, and interfere with them.

Move the UCC Listener initiation to son_slave register handler.
It will start only once if not has been started before.

#756