### PR TITLE
platform_manager:work_queue - add delay between timer checks

### DIFF
--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
@@ -89,7 +89,7 @@ private:
     bool wlan_params_changed_check();
 
 private:
-    const int PLATFORM_READ_CONF_RETRY_SEC    = 10;
+    const int PLATFORM_READ_CONF_RETRY_SEC    = 5;
     const int PLATFORM_READ_CONF_MAX_ATTEMPTS = 10;
 
     config_file::sConfigSlave config;


### PR DESCRIPTION
Before the change, in the case where the platform manager fails to read
wifi settings, there is configured a wait time between retries - but
there is no delay between checks if the wait-period has passed.
This results in a check if the wait-period has passed every one
millisecond, causing a CPU usage of ~48%.
Note that once the platform manages to successfully read the wifi settings,
and prplmesh reaches the operational state, the CPU load is
back to ~0.

After the change, on failure to read the wifi-settings, sleep for the configured delay between reads is performed and even if beerocks_agent is stuck in the stage of reading wifi settings, the CPU load is ~0%.

Fixes #764