### PR TITLE
bpl: read wireless configuration by interface name instead of index

### DIFF
--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -99,16 +99,9 @@ static bool fill_platform_settings(
     /* update message */
     msg->wlan_settings().band_enabled = params.enabled;
     msg->wlan_settings().channel      = params.channel;
-    string_utils::copy_string(msg->wlan_settings().ssid, params.ssid,
-                              beerocks::message::WIFI_SSID_MAX_LENGTH);
-    string_utils::copy_string(msg->wlan_settings().pass, params.passphrase,
-                              beerocks::message::WIFI_PASS_MAX_LENGTH);
-    string_utils::copy_string(msg->wlan_settings().security_type, params.security,
-                              beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH);
 
     LOG(DEBUG) << "wlan settings:"
-               << " ssid=" << msg->wlan_settings().ssid
-               << " sec=" << msg->wlan_settings().security_type << " pass=***"
+               << " band_enabled=" << string_utils::bool_str(msg->wlan_settings().band_enabled)
                << " channel=" << int(msg->wlan_settings().channel);
 
     // initialize wlan params cache
@@ -122,12 +115,6 @@ static bool fill_platform_settings(
 
     params_ptr->band_enabled = params.enabled;
     params_ptr->channel      = params.channel;
-    string_utils::copy_string(params_ptr->ssid, params.ssid,
-                              beerocks::message::WIFI_SSID_MAX_LENGTH);
-    string_utils::copy_string(params_ptr->pass, params.passphrase,
-                              beerocks::message::WIFI_PASS_MAX_LENGTH);
-    string_utils::copy_string(params_ptr->security_type, params.security,
-                              beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH);
 
     iface_wlan_params_map[iface_name] = params_ptr;
 
@@ -615,28 +602,6 @@ bool main_thread::wlan_params_changed_check()
             LOG(DEBUG) << "channel changed";
             wlan_params_changed = true;
         }
-        if (std::string(elm.second->ssid).compare(std::string(params.ssid))) {
-            LOG(DEBUG) << "ssid changed, cached=" << std::string(elm.second->ssid) << ", new="
-                       << std::string(params.ssid, beerocks::message::WIFI_SSID_MAX_LENGTH);
-            string_utils::copy_string(elm.second->ssid, params.ssid,
-                                      beerocks::message::WIFI_SSID_MAX_LENGTH);
-            wlan_params_changed = true;
-        }
-        if (std::string(elm.second->pass).compare(std::string(params.passphrase))) {
-            LOG(DEBUG) << "pass changed";
-            string_utils::copy_string(elm.second->pass, params.passphrase,
-                                      beerocks::message::WIFI_PASS_MAX_LENGTH);
-            wlan_params_changed = true;
-        }
-        if (std::string(elm.second->security_type).compare(std::string(params.security))) {
-            LOG(DEBUG) << "security_type changed, cached=" << std::string(elm.second->security_type)
-                       << ", new="
-                       << std::string(params.security,
-                                      beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH);
-            string_utils::copy_string(elm.second->security_type, params.security,
-                                      beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH);
-            wlan_params_changed = true;
-        }
 
         if (wlan_params_changed) {
             any_slave_changed = true;
@@ -649,13 +614,6 @@ bool main_thread::wlan_params_changed_check()
 
             notification->wlan_settings().band_enabled = elm.second->band_enabled;
             notification->wlan_settings().channel      = elm.second->channel;
-            string_utils::copy_string(notification->wlan_settings().ssid, elm.second->ssid,
-                                      beerocks::message::WIFI_SSID_MAX_LENGTH);
-            string_utils::copy_string(notification->wlan_settings().pass, elm.second->pass,
-                                      beerocks::message::WIFI_PASS_MAX_LENGTH);
-            string_utils::copy_string(notification->wlan_settings().security_type,
-                                      elm.second->security_type,
-                                      beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH);
 
             Socket *sd = get_slave_socket_from_hostap_iface_name(elm.first);
             if (!sd) {

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -114,9 +114,6 @@ typedef struct sPlatformSettings {
 typedef struct sWlanSettings {
     uint8_t band_enabled;
     uint8_t channel;
-    char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
-    char pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
-    char security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
     void struct_swap(){
     }
     void struct_init(){

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -105,15 +105,6 @@ sWlanSettings:
   band_enabled:
     _type: uint8_t
   channel: uint8_t 
-  ssid:
-    _type: char    
-    _length: [ "beerocks::message::WIFI_SSID_MAX_LENGTH" ]
-  pass:
-    _type: char    
-    _length: [ "beerocks::message::WIFI_PASS_MAX_LENGTH" ]
-  security_type:
-    _type: char    
-    _length: [ "beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH" ]
 
 sApSetRestrictedFailsafe:
   _type: struct

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -220,15 +220,6 @@ struct BPL_WLAN_PARAMS {
 
     /* Wi-Fi Channel (0 for ACS) */
     int channel;
-
-    /* Wi-Fi SSID */
-    char ssid[BPL_SSID_LEN];
-
-    /* Wi-Fi KeyPassphrase */
-    char passphrase[BPL_PASS_LEN];
-
-    /* Wi-Fi Securirt Mode */
-    char security[BPL_SEC_LEN];
 };
 
 /**

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -190,9 +190,6 @@ int cfg_get_wifi_params(const char *iface, struct BPL_WLAN_PARAMS *wlan_params)
     }
     wlan_params->enabled = 1;
     wlan_params->channel = 0;
-    utils::copy_string(wlan_params->ssid, "test_ssid", BPL_SSID_LEN);
-    utils::copy_string(wlan_params->passphrase, "test_pass", BPL_PASS_LEN);
-    utils::copy_string(wlan_params->security, "None", BPL_SEC_LEN);
 
     return RETURN_OK;
 }

--- a/framework/platform/bpl/test/bpl_test.cpp
+++ b/framework/platform/bpl/test/bpl_test.cpp
@@ -45,8 +45,8 @@ int main()
             if (beerocks::bpl::cfg_get_wifi_params(inputInterface, &wlan_params) != 0) {
                 MAPF_ERR("Failed to retrieve WiFi params for " << inputInterface << "\n");
             } else {
-                MAPF_INFO("SSID " << wlan_params.ssid << " Security mode " << wlan_params.security
-                                  << " Passphrase " << wlan_params.passphrase << "\n");
+                MAPF_INFO("enabled " << wlan_params.enabled << " channel " << wlan_params.channel
+                                     << "\n");
             }
             break;
         case 11:

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -201,21 +201,6 @@ int cfg_get_wifi_params(const char iface[BPL_IFNAME_LEN], struct BPL_WLAN_PARAMS
         MAPF_INFO("UCI: radio" << index << ": channel is not configured assuming auto\n");
     }
 
-    char ssid[MAX_UCI_BUF_LEN] = {0}, security[MAX_UCI_BUF_LEN] = {0},
-         passphrase[MAX_UCI_BUF_LEN] = {0};
-    retVal |= cfg_uci_get_wireless(TYPE_VAP, index, "ssid", ssid);
-    retVal |= cfg_uci_get_wireless(TYPE_VAP, index, "wav_security_mode", security);
-    std::string mode = std::string(security);
-    if (mode == BPL_WLAN_SEC_WEP64_STR || mode == BPL_WLAN_SEC_WEP128_STR) {
-        retVal |= cfg_get_wep_key(index, -1, passphrase);
-    } else if (mode != BPL_WLAN_SEC_NONE_STR) {
-        retVal |= cfg_uci_get_wireless(TYPE_VAP, index, "key", passphrase);
-    }
-
-    utils::copy_string(wlan_params->ssid, ssid, BPL_SSID_LEN);
-    utils::copy_string(wlan_params->security, security, BPL_SEC_LEN);
-    utils::copy_string(wlan_params->passphrase, passphrase, BPL_PASS_LEN);
-
     return retVal;
 }
 

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.cpp
@@ -82,16 +82,19 @@ int cfg_get_prplmesh_param_int(const std::string &param, int *buf)
     return RETURN_OK;
 }
 
-int cfg_get_channel(int index, int *channel)
+int cfg_get_channel(const std::string &interface_name, int *channel)
 {
     if (!channel) {
         return RETURN_ERR;
     }
 
     char channel_num[MAX_UCI_BUF_LEN] = {0};
-    int status = cfg_uci_get_wireless(TYPE_RADIO, index, "channel", channel_num);
-    if (status == RETURN_ERR)
+    char ifname[BPL_IFNAME_LEN]       = {0};
+
+    utils::copy_string(ifname, interface_name.c_str(), BPL_IFNAME_LEN);
+    if (cfg_uci_get_wireless_from_ifname(TYPE_RADIO, ifname, "channel", channel_num) != RETURN_OK) {
         return RETURN_ERR;
+    }
 
     std::string channel_str(channel_num);
     if (!channel_str.compare("auto")) {
@@ -103,7 +106,7 @@ int cfg_get_channel(int index, int *channel)
     return RETURN_OK;
 }
 
-int cfg_get_wep_key(int index, int keyIndex, char *key)
+int cfg_get_wep_key(const std::string &interface_name, int keyIndex, char *key)
 {
     /*TODO: implement using d/s-pal apis*/
     return RETURN_OK;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.h
@@ -63,15 +63,15 @@ int cfg_get_prplmesh_param_int(const std::string &param, int *buf);
 /**
  * Returns the value of ACS from DB
  *
- * @param [in] index interface index
+ * @param [in] interface_name interface name string
  * @param [out] channel channel number
  *
  * @return 0 on success or -1 on error.
  **/
-int cfg_get_channel(int index, int *channel);
+int cfg_get_channel(const std::string &interface_name, int *channel);
 
 /** API currently not implemented **/
-int cfg_get_wep_key(int index, int keyIndex, char *key);
+int cfg_get_wep_key(const std::string &interface_name, int keyIndex, char *key);
 
 /**
  * set the VAP credentials

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "bpl_cfg_uci.h"
+#include "../../common/utils/utils.h"
+
+#include <string>
 
 extern "C" {
 #include <uci.h>
@@ -160,6 +163,128 @@ int cfg_uci_get_wireless(enum paramType type, int index, const char param[], cha
     }
 
     return status;
+}
+
+int cfg_uci_get_wireless_from_ifname(enum paramType type, const char *interface_name,
+                                     const char param[], char *value)
+{
+    struct uci_context *ctx = uci_alloc_context();
+    if (!ctx) {
+        ERROR("%s, uci alloc context failed!\n", __FUNCTION__);
+        return RETURN_ERR;
+    }
+
+    char lookup_str[MAX_UCI_BUF_LEN] = "wireless";
+    struct uci_ptr ptr;
+    if ((uci_lookup_ptr(ctx, &ptr, lookup_str, true) != UCI_OK)) {
+        ERROR("%s, uci lookup failed!\n", __FUNCTION__);
+        uci_free_context(ctx);
+        return RETURN_ERR;
+    }
+
+    if (!ptr.p) {
+        ERROR("%s, returned pointer is null\n", __FUNCTION__);
+        uci_free_context(ctx);
+        return RETURN_ERR;
+    }
+
+    bool is_section_found = false;
+    struct uci_package *p = ptr.p;
+    struct uci_element *e = nullptr;
+    struct uci_element *n = nullptr;
+    struct uci_section *s = nullptr;
+    // Iterate over all wireless sections in the UCI DB
+    uci_foreach_element(&p->sections, e)
+    {
+        s = uci_to_section(e);
+
+        if (strncmp(s->type, "wifi-iface", MAX_UCI_BUF_LEN))
+            continue;
+
+        // Iterate over all the options in the section
+        uci_foreach_element(&s->options, n)
+        {
+            struct uci_option *o = uci_to_option(n);
+
+            if (o->type != UCI_TYPE_STRING)
+                continue;
+
+            if (strncmp(n->name, "ifname", MAX_UCI_BUF_LEN))
+                continue;
+
+            if (strncmp(interface_name, o->v.string, MAX_UCI_BUF_LEN))
+                continue;
+
+            // We reached the section containing the requested ifname
+            is_section_found = true;
+            break;
+        }
+
+        if (is_section_found) {
+            break;
+        }
+    }
+
+    //if interface not found in wireless
+    if (!is_section_found) {
+        ERROR("%s, interface(%s) not found", __FUNCTION__, interface_name);
+        uci_free_context(ctx);
+        return RETURN_ERR;
+    }
+
+    if (type == TYPE_RADIO) {
+        // create path to the param in the device: wireless.<device>.param
+        bool device_option_exist = false;
+        std::string path_str;
+
+        uci_foreach_element(&s->options, n)
+        {
+            struct uci_option *o = uci_to_option(n);
+
+            if (strncmp(n->name, "device", MAX_UCI_BUF_LEN) == 0 && o->type == UCI_TYPE_STRING) {
+                path_str =
+                    std::string("wireless." + std::string(o->v.string) + "." + std::string(param));
+                device_option_exist = true;
+                break;
+            }
+        }
+        uci_free_context(ctx);
+
+        if (device_option_exist) {
+            // radio not found
+            ERROR("%s device option not found\n", __func__);
+            return RETURN_ERR;
+        }
+
+        char path[MAX_UCI_BUF_LEN] = "";
+        utils::copy_string(path, path_str.c_str(), MAX_UCI_BUF_LEN);
+
+        if (cfg_uci_get(path, value, MAX_UCI_BUF_LEN) != RETURN_OK) {
+            ERROR("%s option N/A. path=%s\n", __func__, path);
+        }
+
+        return RETURN_OK;
+
+    } else { //* type == TYPE_VAP *
+        // read the value from the selected section
+        // get param in the selected section
+        uci_foreach_element(&s->options, n)
+        {
+            struct uci_option *o = uci_to_option(n);
+            // if param is found in options
+            if (strncmp(n->name, param, MAX_UCI_BUF_LEN) == 0 && o->type == UCI_TYPE_STRING) {
+                strncpy_s(value, MAX_UCI_BUF_LEN, o->v.string, MAX_UCI_BUF_LEN - 1);
+                uci_free_context(ctx);
+                return RETURN_OK;
+            }
+        }
+
+        // param not found in option
+        ERROR("%s, interface(%s) found but param(%s) isn't configured\n", __FUNCTION__,
+              interface_name, param);
+        uci_free_context(ctx);
+        return RETURN_ERR;
+    }
 }
 
 int cfg_uci_get_wireless_radio_idx(const char *interfaceName, int *radio_index)

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp
@@ -69,12 +69,13 @@ int cfg_uci_get(char *path, char *value, size_t length)
     return RETURN_OK;
 }
 
-int cfg_uci_get_wireless_int(enum paramType type, int index, const char param[], int *value)
+int cfg_uci_get_wireless_int(enum paramType type, const char *interface_name, const char param[],
+                             int *value)
 {
     int status;
     char val[MAX_UCI_BUF_LEN] = "";
 
-    status = cfg_uci_get_wireless(type, index, param, val);
+    status = cfg_uci_get_wireless_from_ifname(type, interface_name, param, val);
     if (status == RETURN_ERR)
         return RETURN_ERR;
 
@@ -439,12 +440,12 @@ int cfg_uci_get_wireless_idx(char *interfaceName, int *rpc_index)
     return RETURN_ERR;
 }
 
-int cfg_uci_get_wireless_bool(enum paramType type, int index, const char param[], bool *value)
+int cfg_uci_get_wireless_bool(enum paramType type, const char *interface_name, const char param[],
+                              bool *value)
 {
-    int status;
     int res;
 
-    status = cfg_uci_get_wireless_int(type, index, param, &res);
+    int status = cfg_uci_get_wireless_int(type, interface_name, param, &res);
     if (status == RETURN_ERR)
         return RETURN_ERR;
 

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -91,6 +91,9 @@ int cfg_uci_get_radio_param(int index, const char param[], char *value, size_t b
 int cfg_uci_get_wireless_radio_idx(const char *interfaceName, int *radio_index);
 int cfg_uci_get_radio_param_ulong(int index, const char param[], unsigned long *value);
 
+int cfg_uci_get_wireless_from_ifname(enum paramType type, const char *interface_name,
+                                     const char param[], char *value);
+
 } // namespace bpl
 } // namespace beerocks
 

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -84,7 +84,8 @@ namespace bpl {
 int cfg_uci_get_wireless_idx(char *interfaceName, int *rpc_index);
 int cfg_uci_get(char *path, char *value, size_t length);
 int cfg_uci_get_wireless(enum paramType type, int index, const char param[], char *value);
-int cfg_uci_get_wireless_bool(enum paramType type, int index, const char param[], bool *value);
+int cfg_uci_get_wireless_bool(enum paramType type, const char *interface_name, const char param[],
+                              bool *value);
 
 int cfg_uci_get_radio_param_int(int index, const char param[], int *value);
 int cfg_uci_get_radio_param(int index, const char param[], char *value, size_t buf_len);


### PR DESCRIPTION
This PR breaks the dependency of BPL in wireless radio section naming in the UCI config.
The new implementation looks-up the interface name in the wireless config.
If the param is requested from the main radio - a search of the param value is done in the `wireless.<device>.param` where <device> is the device name found in the section where the interface name was found.
```
e.g.
lookup **great_iface_name**:
wireless.**adam**.ifname=**great_iface_name**->
wireless.**adam**.device=**adam_device** ->
read: wireless.**adam_device**.<param>
```
for VAPs, the param is searched in the current section, but again - the section is located using the interface name:
```
lookup **great_iface_name**:
wireless.**adam**.ifname=**great_iface_name**->
read: wireless.**adam**.<param>
```

this PR is rebased to the following PR:
https://github.com/prplfoundation/prplMesh/pull/785

Fixes #574 