### PR TITLE
.gitlab-ci.yml: run the certification tests if TESTS_TO_RUN is set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,7 @@ test-on-netgear-rax40:
     TARGET_DEVICE_NAME: netgear-rax40-1
   needs: ["build-for-netgear-rax40"]
 
-.run-certification-tests:
+run-certification-tests:
   stage: test
   variables:
     # TESTS_TO_RUN needs to be set by the user (or the pipeline schedule)
@@ -181,12 +181,5 @@ test-on-netgear-rax40:
   tags:
     - certs-tests
   timeout: 24h
-
-scheduled-certification-tests:
-  extends: .run-certification-tests
-  only:
-    - schedules
-
-manual-certification-tests:
-  extends: .run-certification-tests
-  when: manual
+  rules:
+    - if: '$TESTS_TO_RUN'


### PR DESCRIPTION
Triggering manual jobs through Gitlab's web UI is convenient, but has
a number of issues:
- When you re-run a manual job, it doesn't take the variables you
  defined before into account
  https://gitlab.com/gitlab-org/gitlab/issues/31367
- It's not currently possible to change the variables when you retry a manual job
  https://gitlab.com/gitlab-org/gitlab/issues/32712

On the other hand running a new pipeline only to run the certification
tests was costly before, because we only had one (non-parallel) runner
to build for the OpenWrt targets. Now that we can do several OpenWrt
builds in parallel, this is less of a problem.

We also now always require TESTS_TO_RUN to be set either by the user,
or by the schedule, so we can now rely on its presence to know if the
certification tests need to be run or not.

Remove the schedule-certification-tests and manual-certification-tests
jobs.

Make .run-certification test a normal job (not a hidden one) and
always create it if $TESTS_TO_RUN is defined.

With those changes, the scheduled pipelines will always run the
certification tests like before, because they set the TESTS_TO_RUN
variable. Pipelines created by users will no longer need the
certification job to be manually triggered.
