### PR TITLE
Fix several problems with the Device Information TLV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ elseif (TARGET_PLATFORM STREQUAL "rdkb")
     set(CMAKE_SKIP_RPATH TRUE)
 elseif (TARGET_PLATFORM STREQUAL "linux")
     add_definitions(-DBEEROCKS_LINUX)
-    set(BEEROCKS_BH_WIRE_IFACE "sim-eth0")
+    set(BEEROCKS_BH_WIRE_IFACE "eth0")
 endif()
 
 ## Components

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1882,7 +1882,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
      * to IEEE_1905 section 6.4.5
      */
     uint32_t speed;
-    if (network_utils::linux_iface_get_speed(bridge_info.iface, speed)) {
+    if (network_utils::linux_iface_get_speed(m_sConfig.wire_iface, speed)) {
         std::shared_ptr<ieee1905_1::cLocalInterfaceInfo> localInterfaceInfo =
             tlvDeviceInformation->create_local_interface_list();
 
@@ -1893,7 +1893,10 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
             media_type = ieee1905_1::eMediaType::IEEE_802_3AB_GIGABIT_ETHERNET;
         }
 
-        localInterfaceInfo->mac()               = network_utils::mac_from_string(bridge_info.mac);
+        // default to zero mac if get_mac fails.
+        std::string wire_iface_mac = network_utils::ZERO_MAC_STRING;
+        network_utils::linux_iface_get_mac(m_sConfig.wire_iface, wire_iface_mac);
+        localInterfaceInfo->mac()               = network_utils::mac_from_string(wire_iface_mac);
         localInterfaceInfo->media_type()        = media_type;
         localInterfaceInfo->media_info_length() = 0;
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1889,7 +1889,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
         ieee1905_1::eMediaType media_type = ieee1905_1::eMediaType::UNKNONWN_MEDIA;
         if (SPEED_100 == speed) {
             media_type = ieee1905_1::eMediaType::IEEE_802_3U_FAST_ETHERNET;
-        } else if (SPEED_1000 == speed) {
+        } else if (SPEED_1000 <= speed) {
             media_type = ieee1905_1::eMediaType::IEEE_802_3AB_GIGABIT_ETHERNET;
         }
 

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -48,12 +48,11 @@ platform_init() {
     control_ip=192.168.250.140
     
     ip link add @BEEROCKS_BRIDGE_IFACE@ address "${base_mac}:00:00" type bridge
-    ip link add @BEEROCKS_BH_WIRE_IFACE@ type dummy
     ip link add wlan0 address "${base_mac}:00:10" type dummy
     ip link add wlan2 address "${base_mac}:00:20" type dummy
     ip link set dev wlan0 up
     ip link set dev wlan2 up
-    for iface in wlan0 wlan2 @BEEROCKS_BH_WIRE_IFACE@ $DATA_IFACE
+    for iface in wlan0 wlan2 $DATA_IFACE
     do
         echo "add $iface to @BEEROCKS_BRIDGE_IFACE@"
         nmcli d set "$iface" managed no
@@ -69,7 +68,7 @@ platform_deinit() {
     echo "platform deinit"
     [ -z "$DATA_IFACE" ] && err "DATA_IFACE not set, abort" && exit 1
     [ -z "$CONTROL_IFACE" ] && err "CONTROL_IFACE not set, abort" && exit 1
-    for iface in wlan0 wlan2 @BEEROCKS_BH_WIRE_IFACE@ $DATA_IFACE
+    for iface in wlan0 wlan2 $DATA_IFACE
     do
         echo "remove $iface from @BEEROCKS_BRIDGE_IFACE@"
         ip link set dev "$iface" nomaster
@@ -77,7 +76,6 @@ platform_deinit() {
     done
     ip link del wlan0
     ip link del wlan2
-    ip link del @BEEROCKS_BH_WIRE_IFACE@
     ip link del @BEEROCKS_BRIDGE_IFACE@
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -856,6 +856,7 @@ typedef struct sWifiCredentials {
     uint8_t force;
     uint8_t radio_dir;
     void struct_swap(){
+        tlvf_swap(8*sizeof(eWiFiSec), reinterpret_cast<uint8_t*>(&wifi_sec));
     }
     void struct_init(){
     }
@@ -1133,6 +1134,8 @@ typedef struct sSteeringEvDisconnect {
         client_mac.struct_swap();
         bssid.struct_swap();
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&reason));
+        tlvf_swap(8*sizeof(eDisconnectSource), reinterpret_cast<uint8_t*>(&source));
+        tlvf_swap(8*sizeof(eDisconnectType), reinterpret_cast<uint8_t*>(&type));
     }
     void struct_init(){
         client_mac.struct_init();
@@ -1165,6 +1168,9 @@ typedef struct sSteeringEvSnrXing {
         client_mac.struct_swap();
         bssid.struct_swap();
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&snr));
+        tlvf_swap(8*sizeof(eSteeringSnrChange), reinterpret_cast<uint8_t*>(&inactveXing));
+        tlvf_swap(8*sizeof(eSteeringSnrChange), reinterpret_cast<uint8_t*>(&highXing));
+        tlvf_swap(8*sizeof(eSteeringSnrChange), reinterpret_cast<uint8_t*>(&lowXing));
     }
     void struct_init(){
         client_mac.struct_init();

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_1905_vs.cpp
@@ -55,6 +55,7 @@ uint8_t& tlvVsClientAssociationEvent::disconnect_type() {
 
 void tlvVsClientAssociationEvent::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_1905_VS), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_bssid->struct_swap();
     m_capabilities->struct_swap();

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -35,6 +35,7 @@ sMacAddr& cACTION_APMANAGER_4ADDR_STA_JOINED::dst_mac() {
 
 void cACTION_APMANAGER_4ADDR_STA_JOINED::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_src_mac->struct_swap();
     m_dst_mac->struct_swap();
 }
@@ -116,6 +117,7 @@ sApChannelSwitch& cACTION_APMANAGER_JOINED_NOTIFICATION::cs_params() {
 
 void cACTION_APMANAGER_JOINED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
     m_cs_params->struct_swap();
 }
@@ -201,6 +203,7 @@ uint8_t& cACTION_APMANAGER_ENABLE_APS_REQUEST::center_channel() {
 
 void cACTION_APMANAGER_ENABLE_APS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_bandwidth));
 }
 
@@ -281,6 +284,7 @@ uint8_t& cACTION_APMANAGER_ENABLE_APS_RESPONSE::success() {
 
 void cACTION_APMANAGER_ENABLE_APS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_ENABLE_APS_RESPONSE::finalize()
@@ -344,6 +348,7 @@ cACTION_APMANAGER_INIT_DONE_NOTIFICATION::~cACTION_APMANAGER_INIT_DONE_NOTIFICAT
 }
 void cACTION_APMANAGER_INIT_DONE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_INIT_DONE_NOTIFICATION::finalize()
@@ -405,6 +410,7 @@ sApSetRestrictedFailsafe& cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANN
 
 void cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -474,6 +480,7 @@ uint8_t& cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::succ
 
 void cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::finalize()
@@ -541,6 +548,7 @@ int8_t& cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::vap_id() {
 
 void cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_HOSTAP_AP_DISABLED_NOTIFICATION::finalize()
@@ -612,6 +620,7 @@ sVapInfo& cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::vap_info() {
 
 void cACTION_APMANAGER_HOSTAP_AP_ENABLED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_vap_info->struct_swap();
 }
 
@@ -683,6 +692,7 @@ cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::~cACTION_APMANAGER_HOSTAP_VAP
 }
 void cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_REQUEST::finalize()
@@ -740,6 +750,7 @@ cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::~cAC
 }
 void cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_HOSTAP_GENERATE_CLIENT_ASSOCIATION_NOTIFICATIONS_REQUEST::finalize()
