### PR TITLE
Bugfix - non EasyMesh mode VAP credentials update/tear down

### DIFF
--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -159,6 +159,10 @@ static bool fill_platform_settings(
             LOG(ERROR) << "Failed reading 'local_master'";
             return false;
         }
+        if ((platform_common_conf.management_mode = bpl::cfg_get_management_mode()) < 0) {
+            LOG(ERROR) << "Failed reading 'management_mode'";
+            return false;
+        }
         if ((platform_common_conf.operating_mode = bpl::cfg_get_operating_mode()) < 0) {
             LOG(ERROR) << "Failed reading 'operating_mode'";
             return false;
@@ -222,6 +226,7 @@ static bool fill_platform_settings(
         uint8_t(platform_common_conf.client_roaming || platform_common_conf.band_steering);
     msg->platform_settings().local_gw           = uint8_t(platform_common_conf.local_gw);
     msg->platform_settings().operating_mode     = uint8_t(platform_common_conf.operating_mode);
+    msg->platform_settings().management_mode    = uint8_t(platform_common_conf.management_mode);
     msg->platform_settings().certification_mode = uint8_t(platform_common_conf.certification_mode);
     msg->platform_settings().stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
@@ -39,6 +39,7 @@ public:
         int band_steering;
         int client_roaming;
         int onboarding;
+        int management_mode;
         int operating_mode;
         int certification_mode;
         int stop_on_failure_attempts;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4050,7 +4050,22 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
         }
     }
 
-    message_com::send_cmdu(ap_manager_socket, cmdu_tx);
+    ///////////////////////////////////////////////////////////////////
+    // TODO https://github.com/prplfoundation/prplMesh/issues/797
+    //
+    // Short term solution
+    // In non-EasyMesh mode, never modify hostapd configuration
+    // and in this case VAPs credentials
+    //
+    // Long term solution
+    // All EasyMesh VAPs will be stored in the platform DB.
+    // All other VAPs are manual, AKA should not be modified by prplMesh
+    ////////////////////////////////////////////////////////////////////
+    if (platform_settings.management_mode != BPL_MGMT_MODE_NOT_MULTIAP) {
+        message_com::send_cmdu(ap_manager_socket, cmdu_tx);
+    } else {
+        LOG(WARNING) << "non-EasyMesh mode - skip updating VAP credentials";
+    }
 
     // Notify backhaul manager that onboarding has finished (certification flow)
     auto onboarding_finished_notification = message_com::create_vs_message<

