### PR TITLE
Hotfix/orderly beerocks agent shutdown

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1457,7 +1457,8 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         // Add the slave socket to the backhaul configuration
         m_sConfig.slave_iface_socket[soc->sta_iface] = soc;
 
-        if (!m_agent_ucc_listener && request->certification_mode() && m_sConfig.ucc_listener_port != 0) {
+        if (!m_agent_ucc_listener && request->certification_mode() &&
+            m_sConfig.ucc_listener_port != 0) {
             m_agent_ucc_listener = std::make_unique<agent_ucc_listener>(
                 *this, m_sConfig.ucc_listener_port, m_sConfig.vendor, m_sConfig.model,
                 m_sConfig.bridge_iface, cert_cmdu_tx);

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -374,8 +374,11 @@ static int run_beerocks_slave(beerocks::config_file::sConfigSlave &beerocks_slav
             }
         }
 
+        LOG(DEBUG) << "backhaul_mgr.stop()";
+        backhaul_mgr.stop();
+
         LOG(DEBUG) << "platform_mgr.stop()";
-        platform_mgr.stop(false);
+        platform_mgr.stop();
     }
 
     LOG(DEBUG) << "Bye Bye!";

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -803,7 +803,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
                                       std::chrono::seconds(PLATFORM_READ_CONF_RETRY_SEC);
                     }
                 }
-            } while (!register_response->valid());
+            } while (!register_response->valid() && !should_stop);
 
             LOG(DEBUG) << "sending ACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE to " << strIfaceName
                        << " sd=" << intptr_t(sd);

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3048,7 +3048,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         request->sta_iface_filter_low() = config.backhaul_wireless_iface_filter_low;
         request->onboarding()           = platform_settings.onboarding;
         request->ruid()                 = hostap_params.iface_mac;
-        request->certification_mode()   = platform_settings.certification_mode;  
+        request->certification_mode()   = platform_settings.certification_mode;
 
         LOG(INFO) << "ACTION_BACKHAUL_REGISTER_REQUEST local_master="
                   << int(platform_settings.local_master)


### PR DESCRIPTION
Before this change, the backhaul manager was not stopped by the slave_main.
This caused a beerocks_agent process crash due to not releasing resources orderly.
Additionally, on platform manager stop, the platform manager waited until a pre-defined number of retries to read settings from the platform.

After this change, the backhaul manager has stopped on an orderly shutdown of the beerocks agent.
Additionally, if the platform manager should_stop is true, the work_queue stops.