### PR TITLE
controller: ucc listener add dev_get_param support

### DIFF
--- a/controller/src/beerocks/master/controller_ucc_listener.cpp
+++ b/controller/src/beerocks/master/controller_ucc_listener.cpp
@@ -49,6 +49,31 @@ void controller_ucc_listener::clear_configuration() { m_database.clear_bss_info_
 bool controller_ucc_listener::handle_dev_get_param(
     std::unordered_map<std::string, std::string> &params, std::string &value)
 {
+    if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
+        if (params.find("ruid") == params.end()) {
+            value = "missing ruid";
+            return false;
+        }
+        if (params.find("ssid") == params.end()) {
+            value = "missing ssid";
+            return false;
+        }
+        auto ruid = net::network_utils::mac_to_string(std::stoull(params["ruid"], nullptr, 16));
+        auto ssid = params["ssid"];
+        auto vaps = m_database.get_hostap_vap_list(ruid);
+        if (vaps.empty()) {
+            value = "ruid " + ruid + " not found";
+            return false;
+        }
+        for (const auto &vap : vaps) {
+            if (std::string(vap.second.ssid) == ssid) {
+                value = vap.second.mac;
+                return true;
+            }
+        }
+        value = "macaddr/bssid not found for ruid " + ruid + " ssid " + ssid;
+        return false;
+    }
     value = "parameter " + params["parameter"] + " not supported";
     return false;
 }


### PR DESCRIPTION
Add dev_get_param support for getting the mac address for a VAP.
This can be used in tests to verify VAP credentials were set as
expected.

Fixes #798

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>