@@ -801,6 +812,7 @@ sVapsList& cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::params() {
 
 void cACTION_APMANAGER_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -870,6 +882,7 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::cs_params()
 
 void cACTION_APMANAGER_HOSTAP_CHANNEL_SWITCH_ACS_START::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -939,6 +952,7 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::cs_params() {
 
 void cACTION_APMANAGER_HOSTAP_CSA_ERROR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -1008,6 +1022,7 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::cs_params() {
 
 void cACTION_APMANAGER_HOSTAP_CSA_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -1077,6 +1092,7 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::cs_params() {
 
 void cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -1155,6 +1171,7 @@ std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_
 
 void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
         m_supported_channels_list[i].struct_swap();
@@ -1237,6 +1254,7 @@ sDfsCacCompleted& cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::param
 
 void cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1306,6 +1324,7 @@ sDfsChannelAvailable& cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATIO
 
 void cACTION_APMANAGER_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1375,6 +1394,7 @@ sMacAddr& cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::mac() {
 
 void cACTION_APMANAGER_HOSTAP_ADD_4ADDR_STA_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1444,6 +1464,7 @@ sMacAddr& cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::mac() {
 
 void cACTION_APMANAGER_HOSTAP_DEL_4ADDR_STA_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1513,6 +1534,7 @@ sNeighborSetParams11k& cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::params
 
 void cACTION_APMANAGER_HOSTAP_SET_NEIGHBOR_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1582,6 +1604,7 @@ sNeighborRemoveParams11k& cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::
 
 void cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1651,6 +1674,7 @@ sClientAssociationParams& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::para
 
 void cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1720,6 +1744,7 @@ sClientDisconnectionParams& cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::
 
 void cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1801,7 +1826,9 @@ uint32_t& cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::reason() {
 
 void cACTION_APMANAGER_CLIENT_DISCONNECT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
+    tlvf_swap(8*sizeof(eDisconnectType), reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_reason));
 }
 
@@ -1889,6 +1916,7 @@ sClientDisconnectResponse& cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::params(
 
 void cACTION_APMANAGER_CLIENT_DISCONNECT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1962,6 +1990,7 @@ sMacAddr& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::bssid() {
 
 void cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_bssid->struct_swap();
 }
@@ -2043,6 +2072,7 @@ sMacAddr& cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::bssid() {
 
 void cACTION_APMANAGER_CLIENT_ALLOW_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_bssid->struct_swap();
 }
@@ -2120,6 +2150,7 @@ sNodeRssiMeasurementRequest& cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUES
 
 void cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2189,6 +2220,7 @@ sNodeRssiMeasurement& cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::par
 
 void cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2258,6 +2290,7 @@ sMacAddr& cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::mac() {
 
 void cACTION_APMANAGER_CLIENT_IRE_CONNECTED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -2331,6 +2364,7 @@ sMacAddr& cACTION_APMANAGER_ACK::sta_mac() {
 
 void cACTION_APMANAGER_ACK::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_sta_mac->struct_swap();
 }
 
@@ -2406,6 +2440,7 @@ sNodeBssSteerRequest& cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::params() {
 
 void cACTION_APMANAGER_CLIENT_BSS_STEER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2475,6 +2510,7 @@ sNodeBssSteerResponse& cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::params() {
 
 void cACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2544,6 +2580,7 @@ sMacAddr& cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
 
 void cACTION_APMANAGER_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -2613,6 +2650,7 @@ sSteeringClientSetRequest& cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::params
 
 void cACTION_APMANAGER_STEERING_CLIENT_SET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2682,6 +2720,7 @@ sSteeringClientSetResponse& cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::para
 
 void cACTION_APMANAGER_STEERING_CLIENT_SET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2751,6 +2790,7 @@ sSteeringEvProbeReq& cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::pa
 
 void cACTION_APMANAGER_STEERING_EVENT_PROBE_REQ_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2820,6 +2860,7 @@ sSteeringEvAuthFail& cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::pa
 
 void cACTION_APMANAGER_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2955,6 +2996,7 @@ bool cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::add_wifi_credentials(std
 
 void cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     for (size_t i = 0; i < (size_t)*m_wifi_credentials_size; i++){
         std::get<1>(wifi_credentials(i)).class_swap();
     }
@@ -3038,6 +3080,7 @@ cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::~cACTION_APMANAGER_HEARTBEAT_NOTIFICAT
 }
 void cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_HEARTBEAT_NOTIFICATION::finalize()
@@ -3095,6 +3138,7 @@ cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::~cACTION_APMANAGER_READ_ACS_REPORT_RE
 }
 void cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_APMANAGER_READ_ACS_REPORT_REQUEST::finalize()
@@ -3161,6 +3205,7 @@ std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_RE
 
 void cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
         m_supported_channels_list[i].struct_swap();
     }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -105,6 +105,7 @@ uint8_t& cACTION_BACKHAUL_REGISTER_REQUEST::certification_mode() {
 
 void cACTION_BACKHAUL_REGISTER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_ruid->struct_swap();
 }
 
@@ -218,6 +219,7 @@ uint8_t& cACTION_BACKHAUL_REGISTER_RESPONSE::is_backhaul_manager() {
 
 void cACTION_BACKHAUL_REGISTER_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BACKHAUL_REGISTER_RESPONSE::finalize()
@@ -281,6 +283,7 @@ cACTION_BACKHAUL_BUSY_NOTIFICATION::~cACTION_BACKHAUL_BUSY_NOTIFICATION() {
 }
 void cACTION_BACKHAUL_BUSY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BACKHAUL_BUSY_NOTIFICATION::finalize()
@@ -514,6 +517,7 @@ std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::supp
 
 void cACTION_BACKHAUL_ENABLE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_iface_mac->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_security_type));
     m_preferred_bssid->struct_swap();
@@ -676,6 +680,7 @@ sBackhaulParams& cACTION_BACKHAUL_CONNECTED_NOTIFICATION::params() {
 
 void cACTION_BACKHAUL_CONNECTED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -745,6 +750,7 @@ uint8_t& cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::stopped() {
 
 void cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BACKHAUL_DISCONNECTED_NOTIFICATION::finalize()
@@ -820,6 +826,7 @@ uint8_t& cACTION_BACKHAUL_ENABLE_APS_REQUEST::center_channel() {
 
 void cACTION_BACKHAUL_ENABLE_APS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_bandwidth));
 }
 
@@ -900,6 +907,7 @@ sBackhaulRoam& cACTION_BACKHAUL_ROAM_REQUEST::params() {
 
 void cACTION_BACKHAUL_ROAM_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -969,6 +977,7 @@ uint8_t& cACTION_BACKHAUL_ROAM_RESPONSE::connected() {
 
 void cACTION_BACKHAUL_ROAM_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BACKHAUL_ROAM_RESPONSE::finalize()
@@ -1032,6 +1041,7 @@ cACTION_BACKHAUL_RESET::~cACTION_BACKHAUL_RESET() {
 }
 void cACTION_BACKHAUL_RESET::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BACKHAUL_RESET::finalize()
@@ -1093,6 +1103,7 @@ sMacAddr& cACTION_BACKHAUL_4ADDR_CONNECTED::mac() {
 
 void cACTION_BACKHAUL_4ADDR_CONNECTED::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1162,6 +1173,7 @@ sBackhaulRssi& cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::params() {
 
 void cACTION_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1231,6 +1243,7 @@ uint32_t& cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::attempts() {
 
 void cACTION_BACKHAUL_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_attempts));
 }
 
@@ -1295,6 +1308,7 @@ cACTION_BACKHAUL_ONBOARDING_FINISHED_NOTIFICATION::~cACTION_BACKHAUL_ONBOARDING_
 }
 void cACTION_BACKHAUL_ONBOARDING_FINISHED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BACKHAUL_ONBOARDING_FINISHED_NOTIFICATION::finalize()
@@ -1356,6 +1370,7 @@ sNodeRssiMeasurementRequest& cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST
 
 void cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1425,6 +1440,7 @@ sNodeRssiMeasurement& cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::para
 
 void cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1494,6 +1510,7 @@ sMacAddr& cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
 
 void cACTION_BACKHAUL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1567,6 +1584,7 @@ sVapsList& cACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::params() {
 
 void cACTION_BACKHAUL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_ruid->struct_swap();
     m_params->struct_swap();
 }
@@ -1652,6 +1670,7 @@ sMacAddr& cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::bssid() {
 
 void cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_iface_mac->struct_swap();
     m_client_mac->struct_swap();
     m_bssid->struct_swap();
@@ -1745,6 +1764,7 @@ sMacAddr& cACTION_BACKHAUL_CLIENT_DISCONNECTED_NOTIFICATION::bssid() {
 
 void cACTION_BACKHAUL_CLIENT_DISCONNECTED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     m_iface_mac->struct_swap();
     m_client_mac->struct_swap();
     m_bssid->struct_swap();

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -27,6 +27,7 @@ cACTION_BML_PING_REQUEST::~cACTION_BML_PING_REQUEST() {
 }
 void cACTION_BML_PING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_PING_REQUEST::finalize()
@@ -84,6 +85,7 @@ cACTION_BML_PING_RESPONSE::~cACTION_BML_PING_RESPONSE() {
 }
 void cACTION_BML_PING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_PING_RESPONSE::finalize()
@@ -141,6 +143,7 @@ cACTION_BML_NW_MAP_REQUEST::~cACTION_BML_NW_MAP_REQUEST() {
 }
 void cACTION_BML_NW_MAP_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_NW_MAP_REQUEST::finalize()
@@ -256,6 +259,7 @@ bool cACTION_BML_NW_MAP_RESPONSE::alloc_buffer(size_t count) {
 
 void cACTION_BML_NW_MAP_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_node_num));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_buffer_size));
 }
@@ -394,6 +398,7 @@ bool cACTION_BML_NW_MAP_UPDATE::alloc_buffer(size_t count) {
 
 void cACTION_BML_NW_MAP_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_node_num));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_buffer_size));
 }
@@ -532,6 +537,7 @@ bool cACTION_BML_STATS_UPDATE::alloc_buffer(size_t count) {
 
 void cACTION_BML_STATS_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_num_of_stats_bulks));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_buffer_size));
 }
@@ -666,6 +672,7 @@ bool cACTION_BML_EVENTS_UPDATE::alloc_buffer(size_t count) {
 
 void cACTION_BML_EVENTS_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_buffer_size));
 }
 
@@ -739,6 +746,7 @@ cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::~cACTION_BML_REGISTER_TO_NW_MAP_
 }
 void cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_REQUEST::finalize()
