### PR TITLE
Hotfix/bpl uci remove swpal dependency

### DIFF
--- a/framework/platform/bpl/CMakeLists.txt
+++ b/framework/platform/bpl/CMakeLists.txt
@@ -35,10 +35,19 @@ if (TARGET_PLATFORM STREQUAL "openwrt")
 
         # UGW specific libraries
         find_package(ubus REQUIRED)
-        find_package(safec REQUIRED)
+
+        find_package(safec QUIET)
+        if (safec_FOUND)
+            list(APPEND BPL_LIBS safec)
+            add_definitions(-DUSE_LIBSAFEC)
+    
+            # Signal libsafec that we support the C99 standard
+            add_definitions(-DHAVE_C99)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+        endif()
 
         link_directories(${PLATFORM_STAGING_DIR}/usr/lib)
-        list(APPEND BPL_LIBS ubus nl-3 nl-route-3 bridge dl uci ubox safec)
+        list(APPEND BPL_LIBS ubus nl-3 nl-route-3 bridge dl uci ubox)
 
         # Signal libsafec that we support the C99 standard
         add_definitions(-DHAVE_C99)
@@ -70,9 +79,12 @@ elseif (TARGET_PLATFORM STREQUAL "rdkb")
 
     # RDKB specific libraries
     find_package(ubus REQUIRED)
-    find_package(slibc REQUIRED)
 