--- a/common/beerocks/bcl/include/bcl/beerocks_async_work_queue.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_async_work_queue.h
@@ -20,7 +20,7 @@ namespace beerocks {
 
 class async_work_queue : public thread_base {
 public:
-    async_work_queue()  = default;
+    async_work_queue() = default;
     ~async_work_queue();
 
     template <typename R, typename... Args, typename F> std::future<R> enqueue(F func, Args... args)

--- a/common/beerocks/bcl/source/beerocks_async_work_queue.cpp
+++ b/common/beerocks/bcl/source/beerocks_async_work_queue.cpp
@@ -14,9 +14,7 @@
 
 namespace beerocks {
 
-async_work_queue::~async_work_queue() {
-    async_work_queue::before_stop();
-}
+async_work_queue::~async_work_queue() { async_work_queue::before_stop(); }
 
 bool async_work_queue::init() { return true; }
 

--- a/common/beerocks/bcl/source/beerocks_thread_base.cpp
+++ b/common/beerocks/bcl/source/beerocks_thread_base.cpp
@@ -10,7 +10,8 @@
 
 using namespace beerocks;
 
-thread_base::~thread_base() {
+thread_base::~thread_base()
+{
     should_stop = true;
     thread_base::before_stop();
     join();

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1082,8 +1082,7 @@ bool ap_wlan_hal_dwpal::update_vap_credentials(
     for (const auto &it : hostapd_config_vaps) {
         // Skip STAs
         std::string entry_mode;
-        if (hostapd_config_get_value(it.second, "mode", entry_mode) &&
-            entry_mode != "ap") {
+        if (hostapd_config_get_value(it.second, "mode", entry_mode) && entry_mode != "ap") {
             continue;
         }
         // Count the the total of available for reconfiguration VAPs

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -83,6 +83,7 @@ typedef struct sPlatformSettings {
     uint8_t local_master;
     uint8_t local_gw;
     uint8_t operating_mode;
+    uint8_t management_mode;
     uint8_t mem_only_psk;
     uint8_t certification_mode;
     uint8_t stop_on_failure_attempts;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -74,7 +74,8 @@ sPlatformSettings:
   onboarding: uint8_t 
   local_master: uint8_t 
   local_gw: uint8_t 
-  operating_mode: uint8_t 
+  operating_mode: uint8_t
+  management_mode: uint8_t
   mem_only_psk: uint8_t
 
   certification_mode: uint8_t 

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -51,6 +51,12 @@ namespace bpl {
 #define BPL_OPER_MODE_WDS_REPEATER 3
 #define BPL_OPER_MODE_L2NAT_CLIENT 4
 
+/* Platform Management Mode */
+#define BPL_MGMT_MODE_MULTIAP_CONTROLLER_AGENT 0 /* EasyMesh controller and agent */
+#define BPL_MGMT_MODE_MULTIAP_CONTROLLER 1       /* EasyMesh controller */
+#define BPL_MGMT_MODE_MULTIAP_AGENT 2            /* EasyMesh agent */
+#define BPL_MGMT_MODE_NOT_MULTIAP 3              /* Non EasyMesh */
+
 /* Platform Certification Mode */
 #define BPL_CERTIFICATION_MODE_OFF 0
 #define BPL_CERTIFICATION_MODE_ON 1
@@ -259,6 +265,18 @@ int cfg_is_master();
  * @return -1 Error.
  */
 int cfg_get_operating_mode();
+
+/**
+ * Returns the current management mode configuration.
+ *
+ * @return valid possibilities:
+ *   BPL_MGMT_MODE_MULTIAP_CONTROLLER_AGENT,
+ *   BPL_MGMT_MODE_MULTIAP_CONTROLLER,
+ *   BPL_MGMT_MODE_MULTIAP_AGENT,
+ *   BPL_MGMT_MODE_NOT_MULTIAP
+ * @return -1 Error.
+ */
+int cfg_get_management_mode();
 
 /**
  * Returns certification mode value.

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -83,20 +83,18 @@ int cfg_is_enabled() { return 1; }
 
 int cfg_is_master()
 {
-    std::string mode_str;
-    if (cfg_get_param("management_mode=", mode_str) < 0) {
-        MAPF_ERR("cfg_is_master: Failed to read ManagementMode");
+    switch (cfg_get_management_mode()) {
+    case BPL_MGMT_MODE_MULTIAP_CONTROLLER_AGENT:
+        return 1;
+    case BPL_MGMT_MODE_MULTIAP_CONTROLLER:
+        return 1;
+    case BPL_MGMT_MODE_MULTIAP_AGENT:
+        return 0;
+    case BPL_MGMT_MODE_NOT_MULTIAP:
+        return (cfg_get_operating_mode() == BPL_OPER_MODE_GATEWAY) ? 1 : 0;
+    default:
         return RETURN_ERR;
     }
-
-    if (mode_str == "Multi-AP-Controller-and-Agent" || mode_str == "Multi-AP-Controller")
-        return 1;
-    else if (mode_str == "Multi-AP-Agent")
-        return 0;
-
-    MAPF_ERR("cfg_is_master: Unexpected management_mode " << mode_str);
-
-    return RETURN_ERR;
 }
 
 int cfg_get_management_mode()

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -99,6 +99,29 @@ int cfg_is_master()
     return RETURN_ERR;
 }
 
+int cfg_get_management_mode()
+{
+    int retVal = RETURN_ERR;
+    std::string mgmt_mode;
+    if (cfg_get_param("management_mode=", mgmt_mode) < 0) {
+        MAPF_ERR("cfg_get_management_mode: Failed to read management_mode");
+        return -1;
+    }
+
+    if (mgmt_mode == "Multi-AP-Controller-and-Agent") {
+        return BPL_MGMT_MODE_MULTIAP_CONTROLLER_AGENT;
+    } else if (mgmt_mode == "Multi-AP-Controller") {
+        return BPL_MGMT_MODE_MULTIAP_CONTROLLER;
+    } else if (mgmt_mode == "Multi-AP-Agent") {
+        return BPL_MGMT_MODE_MULTIAP_AGENT;
+    } else if (mgmt_mode == "Not-Multi-AP") {
+        return BPL_MGMT_MODE_NOT_MULTIAP;
+    }
+
+    MAPF_ERR("cfg_get_management_mode: Unexpected management_mode");
+    return retVal;
+}
+
 int cfg_get_operating_mode()
 {
     int retVal = 0;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -55,6 +55,31 @@ int cfg_is_master()
     return retVal;
 }
 
+int cfg_get_management_mode()
+{
+    int retVal                                = 0;
+    char mgmt_mode[BPL_GW_DB_MANAGE_MODE_LEN] = {0};
+    if (cfg_get_prplmesh_param("management_mode", mgmt_mode, BPL_GW_DB_MANAGE_MODE_LEN) < 0) {
+        MAPF_ERR("cfg_get_management_mode: Failed to read management_mode");
+        retVal = -1;
+    } else {
+        std::string mode_str(mgmt_mode);
+        if (mode_str == "Multi-AP-Controller-and-Agent") {
+            retVal = BPL_MGMT_MODE_MULTIAP_CONTROLLER_AGENT;
+        } else if (mode_str == "Multi-AP-Controller") {
+            retVal = BPL_MGMT_MODE_MULTIAP_CONTROLLER;
+        } else if (mode_str == "Multi-AP-Agent") {
+            retVal = BPL_MGMT_MODE_MULTIAP_AGENT;
+        } else if (mode_str == "Not-Multi-AP") {
+            retVal = BPL_MGMT_MODE_NOT_MULTIAP;
+        } else {
+            MAPF_ERR("cfg_get_management_mode: Unexpected management_mode");
+            retVal = -1;
+        }
+    }
+    return retVal;
+}
+
 int cfg_get_operating_mode()
 {
     int retVal                            = 0;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -34,25 +34,18 @@ int cfg_is_enabled()
 
 int cfg_is_master()
 {
-    int retVal                               = 0;
-    char man_mode[BPL_GW_DB_MANAGE_MODE_LEN] = {0};
-    if (cfg_get_prplmesh_param("management_mode", man_mode, BPL_GW_DB_MANAGE_MODE_LEN) < 0) {
-        MAPF_ERR("cfg_is_master: Failed to read ManagementMode\n");
-        retVal = -1;
-    } else {
-        std::string mode_str(man_mode);
-        if (mode_str == "Multi-AP-Controller-and-Agent") {
-            retVal = 1;
-        } else if (mode_str == "Proprietary-Mesh") {
-            retVal = 1;
-        } else if (mode_str == "Multi-AP-Agent") {
-            retVal = 0;
-        } else {
-            MAPF_ERR("cfg_is_master: Unexpected ManagementMode\n");
-            retVal = -1;
-        }
+    switch (cfg_get_management_mode()) {
+    case BPL_MGMT_MODE_MULTIAP_CONTROLLER_AGENT:
+        return 1;
+    case BPL_MGMT_MODE_MULTIAP_CONTROLLER:
+        return 1;
+    case BPL_MGMT_MODE_MULTIAP_AGENT:
+        return 0;
+    case BPL_MGMT_MODE_NOT_MULTIAP:
+        return (cfg_get_operating_mode() == BPL_OPER_MODE_GATEWAY) ? 1 : 0;
+    default:
+        return -1;
     }
-    return retVal;
 }
 
 int cfg_get_management_mode()

--- a/framework/transport/ieee1905_transport/include/mapf/transport/ieee1905_transport_messages.h
+++ b/framework/transport/ieee1905_transport/include/mapf/transport/ieee1905_transport_messages.h
@@ -257,7 +257,7 @@ public:
     virtual const std::string topic_prefix() const { return kTopicPrefix; }
 };
 
-class InterfaceConfigurationMessage: public Message {
+class InterfaceConfigurationMessage : public Message {
     static const uint8_t kVersion   = 0;
     static const int kMaxInterfaces = 32;
 
@@ -287,8 +287,7 @@ public:
     {
     }
 
-    InterfaceConfigurationMessage(const std::string &topic,
-                                         std::initializer_list<Frame> frames)
+    InterfaceConfigurationMessage(const std::string &topic, std::initializer_list<Frame> frames)
         : Message(topic, frames)
     {
         // maximum one frame is allowed (if none are given we will allocate one below)


### PR DESCRIPTION
In EasyMesh mode, as part of autoconfiguration, the radio agent sends a
message to the AP manager to update VAP credentials which results with
an updated credentials or a full radio teardown.
In non EasyMesh mode, this should never happen - so add a check for that
and only send the message to the ap manager when in EasyMesh management
mode.

Fixes #797.