@@ -796,6 +804,7 @@ cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::~cACTION_BML_REGISTER_TO_NW_MAP
 }
 void cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_REGISTER_TO_NW_MAP_UPDATES_RESPONSE::finalize()
@@ -853,6 +862,7 @@ cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::~cACTION_BML_UNREGISTER_FROM
 }
 void cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_REQUEST::finalize()
@@ -910,6 +920,7 @@ cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::~cACTION_BML_UNREGISTER_FRO
 }
 void cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_UNREGISTER_FROM_NW_MAP_UPDATES_RESPONSE::finalize()
@@ -967,6 +978,7 @@ cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::~cACTION_BML_SET_LEGACY_CLIENT_R
 }
 void cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_RESPONSE::finalize()
@@ -1024,6 +1036,7 @@ cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::~cACTION_BML_GET_LEGACY_CLIENT_RO
 }
 void cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_REQUEST::finalize()
@@ -1081,6 +1094,7 @@ cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::~cACTION_BML_REGISTER_TO_EVENTS_
 }
 void cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_REQUEST::finalize()
@@ -1138,6 +1152,7 @@ cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::~cACTION_BML_REGISTER_TO_EVENTS
 }
 void cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_REGISTER_TO_EVENTS_UPDATES_RESPONSE::finalize()
@@ -1195,6 +1210,7 @@ cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::~cACTION_BML_UNREGISTER_FROM
 }
 void cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_REQUEST::finalize()
@@ -1252,6 +1268,7 @@ cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::~cACTION_BML_UNREGISTER_FRO
 }
 void cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_UNREGISTER_FROM_EVENTS_UPDATES_RESPONSE::finalize()
@@ -1309,6 +1326,7 @@ cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::~cACTION_BML_REGISTER_TO_STATS_UP
 }
 void cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_REGISTER_TO_STATS_UPDATES_REQUEST::finalize()
@@ -1366,6 +1384,7 @@ cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::~cACTION_BML_REGISTER_TO_STATS_U
 }
 void cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_REGISTER_TO_STATS_UPDATES_RESPONSE::finalize()
@@ -1423,6 +1442,7 @@ cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::~cACTION_BML_UNREGISTER_FROM_
 }
 void cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_REQUEST::finalize()
@@ -1480,6 +1500,7 @@ cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::~cACTION_BML_UNREGISTER_FROM
 }
 void cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_UNREGISTER_FROM_STATS_UPDATES_RESPONSE::finalize()
@@ -1541,6 +1562,7 @@ uint8_t& cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::isEnable() {
 
 void cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_LEGACY_CLIENT_ROAMING_REQUEST::finalize()
@@ -1608,6 +1630,7 @@ uint8_t& cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_LEGACY_CLIENT_ROAMING_RESPONSE::finalize()
@@ -1675,6 +1698,7 @@ uint8_t& cACTION_BML_SET_CLIENT_ROAMING_REQUEST::isEnable() {
 
 void cACTION_BML_SET_CLIENT_ROAMING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CLIENT_ROAMING_REQUEST::finalize()
@@ -1738,6 +1762,7 @@ cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::~cACTION_BML_SET_CLIENT_ROAMING_RESPONS
 }
 void cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CLIENT_ROAMING_RESPONSE::finalize()
@@ -1795,6 +1820,7 @@ cACTION_BML_GET_CLIENT_ROAMING_REQUEST::~cACTION_BML_GET_CLIENT_ROAMING_REQUEST(
 }
 void cACTION_BML_GET_CLIENT_ROAMING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CLIENT_ROAMING_REQUEST::finalize()
@@ -1856,6 +1882,7 @@ uint8_t& cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CLIENT_ROAMING_RESPONSE::finalize()
@@ -1923,6 +1950,7 @@ uint8_t& cACTION_BML_SET_DFS_REENTRY_REQUEST::isEnable() {
 
 void cACTION_BML_SET_DFS_REENTRY_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_DFS_REENTRY_REQUEST::finalize()
@@ -1986,6 +2014,7 @@ cACTION_BML_SET_DFS_REENTRY_RESPONSE::~cACTION_BML_SET_DFS_REENTRY_RESPONSE() {
 }
 void cACTION_BML_SET_DFS_REENTRY_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_DFS_REENTRY_RESPONSE::finalize()
@@ -2043,6 +2072,7 @@ cACTION_BML_GET_DFS_REENTRY_REQUEST::~cACTION_BML_GET_DFS_REENTRY_REQUEST() {
 }
 void cACTION_BML_GET_DFS_REENTRY_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_DFS_REENTRY_REQUEST::finalize()
@@ -2104,6 +2134,7 @@ uint8_t& cACTION_BML_GET_DFS_REENTRY_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_DFS_REENTRY_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_DFS_REENTRY_RESPONSE::finalize()
@@ -2171,6 +2202,7 @@ uint8_t& cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::isEnable
 
 void cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::finalize()
@@ -2234,6 +2266,7 @@ cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::~cACTION_BML_SET
 }
 void cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::finalize()
@@ -2291,6 +2324,7 @@ cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::~cACTION_BML_GET_
 }
 void cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_REQUEST::finalize()
@@ -2352,6 +2386,7 @@ uint8_t& cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::isEnabl
 
 void cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CLIENT_ROAMING_PREFER_SIGNAL_STRENGTH_RESPONSE::finalize()
@@ -2419,6 +2454,7 @@ uint8_t& cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::isEnable() {
 
 void cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CLIENT_BAND_STEERING_REQUEST::finalize()
@@ -2482,6 +2518,7 @@ cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::~cACTION_BML_SET_CLIENT_BAND_STEE
 }
 void cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CLIENT_BAND_STEERING_RESPONSE::finalize()
@@ -2539,6 +2576,7 @@ cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::~cACTION_BML_GET_CLIENT_BAND_STEER
 }
 void cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CLIENT_BAND_STEERING_REQUEST::finalize()
@@ -2600,6 +2638,7 @@ uint8_t& cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CLIENT_BAND_STEERING_RESPONSE::finalize()
@@ -2667,6 +2706,7 @@ uint8_t& cACTION_BML_SET_IRE_ROAMING_REQUEST::isEnable() {
 
 void cACTION_BML_SET_IRE_ROAMING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_IRE_ROAMING_REQUEST::finalize()
@@ -2730,6 +2770,7 @@ cACTION_BML_SET_IRE_ROAMING_RESPONSE::~cACTION_BML_SET_IRE_ROAMING_RESPONSE() {
 }
 void cACTION_BML_SET_IRE_ROAMING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_IRE_ROAMING_RESPONSE::finalize()
@@ -2787,6 +2828,7 @@ cACTION_BML_GET_IRE_ROAMING_REQUEST::~cACTION_BML_GET_IRE_ROAMING_REQUEST() {
 }
 void cACTION_BML_GET_IRE_ROAMING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_IRE_ROAMING_REQUEST::finalize()
@@ -2848,6 +2890,7 @@ uint8_t& cACTION_BML_GET_IRE_ROAMING_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_IRE_ROAMING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_IRE_ROAMING_RESPONSE::finalize()
@@ -2915,6 +2958,7 @@ uint8_t& cACTION_BML_SET_LOAD_BALANCER_REQUEST::isEnable() {
 
 void cACTION_BML_SET_LOAD_BALANCER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_LOAD_BALANCER_REQUEST::finalize()
@@ -2978,6 +3022,7 @@ cACTION_BML_SET_LOAD_BALANCER_RESPONSE::~cACTION_BML_SET_LOAD_BALANCER_RESPONSE(
 }
 void cACTION_BML_SET_LOAD_BALANCER_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_LOAD_BALANCER_RESPONSE::finalize()
@@ -3035,6 +3080,7 @@ cACTION_BML_GET_LOAD_BALANCER_REQUEST::~cACTION_BML_GET_LOAD_BALANCER_REQUEST() 
 }
 void cACTION_BML_GET_LOAD_BALANCER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_LOAD_BALANCER_REQUEST::finalize()
@@ -3096,6 +3142,7 @@ uint8_t& cACTION_BML_GET_LOAD_BALANCER_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_LOAD_BALANCER_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_LOAD_BALANCER_RESPONSE::finalize()
@@ -3163,6 +3210,7 @@ uint8_t& cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::isEnable() {
 
 void cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_SERVICE_FAIRNESS_REQUEST::finalize()
@@ -3226,6 +3274,7 @@ cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::~cACTION_BML_SET_SERVICE_FAIRNESS_RES
 }
 void cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_SERVICE_FAIRNESS_RESPONSE::finalize()
@@ -3283,6 +3332,7 @@ cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::~cACTION_BML_GET_SERVICE_FAIRNESS_REQU
 }
 void cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_SERVICE_FAIRNESS_REQUEST::finalize()
@@ -3344,6 +3394,7 @@ uint8_t& cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_SERVICE_FAIRNESS_RESPONSE::finalize()
@@ -3411,6 +3462,7 @@ sLoggingLevelChange& cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::params() {
 
 void cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3476,6 +3528,7 @@ cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::~cACTION_BML_CHANGE_MODULE_LOG
 }
 void cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE::finalize()
