### PR TITLE
HOTFIX fix dcs results

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -1984,7 +1984,7 @@ class cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE : public BaseClass
         uint8_t& op_error_code();
         //0 - Not reached end of response, 1 - reached end of respons
         uint8_t& last();
-        uint32_t& results_size();
+        uint8_t& results_size();
         std::tuple<bool, sChannelScanResults&> results(size_t idx);
         bool alloc_results(size_t count = 1);
         void class_swap() override;
@@ -1997,7 +1997,7 @@ class cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE : public BaseClass
         uint8_t* m_result_status = nullptr;
         uint8_t* m_op_error_code = nullptr;
         uint8_t* m_last = nullptr;
-        uint32_t* m_results_size = nullptr;
+        uint8_t* m_results_size = nullptr;
         sChannelScanResults* m_results = nullptr;
         size_t m_results_idx__ = 0;
         int m_lock_order_counter__ = 0;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -6481,8 +6481,8 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::last() {
     return (uint8_t&)(*m_last);
 }
 
-uint32_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::results_size() {
-    return (uint32_t&)(*m_results_size);
+uint8_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::results_size() {
+    return (uint8_t&)(*m_results_size);
 }
 
 std::tuple<bool, sChannelScanResults&> cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::results(size_t idx) {
@@ -6525,7 +6525,6 @@ bool cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::alloc_results(size_t count) 
 
 void cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::class_swap()
 {
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(m_results_size));
     for (size_t i = 0; i < (size_t)*m_results_size; i++){
         m_results[i].struct_swap();
     }
@@ -6564,7 +6563,7 @@ size_t cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::get_initial_size()
     class_size += sizeof(uint8_t); // result_status
     class_size += sizeof(uint8_t); // op_error_code
     class_size += sizeof(uint8_t); // last
-    class_size += sizeof(uint32_t); // results_size
+    class_size += sizeof(uint8_t); // results_size
     return class_size;
 }
 
@@ -6589,15 +6588,14 @@ bool cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    m_results_size = (uint32_t*)m_buff_ptr__;
+    m_results_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_results_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
     m_results = (sChannelScanResults*)m_buff_ptr__;
-    uint32_t results_size = *m_results_size;
-    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&results_size)); }
+    uint8_t results_size = *m_results_size;
     m_results_idx__ = results_size;
     if (!buffPtrIncrementSafe(sizeof(sChannelScanResults) * (results_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sChannelScanResults) * (results_size) << ") Failed!";

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -430,7 +430,7 @@ cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE:
     _type: uint8_t
     _comment: 0 - Not reached end of response, 1 - reached end of respons
   results_size:
-    _type: uint32_t
+    _type: uint8_t
     _length_var: True
   results:
     _type: sChannelScanResults

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -612,7 +612,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
 }
 
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP *output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan)
 {

--- a/controller/src/beerocks/bml/bml.h
+++ b/controller/src/beerocks/bml/bml.h
@@ -601,7 +601,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
  * @return BML_RET_OK on success.
  */
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP *output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan);
 

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -211,7 +211,7 @@ public:
     * 
     * @return BML_RET_OK on success.
     */
-    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **results,
+    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP *results,
                              unsigned int &results_size, const unsigned int max_results_size,
                              uint8_t &result_status, bool is_single_scan);
 

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -1216,7 +1216,8 @@ int cli_bml::set_dcs_continuous_scan_params_caller(int numOfArgs)
 
     std::string::size_type pos;
     //[radio_mac=<radio_mac> dwell_time=<dwell_time> interval_time='<interval_time>']"