-    list(APPEND BPL_LIBS nl-3 nl-route-3 bridge dl swpal uci ubox ubus slibc)
+    find_package(slibc REQUIRED)
+    list(APPEND BPL_LIBS slibc)
+    add_definitions(-DUSE_SLIBC)
+
+    list(APPEND BPL_LIBS nl-3 nl-route-3 bridge dl uci ubox ubus)
 
     # Install the UCI DB files
     file(GLOB_RECURSE bpl_uci_db_files ${MODULE_PATH}/uci/db/prplmesh_db*)

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
@@ -17,17 +17,17 @@ namespace bpl {
 int cfg_get_index_from_interface(const std::string &inputIfName, int *nIndex)
 {
     char ifname[BPL_IFNAME_LEN] = {0};
-    int rpcIndex                = -1;
+    int uci_idx                = -1;
 
     if (!nIndex) {
         return RETURN_ERR;
     }
     utils::copy_string(ifname, inputIfName.c_str(), BPL_IFNAME_LEN);
 
-    const int ifType = (inputIfName.find('.') != std::string::npos) ? TYPE_VAP : TYPE_RADIO;
+    const auto ifType = (inputIfName.find('.') != std::string::npos) ? TYPE_VAP : TYPE_RADIO;
 
-    if (cfg_uci_get_wireless_idx(ifname, &rpcIndex) == RETURN_OK) {
-        *nIndex = UCI_RETURN_INDEX(ifType, rpcIndex);
+    if (cfg_uci_get_wireless_idx(ifname, &uci_idx) == RETURN_OK) {
+        *nIndex = uci_to_rpc_index(ifType, uci_idx);
     } else {
         return RETURN_ERR;
     }

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
@@ -11,6 +11,14 @@
 #include "bpl_cfg_helper.h"
 #include "bpl_cfg_uci.h"
 
+#define LOGF_LOG_CRIT(args...) PRINTF("CRIT", ##args)
+#define LOGF_LOG_ERROR(args...) PRINTF("ERROR", ##args)
+#define LOGF_LOG_WARN(args...) PRINTF("WARN", ##args)
+#define LOGF_LOG_INFO(args...) PRINTF("INFO", ##args)
+#define LOGF_LOG_DEBUG(args...) PRINTF("DEBUG", ##args)
+
+#define PRINTF(LEVEL, fmt, args...) printf(LEVEL ":{%s, %d}:" fmt, __func__, __LINE__, ##args)
+
 namespace beerocks {
 namespace bpl {
 
@@ -29,7 +37,14 @@ int cfg_get_index_from_interface(const std::string &inputIfName, int *nIndex)
     if (cfg_uci_get_wireless_idx(ifname, &uci_idx) == RETURN_OK) {
         *nIndex = uci_to_rpc_index(ifType, uci_idx);
     } else {
+        ERROR("cfg_get_index_from_interface() failed: ifname=%s, uci_idx=%d\n", ifname, uci_idx);
         return RETURN_ERR;
+    }
+
+    if (*nIndex < 0) {
+        ERROR("uci_to_rpc_index() failed: ifname=%s, uci_idx=%d, ifType=%d\n", ifname, uci_idx, 
+                    int(ifType));
+        return RETURN_ERR; 
     }
 
     return RETURN_OK;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "bpl_cfg_uci.h"
+#include <string>
 
 extern "C" {
 #include <uci.h>
@@ -19,6 +20,216 @@ extern "C" {
 #define LOGF_LOG_DEBUG(args...) PRINTF("DEBUG", ##args)
 
 #define PRINTF(LEVEL, fmt, args...) printf(LEVEL ":{%s, %d}:" fmt, __func__, __LINE__, ##args)
+
+/**************************************************************************/
+/*! \fn int uci_converter_get(char* path, char* value, size_t length)
+ **************************************************************************
+ *  \brief generic get from UCI database
+ *  \param[in] char *path - variable full name to get (config file.device name.option) for example wireless.default_radio45.wps_state
+ *  \param[out] char *value - value from UCI DB 
+ *  \param[in] size_t length - size of value buffer
+ *  \return 0 if success, negative if error / timeout
+ ***************************************************************************/
+int uci_converter_get(char* path, char* value, size_t length)
+{
+	struct uci_ptr ptr;
+	struct uci_context *cont = uci_alloc_context();
+
+	if (!cont)
+		return RETURN_ERR;
+
+	if ((path == NULL) || (value == NULL)) {
+		ERROR("%s, path or value is NULL!\n", __FUNCTION__);
+		uci_free_context(cont);
+		return RETURN_ERR;
+	}
+
+	if (uci_lookup_ptr(cont, &ptr, path, true) != UCI_OK || !ptr.o) {
+		uci_free_context(cont);
+		return RETURN_ERR;
+	}
+
+	strncpy_s(value, length, ptr.o->v.string, strnlen_s(ptr.o->v.string, length - 1));
+
+	uci_free_context(cont);
+
+	return RETURN_OK;
+}
+
+/**************************************************************************/
+/*! \fn int uci_converter_get_str(enum paramType type, int index, const char param[], char *value)
+ **************************************************************************
+ *  \brief get a specific radio or VAP param string from UCI database
+ *  \param[in] enum paramType type - TYPE_RADIO / TYPE_RADIO_VAP / TYPE_VAP
+ *  \param[in] int index - radio or VAP index (regular index, not UCI index)
+ *  \param[in] const char param[] - param name to get (not full path)
+ *  \param[out] char *value - string value from UCI DB 
+ *  \return 0 if success, negative if error / timeout
+ ***************************************************************************/
+int uci_converter_get_str(enum paramType type, int index, const char param[], char *value)
+{
+	int status;
+	char path[MAX_UCI_BUF_LEN] = "";
+	char radio_str[] = "default_radio"; /* == TYPE_VAP / TYPE_RADIO_VAP */
+
+	if ((param == NULL) || (value == NULL)) {
+		ERROR("%s, param or value is NULL!\n", __FUNCTION__);
+		return RETURN_ERR;
+	}
+
+	if (type == TYPE_RADIO)
+		strncpy_s(radio_str, sizeof(radio_str), "radio", 5);
+
+	status = sprintf_s(path, MAX_UCI_BUF_LEN, "wireless.%s%d.%s", radio_str, rpc_to_uci_index(type, index), param);
+	if (status <= 0) {
+		ERROR("%s failed sprintf_s.  index=%d param=%s\n", __func__, index, param);
+		return RETURN_ERR;
+	}
+
+	status = uci_converter_get(path, value, MAX_UCI_BUF_LEN);
+	if (status == RETURN_OK) {
+		DEBUG("%s index=%d %s=%s\n", __func__, index, param, value);
+	} else {
+		INFO("%s option N/A. index=%d param=%s\n", __func__, index, param);
+	}
+
+	return status;
+}
+
+/**************************************************************************/
+/*! \fn int dummy_to_radio_index(enum paramType iftype, int index)
+ **************************************************************************
+ *  \brief convert dummy vap uci index to radio uci index using uci-db
+ *  \param[in] int index - The uci index of the dummy vap
+ *  \return the index if success, negative if error
+ ***************************************************************************/
+static int dummy_to_radio_index(int index)
+{
+	char radio[MAX_UCI_BUF_LEN] = "";
+	if (uci_converter_get_str(TYPE_RADIO_VAP, uci_to_rpc_index(TYPE_RADIO_VAP, index), "device", radio) == RETURN_ERR)
+		return RETURN_ERR;
+
+	return (radio[sizeof("radio") -1] - '0');
+
+}
+
+/**************************************************************************/
+/*! \fn int uci_converter_is_dummy(int uci_index)
+ **************************************************************************
+ *  \brief get wheter vap is dummy or not based on uci index
+ *  \param[in] int uci_index - The index of the vap entry
+ *  \return true if dummy, false if not dummy / error
+ ***************************************************************************/
+static bool uci_converter_is_dummy(int uci_index)
+{
+	int status;
+	char path[MAX_UCI_BUF_LEN] = "";
+	char uci_ret[MAX_UCI_BUF_LEN] = "";
+
+	status = sprintf_s(path, MAX_UCI_BUF_LEN, "wireless.radio_vap_rpc_indexes.index%d", uci_to_rpc_index(TYPE_RADIO_VAP, uci_index));
+	if (status <= 0) {
+		ERROR("%s failed sprintf_s.  index=%d\n", __func__, uci_index);
+		return false;
+	}
+
+	status = uci_converter_get(path, uci_ret, MAX_UCI_BUF_LEN);
+	if ((status == RETURN_OK) && (std::stoi(uci_ret) == uci_index))
+		return true;
+	return false;
+}
+
+/**************************************************************************/
+/*! \fn int rpc_to_uci_index(enum paramType iftype, int index)
+ **************************************************************************
+ *  \brief convert rpc index to uci index using uci-db
+ *  \param[in] enum paramType ifType: TYPE_RADIO/TYPE_RADIO_VAP/TYPE_VAP
+ *  \param[in] int index - The rpc index
+ *  \return the index if success, negative if error
+ ***************************************************************************/
+int rpc_to_uci_index(enum paramType iftype, int index)
+{
+	char index_path[MAX_UCI_BUF_LEN] = "";
+	char index_path_pre[MAX_UCI_BUF_LEN] = "";
+	char value_str[MAX_UCI_BUF_LEN] = "";
+	int status = 0;
+	switch(iftype)
+	{
+		case TYPE_RADIO:
+			status = sprintf_s(index_path_pre, MAX_UCI_BUF_LEN, "wireless.radio_rpc_indexes");
+			break;
+		case TYPE_RADIO_VAP:
+			status = sprintf_s(index_path_pre, MAX_UCI_BUF_LEN, "wireless.radio_vap_rpc_indexes");
+			break;
+		case TYPE_VAP:
+			status = sprintf_s(index_path_pre, MAX_UCI_BUF_LEN, "wireless.vap_rpc_indexes");
+			break;
+		default:
+			ERROR("%s invalid iftype.", __func__);
+			return RETURN_ERR;
+	}
+	if (status <= 0) {
+		ERROR("%s failed sprintf_s.", __func__);
+		return RETURN_ERR;
+	}
+
+	status = sprintf_s(index_path, MAX_UCI_BUF_LEN, "%s.index%d",
+			   index_path_pre, index);
+	if (status <= 0) {
+		ERROR("%s failed sprintf_s.  index=%d", __func__, index);
+		return RETURN_ERR;
+	}
+
+	status = uci_converter_get(index_path, value_str, MAX_UCI_BUF_LEN);
+	if (status == RETURN_ERR)
+		return RETURN_ERR;
+	return std::stoi(value_str);
+}
+
+/**************************************************************************/
+/*! \fn int uci_to_rpc_index(enum paramType iftype, int index)
+ **************************************************************************
+ *  \brief convert uci index to rpc index using uci-db
+ *  \param[in] enum paramType ifType: TYPE_RADIO/TYPE_RADIO_VAP/TYPE_VAP
+ *  \param[in] int index - The uci index
+ *  \return the index if success, negative if error
+ ***************************************************************************/
+int uci_to_rpc_index(enum paramType iftype, int index)
+{
+	char index_path[MAX_UCI_BUF_LEN] = "";
+	char index_path_pre[MAX_UCI_BUF_LEN] = "";
+	char value_str[MAX_UCI_BUF_LEN] = "";
+	int status = 0;
+	switch(iftype)
+	{
+		case TYPE_RADIO:
+			status = sprintf_s(index_path_pre, MAX_UCI_BUF_LEN, "wireless.radio");
+			break;
+		case TYPE_RADIO_VAP:
+			/* fall through */
+		case TYPE_VAP:
+			status = sprintf_s(index_path_pre, MAX_UCI_BUF_LEN, "wireless.default_radio");
+			break;
+		default:
+			ERROR("%s invalid iftype.", __func__);
+			return RETURN_ERR;
+	}
+	if (status <= 0) {
+		ERROR("%s failed sprintf_s.", __func__);
+		return RETURN_ERR;
+	}
+
+	status = sprintf_s(index_path, MAX_UCI_BUF_LEN, "%s%d.rpc_index",
+			   index_path_pre, index);
+	if (status <= 0) {
+		ERROR("%s failed sprintf_s. index=%d", __func__, index);
+		return RETURN_ERR;
+	}
+
+	status = uci_converter_get(index_path, value_str, MAX_UCI_BUF_LEN);
+	if (status == RETURN_ERR)
+		return RETURN_ERR;
+	return std::stoi(value_str);
+}
 
 namespace beerocks {
 namespace bpl {
@@ -123,7 +334,7 @@ int cfg_uci_get_wireless(enum paramType type, int index, const char param[], cha
     }
 
     status = snprintf_s(path, MAX_UCI_BUF_LEN, "wireless.%s%d.%s", radio_str,
-                        UCI_INDEX(type, index), param);
+                        rpc_to_uci_index(type, index), param);
     if (status <= 0) {
         ERROR("%s failed snprintf.  index=%d param=%s\n", __func__, index, param);
         return RETURN_ERR;
@@ -256,15 +467,20 @@ int cfg_uci_get_wireless_idx(char *interfaceName, int *rpc_index)
 
             scanf_res = sscanf_s(s->e.name, "default_radio%d", rpc_index);
 
-            if (scanf_res < 1 || *rpc_index < 0 ||
-                *rpc_index > DUMMY_VAP_OFFSET + MAX_NUM_OF_RADIOS) {
+            if (scanf_res < 1 || *rpc_index < 0) {
                 *rpc_index = -1;
                 uci_free_context(ctx);
                 return RETURN_ERR;
             }
 
-            *rpc_index =
-                (*rpc_index >= DUMMY_VAP_OFFSET) ? (*rpc_index - DUMMY_VAP_OFFSET) : *rpc_index;
+            /* if it is dummy we want the radio index, not the dummy one */
+			if (uci_converter_is_dummy(*rpc_index)) {
+				*rpc_index = dummy_to_radio_index(*rpc_index);
+				if (*rpc_index == RETURN_ERR) {
+					uci_free_context(ctx);
+					return RETURN_ERR;
+				}
+			}
             uci_free_context(ctx);
             return RETURN_OK;
         }

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
@@ -344,7 +344,9 @@ int cfg_uci_get_wireless(enum paramType type, int index, const char param[], cha
     if (status == RETURN_OK) {
         // DEBUG("%s index=%d %s=%s\n", __func__, index, param, value);
     } else {
-        ERROR("%s option N/A. index=%d param=%s\n", __func__, index, param);
+        ERROR("%s radio_str=%s, rcp_idx=%d, param=%s\n", __func__, radio_str, 
+                rpc_to_uci_index(type, index), param);
+        ERROR("%s option N/A. path=%s\n", __func__, path);
     }
 
     return status;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -9,20 +9,18 @@
 #ifndef BPL_CFG_UCI_H_
 #define BPL_CFG_UCI_H_
 
-#ifdef BEEROCKS_UGW
+#include <cstring>
 
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#ifdef USE_LIBSAFEC
 #define restrict __restrict
 #include <libsafec/safe_str_lib.h>
 #undef snprintf_s
 #define snprintf_s snprintf
-
-#ifndef u_int_32
-#define u_int_32 unsigned int
+#elif USE_SLIBC
+#include <slibc/stdio.h>
+#include <slibc/string.h>
+#else
+#error "No safe C library defined, define either USE_LIBSAFEC or USE_SLIBC"
 #endif
 
 #ifndef _cplusplus
@@ -63,13 +61,6 @@
            (((rpcIndex - VAP_RPC_IDX_OFFSET) / MAX_VAPS_PER_RADIO) / RADIO_INDEX_SKIP))
 
 enum paramType { TYPE_RADIO = 0, TYPE_VAP };
-
-#elif BEEROCKS_RDKB
-
-#include <slibc/stdio.h>
-#include <slibc/string.h>
-#include <uci_wrapper.h>
-#endif
 
 namespace beerocks {
 namespace bpl {

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -34,33 +34,16 @@
 #define DEBUG(fmt, args...) LOGF_LOG_DEBUG(fmt, ##args)
 
 #define MAX_UCI_BUF_LEN 64
-#define DUMMY_VAP_OFFSET 100
 #define MAX_NUM_OF_RADIOS 3
 
 #define RETURN_ERR_NOT_FOUND -2
 #define RETURN_ERR -1
 #define RETURN_OK 0
 
-/* use only even phy numbers since odd phy's are used for station interfaces */
-#define RADIO_INDEX_SKIP 2
-#define VAP_RPC_IDX_OFFSET 10
-#define MAX_VAPS_PER_RADIO 16
+enum paramType { TYPE_RADIO = 0, TYPE_RADIO_VAP, TYPE_VAP };
 
-#define UCI_INDEX(iftype, index)                                                                   \
-    iftype == TYPE_RADIO                                                                           \
-        ? (RADIO_INDEX_SKIP * index)                                                               \
-        : (VAP_RPC_IDX_OFFSET + (MAX_VAPS_PER_RADIO * RADIO_INDEX_SKIP * (index % 2)) +            \
-           ((index - (index % 2)) / 2))
-
-#define UCI_RETURN_INDEX(iftype, rpcIndex)                                                         \
-    iftype == TYPE_RADIO                                                                           \
-        ? (rpcIndex / RADIO_INDEX_SKIP)                                                            \
-        : (2 * (rpcIndex -                                                                         \
-                (VAP_RPC_IDX_OFFSET +                                                              \
-                 MAX_VAPS_PER_RADIO * ((rpcIndex - VAP_RPC_IDX_OFFSET) / MAX_VAPS_PER_RADIO))) +   \
-           (((rpcIndex - VAP_RPC_IDX_OFFSET) / MAX_VAPS_PER_RADIO) / RADIO_INDEX_SKIP))
-
-enum paramType { TYPE_RADIO = 0, TYPE_VAP };
+int rpc_to_uci_index(enum paramType iftype, int index);
+int uci_to_rpc_index(enum paramType iftype, int index);
 
 namespace beerocks {
 namespace bpl {


### PR DESCRIPTION
Dependency to swpal, shouldn't have ever been.
swpal has changed and it caused prplMesh to break.
Fix it by removing swpal dependency, and unite common RDKB and UGW code.

Since uci_wrapper.h from swpal is no longer included, we need to copy
the latest changes from this file.
Align changes on UCI converter macros to latest swpal changes.