### PR TITLE
common: bcl: beerocks_string_utils: correct GNUC macro

### DIFF
--- a/common/beerocks/bcl/include/bcl/beerocks_string_utils.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_string_utils.h
@@ -73,7 +73,7 @@ public:
 
     static std::vector<std::string> str_split(const std::string &s, char delim);
 
-#ifndef __GCC__
+#ifndef __GNUC__
 #define __builtin_FILE() __FILE__
 #define __builtin_LINE() __LINE__
 #endif


### PR DESCRIPTION
As noticed by @morantr, the stoi() function didn't report correct file and
line information any more. This is because commit e439080f76, that
replaced `__builtin_FILE()` and `__builtin_LINE()` with the standard
`__FILE__` and `__LINE__` macros on non-GCC compilers, used the wrong define
to check for GCC.

Use `__GNUC__` to check for GCC instead of the non-existent `__GCC__`.