### PR TITLE
Make sure topology response contains up-to-date VAP list

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1707,19 +1707,17 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
     case beerocks_message::ACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION: {
         LOG(DEBUG) << "ACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION received from iface "
                    << soc->hostap_iface;
-        if (m_agent_ucc_listener) {
-            auto msg = beerocks_header->addClass<
-                beerocks_message::cACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
-            if (!msg) {
-                LOG(ERROR)
-                    << "Failed building ACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION message!";
-                return false;
-            }
+        auto msg = beerocks_header->addClass<
+            beerocks_message::cACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION>();
+        if (!msg) {
+            LOG(ERROR) << "Failed parsing BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION message!";
+            return false;
+        }
 
+        m_radio_info_map[msg->ruid()].vaps_list = msg->params();
+        if (m_agent_ucc_listener) {
             m_agent_ucc_listener->update_vaps_list(network_utils::mac_to_string(msg->ruid()),
                                                    msg->params());
-
-            m_radio_info_map[msg->ruid()].vaps_list = msg->params();
         }
         break;
     }

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1956,6 +1956,8 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
         for (const auto &vap : vaps_list.vaps) {
             if (vap.mac == network_utils::ZERO_MAC)
                 continue;
+            if (vap.ssid[0] == '\0')
+                continue;
             auto radio_bss_list           = radio_list->create_radio_bss_list();
             radio_bss_list->radio_bssid() = vap.mac;
             auto ssid =

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -201,6 +201,11 @@ bool ap_wlan_hal_dummy::update_vap_credentials(
         m_radio_info.available_vaps[vap_id++].ssid = bss_info_conf.ssid;
     }
 
+    /* Tear down all other VAPs */
+    while (vap_id < predefined_vaps_num) {
+        m_radio_info.available_vaps[vap_id++].ssid.clear();
+    }
+
     return true;
 }
 

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -297,7 +297,7 @@ bool base_wlan_hal_dummy::refresh_radio_info()
     }
     std::string radio_mac;
     beerocks::net::network_utils::linux_iface_get_mac(m_radio_info.iface_name, radio_mac);
-    for (int vap_id = 0; vap_id < 4; vap_id++) {
+    for (int vap_id = 0; vap_id < predefined_vaps_num; vap_id++) {
         auto mac = beerocks::net::network_utils::mac_from_string(radio_mac);
         mac.oct[5] += vap_id;
         m_radio_info.available_vaps[vap_id].mac = beerocks::net::network_utils::mac_to_string(mac);

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
@@ -75,6 +75,8 @@ protected:
     bool dummy_send_cmd(const std::string &cmd, char **reply); // for external process
     bool dummy_send_cmd(const std::string &cmd);
 
+    static const int predefined_vaps_num = 4;
+
     // Private data-members:
 private:
     const uint32_t AP_ENABELED_TIMEOUT_SEC           = 15;

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -168,6 +168,8 @@ test_ap_config_bss_tear_down() {
     sleep 3
     check_log ${REPEATER1} agent_wlan0 "ssid: Multi-AP-24G-1, .* fronthaul"
     check_log ${REPEATER1} agent_wlan2 "ssid: .* teardown"
+    agent1_wlan0_ssid="$(send_bml_command bml_conn_map | sed -n "/fVAP.*$mac_agent1_wlan0/s/.*ssid: //p")"
+    check [ "$agent1_wlan0_ssid" = "Multi-AP-24G-1" ]
 
     # SSIDs have been removed for the CTT Agent1's front radio
     send_CAPI_command ${GATEWAY} "DEV_SET_CONFIG,bss_info1,$MAC_AGENT1 8x" $redirect
@@ -176,7 +178,9 @@ test_ap_config_bss_tear_down() {
 
     sleep 3
     check_log ${REPEATER1} agent_wlan0 "ssid: .* teardown"
-    
+    agent1_wlan0_ssid="$(send_bml_command bml_conn_map | sed -n "/fVAP.*$mac_agent1_wlan0/s/.*ssid: //p")"
+    check [ "$agent1_wlan0_ssid" = "N/A" ]
+
     return $check_error
 }
 


### PR DESCRIPTION
Fixes #791.

In certification tests, it turns out that the teardown test 4.4.3 fails because the AP Operational BSS TLV is not empty.

First I added a test that the VAP list is updated to test_flows.sh
This uncovered a number of issues.

The first problem is that the VAP list doesn't get updated in dummy when a BSS is torn down.
However, this doesn't affect certification.
It does affect test_flows, so it needed to be fixed.

The second problem is that the VAP list doesn't get updated if there is no UCC listener.
Again, this doesn't affect certification, because in certification mode there *is* a UCC listener.

Finally, the AP Operational BSS TLV contains BSSes even for the VAPs that are torn down.
That is simply fixed by excluding the VAPs with empty SSID.
Unfortunately, I didn't find a way to check this in test_flows.
I use bml_conn_map in test_flows, but that uses a vendor specific message rather than Topology Response.