### PR TITLE
controller: Fix unmonitored client issue

### DIFF
--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -294,6 +294,12 @@ void son_actions::handle_dead_node(std::string mac, std::string hostap_mac, db &
 
         const auto parent_radio = database.get_node_parent_radio(hostap_mac);
         son_actions::send_cmdu_to_agent(agent_mac, cmdu_tx, database, parent_radio);
+
+        // If there is running association handleing task already, terminate it.
+        int prev_task_id = database.get_association_handling_task_id(mac);
+        if (tasks.is_task_running(prev_task_id)) {
+            tasks.kill_task(prev_task_id);
+        }
     }
     if (parent_hostap_mac == hostap_mac) {
         if (mac_type == beerocks::TYPE_IRE_BACKHAUL || mac_type == beerocks::TYPE_CLIENT) {


### PR DESCRIPTION
Currently, if a client gets connected, an association handling task starts running.
While it runs the client can disconnect and connect again before the the
the task has finished.
On disconnect, the controller shut down the monitoring, and on connection
it runs the association handling task which starts the monitoring.
But if a task is already running, the new task will immediately finish, and
the client will stay unmonitored.
To solve it, kill any running association handling tasks on a client when
it disconnects. That way, it is promised that any task that will be triggered
after disconnect and connect event, will keep running.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>