### PR TITLE
.gitlab-ci.yml: fix typo in device under test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,7 +162,7 @@ test-on-netgear-rax40:
   variables:
     # TESTS_TO_RUN needs to be set by the user (or the pipeline schedule)
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplMesh/"
-    # device to test with: prplmesh for dummy bwl, prplmesh-rax40 for dwpal on rax40
+    # device to test with: prplmesh for dummy bwl, netgear-rax40 for dwpal on rax40
     DEVICE_UNDER_TEST: prplmesh
   script:
       - |


### PR DESCRIPTION
Now that we deploy to any $DEVICE_UNDER_TEST, prplmesh-rax40 cannot be
used anymore, as there is no build job for it.

Rename prplmesh-rax40 to netgear-rax40.

The corresponding changes have been made to the certification repository.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>