### PR TITLE
[TASK] Certification mode compile time flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 option (BUILD_AGENT "Build EasyMesh agent" ON)
 option (BUILD_CONTROLLER "Build EasyMesh controller" ON)
+option (CERTIFICATION "EasyMesh certification support" ON)
 
 ## Generic checks and defaults
 

--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -366,6 +366,7 @@ bool beerocks_ucc_listener::init()
         should_stop = true;
         return false;
     }
+    LOG(DEBUG) << "Starting UCC listener on port " << int(m_port);
 
     return socket_thread::init();
 }

--- a/framework/platform/bpl/CMakeLists.txt
+++ b/framework/platform/bpl/CMakeLists.txt
@@ -11,6 +11,11 @@ file(GLOB_RECURSE bpl_common_sources ${MODULE_PATH}/common/*.c*)
 # Common libraries
 find_package(elpp REQUIRED)
 
+if (CERTIFICATION)
+    message(STATUS "Certification support")
+    add_definitions(-DCERTIFICAITON)
+endif()
+
 # OpenWRT
 if (TARGET_PLATFORM STREQUAL "openwrt")
 

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -84,11 +84,13 @@ int cfg_get_operating_mode()
 
 int cfg_get_certification_mode()
 {
-    int retVal = -1;
+    int retVal = BPL_CERTIFICATION_MODE_OFF;
+#ifndef CERTIFICATION
     if (cfg_get_prplmesh_param_int("certification_mode", &retVal) == RETURN_ERR) {
         MAPF_ERR("cfg_get_certification_mode: Failed to read certification_mode parameter\n");
         return RETURN_ERR;
     }
+#endif
     return retVal;
 }
 


### PR DESCRIPTION
Currently, certification mode can be enabled/disabled in runtime via UCI. This is a security breach in a real product since it opens the controller and agent to an attack via CAPI command socket which is not protected.

This is not an issue in a side version used for certification, but must not be allowed in a real product.

Therefore - add a compile-time flag - `CERTIFICATION`, default `ON`.
If `OFF`, we always return false in `cfg_get_certification_mode()`.
