### PR TITLE
Feature/ucc listener single port

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -39,6 +39,7 @@
 
 // BPL Error Codes
 #include <bpl/bpl_err.h>
+#include <bpl/bpl_cfg.h>
 
 using namespace beerocks::net;
 
@@ -1458,7 +1459,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         m_sConfig.slave_iface_socket[soc->sta_iface] = soc;
 
         if (!m_agent_ucc_listener && request->certification_mode() &&
-            m_sConfig.ucc_listener_port != 0) {
+            m_sConfig.ucc_listener_port != 0 && !bpl::cfg_is_master()) {
             m_agent_ucc_listener = std::make_unique<agent_ucc_listener>(
                 *this, m_sConfig.ucc_listener_port, m_sConfig.vendor, m_sConfig.model,
                 m_sConfig.bridge_iface, cert_cmdu_tx);

--- a/controller/config/beerocks_controller.conf.in
+++ b/controller/config/beerocks_controller.conf.in
@@ -10,7 +10,7 @@ temp_path=@TMP_PATH@
 
 vendor=Intel
 model=prplMesh
-ucc_listener_port=8001 # 0 - disabled
+ucc_listener_port=8002 # 0 - disabled
 
 # Features:
 #   DFS reentry feature:


### PR DESCRIPTION
Use the same port for the UCC listener on both agent and controller.

Also include the changes from https://github.com/prplfoundation/prplMesh/pull/766 , because they are both required to run agent tests on rax40.