### PR TITLE
github/workflows: add merge when ready workflow

### DIFF
--- a/.github/workflows/merge_when_ready.yml
+++ b/.github/workflows/merge_when_ready.yml
@@ -1,6 +1,8 @@
 name: Merge Bot
 
 on:
+  check_suite:
+    types: [completed]
   pull_request:
     types:
       - labeled # MergeWhenReady added
@@ -27,3 +29,4 @@ jobs:
         checks_enabled: true
         reviewers: true
         method: rebase
+        test: true # make the bot comment instead of taking action

--- a/.github/workflows/merge_when_ready.yml
+++ b/.github/workflows/merge_when_ready.yml
@@ -3,16 +3,6 @@ name: Merge Bot
 on:
   check_suite:
     types: [completed]
-  pull_request:
-    types:
-      - labeled # MergeWhenReady added
-      - review_request_removed # Blocking review removed
-      - review_requested
-      - unlabeled # don't merge label removed
-  pull_request_review:
-    types:
-      - dismissed # Blocking review removed
-      - submitted # Approving review added
   status: # CI
 
 jobs:

--- a/.github/workflows/merge_when_ready.yml
+++ b/.github/workflows/merge_when_ready.yml
@@ -1,0 +1,29 @@
+name: Merge Bot
+
+on:
+  pull_request:
+    types:
+      - labeled # MergeWhenReady added
+      - review_request_removed # Blocking review removed
+      - review_requested
+      - unlabeled # don't merge label removed
+  pull_request_review:
+    types:
+      - dismissed # Blocking review removed
+      - submitted # Approving review added
+  status: # CI
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    name: Merge when ready
+    steps:
+    - name: Integration check
+      uses: squalrus/merge-bot@v0.4.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        labels: "MergeWhenReady"
+        blocking-labels: "don't merge"
+        checks_enabled: true
+        reviewers: true
+        method: rebase


### PR DESCRIPTION
Using [PR merge bot](https://github.com/marketplace/actions/pr-merge-bot), automatically merge a pull request when the
checks pass and the MergeWhenReady tag is set.