### PR TITLE
Hotfix/fix dcs get results

### DIFF
--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
@@ -384,11 +384,15 @@ static bool translate_nl_data_to_bwl_results(sChannelScanResults &results,
         results.beacon_period_ms = (unsigned int)nla_get_u16(bss[NL80211_BSS_BEACON_INTERVAL]);
     }
 
-    // get signal strength
+    // get signal strength, signal strength units not specified, scaled to 0-100
     if (bss[NL80211_BSS_SIGNAL_UNSPEC]) {
-        results.signal_strength_dBm = (nla_get_u8(bss[NL80211_BSS_SIGNAL_UNSPEC])) / 100;
+        //signal strength of the probe response/beacon in unspecified units, scaled to 0..100 <u8>
+        results.signal_strength_dBm =
+            int32_t(nla_get_u8(bss[NL80211_BSS_SIGNAL_UNSPEC]));
     } else if (bss[NL80211_BSS_SIGNAL_MBM]) {
-        results.signal_strength_dBm = (nla_get_u32(bss[NL80211_BSS_SIGNAL_MBM])) / 100;
+        //signal strength of probe response/beacon in mBm (100 * dBm) <s32>
+        results.signal_strength_dBm =
+            int32_t(nla_get_u32(bss[NL80211_BSS_SIGNAL_MBM])) / 100;
     }
 
     //get information elements from information-elements-buffer or from beacon

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -1984,7 +1984,7 @@ class cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE : public BaseClass
         uint8_t& op_error_code();
         //0 - Not reached end of response, 1 - reached end of respons
         uint8_t& last();
-        uint32_t& results_size();
+        uint8_t& results_size();
         std::tuple<bool, sChannelScanResults&> results(size_t idx);
         bool alloc_results(size_t count = 1);
         void class_swap() override;
@@ -1997,7 +1997,7 @@ class cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE : public BaseClass
         uint8_t* m_result_status = nullptr;
         uint8_t* m_op_error_code = nullptr;
         uint8_t* m_last = nullptr;
-        uint32_t* m_results_size = nullptr;
+        uint8_t* m_results_size = nullptr;
         sChannelScanResults* m_results = nullptr;
         size_t m_results_idx__ = 0;
         int m_lock_order_counter__ = 0;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -6573,8 +6573,8 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::last() {
     return (uint8_t&)(*m_last);
 }
 
