### PR TITLE
Hotfix/ucc listener get param

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -109,13 +109,12 @@ void agent_ucc_listener::update_vaps_list(std::string ruid, beerocks_message::sV
 bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
                                               std::string &value)
 {
-    if (params["parameter"] == "alid") {
-        if (!net::network_utils::linux_iface_get_mac("br-lan", value)) {
-            value = "failed to get br-lan mac address";
-            return false;
-        }
+    auto parameter = params["parameter"];
+    std::transform(parameter.begin(), parameter.end(), parameter.begin(), ::tolower);
+    if (parameter == "alid") {
+        value = m_bridge_mac;
         return true;
-    } else if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
+    } else if (parameter == "macaddr" || parameter == "bssid") {
         if (params.find("ruid") == params.end()) {
             value = "missing ruid";
             return false;
@@ -141,7 +140,7 @@ bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, st
         value = "macaddr/bssid not found for ruid " + ruid + " ssid " + ssid;
         return false;
     }
-    value = "parameter " + params["parameter"] + " not supported";
+    value = "parameter " + parameter + " not supported";
     return false;
 }
 /**

--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -109,7 +109,13 @@ void agent_ucc_listener::update_vaps_list(std::string ruid, beerocks_message::sV
 bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, std::string> &params,
                                               std::string &value)
 {
-    if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
+    if (params["parameter"] == "alid") {
+        if (!net::network_utils::linux_iface_get_mac("br-lan", value)) {
+            value = "failed to get br-lan mac address";
+            return false;
+        }
+        return true;
+    } else if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
         if (params.find("ruid") == params.end()) {
             value = "missing ruid";
             return false;

--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -563,22 +563,14 @@ void beerocks_ucc_listener::handle_wfa_ca_command(const std::string &command)
             LOG(ERROR) << "failed to send reply";
             break;
         }
-        auto parameter = params["parameter"];
-        std::transform(parameter.begin(), parameter.end(), parameter.begin(), ::tolower);
         std::string value;
-        if (parameter == "alid") {
-            if (!net::network_utils::linux_iface_get_mac("br-lan", value)) {
-                LOG(ERROR) << "failed to get br-lan mac address";
-                reply_ucc(eWfaCaStatus::ERROR, "failed to get br-lan mac address");
-                break;
-            }
-        } else if (!handle_dev_get_param(params, value)) {
-            LOG(ERROR) << "failed to get parameter " << parameter << "error: " << value;
+        if (!handle_dev_get_param(params, value)) {
+            LOG(ERROR) << "failed to get parameter " << params["parameter"] << "error: " << value;
             reply_ucc(eWfaCaStatus::ERROR, value);
             break;
         }
         // Success
-        reply_ucc(eWfaCaStatus::COMPLETE, parameter + "," + value);
+        reply_ucc(eWfaCaStatus::COMPLETE, params["parameter"] + "," + value);
         break;
     }
     case eWfaCaCommand::DEV_RESET_DEFAULT: {

--- a/controller/src/beerocks/master/controller_ucc_listener.cpp
+++ b/controller/src/beerocks/master/controller_ucc_listener.cpp
@@ -49,7 +49,13 @@ void controller_ucc_listener::clear_configuration() { m_database.clear_bss_info_
 bool controller_ucc_listener::handle_dev_get_param(
     std::unordered_map<std::string, std::string> &params, std::string &value)
 {
-    if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
+    if (params["parameter"] == "alid") {
+        if (!net::network_utils::linux_iface_get_mac("br-lan", value)) {
+            value = "failed to get br-lan mac address";
+            return false;
+        }
+        return true;
+    } else if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
         if (params.find("ruid") == params.end()) {
             value = "missing ruid";
             return false;

--- a/controller/src/beerocks/master/controller_ucc_listener.cpp
+++ b/controller/src/beerocks/master/controller_ucc_listener.cpp
@@ -49,13 +49,12 @@ void controller_ucc_listener::clear_configuration() { m_database.clear_bss_info_
 bool controller_ucc_listener::handle_dev_get_param(
     std::unordered_map<std::string, std::string> &params, std::string &value)
 {
-    if (params["parameter"] == "alid") {
-        if (!net::network_utils::linux_iface_get_mac("br-lan", value)) {
-            value = "failed to get br-lan mac address";
-            return false;
-        }
+    auto parameter = params["parameter"];
+    std::transform(parameter.begin(), parameter.end(), parameter.begin(), ::tolower);
+    if (parameter == "alid") {
+        value = m_database.get_local_bridge_mac();
         return true;
-    } else if (params["parameter"] == "macaddr" || params["parameter"] == "bssid") {
+    } else if (parameter == "macaddr" || parameter == "bssid") {
         if (params.find("ruid") == params.end()) {
             value = "missing ruid";
             return false;
@@ -80,7 +79,7 @@ bool controller_ucc_listener::handle_dev_get_param(
         value = "macaddr/bssid not found for ruid " + ruid + " ssid " + ssid;
         return false;
     }
-    value = "parameter " + params["parameter"] + " not supported";
+    value = "parameter " + parameter + " not supported";
     return false;
 }
 


### PR DESCRIPTION
The UCC command to get the device ALid `dev_get_parameter,program,map,parameter,ALid` is currently implemented in the UCC listener base class, thus using hard coded bridge name "br-lan".
For most devices this is fine, but in this is not the case for others, such as CGR, where the bridge interface is called "brlan0".
Since both the controller UCC listener and the agent UCC listener hold the bridge name as part of the database / member, move handling to the derived classes.
This allows running UTAF autoconfig tests on RDKB.