@@ -3537,6 +3590,7 @@ sWifiCredentials& cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::params() {
 
 void cACTION_BML_WIFI_CREDENTIALS_UPDATE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3606,6 +3660,7 @@ uint32_t& cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::error_code() {
 
 void cACTION_BML_WIFI_CREDENTIALS_UPDATE_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -3674,6 +3729,7 @@ sRestrictedChannels& cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::params() {
 
 void cACTION_BML_SET_RESTRICTED_CHANNELS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3743,6 +3799,7 @@ uint32_t& cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::error_code() {
 
 void cACTION_BML_SET_RESTRICTED_CHANNELS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -3811,6 +3868,7 @@ sRestrictedChannels& cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::params() {
 
 void cACTION_BML_GET_RESTRICTED_CHANNELS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3880,6 +3938,7 @@ sRestrictedChannels& cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::params() {
 
 void cACTION_BML_GET_RESTRICTED_CHANNELS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3949,6 +4008,7 @@ uint8_t& cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::isEnable() {
 
 void cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CERTIFICATION_MODE_REQUEST::finalize()
@@ -4012,6 +4072,7 @@ cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::~cACTION_BML_SET_CERTIFICATION_MODE
 }
 void cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_SET_CERTIFICATION_MODE_RESPONSE::finalize()
@@ -4069,6 +4130,7 @@ cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::~cACTION_BML_GET_CERTIFICATION_MODE_
 }
 void cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CERTIFICATION_MODE_REQUEST::finalize()
@@ -4130,6 +4192,7 @@ uint8_t& cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::isEnable() {
 
 void cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_GET_CERTIFICATION_MODE_RESPONSE::finalize()
@@ -4239,6 +4302,7 @@ bool cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::alloc_vap_list(size_t count) 
 
 void cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
     for (size_t i = 0; i < (size_t)*m_vap_list_size; i++){
         m_vap_list[i].struct_swap();
@@ -4324,6 +4388,7 @@ uint32_t& cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::result() {
 
 void cACTION_BML_SET_VAP_LIST_CREDENTIALS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
 }
 
@@ -4434,6 +4499,7 @@ bool cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::alloc_vap_list(size_t count)
 
 void cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
     for (size_t i = 0; i < (size_t)*m_vap_list_size; i++){
         m_vap_list[i].struct_swap();
@@ -4519,6 +4585,7 @@ uint32_t& cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::result() {
 
 void cACTION_BML_GET_VAP_LIST_CREDENTIALS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
 }
 
@@ -4599,6 +4666,7 @@ uint8_t& cACTION_BML_STEERING_SET_GROUP_REQUEST::remove() {
 
 void cACTION_BML_STEERING_SET_GROUP_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_steeringGroupIndex));
     m_cfg_2->struct_swap();
     m_cfg_5->struct_swap();
@@ -4689,6 +4757,7 @@ int32_t& cACTION_BML_STEERING_SET_GROUP_RESPONSE::error_code() {
 
 void cACTION_BML_STEERING_SET_GROUP_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -4773,6 +4842,7 @@ uint8_t& cACTION_BML_STEERING_CLIENT_SET_REQUEST::remove() {
 
 void cACTION_BML_STEERING_CLIENT_SET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_steeringGroupIndex));
     m_bssid->struct_swap();
     m_client_mac->struct_swap();
@@ -4871,6 +4941,7 @@ int32_t& cACTION_BML_STEERING_CLIENT_SET_RESPONSE::error_code() {
 
 void cACTION_BML_STEERING_CLIENT_SET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -4939,6 +5010,7 @@ uint8_t& cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::unregister() {
 
 void cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_REQUEST::finalize()
@@ -5006,6 +5078,7 @@ int32_t& cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::error_code() {
 
 void cACTION_BML_STEERING_EVENT_REGISTER_UNREGISTER_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -5090,9 +5163,11 @@ uint32_t& cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::reason() {
 
 void cACTION_BML_STEERING_CLIENT_DISCONNECT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_steeringGroupIndex));
     m_bssid->struct_swap();
     m_client_mac->struct_swap();
+    tlvf_swap(8*sizeof(eDisconnectType), reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_reason));
 }
 
@@ -5187,6 +5262,7 @@ int32_t& cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::error_code() {
 
 void cACTION_BML_STEERING_CLIENT_DISCONNECT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -5263,6 +5339,7 @@ sMacAddr& cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::client_mac() {
 
 void cACTION_BML_STEERING_CLIENT_MEASURE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_steeringGroupIndex));
     m_bssid->struct_swap();
     m_client_mac->struct_swap();
@@ -5347,6 +5424,7 @@ int32_t& cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::error_code() {
 
 void cACTION_BML_STEERING_CLIENT_MEASURE_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -5465,6 +5543,7 @@ bool cACTION_BML_STEERING_EVENTS_UPDATE::alloc_buffer(size_t count) {
 
 void cACTION_BML_STEERING_EVENTS_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_buffer_size));
 }
 
@@ -5542,6 +5621,7 @@ sMacAddr& cACTION_BML_TRIGGER_TOPOLOGY_QUERY::al_mac() {
 
 void cACTION_BML_TRIGGER_TOPOLOGY_QUERY::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_al_mac->struct_swap();
 }
 
@@ -5615,6 +5695,7 @@ sMacAddr& cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::ruid() {
 
 void cACTION_BML_TRIGGER_CHANNEL_SELECTION_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_al_mac->struct_swap();
     m_ruid->struct_swap();
 }
@@ -5696,6 +5777,7 @@ sChannelScanRequestParams& cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUES
 
 void cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
     m_params->struct_swap();
 }
@@ -5773,6 +5855,7 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE::op_error_code(
 
 void cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE::finalize()
@@ -5840,6 +5923,7 @@ sMacAddr& cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST::radio_mac() {
 
 void cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 
@@ -5909,6 +5993,7 @@ sChannelScanRequestParams& cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_RESPON
 
 void cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -5982,6 +6067,7 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST::isEnable() {
 
 void cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 
@@ -6057,6 +6143,7 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE::op_error_code(
 
 void cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE::finalize()
@@ -6124,6 +6211,7 @@ sMacAddr& cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST::radio_mac() {
 
 void cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 
@@ -6193,6 +6281,7 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE::isEnable() {
 
 void cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_RESPONSE::finalize()
@@ -6260,6 +6349,7 @@ sTriggerChannelScanParams& cACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST::scan_par
 
 void cACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_scan_params->struct_swap();
 }
 
@@ -6329,6 +6419,7 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE::op_error_code() {
 
 void cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE::finalize()
@@ -6400,6 +6491,7 @@ uint8_t& cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST::scan_mode() {
 
 void cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 
@@ -6525,6 +6617,7 @@ bool cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::alloc_results(size_t count) 
 
 void cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_results_size));
     for (size_t i = 0; i < (size_t)*m_results_size; i++){
         m_results[i].struct_swap();
@@ -6619,6 +6712,7 @@ cACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST::~cACTION_BML_CHANNEL_SCAN_DUMP_RE
 }
 void cACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_REQUEST::finalize()
@@ -6676,6 +6770,7 @@ cACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_RESPONSE::~cACTION_BML_CHANNEL_SCAN_DUMP_R
 }
 void cACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_BML_CHANNEL_SCAN_DUMP_RESULTS_RESPONSE::finalize()

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_cli.cpp
@@ -31,6 +31,7 @@ int8_t& cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::isEnable() {
 
 void cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CLI_ENABLE_DIAGNOSTICS_MEASUREMENTS::finalize()
@@ -98,6 +99,7 @@ int8_t& cACTION_CLI_ENABLE_LOAD_BALANCER::isEnable() {
 
 void cACTION_CLI_ENABLE_LOAD_BALANCER::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CLI_ENABLE_LOAD_BALANCER::finalize()
@@ -165,6 +167,7 @@ int8_t& cACTION_CLI_ENABLE_DEBUG::isEnable() {
 
 void cACTION_CLI_ENABLE_DEBUG::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CLI_ENABLE_DEBUG::finalize()
@@ -232,6 +235,7 @@ int32_t& cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::attempts() {
 
 void cACTION_CLI_SET_SLAVES_STOP_ON_FAILURE_ATTEMPTS::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_attempts));
 }
 
@@ -304,6 +308,7 @@ int8_t& cACTION_CLI_RESPONSE_INT::currentValue() {
 
 void cACTION_CLI_RESPONSE_INT::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CLI_RESPONSE_INT::finalize()
@@ -427,6 +432,7 @@ bool cACTION_CLI_RESPONSE_STR::alloc_buffer(size_t count) {
 
 void cACTION_CLI_RESPONSE_STR::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_buffer_size));
 }
 
@@ -512,6 +518,7 @@ uint16_t& cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::center_frequency() {
 
 void cACTION_CLI_CROSS_RX_RSSI_MEASUREMENT::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
     m_hostap_mac->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_center_frequency));
@@ -597,6 +604,7 @@ sMacAddr& cACTION_CLI_OPTIMAL_PATH_TASK::client_mac() {
 
 void cACTION_CLI_OPTIMAL_PATH_TASK::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
 }
 
@@ -666,6 +674,7 @@ sMacAddr& cACTION_CLI_LOAD_BALANCER_TASK::ap_mac() {
 
 void cACTION_CLI_LOAD_BALANCER_TASK::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_ap_mac->struct_swap();
 }
 
@@ -731,6 +740,7 @@ cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::~cACTION_CLI_IRE_NETWORK_OPTIMIZATION
 }
 void cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CLI_IRE_NETWORK_OPTIMIZATION_TASK::finalize()
@@ -792,6 +802,7 @@ sMacAddr& cACTION_CLI_DUMP_NODE_INFO::mac() {
 
 void cACTION_CLI_DUMP_NODE_INFO::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -869,6 +880,7 @@ uint16_t& cACTION_CLI_PING_SLAVE_REQUEST::size() {
 
 void cACTION_CLI_PING_SLAVE_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_num_of_req));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_size));
@@ -956,6 +968,7 @@ uint16_t& cACTION_CLI_PING_ALL_SLAVES_REQUEST::size() {
 
 void cACTION_CLI_PING_ALL_SLAVES_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_num_of_req));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_size));
 }
@@ -1031,6 +1044,7 @@ sMacAddr& cACTION_CLI_BACKHAUL_SCAN_RESULTS::mac() {
 
 void cACTION_CLI_BACKHAUL_SCAN_RESULTS::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1104,6 +1118,7 @@ sMacAddr& cACTION_CLI_BACKHAUL_ROAM_REQUEST::bssid() {
 
 void cACTION_CLI_BACKHAUL_ROAM_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_slave_mac->struct_swap();
     m_bssid->struct_swap();
 }
@@ -1185,6 +1200,7 @@ sMacAddr& cACTION_CLI_CLIENT_ALLOW_REQUEST::hostap_mac() {
 
 void cACTION_CLI_CLIENT_ALLOW_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
     m_hostap_mac->struct_swap();
 }
@@ -1266,6 +1282,7 @@ sMacAddr& cACTION_CLI_CLIENT_DISALLOW_REQUEST::hostap_mac() {
 
 void cACTION_CLI_CLIENT_DISALLOW_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
     m_hostap_mac->struct_swap();
 }
@@ -1351,7 +1368,9 @@ uint32_t& cACTION_CLI_CLIENT_DISCONNECT_REQUEST::reason() {
 
 void cACTION_CLI_CLIENT_DISCONNECT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
+    tlvf_swap(8*sizeof(eDisconnectType), reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_reason));
 }
 
@@ -1441,6 +1460,7 @@ uint32_t& cACTION_CLI_CLIENT_BSS_STEER_REQUEST::disassoc_timer_ms() {
 
 void cACTION_CLI_CLIENT_BSS_STEER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
     m_bssid->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_disassoc_timer_ms));
