### PR TITLE
Hotfix/deploy enable certification mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,7 @@ test-on-netgear-rax40:
       - |
         if [ "$DEVICE_UNDER_TEST" != prplmesh ] ; then
             echo "Deploying to $DEVICE_UNDER_TEST"
-            tools/deploy_ipk.sh $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/*.ipk
+            tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/*.ipk
         fi
       - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
   artifacts:

--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -1,23 +1,31 @@
 #!/bin/sh -e
 
-SSH_OPTIONS="-oBatchMode=yes"
+usage() {
+    echo "usage: $(basename "$0") [-h]"
+    echo "  options:"
+    echo "      -h|--help - show this help menu"
+    echo "      --certification-mode - enable certification-mode on the target"
+}
 
-if ! ssh "$SSH_OPTIONS" "$1" /bin/true ; then
-    echo "Error: $1 unreachable via ssh"
-    exit 1
-fi
+deploy() {
+    SSH_OPTIONS="-oBatchMode=yes"
 
-TARGET="$1"
-IPK="$2"
-IPK_FILENAME="$(basename "$2")"
-DEST_FOLDER=/tmp/prplmesh_ipks
+    if ! ssh "$SSH_OPTIONS" "$1" /bin/true ; then
+        echo "Error: $1 unreachable via ssh"
+        exit 1
+    fi
 
-echo "Removing previous ipks"
-ssh "$TARGET" "rm -rf \"$DEST_FOLDER\" ; mkdir -p \"$DEST_FOLDER\""
-echo "Copying $IPK to $TARGET:$DEST_FOLDER/$IPK_FILENAME"
-scp "$IPK" "$TARGET:$DEST_FOLDER/$IPK_FILENAME"
+    TARGET="$1"
+    IPK="$2"
+    IPK_FILENAME="$(basename "$2")"
+    DEST_FOLDER=/tmp/prplmesh_ipks
 
-ssh "$TARGET" <<EOF
+    echo "Removing previous ipks"
+    ssh "$TARGET" "rm -rf \"$DEST_FOLDER\" ; mkdir -p \"$DEST_FOLDER\""
+    echo "Copying $IPK to $TARGET:$DEST_FOLDER/$IPK_FILENAME"
+    scp "$IPK" "$TARGET:$DEST_FOLDER/$IPK_FILENAME"
+
+    ssh "$TARGET" <<EOF
 # we don't want opkg to stay locked with a previous failed invocation.
 # when using this, make sure no one is using opkg in the meantime!
 pgrep opkg | xargs kill -SIGINT
@@ -28,4 +36,33 @@ rm -rf /opt/prplmesh
 opkg install -V2 "$DEST_FOLDER/$IPK_FILENAME"
 EOF
 
-echo "Done"
+    if [ "$CERTIFICATION_MODE" = true ] ; then
+        echo "Certification mode will be enabled on the target"
+        ssh "$TARGET" "uci set prplmesh.config.certification_mode=1 && uci commit"
+        echo "Certification mode enabled on the target."
+    fi
+    echo "Done"
+}
+
+main() {
+        OPTS=$(getopt -o 'h' --long help,certification-mode -n 'parse-options' -- "$@")
+
+    if [ "$?" != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
+
+    eval set -- "$OPTS"
+
+    while true; do
+        case "$1" in
+            --certification-mode)
+                CERTIFICATION_MODE=true
+                shift
+                ;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1 ;;
+        esac
+    done
+
+    deploy "$@"
+}
+
+main "$@"


### PR DESCRIPTION
With commit dd9d7fe6c8fc4f2f8ce1e1527b2186fb83d75e79, the UCC listener
won't run on the controller unless certification_mode is set to 1.

Since we don't want the certification mode to default to 1, it makes
sense to be able to enable it on the target right after deploying (to
be able to run the certification tests from CI for example).

Update the deploy script to have a '--certification-mode' option to enable certification mode on the target.
Use the new option in CI.