### PR TITLE
common: prplmesh_utils.sh: monitor the agents and controller

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -141,6 +141,27 @@ prplmesh_delete_logs() {
     rm -rf /tmp/${SUDO_USER:-${USER}}/beerocks/logs
 }
 
+prplmesh_watchdog() {
+    # Store PIDs of the Controller and Agents
+    local CURR_PIDS="$(pgrep 'beerocks_(agent|controller)' | wc -l)"
+    local PREV_PIDS="$CURR_PIDS"
+
+    # Make sure there's at least one PID to monitor
+    if [ -z "$CURR_PIDS" ]; then
+        echo "No controller or agent processes found."
+        return
+    fi
+
+    # Monitor the number of running processes
+    while [ $CURR_PIDS -ge $PREV_PIDS ]; do
+        sleep 1
+        CURR_PIDS="$(pgrep 'beerocks_(agent|controller)' | wc -l)"
+        if [ $CURR_PIDS -gt $PREV_PIDS ]; then
+            PREV_PIDS=$CURR_PIDS
+        fi
+    done
+}
+
 roll_logs_function()
 {
     ROLL_PROGRESS_DIR="roll_in_progress.lock"
@@ -315,7 +336,8 @@ main() {
             ;;
         "start_wait")
             start_function
-            wait -n
+            prplmesh_watchdog
+            stop_function
             ;;
         "stop")
             stop_function

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -131,6 +131,7 @@ prplmesh_agent_start() {
 prplmesh_agent_stop() {
     echo "prplmesh_agent_stop - stopping beerocks_agent process..."
     killall_program beerocks_agent
+    killall_program beerocks_monitor
 }
 
 prplmesh_delete_logs() {


### PR DESCRIPTION
On UGW we see multiple beerocks process instances due to 'wait -n'
not working properly and causing prplmesh_utils.sh to exit even if
all beerocks processes are still running.
The 'procd' service, which expects the prplmesh_utils.sh start_wait
command o wait until some failure causes an exit, restarts the
prplmesh_utils.sh which created new instances of the beerocks processes.

Changed the way the start_wait waits for the beerocks_agent and
beerocks_controller processes. If a process crashed, stop_function is
called.