@@ -1529,6 +1549,7 @@ sMacAddr& cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::client_mac() {
 
 void cACTION_CLI_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_hostap_mac->struct_swap();
     m_client_mac->struct_swap();
 }
@@ -1614,6 +1635,7 @@ uint8_t& cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::channel() {
 
 void cACTION_CLI_CLIENT_CHANNEL_LOAD_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_hostap_mac->struct_swap();
     m_client_mac->struct_swap();
 }
@@ -1737,6 +1759,7 @@ int16_t& cACTION_CLI_CLIENT_BEACON_11K_REQUEST::op_class() {
 
 void cACTION_CLI_CLIENT_BEACON_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_client_mac->struct_swap();
     m_bssid->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_duration));
@@ -1879,6 +1902,7 @@ uint8_t& cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::group_identity() {
 
 void cACTION_CLI_CLIENT_STATISTICS_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_hostap_mac->struct_swap();
     m_client_mac->struct_swap();
     m_peer_mac->struct_swap();
@@ -1974,6 +1998,7 @@ sApChannelSwitch& cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::cs_params() {
 
 void cACTION_CLI_HOSTAP_CHANNEL_SWITCH_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_cs_params->struct_swap();
 }
@@ -2063,6 +2088,7 @@ int8_t& cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::vap_id() {
 
 void cACTION_CLI_HOSTAP_SET_NEIGHBOR_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_ap_mac->struct_swap();
     m_bssid->struct_swap();
 }
@@ -2160,6 +2186,7 @@ int8_t& cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::vap_id() {
 
 void cACTION_CLI_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_ap_mac->struct_swap();
     m_bssid->struct_swap();
 }
@@ -2243,6 +2270,7 @@ sMacAddr& cACTION_CLI_HOSTAP_STATS_MEASUREMENT::ap_mac() {
 
 void cACTION_CLI_HOSTAP_STATS_MEASUREMENT::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CLI), reinterpret_cast<uint8_t*>(m_action_op));
     m_ap_mac->struct_swap();
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -90,6 +90,7 @@ uint8_t& cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::is_slave_reconf() {
 
 void cACTION_CONTROL_SLAVE_JOINED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_platform_settings->struct_swap();
     m_wlan_settings->struct_swap();
     m_backhaul_params->struct_swap();
@@ -255,6 +256,7 @@ sSonConfig& cACTION_CONTROL_SLAVE_JOINED_RESPONSE::config() {
 
 void cACTION_CONTROL_SLAVE_JOINED_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_config->struct_swap();
 }
 
@@ -353,6 +355,7 @@ sNodeHostap& cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::hostap() {
 
 void cACTION_CONTROL_SLAVE_JOINED_4ADDR_MODE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_backhaul_iface_mac->struct_swap();
     m_backhaul_ipv4->struct_swap();
     m_bridge_iface_mac->struct_swap();
@@ -454,6 +457,7 @@ sSonConfig& cACTION_CONTROL_SON_CONFIG_UPDATE::config() {
 
 void cACTION_CONTROL_SON_CONFIG_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_config->struct_swap();
 }
 
@@ -564,6 +568,7 @@ bool cACTION_CONTROL_CONTROLLER_PING_REQUEST::alloc_data(size_t count) {
 
 void cACTION_CONTROL_CONTROLLER_PING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_total));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_seq));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_size));
@@ -688,6 +693,7 @@ bool cACTION_CONTROL_CONTROLLER_PING_RESPONSE::alloc_data(size_t count) {
 
 void cACTION_CONTROL_CONTROLLER_PING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_total));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_seq));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_size));
@@ -812,6 +818,7 @@ bool cACTION_CONTROL_AGENT_PING_REQUEST::alloc_data(size_t count) {
 
 void cACTION_CONTROL_AGENT_PING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_total));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_seq));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_size));
@@ -936,6 +943,7 @@ bool cACTION_CONTROL_AGENT_PING_RESPONSE::alloc_data(size_t count) {
 
 void cACTION_CONTROL_AGENT_PING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_total));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_seq));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_size));