-    for (int i = 1; i < numOfArgs; i++) { //first optional arg
+    for (int i = 0; i < numOfArgs; i++) { //first optional arg
+        std::cout << "args[" << i << "]: " << args.stringArgs[i] << std::endl;;
         if ((pos = args.stringArgs[i].find("radio_mac=")) != std::string::npos) {
             radio_mac = args.stringArgs[i].substr(pos + sizeof("radio_mac"));
         } else if ((pos = args.stringArgs[i].find("dwell_time=")) != std::string::npos) {

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -1831,7 +1831,7 @@ int cli_bml::steering_client_measure(uint32_t steeringGroupIndex, const std::str
  */
 int cli_bml::set_dcs_continuous_scan_enable(const std::string &radio_mac, int8_t enable)
 {
-    std::cout << __func__ << ", mac=" << radio_mac << ", enable=" << enable << std::endl;
+    std::cout << __func__ << ", mac=" << radio_mac << ", enable=" << ((enable==1)?"true":"false") << std::endl;
 
     int ret = bml_set_dcs_continuous_scan_enable(ctx, radio_mac.c_str(), enable);
 
@@ -2019,12 +2019,13 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
         return -1;
     }
 
-    BML_NEIGHBOR_AP results[max_results_size] = {0};
+    BML_NEIGHBOR_AP results[max_results_size];
+    //BML_NEIGHBOR_AP* results = reinterpret_cast<BML_NEIGHBOR_AP *>(calloc(max_results_size, sizeof(struct BML_NEIGHBOR_AP)));
 
     uint8_t status             = 0;
     unsigned int results_count = max_results_size;
     int ret                    = bml_get_dcs_scan_results(ctx, radio_mac.c_str(),
-                                       reinterpret_cast<BML_NEIGHBOR_AP **>(&results),
+                                       reinterpret_cast<BML_NEIGHBOR_AP *>(results),
                                        &results_count, &status, is_single_scan);
 
     if (ret == BML_RET_OK) {

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -1970,8 +1970,7 @@ void son_management::handle_bml_message(Socket *sd,
         // Clear flags
         auto result_status = eChannelScanErrCode::CHANNEL_SCAN_SUCCESS;
         auto op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS;
-        uint8_t last       = 0;
-
+        
         // Get scan statuses
         auto scan_in_progress = database.get_channel_scan_in_progress(radio_mac, is_single_scan);
         if (scan_in_progress) {
@@ -1992,20 +1991,32 @@ void son_management::handle_bml_message(Socket *sd,
 
         LOG(DEBUG) << "scan_results received for hostap_mac= " << radio_mac << std::endl
                    << "scan_results_size= " << scan_results_size;
-
-        auto response = message_com::create_vs_message<
-            beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>(cmdu_tx,
-                                                                             beerocks_header->id());
+        auto gen_new_results_response = [&cmdu_tx, &beerocks_header]()
+            -> std::shared_ptr<beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE> {
+            auto res_msg = message_com::create_vs_message<
+                beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>(
+                cmdu_tx, beerocks_header->id());
+            return res_msg;
+        };
+        auto send_results_response =
+            [&sd, &cmdu_tx](
+                std::shared_ptr<beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>
+                    &res_msg,
+                const eChannelScanErrCode result_status, const eChannelScanOpErrCode op_error_code,
+                bool is_last = true) {
+                res_msg->result_status() = uint8_t(result_status);
+                res_msg->op_error_code() = uint8_t(op_error_code);
+                res_msg->last()          = (is_last) ? 1 : 0;
+                message_com::send_cmdu(sd, cmdu_tx);
+            };
 
         // If there was an error before, send the results with a failed status
         if (op_error_code != eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS ||
             result_status != eChannelScanErrCode::CHANNEL_SCAN_SUCCESS) {
             LOG(ERROR) << "Something went wrong, sending CMDU with error code: ["
                        << (int)op_error_code << "] & result status [" << (int)result_status << "].";
-            response->result_status() = uint8_t(result_status);
-            response->op_error_code() = uint8_t(op_error_code);
-            response->last()          = 1;
-            message_com::send_cmdu(sd, cmdu_tx);
+            auto response = gen_new_results_response();
+            send_results_response(response,result_status,op_error_code);
 
             break;
         }
@@ -2013,95 +2024,51 @@ void son_management::handle_bml_message(Socket *sd,
         //Results avaliablity check
         if (scan_results_size == 0) {
             LOG(DEBUG) << "no scan results are available";
-            response->result_status() = uint8_t(eChannelScanErrCode::CHANNEL_SCAN_RESULTS_EMPTY);
-            response->op_error_code() = uint8_t(op_error_code);
-            response->last()          = 1;
-            message_com::send_cmdu(sd, cmdu_tx);
+            auto response = gen_new_results_response();
+            send_results_response(response,eChannelScanErrCode::CHANNEL_SCAN_RESULTS_EMPTY,op_error_code);
+            break;
         }
 
-        // Set const sized for message building
-        const size_t tlvEndSize    = ieee1905_1::tlvEndOfMessage::get_initial_size();
-        const size_t result_size   = sizeof(beerocks_message::sChannelScanResults);
-        const size_t ext_data_size = sizeof(result_status) + sizeof(op_error_code) + sizeof(last);
-        int remaining_results      = scan_results_size;
-        int response_result_index  = 0;
-        beerocks_message::sChannelScanResults *results = nullptr;
+        //LOG(DEBUG) << "Creating response";
+        size_t reserved_size = (message_com::get_vs_cmdu_size_on_buffer<
+                                beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>());
+        auto response        = gen_new_results_response();
+        size_t max_size      = cmdu_tx.getMessageBuffLength() - reserved_size;
+        //LOG(DEBUG) << "Starting to iterate over results";
+        for (auto &dump : scan_results) {
 
-        for (auto dump : scan_results) {
+            //LOG(DEBUG) << "size left in cmdu: " << max_size;
+            if (max_size < sizeof(dump)) {
 
-            if (results == nullptr) {
-                LOG(DEBUG) << "Creating new ACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE !";
-                response = message_com::create_vs_message<
-                    beerocks_message::cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE>(
-                    cmdu_tx, beerocks_header->id());
-                if (!response) {
-                    LOG(ERROR) << "Failed building message "
-                                  "cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE !";
-                    return;
-                }
-
-                //reset message flags
-                result_status = eChannelScanErrCode::CHANNEL_SCAN_SUCCESS;
-                op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS;
-                last          = 0;
-
-                // Need to find how much results we can allocate before running out of room
-                int size_left = cmdu_tx.getMessageBuffLength() - cmdu_tx.getMessageLength() -
-                                tlvEndSize - ext_data_size;
-                int cmdu_max_avaliable_result_count = size_left / result_size;
-                int cmdu_max_result_count = cmdu_max_avaliable_result_count > remaining_results
-                                                ? remaining_results
-                                                : cmdu_max_avaliable_result_count;
-
-                LOG(DEBUG) << "Allocating space for " << cmdu_max_result_count << " results";
-                if (response->alloc_results(cmdu_max_result_count) == false) {
-                    LOG(ERROR) << "Failed buffer allocation to size = "
-                               << int(cmdu_max_result_count);
-                    op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
-                    break;
-                }
-
-                // Getting response results' pointer
-                auto results_tuple = response->results(0);
-                if (std::get<0>(results_tuple) == false) {
-                    LOG(ERROR) << "response->results access fail!";
-                    op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
-                    break;
-                }
-                results               = &std::get<1>(results_tuple);
-                response_result_index = 0;
+                LOG(DEBUG) << "Reached limit on CMDU, Sending..";
+                send_results_response(response,result_status,op_error_code, false);
+                LOG(DEBUG) << "Creating new CMDU";
+                response = gen_new_results_response();
+                max_size = cmdu_tx.getMessageBuffLength() - reserved_size;
+            } 
+            //LOG(DEBUG) << "Allocating space";
+            if(!response->alloc_results()) {
+                LOG(ERROR) << "Failed buffer allocation";
+                op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
+                break;
             }
-            LOG(DEBUG) << "Adding result to CMDU";
+            max_size -= sizeof(dump);
 
-            results[response_result_index++] = dump;
-            remaining_results--;
-
-            if (remaining_results <= 0) {
-                LOG(DEBUG) << "reached end of results";
-                last = 1;
+            //LOG(DEBUG) << "Accesing results";
+            auto num_of_res = response->results_size();
+            if(!std::get<0>(response->results(num_of_res - 1))) {
+                LOG(ERROR) << "Failed accessing results buffer";
+                op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
+                break;
             }
-            if (response_result_index >= (int)response->results_size() || remaining_results <= 0) {
-                LOG(DEBUG) << "reached CMDU capacity";
+            auto &dump_msg = std::get<1>(response->results(num_of_res - 1));
 
-                response->result_status() = uint8_t(result_status);
-                response->op_error_code() = uint8_t(op_error_code);
-                response->last()          = last;
-                message_com::send_cmdu(sd, cmdu_tx);
-
-                //clears result, this will cause another response to be created
-                if (remaining_results > 0) {
-                    results = nullptr;
-                }
-            }
+            //LOG(DEBUG) << "Copying result";
+            dump_msg = dump;         
         }
-
-        if (op_error_code != eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS) {
-            LOG(ERROR) << "Something went wrong, this shouldn't be reached";
-            response->result_status() = uint8_t(result_status);
-            response->op_error_code() = uint8_t(op_error_code);
-            response->last()          = 1;
-            message_com::send_cmdu(sd, cmdu_tx);
-        }
+        LOG(DEBUG) << "Finished all results, Sending final CMDU";
+        send_results_response(response,result_status,op_error_code, true);
+        //LOG(DEBUG) << "CMDU sent";
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST: {


### PR DESCRIPTION
This PR fixes issues in the DCS featue's get results flow

- 1st commit) Fixes results_size issue causing the controller to crush whenever ACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE is sent
- 2nd commit) Fixes the "get scan results" flow in bml & son_management
- 3rd commit) Fixes additional issue found in bml cli, set continuous params. the cli was not sending the radio_mac address causing the api to malfunction