### PR TITLE
bpl: Align bpl to latest swpal changes

### DIFF
--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
@@ -24,7 +24,7 @@ int cfg_get_index_from_interface(const std::string &inputIfName, int *nIndex)
     }
     utils::copy_string(ifname, inputIfName.c_str(), BPL_IFNAME_LEN);
 
-    const int ifType = (inputIfName.find('.') != std::string::npos) ? TYPE_VAP : TYPE_RADIO;
+    const paramType ifType = (inputIfName.find('.') != std::string::npos) ? TYPE_VAP : TYPE_RADIO;
 
     if (cfg_uci_get_wireless_idx(ifname, &rpcIndex) == RETURN_OK) {
         *nIndex = UCI_RETURN_INDEX(ifType, rpcIndex);

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -68,7 +68,14 @@ enum paramType { TYPE_RADIO = 0, TYPE_VAP };
 
 #include <slibc/stdio.h>
 #include <slibc/string.h>
+
+extern "C" {
 #include <uci_wrapper.h>
+
+#define UCI_INDEX(iftype, rpc_index) rpc_to_uci_index(iftype, rpc_index)
+#define UCI_RETURN_INDEX(iftype, uci_idx) uci_to_rpc_index(ifType, uci_idx)
+}
+
 #endif
 
 namespace beerocks {


### PR DESCRIPTION
On swpal the macros UCI_INDEX/UCI_RETURN_INDEX were replaced with functions.
Since UGW is using these macros, create new macros that call to the new functions on RDKB.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>