-uint32_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::results_size() {
-    return (uint32_t&)(*m_results_size);
+uint8_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::results_size() {
+    return (uint8_t&)(*m_results_size);
 }
 
 std::tuple<bool, sChannelScanResults&> cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::results(size_t idx) {
@@ -6618,7 +6618,6 @@ bool cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::alloc_results(size_t count) 
 void cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
-    tlvf_swap(32, reinterpret_cast<uint8_t*>(m_results_size));
     for (size_t i = 0; i < (size_t)*m_results_size; i++){
         m_results[i].struct_swap();
     }
@@ -6657,7 +6656,7 @@ size_t cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::get_initial_size()
     class_size += sizeof(uint8_t); // result_status
     class_size += sizeof(uint8_t); // op_error_code
     class_size += sizeof(uint8_t); // last
-    class_size += sizeof(uint32_t); // results_size
+    class_size += sizeof(uint8_t); // results_size
     return class_size;
 }
 
@@ -6682,15 +6681,14 @@ bool cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    m_results_size = (uint32_t*)m_buff_ptr__;
+    m_results_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_results_size = 0;
-    if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
     m_results = (sChannelScanResults*)m_buff_ptr__;
-    uint32_t results_size = *m_results_size;
-    if (m_parse__) {  tlvf_swap(32, reinterpret_cast<uint8_t*>(&results_size)); }
+    uint8_t results_size = *m_results_size;
     m_results_idx__ = results_size;
     if (!buffPtrIncrementSafe(sizeof(sChannelScanResults) * (results_size))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sChannelScanResults) * (results_size) << ") Failed!";

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -430,7 +430,7 @@ cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE:
     _type: uint8_t
     _comment: 0 - Not reached end of response, 1 - reached end of respons
   results_size:
-    _type: uint32_t
+    _type: uint8_t
     _length_var: True
   results:
     _type: sChannelScanResults

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -612,7 +612,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
 }
 
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP *output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan)
 {

--- a/controller/src/beerocks/bml/bml.h
+++ b/controller/src/beerocks/bml/bml.h
@@ -601,7 +601,7 @@ int bml_get_dcs_continuous_scan_params(BML_CTX ctx, const char *radio_mac, int *
  * @return BML_RET_OK on success.
  */
 int bml_get_dcs_scan_results(BML_CTX ctx, const char *radio_mac,
-                             struct BML_NEIGHBOR_AP **output_results,
+                             struct BML_NEIGHBOR_AP *output_results,
                              unsigned int *output_results_size, unsigned char *output_result_status,
                              bool is_single_scan);
 

--- a/controller/src/beerocks/bml/bml_defs.h
+++ b/controller/src/beerocks/bml/bml_defs.h
@@ -555,40 +555,40 @@ struct BML_STATS_ITER {
 };
 
 struct BML_NEIGHBOR_AP {
-    char ap_SSID[BML_SSID_MAX_LENGTH];
     //The current service set identifier in use by the neighboring WiFi SSID. The value MAY be empty for hidden SSIDs.
-    unsigned char ap_BSSID[BML_MAC_ADDR_LEN];
+    char ap_SSID[BML_SSID_MAX_LENGTH];
     //The BSSID used for the neighboring WiFi SSID.
-    uint8_t ap_Mode;
+    uint8_t ap_BSSID[BML_MAC_ADDR_LEN];
     //The mode the neighboring WiFi radio is operating in. Enumerate
-    uint32_t ap_Channel;
+    uint8_t ap_Mode;
     //The current radio channel used by the neighboring WiFi radio.
-    int32_t ap_SignalStrength;
+    uint32_t ap_Channel;
     //An indicator of radio signal strength (RSSI) of the neighboring WiFi radio measured in dBm, as an average of the last 100 packets received.
+    int32_t ap_SignalStrength;
+    //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
     uint8_t ap_SecurityModeEnabled[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
     //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
     uint8_t ap_EncryptionMode[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
-    //The type of encryption the neighboring WiFi SSID advertises. Enumerate List.
-    uint8_t ap_OperatingFrequencyBand;
     //Indicates the frequency band at which the radio this SSID instance is operating. Enumerate
-    uint8_t ap_SupportedStandards[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    uint8_t ap_OperatingFrequencyBand;
     //List items indicate which IEEE 802.11 standards thisResultinstance can support simultaneously, in the frequency band specified byOperatingFrequencyBand. Enumerate List
-    uint8_t ap_OperatingStandards;
+    uint8_t ap_SupportedStandards[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
     //Indicates which IEEE 802.11 standard that is detected for this Result. Enumerate
-    uint8_t ap_OperatingChannelBandwidth;
+    uint8_t ap_OperatingStandards;
     //Indicates the bandwidth at which the channel is operating. Enumerate
-    uint32_t ap_BeaconPeriod;
+    uint8_t ap_OperatingChannelBandwidth;
     //Time interval (inms) between transmitting beacons.
-    int32_t ap_Noise;
+    uint32_t ap_BeaconPeriod;
     //Indicator of average noise strength (indBm) received from the neighboring WiFi radio.
-    uint32_t ap_BasicDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    int32_t ap_Noise;
     //Basic data transmit rates (in Kbps) for the SSID.
-    uint32_t ap_SupportedDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
+    uint32_t ap_BasicDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
     //Data transmit rates (in Kbps) for unicast frames at which the SSID will permit a station to connect.
-    uint32_t ap_DTIMPeriod;
+    uint32_t ap_SupportedDataTransferRates[BML_CHANNEL_SCAN_ENUM_LIST_SIZE];
     //The number of beacon intervals that elapse between transmission of Beacon frames containing a TIM element whose DTIM count field is 0. This value is transmitted in the DTIM Period field of beacon frames. [802.11-2012]
-    uint32_t ap_ChannelUtilization;
+    uint32_t ap_DTIMPeriod;
     //Indicates the fraction of the time AP senses that the channel is in use by the neighboring AP for transmissions.
+    uint32_t ap_ChannelUtilization;
 };
 
 /****************************************************************************/

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -1571,7 +1571,7 @@ int bml_internal::get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP *res
                                        const unsigned int max_results_size, uint8_t &result_status,
                                        bool is_single_scan)
 {
-    if (!results || !results_size || !result_status) {
+    if (!results || max_results_size == 0) {
         LOG(ERROR) << "Function is called, but no data is being requested!";
         return (-BML_RET_INVALID_DATA);
     }

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -1566,7 +1566,7 @@ int bml_internal::get_dcs_continuous_scan_params(const sMacAddr &mac, int *dwell
     return (iRet);
 }
 
-int bml_internal::get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **results,
+int bml_internal::get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP *results,
                                        unsigned int &results_size,
                                        const unsigned int max_results_size, uint8_t &result_status,
                                        bool is_single_scan)
@@ -1645,7 +1645,7 @@ int bml_internal::get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **re
     //output_results_size will be set to the number of actual returning results
     results_size = 0;
     for (auto &res : scan_results) {
-        auto &out = ((*results)[results_size]);
+        auto &out = results[results_size];
         translate_channel_scan_results(res, out);
         results_size += 1;
     }

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -211,7 +211,7 @@ public:
     * 
     * @return BML_RET_OK on success.
     */
-    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP **results,
+    int get_dcs_scan_results(const sMacAddr &mac, BML_NEIGHBOR_AP *results,
                              unsigned int &results_size, const unsigned int max_results_size,
                              uint8_t &result_status, bool is_single_scan);
 

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -2024,10 +2024,10 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
                 auto res = results[i];
                 std::cout << "result[" << i << "]:" << std::endl
                           << "  ssid=" << res.ap_SSID << std::endl
-                          << "  bssid=" << res.ap_BSSID << std::endl
+                          << "  bssid=" << network_utils::mac_to_string(res.ap_BSSID) << std::endl
                           << "  mode=" << int(res.ap_Mode) << std::endl
                           << "  channel=" << int(res.ap_Channel) << std::endl
-                          << "  signal_strength=" << int(res.ap_SignalStrength) << std::endl
+                          << "  signal_strength_dbm=" << res.ap_SignalStrength << std::endl
                           << "  security_mode_enabled="
                           << string_from_int_array(res.ap_SecurityModeEnabled,
                                                    BML_CHANNEL_SCAN_ENUM_LIST_SIZE)
@@ -2036,27 +2036,27 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
                           << string_from_int_array(res.ap_EncryptionMode,
                                                    BML_CHANNEL_SCAN_ENUM_LIST_SIZE)
                           << std::endl
-                          << "  operating_frequency_band=" << res.ap_OperatingFrequencyBand
+                          << "  operating_frequency_band=" << int(res.ap_OperatingFrequencyBand)
                           << std::endl
                           << "  supported_standards="
                           << string_from_int_array(res.ap_SupportedStandards,
                                                    BML_CHANNEL_SCAN_ENUM_LIST_SIZE)
                           << std::endl
-                          << "  operating_standards=" << res.ap_OperatingStandards << std::endl
-                          << "  operating_channel_bandwidth=" << res.ap_OperatingChannelBandwidth
-                          << std::endl
-                          << "  beacon_period=" << (int)res.ap_BeaconPeriod << std::endl
-                          << "  noise=" << (int)res.ap_Noise << std::endl
-                          << "  basic_data_transfer_rates="
+                          << "  operating_standards=" << int(res.ap_OperatingStandards) << std::endl
+                          << "  operating_channel_bandwidth="
+                          << int(res.ap_OperatingChannelBandwidth) << std::endl
+                          << "  beacon_period_ms=" << int(res.ap_BeaconPeriod) << std::endl
+                          << "  noise_dbm=" << int(res.ap_Noise) << std::endl
+                          << "  basic_data_transfer_rates_kbps="
                           << string_from_int_array(res.ap_BasicDataTransferRates,
                                                    BML_CHANNEL_SCAN_ENUM_LIST_SIZE)
                           << std::endl
-                          << "  supported_data_transfer_rates="
+                          << "  supported_data_transfer_rates_kbps="
                           << string_from_int_array(res.ap_SupportedDataTransferRates,
                                                    BML_CHANNEL_SCAN_ENUM_LIST_SIZE)
                           << std::endl
-                          << "  dtim_period=" << (int)res.ap_DTIMPeriod << std::endl
-                          << "  channel_utilization=" << (int)res.ap_ChannelUtilization
+                          << "  dtim_period=" << int(res.ap_DTIMPeriod) << std::endl
+                          << "  channel_utilization=" << int(res.ap_ChannelUtilization)
                           << std::endl;
             }
         }

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -2019,13 +2019,12 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
         return -1;
     }
 
-    BML_NEIGHBOR_AP results[max_results_size] = {0};
+    BML_NEIGHBOR_AP results[max_results_size];
 
     uint8_t status             = 0;
     unsigned int results_count = max_results_size;
-    int ret                    = bml_get_dcs_scan_results(ctx, radio_mac.c_str(),
-                                       reinterpret_cast<BML_NEIGHBOR_AP **>(&results),
-                                       &results_count, &status, is_single_scan);
+    int ret                    = bml_get_dcs_scan_results(ctx, radio_mac.c_str(), results,
+                                                          &results_count, &status, is_single_scan);
 
     if (ret == BML_RET_OK) {
         if (results_count > max_results_size) {

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -24,17 +24,6 @@ using namespace net;
 /////////////////////////// Local Module Functions ///////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-static const std::string string_from_int_array(void *arr, size_t arr_max_size)
-{
-    std::stringstream ss;
-    if (arr) {
-        for (size_t i = 0; i < arr_max_size; i++) {
-            ss << ((i != 0) ? ", " : "") << int(static_cast<int *>(arr)[i]);
-        }
-    }
-    return ss.str();
-}
-
 static void fill_conn_map_node(
     std::unordered_multimap<std::string, std::shared_ptr<cli_bml::conn_map_node_t>> &conn_map_nodes,
     struct BML_NODE *node)
@@ -2075,4 +2064,16 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
     printBmlReturnVals("bml_get_dcs_scan_results", ret);
 
     return 0;
+}
+
+template <typename T>
+const std::string cli_bml::string_from_int_array(T *arr, size_t arr_max_size)
+{
+    std::stringstream ss;
+    if (arr) {
+        for (size_t i = 0; i < arr_max_size; i++) {
+            ss << ((i != 0) ? ", " : "") << (unsigned int)(arr[i]);
+        }
+    }
+    return ss.str();
 }

--- a/controller/src/beerocks/cli/beerocks_cli_bml.h
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.h
@@ -205,6 +205,8 @@ private:
                               const std::string &channel_pool);
     int get_dcs_scan_results(const std::string &radio_mac, uint32_t max_results_size,
                              bool is_single_scan = false);
+    template <typename T>
+    const std::string string_from_int_array(T *arr, size_t arr_max_size);
     // Variable
     std::string beerocks_conf_path;
     BML_CTX ctx = nullptr;


### PR DESCRIPTION
**To be merged after #807**

all DCS code has been ported #562 
DCS Validation has been started on both RDKB/UGW platforms.

This PR is used to fix an issue with the DCS feature's "get results" flow
This PR contains:
- a fix to the bml message results_size variable
- changes to the get results flow in the son_management
- extended logs in bml_internal
- fix casting error in bml_internal
- fix validation error in bml_internal