### PR TITLE
tools: deploy_ipk.sh: fix missing quotes when using eval

### DIFF
--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -46,7 +46,7 @@ EOF
 
     if [ "$CERTIFICATION_MODE" = true ] ; then
         echo "Certification mode will be enabled on the target"
-        eval ssh "$SSH_OPTIONS" "$TARGET" "uci set prplmesh.config.certification_mode=1 && uci commit"
+        eval ssh "$SSH_OPTIONS" "$TARGET" \""uci set prplmesh.config.certification_mode=1 && uci commit"\"
         echo "Certification mode enabled on the target."
     fi
     echo "Done"


### PR DESCRIPTION
Since 96c75adedf824dbab4dd0abd9ccc10b3473f94d4 eval is used to expand
the dynamically built SSH_OPTIONS.

Without an additional level of quoting, '&&' ends the arguments to the
ssh command, and "uci commit" gets executed locally.

Add another level of quoting around the uci commands so that they are
fed to ssh as a single argument.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>