@@ -1019,6 +1027,7 @@ sArpQuery& cACTION_CONTROL_ARP_QUERY_REQUEST::params() {
 
 void cACTION_CONTROL_ARP_QUERY_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1088,6 +1097,7 @@ sArpMonitorData& cACTION_CONTROL_ARP_QUERY_RESPONSE::params() {
 
 void cACTION_CONTROL_ARP_QUERY_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1161,6 +1171,7 @@ uint8_t& cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::operational() {
 
 void cACTION_CONTROL_PLATFORM_OPERATIONAL_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_bridge_mac->struct_swap();
 }
 
@@ -1236,6 +1247,7 @@ sBackhaulRssi& cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::params() {
 
 void cACTION_CONTROL_BACKHAUL_DL_RSSI_REPORT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1301,6 +1313,7 @@ cACTION_CONTROL_BACKHAUL_RESET::~cACTION_CONTROL_BACKHAUL_RESET() {
 }
 void cACTION_CONTROL_BACKHAUL_RESET::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_BACKHAUL_RESET::finalize()
@@ -1362,6 +1375,7 @@ sBackhaulRoam& cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::params() {
 
 void cACTION_CONTROL_BACKHAUL_ROAM_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1431,6 +1445,7 @@ sLoggingLevelChange& cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::params() {
 
 void cACTION_CONTROL_CHANGE_MODULE_LOGGING_LEVEL::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1500,6 +1515,7 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::cs_params() {
 
 void cACTION_CONTROL_HOSTAP_CSA_ERROR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -1569,6 +1585,7 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::cs_params() {
 
 void cACTION_CONTROL_HOSTAP_CSA_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -1638,6 +1655,7 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::cs_params() {
 
 void cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -1716,6 +1734,7 @@ std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NO
 
 void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
         m_supported_channels[i].struct_swap();
@@ -1798,6 +1817,7 @@ sDfsCacCompleted& cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::params(
 
 void cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1867,6 +1887,7 @@ sDfsChannelAvailable& cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION:
 
 void cACTION_CONTROL_HOSTAP_DFS_CHANNEL_AVAILABLE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1936,6 +1957,7 @@ sApSetRestrictedFailsafe& cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL
 
 void cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2005,6 +2027,7 @@ uint8_t& cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::succes
 
 void cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_HOSTAP_SET_RESTRICTED_FAILSAFE_CHANNEL_RESPONSE::finalize()
@@ -2072,6 +2095,7 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::cs_params() {
 
 void cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_ACS_START::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -2141,6 +2165,7 @@ uint32_t& cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::attemp
 
 void cACTION_CONTROL_HOSTAP_UPDATE_STOP_ON_FAILURE_ATTEMPTS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_attempts));
 }
 
@@ -2205,6 +2230,7 @@ cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::~cACTION_CONTROL_HOSTAP_DISABLED_BY_M
 }
 void cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_HOSTAP_DISABLED_BY_MASTER::finalize()
@@ -2266,6 +2292,7 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::cs_params() {
 
 void cACTION_CONTROL_HOSTAP_CHANNEL_SWITCH_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
 }
 
@@ -2335,6 +2362,7 @@ uint8_t& cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::sync() {
 
 void cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST::finalize()
@@ -2444,6 +2472,7 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
 
 void cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_ap_stats->struct_swap();
     for (size_t i = 0; i < (size_t)*m_sta_stats_size; i++){
         m_sta_stats[i].struct_swap();
@@ -2530,6 +2559,7 @@ sApLoadNotificationParams& cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION:
 
 void cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2599,6 +2629,7 @@ sNeighborSetParams11k& cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::params()
 
 void cACTION_CONTROL_HOSTAP_SET_NEIGHBOR_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2668,6 +2699,7 @@ sNeighborRemoveParams11k& cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::pa
 
 void cACTION_CONTROL_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2737,6 +2769,7 @@ sApActivityNotificationParams& cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::par
 
 void cACTION_CONTROL_HOSTAP_ACTIVITY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2806,6 +2839,7 @@ sVapsList& cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::params() {
 
 void cACTION_CONTROL_HOSTAP_VAPS_LIST_UPDATE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2875,6 +2909,7 @@ int8_t& cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::vap_id() {
 
 void cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_HOSTAP_AP_DISABLED_NOTIFICATION::finalize()
@@ -2946,6 +2981,7 @@ sVapInfo& cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::vap_info() {
 
 void cACTION_CONTROL_HOSTAP_AP_ENABLED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_vap_info->struct_swap();
 }
 
@@ -3021,6 +3057,7 @@ sClientMonitoringParams& cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::params
 
 void cACTION_CONTROL_CLIENT_START_MONITORING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3090,6 +3127,7 @@ uint8_t& cACTION_CONTROL_CLIENT_START_MONITORING_RESPONSE::success() {
 
 void cACTION_CONTROL_CLIENT_START_MONITORING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_CLIENT_START_MONITORING_RESPONSE::finalize()
@@ -3157,6 +3195,7 @@ sMacAddr& cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::mac() {
 
 void cACTION_CONTROL_CLIENT_STOP_MONITORING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -3226,6 +3265,7 @@ sNodeRssiMeasurementRequest& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3295,6 +3335,7 @@ sNodeRssiMeasurement& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::param
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3364,6 +3405,7 @@ sMacAddr& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::mac() {
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -3433,6 +3475,7 @@ sMacAddr& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -3502,6 +3545,7 @@ sNodeRssiMeasurement& cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::p
 
 void cACTION_CONTROL_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3571,6 +3615,7 @@ sMacAddr& cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::mac() {
 
 void cACTION_CONTROL_CLIENT_NO_ACTIVITY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -3640,6 +3685,7 @@ sMacAddr& cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::mac() {
 
 void cACTION_CONTROL_CLIENT_NO_RESPONSE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -3713,6 +3759,7 @@ beerocks::net::sIpv4Addr& cACTION_CONTROL_CLIENT_NEW_IP_ADDRESS_NOTIFICATION::ip
 
 void cACTION_CONTROL_CLIENT_NEW_IP_ADDRESS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_ipv4->struct_swap();
 }
@@ -3802,7 +3849,9 @@ uint32_t& cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::reason() {
 
 void cACTION_CONTROL_CLIENT_DISCONNECT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
+    tlvf_swap(8*sizeof(eDisconnectType), reinterpret_cast<uint8_t*>(m_type));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_reason));
 }
 
@@ -3890,6 +3939,7 @@ sClientDisconnectResponse& cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::params() 
 
 void cACTION_CONTROL_CLIENT_DISCONNECT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -3990,6 +4040,7 @@ bool cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::set_name(const char str[
 }
 void cACTION_CONTROL_CLIENT_DHCP_COMPLETE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_ipv4->struct_swap();
 }
@@ -4074,6 +4125,7 @@ sArpMonitorData& cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::params() {
 
 void cACTION_CONTROL_CLIENT_ARP_MONITOR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4143,6 +4195,7 @@ sBeaconRequest11k& cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::params() {
 
 void cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4212,6 +4265,7 @@ sBeaconResponse11k& cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::params() {
 
 void cACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4281,6 +4335,7 @@ sStaChannelLoadRequest11k& cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::para
 
 void cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4350,6 +4405,7 @@ sStaChannelLoadResponse11k& cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::pa
 
 void cACTION_CONTROL_CLIENT_CHANNEL_LOAD_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4419,6 +4475,7 @@ sStatisticsRequest11k& cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::params() {
 
 void cACTION_CONTROL_CLIENT_STATISTICS_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4488,6 +4545,7 @@ sStatisticsResponse11k& cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::params()
 
 void cACTION_CONTROL_CLIENT_STATISTICS_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4557,6 +4615,7 @@ sMacAddr& cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::mac() {
 
 void cACTION_CONTROL_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -4626,6 +4685,7 @@ sLinkMeasurementsResponse11k& cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPO
 
 void cACTION_CONTROL_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4695,6 +4755,7 @@ sSteeringSetGroupRequest& cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::par
 
 void cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4764,6 +4825,7 @@ sSteeringSetGroupResponse& cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::p
 
 void cACTION_CONTROL_STEERING_CLIENT_SET_GROUP_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4833,6 +4895,7 @@ sSteeringClientSetRequest& cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::params()
 
 void cACTION_CONTROL_STEERING_CLIENT_SET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4902,6 +4965,7 @@ sSteeringClientSetResponse& cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::params
 
 void cACTION_CONTROL_STEERING_CLIENT_SET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -4971,6 +5035,7 @@ sSteeringEvActivity& cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION
 
 void cACTION_CONTROL_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -5040,6 +5105,7 @@ sSteeringEvSnrXing& cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::params
 
 void cACTION_CONTROL_STEERING_EVENT_SNR_XING_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -5109,6 +5175,7 @@ sSteeringEvProbeReq& cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::para
 
 void cACTION_CONTROL_STEERING_EVENT_PROBE_REQ_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -5178,6 +5245,7 @@ sSteeringEvAuthFail& cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::para
 
 void cACTION_CONTROL_STEERING_EVENT_AUTH_FAIL_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -5247,6 +5315,7 @@ sTriggerChannelScanParams& cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST::sc
 
 void cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_scan_params->struct_swap();
 }
 
@@ -5316,6 +5385,7 @@ uint8_t& cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE::success() {
 
 void cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE::finalize()
@@ -5383,6 +5453,7 @@ sMacAddr& cACTION_CONTROL_CHANNEL_SCAN_TRIGGERED_NOTIFICATION::radio_mac() {
 
 void cACTION_CONTROL_CHANNEL_SCAN_TRIGGERED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 
@@ -5460,6 +5531,7 @@ uint8_t& cACTION_CONTROL_CHANNEL_SCAN_RESULTS_NOTIFICATION::is_dump() {
 
 void cACTION_CONTROL_CHANNEL_SCAN_RESULTS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_scan_results->struct_swap();
     m_radio_mac->struct_swap();
 }
@@ -5548,6 +5620,7 @@ sMacAddr& cACTION_CONTROL_CHANNEL_SCAN_ABORT_NOTIFICATION::radio_mac() {
 
 void cACTION_CONTROL_CHANNEL_SCAN_ABORT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 
@@ -5623,6 +5696,7 @@ sMacAddr& cACTION_CONTROL_CHANNEL_SCAN_FINISHED_NOTIFICATION::radio_mac() {
 
 void cACTION_CONTROL_CHANNEL_SCAN_FINISHED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_radio_mac->struct_swap();
 }
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_header.cpp
@@ -64,6 +64,7 @@ uint16_t& cACTION_HEADER::length() {
 void cACTION_HEADER::class_swap()
 {
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_magic));
+    tlvf_swap(8*sizeof(eAction), reinterpret_cast<uint8_t*>(m_action));
     m_radio_mac->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_id));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -31,6 +31,7 @@ int8_t& cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::vap_id() {
 
 void cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_HOSTAP_AP_DISABLED_NOTIFICATION::finalize()
@@ -94,6 +95,7 @@ cACTION_MONITOR_JOINED_NOTIFICATION::~cACTION_MONITOR_JOINED_NOTIFICATION() {
 }
 void cACTION_MONITOR_JOINED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_JOINED_NOTIFICATION::finalize()
@@ -155,6 +157,7 @@ sSonConfig& cACTION_MONITOR_SON_CONFIG_UPDATE::config() {
 
 void cACTION_MONITOR_SON_CONFIG_UPDATE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_config->struct_swap();
 }
 
@@ -224,6 +227,7 @@ sLoggingLevelChange& cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::params() {
 
 void cACTION_MONITOR_CHANGE_MODULE_LOGGING_LEVEL::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -293,6 +297,7 @@ uint32_t& cACTION_MONITOR_ERROR_NOTIFICATION::error_code() {
 
 void cACTION_MONITOR_ERROR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_error_code));
 }
 
@@ -357,6 +362,7 @@ cACTION_MONITOR_ERROR_NOTIFICATION_ACK::~cACTION_MONITOR_ERROR_NOTIFICATION_ACK(
 }
 void cACTION_MONITOR_ERROR_NOTIFICATION_ACK::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_ERROR_NOTIFICATION_ACK::finalize()
@@ -414,6 +420,7 @@ cACTION_MONITOR_HEARTBEAT_NOTIFICATION::~cACTION_MONITOR_HEARTBEAT_NOTIFICATION(
 }
 void cACTION_MONITOR_HEARTBEAT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_HEARTBEAT_NOTIFICATION::finalize()
@@ -475,6 +482,7 @@ sClientMonitoringParams& cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::params
 
 void cACTION_MONITOR_CLIENT_START_MONITORING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -544,6 +552,7 @@ uint8_t& cACTION_MONITOR_CLIENT_START_MONITORING_RESPONSE::success() {
 
 void cACTION_MONITOR_CLIENT_START_MONITORING_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_CLIENT_START_MONITORING_RESPONSE::finalize()
@@ -611,6 +620,7 @@ sMacAddr& cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::mac() {
 
 void cACTION_MONITOR_CLIENT_STOP_MONITORING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -680,6 +690,7 @@ sNodeRssiMeasurementRequest& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST:
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -757,6 +768,7 @@ uint8_t& cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::channel() {
 
 void cACTION_MONITOR_CLIENT_DISCONNECT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_ipv4->struct_swap();
 }
@@ -840,6 +852,7 @@ sNodeRssiMeasurement& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::p
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -909,6 +922,7 @@ sNodeRssiMeasurement& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::param
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -978,6 +992,7 @@ sMacAddr& cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::mac() {
 
 void cACTION_MONITOR_CLIENT_NO_RESPONSE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1047,6 +1062,7 @@ sMacAddr& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::mac() {
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_START_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1116,6 +1132,7 @@ sMacAddr& cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::mac() {
 
 void cACTION_MONITOR_CLIENT_RX_RSSI_MEASUREMENT_CMD_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1185,6 +1202,7 @@ sMacAddr& cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::mac() {
 
 void cACTION_MONITOR_CLIENT_NO_ACTIVITY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -1254,6 +1272,7 @@ sApActivityNotificationParams& cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::par
 
 void cACTION_MONITOR_HOSTAP_ACTIVITY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1323,6 +1342,7 @@ uint8_t& cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::sync() {
 
 void cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_REQUEST::finalize()
@@ -1394,6 +1414,7 @@ int8_t& cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::new_hostap_enabled_s
 
 void cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION::finalize()
@@ -1509,6 +1530,7 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
 
 void cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_ap_stats->struct_swap();
     for (size_t i = 0; i < (size_t)*m_sta_stats_size; i++){
         m_sta_stats[i].struct_swap();
@@ -1595,6 +1617,7 @@ sApLoadNotificationParams& cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION:
 
 void cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1664,6 +1687,7 @@ sBeaconRequest11k& cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::params() {
 
 void cACTION_MONITOR_CLIENT_BEACON_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1733,6 +1757,7 @@ sBeaconResponse11k& cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::params() {
 
 void cACTION_MONITOR_CLIENT_BEACON_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1802,6 +1827,7 @@ sStaChannelLoadRequest11k& cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::para
 
 void cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1871,6 +1897,7 @@ sStaChannelLoadResponse11k& cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::pa
 
 void cACTION_MONITOR_CLIENT_CHANNEL_LOAD_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -1940,6 +1967,7 @@ sStatisticsRequest11k& cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::params() {
 
 void cACTION_MONITOR_CLIENT_STATISTICS_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2009,6 +2037,7 @@ sStatisticsResponse11k& cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::params()
 
 void cACTION_MONITOR_CLIENT_STATISTICS_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2078,6 +2107,7 @@ sMacAddr& cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::mac() {
 
 void cACTION_MONITOR_CLIENT_LINK_MEASUREMENT_11K_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
 }
 
@@ -2147,6 +2177,7 @@ sLinkMeasurementsResponse11k& cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPO
 
 void cACTION_MONITOR_CLIENT_LINK_MEASUREMENTS_11K_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2220,6 +2251,7 @@ beerocks::net::sIpv4Addr& cACTION_MONITOR_CLIENT_NEW_IP_ADDRESS_NOTIFICATION::ip
 
 void cACTION_MONITOR_CLIENT_NEW_IP_ADDRESS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_ipv4->struct_swap();
 }
@@ -2297,6 +2329,7 @@ sSteeringSetGroupRequest& cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::par
 
 void cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2366,6 +2399,7 @@ sSteeringSetGroupResponse& cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::p
 
 void cACTION_MONITOR_STEERING_CLIENT_SET_GROUP_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2435,6 +2469,7 @@ sSteeringClientSetRequest& cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::params()
 
 void cACTION_MONITOR_STEERING_CLIENT_SET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2504,6 +2539,7 @@ sSteeringClientSetResponse& cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::params
 
 void cACTION_MONITOR_STEERING_CLIENT_SET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2573,6 +2609,7 @@ sSteeringEvActivity& cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION
 
 void cACTION_MONITOR_STEERING_EVENT_CLIENT_ACTIVITY_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2642,6 +2679,7 @@ sSteeringEvSnrXing& cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::params
 
 void cACTION_MONITOR_STEERING_EVENT_SNR_XING_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -2711,6 +2749,7 @@ sTriggerChannelScanParams& cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST::sc
 
 void cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_scan_params->struct_swap();
 }
 
@@ -2780,6 +2819,7 @@ uint8_t& cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE::success() {
 
 void cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE::finalize()
@@ -2843,6 +2883,7 @@ cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION::~cACTION_MONITOR_CHANNEL_SC
 }
 void cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_CHANNEL_SCAN_TRIGGERED_NOTIFICATION::finalize()
@@ -2908,6 +2949,7 @@ uint8_t& cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION::is_dump() {
 
 void cACTION_MONITOR_CHANNEL_SCAN_RESULTS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     m_scan_results->struct_swap();
 }
 
@@ -2984,6 +3026,7 @@ uint8_t& cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION::reason() {
 
 void cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_CHANNEL_SCAN_ABORT_NOTIFICATION::finalize()
@@ -3047,6 +3090,7 @@ cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION::~cACTION_MONITOR_CHANNEL_SCA
 }
 void cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_MONITOR_CHANNEL_SCAN_FINISHED_NOTIFICATION::finalize()

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -31,6 +31,7 @@ uint8_t& cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::i
 
 void cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_SON_SLAVE_BACKHAUL_CONNECTION_COMPLETE_NOTIFICATION::finalize()
@@ -121,6 +122,7 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::set_iface_name(const char str[
 }
 void cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST::finalize()
@@ -197,6 +199,7 @@ uint32_t& cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::valid() {
 
 void cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_platform_settings->struct_swap();
     m_wlan_settings->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_valid));
@@ -281,6 +284,7 @@ sArpMonitorData& cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::params() {
 
 void cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -350,6 +354,7 @@ sWlanSettings& cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::wlan_settings(
 
 void cACTION_PLATFORM_WLAN_PARAMS_CHANGED_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_wlan_settings->struct_swap();
 }
 
@@ -458,6 +463,8 @@ bool cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::set_hostname(const char str[], 
 }
 void cACTION_PLATFORM_DHCP_MONITOR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
+    tlvf_swap(8*sizeof(eDHCPOp), reinterpret_cast<uint8_t*>(m_dhcp_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_op));
     m_mac->struct_swap();
     m_ipv4->struct_swap();
@@ -555,6 +562,7 @@ sLoggingLevelChange& cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::params() {
 
 void cACTION_PLATFORM_CHANGE_MODULE_LOGGING_LEVEL::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -624,6 +632,7 @@ sArpQuery& cACTION_PLATFORM_ARP_QUERY_REQUEST::params() {
 
 void cACTION_PLATFORM_ARP_QUERY_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -693,6 +702,7 @@ sArpMonitorData& cACTION_PLATFORM_ARP_QUERY_RESPONSE::params() {
 
 void cACTION_PLATFORM_ARP_QUERY_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -758,6 +768,7 @@ cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::~cACTION_PLATFORM_ONBOARD_QUERY_REQUEST(
 }
 void cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_ONBOARD_QUERY_REQUEST::finalize()
@@ -819,6 +830,7 @@ sOnboarding& cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::params() {
 
 void cACTION_PLATFORM_ONBOARD_QUERY_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -888,6 +900,7 @@ sOnboarding& cACTION_PLATFORM_ONBOARD_SET_REQUEST::params() {
 
 void cACTION_PLATFORM_ONBOARD_SET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
 }
 
@@ -980,6 +993,7 @@ bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::set_iface_name(const char str[], s
 }
 void cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_WPS_ONBOARDING_REQUEST::finalize()
@@ -1048,6 +1062,7 @@ uint8_t& cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::vap_id() {
 
 void cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_WIFI_CREDENTIALS_GET_REQUEST::finalize()
@@ -1123,6 +1138,7 @@ uint32_t& cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::result() {
 
 void cACTION_PLATFORM_WIFI_CREDENTIALS_GET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_front_params->struct_swap();
     m_back_params->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
@@ -1203,6 +1219,7 @@ cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::~cACTION_PLATFORM_ADMIN_CREDENTI
 }
 void cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_REQUEST::finalize()
@@ -1268,6 +1285,7 @@ uint32_t& cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::result() {
 
 void cACTION_PLATFORM_ADMIN_CREDENTIALS_GET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
 }
@@ -1340,6 +1358,7 @@ cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::~cACTION_PLATFORM_DEVICE_INFO_GET_REQU
 }
 void cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_DEVICE_INFO_GET_REQUEST::finalize()
@@ -1405,6 +1424,7 @@ uint32_t& cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::result() {
 
 void cACTION_PLATFORM_DEVICE_INFO_GET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
 }
@@ -1477,6 +1497,7 @@ cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::~cACTION_PLATFORM_LOCAL_MASTER_GET_RE
 }
 void cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_LOCAL_MASTER_GET_REQUEST::finalize()
@@ -1538,6 +1559,7 @@ uint8_t& cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::local_master() {
 
 void cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_LOCAL_MASTER_GET_RESPONSE::finalize()
@@ -1605,6 +1627,7 @@ sVersions& cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::versions() {
 
 void cACTION_PLATFORM_VERSION_MISMATCH_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_versions->struct_swap();
 }
 
@@ -1674,6 +1697,7 @@ sVersions& cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::versions() {
 
 void cACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_versions->struct_swap();
 }
 
@@ -1739,6 +1763,7 @@ cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::~cACTION_PLATFORM_GET_MASTER
 }
 void cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_REQUEST::finalize()
@@ -1804,6 +1829,7 @@ uint32_t& cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::result() {
 
 void cACTION_PLATFORM_GET_MASTER_SLAVE_VERSIONS_RESPONSE::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     m_versions->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
 }
@@ -1907,6 +1933,7 @@ bool cACTION_PLATFORM_ERROR_NOTIFICATION::set_data(const char str[], size_t size
 }
 void cACTION_PLATFORM_ERROR_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_code));
 }
 
@@ -2052,6 +2079,7 @@ uint8_t& cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::status_operational
 
 void cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_WIFI_INTERFACE_STATUS_NOTIFICATION::finalize()
@@ -2157,6 +2185,7 @@ uint8_t& cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::operational() {
 
 void cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::class_swap()
 {
+    tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
 }
 
 bool cACTION_PLATFORM_OPERATIONAL_NOTIFICATION::finalize()

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/s802_11SpecificInformation.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/s802_11SpecificInformation.h
@@ -39,6 +39,7 @@ typedef struct s802_11SpecificInformation {
     uint8_t ap_channel_center_frequency_index2;
     void struct_swap(){
         network_membership.struct_swap();
+        tlvf_swap(8*sizeof(eRole), reinterpret_cast<uint8_t*>(&role));
     }
     void struct_init(){
         network_membership.struct_init();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlv1905NeighborDevice.h
@@ -44,6 +44,7 @@ class tlv1905NeighborDevice : public BaseClass
             eBridgesExist bridges_exist;
             void struct_swap(){
                 mac.struct_swap();
+                tlvf_swap(8*sizeof(eBridgesExist), reinterpret_cast<uint8_t*>(&bridges_exist));
             }
             void struct_init(){
                 mac.struct_init();

--- a/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonEventNotification.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/ieee_1905_1/tlvPushButtonEventNotification.h
@@ -40,6 +40,7 @@ class tlvPushButtonEventNotification : public BaseClass
             uint8_t k_octets_of_media_specific_information;
             s802_11SpecificInformation media_specific_information;
             void struct_swap(){
+                tlvf_swap(8*sizeof(eMediaType), reinterpret_cast<uint8_t*>(&media_type));
                 media_specific_information.struct_swap();
             }
             void struct_init(){

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvAutoconfigFreqBand.cpp
@@ -40,6 +40,7 @@ tlvAutoconfigFreqBand::eValue& tlvAutoconfigFreqBand::value() {
 void tlvAutoconfigFreqBand::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eValue), reinterpret_cast<uint8_t*>(m_value));
 }
 
 bool tlvAutoconfigFreqBand::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -272,6 +272,7 @@ bool cLocalInterfaceInfo::alloc_media_info(size_t count) {
 void cLocalInterfaceInfo::class_swap()
 {
     m_mac->struct_swap();
+    tlvf_swap(8*sizeof(eMediaType), reinterpret_cast<uint8_t*>(m_media_type));
 }
 
 bool cLocalInterfaceInfo::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricQuery.cpp
@@ -48,7 +48,9 @@ tlvLinkMetricQuery::eLinkMetricsType& tlvLinkMetricQuery::link_metrics() {
 void tlvLinkMetricQuery::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eNeighborType), reinterpret_cast<uint8_t*>(m_neighbor_type));
     m_mac_al_1905_device->struct_swap();
+    tlvf_swap(8*sizeof(eLinkMetricsType), reinterpret_cast<uint8_t*>(m_link_metrics));
 }
 
 bool tlvLinkMetricQuery::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvLinkMetricResultCode.cpp
@@ -40,6 +40,7 @@ tlvLinkMetricResultCode::eValue& tlvLinkMetricResultCode::value() {
 void tlvLinkMetricResultCode::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eValue), reinterpret_cast<uint8_t*>(m_value));
 }
 
 bool tlvLinkMetricResultCode::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSearchedRole.cpp
@@ -40,6 +40,7 @@ tlvSearchedRole::eValue& tlvSearchedRole::value() {
 void tlvSearchedRole::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eValue), reinterpret_cast<uint8_t*>(m_value));
 }
 
 bool tlvSearchedRole::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedFreqBand.cpp
@@ -40,6 +40,7 @@ tlvSupportedFreqBand::eValue& tlvSupportedFreqBand::value() {
 void tlvSupportedFreqBand::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eValue), reinterpret_cast<uint8_t*>(m_value));
 }
 
 bool tlvSupportedFreqBand::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvSupportedRole.cpp
@@ -40,6 +40,7 @@ tlvSupportedRole::eValue& tlvSupportedRole::value() {
 void tlvSupportedRole::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eValue), reinterpret_cast<uint8_t*>(m_value));
 }
 
 bool tlvSupportedRole::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelSelectionResponse.cpp
@@ -45,6 +45,7 @@ void tlvChannelSelectionResponse::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
+    tlvf_swap(8*sizeof(eResponseCode), reinterpret_cast<uint8_t*>(m_response_code));
 }
 
 bool tlvChannelSelectionResponse::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
@@ -92,6 +92,7 @@ void tlvClientAssociationControlRequest::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_bssid_to_block_client->struct_swap();
+    tlvf_swap(8*sizeof(eAssociationControl), reinterpret_cast<uint8_t*>(m_association_control));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_validity_period_sec));
     for (size_t i = 0; i < (size_t)*m_sta_list_length; i++){
         m_sta_list[i].struct_swap();

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationEvent.cpp
@@ -50,6 +50,7 @@ void tlvClientAssociationEvent::class_swap()
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_client_mac->struct_swap();
     m_bssid->struct_swap();
+    tlvf_swap(8*sizeof(eAssociationEvent), reinterpret_cast<uint8_t*>(m_association_event));
 }
 
 bool tlvClientAssociationEvent::finalize()

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvHigherLayerData.cpp
@@ -74,6 +74,7 @@ bool tlvHigherLayerData::alloc_payload(size_t count) {
 void tlvHigherLayerData::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
+    tlvf_swap(8*sizeof(eProtocol), reinterpret_cast<uint8_t*>(m_protocol));
 }
 
 bool tlvHigherLayerData::finalize()

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -127,6 +127,9 @@ class TypeInfo:
             elif len(self.type_str) > 2 and (str(self.type_str[1]).isupper() or str(self.type_str[1]).isdigit()):
                 if self.type_str[0] == "e":
                     self.type = TypeInfo.ENUM
+                    self.swap_prefix = "tlvf_swap(8*sizeof(" + self.type_str + "), reinterpret_cast<uint8_t*>("
+                    self.swap_suffix = "))"
+                    self.swap_needed = True
                 elif self.type_str[0] == "s":
                     self.type = TypeInfo.STRUCT
                     self.swap_suffix = TypeInfo.STRUCT_SWAP_FUNCTION_NAME

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -17,13 +17,10 @@ base_mac="$1"; shift
 run ip link add          br-lan   address "${base_mac}:00:00" type bridge
 run ip link add          wlan0    address "${base_mac}:00:10" type dummy
 run ip link add          wlan2    address "${base_mac}:00:20" type dummy
-run ip link add          sim-eth0 address "${base_mac}:00:30" type dummy
-run ip link set      dev sim-eth0 master br-lan
 run ip link set      dev eth0     master br-lan
 run ip link set      dev wlan0    master br-lan
 run ip link set      dev wlan2    master br-lan
 run ip address flush dev eth0
-run ip link set      dev sim-eth0 up
 run ip link set      dev wlan0    up
 run ip link set      dev wlan2    up
 run ip address add   dev br-lan "$bridge_ip"


### PR DESCRIPTION
As reported by @mariomaz, the Device Information TLV was not correct.
This PR fixes all of the issues.

Unfortunately, since we don't inspect the packets sent over the wire, it's not possible to add a test to test_flows.