### PR TITLE
Hotfix/dwpal attach before enable

### DIFF
--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -2325,7 +2325,7 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         FieldsToParse fieldsToParse[] = {
             {NULL /*opCode*/, &numOfValidArgs[0], DWPAL_STR_PARAM, NULL, 0},
             {NULL, &numOfValidArgs[1], DWPAL_STR_PARAM, NULL, 0},
-            {(void *)&msg->params.success, &numOfValidArgs[2], DWPAL_CHAR_PARAM, "success=", 0},
+            {(void *)&msg->params.success, &numOfValidArgs[2], DWPAL_CHAR_PARAM, "cac_status=", 0},
             {(void *)&msg->params.frequency, &numOfValidArgs[3], DWPAL_INT_PARAM, "freq=", 0},
             {(void *)&msg->params.timeout, &numOfValidArgs[4], DWPAL_INT_PARAM, "timeout=", 0},
             {(void *)&chan_width, &numOfValidArgs[5], DWPAL_CHAR_PARAM, "chan_width=", 0},

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -205,51 +205,8 @@ bool base_wlan_hal_dwpal::fsm_setup()
                            << ", fixed_dfs_channel=" << int(fixed_dfs_channel)
                            << ", fixed_channel=" << int(fixed_channel);
 
-                // AP is Enabled
                 LOG(DEBUG) << "wifi_ctrl_enabled  = " << int(m_radio_info.wifi_ctrl_enabled);
-
-                bool error = false;
-                if (fixed_dfs_channel) {
-                    if (m_radio_info.tx_enabled) {
-                        LOG(DEBUG) << "ap_enabled tx = " << int(m_radio_info.tx_enabled);
-                        return true;
-                    } else {
-                        LOG(ERROR) << "ap_enabled with tx OFF!";
-                        error = true;
-                    }
-                } else if (fixed_channel) {
-                    if (m_radio_info.wifi_ctrl_enabled == 1) {
-                        if (m_radio_info.tx_enabled) {
-                            LOG(DEBUG) << "ap_enabled tx = " << int(m_radio_info.tx_enabled);
-                            return true;
-                        } else {
-                            LOG(ERROR) << "ap_enabled with tx OFF!";
-                            error = true;
-                        }
-                    }
-                } else { // Auto Channel
-                    if (m_radio_info.wifi_ctrl_enabled == 1) {
-                        if (m_radio_info.tx_enabled) {
-                            LOG(DEBUG) << "ap_enabled tx = " << int(m_radio_info.tx_enabled);
-                            return true;
-                        } else {
-                            LOG(ERROR) << "ap_enabled with tx OFF!";
-                            error = true;
-                        }
-                    } else if (m_radio_info.wifi_ctrl_enabled != 0) {
-                        LOG(ERROR)
-                            << "Auto channel, invalid wifi_ctrl_enabled value. wifi_ctrl_enabled="
-                            << m_radio_info.wifi_ctrl_enabled;
-                        error = true;
-                    }
-                }
-
-                if (error || (std::chrono::steady_clock::now() >= m_state_timeout)) {
-                    return (transition.change_destination(dwpal_fsm_state::Detach));
-                }
-
-                // Remain in the current state
-                return false;
+                return true;
             })
 
         //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Since prplmesh is passive (passive mode is the only mode), there is no
reason to wait till the hostapd gets to ENABLED (which is what
wifi_ctrl_enabled == 1 means).
Actually, there is no point to wait in static channel as well, since we
simply do not rely on the hostapd status, and if we do, it is a bug, and
we should not stop the attach FSM on this.
So - simply always pring the radio info and complete the attach FSM.

As a welcome consequence, the whole prplMesh init becomes much faster as
we don't wait for CAC to complete.

As another welcome consequence of this, which is why I came around to
debug this in the first case, the controller UCC listener now starts
much sooner, since it depends on the backhaul manager slave to join
which on many occasions used to be the one waiting for CAC, resulting
with no listener for more than a minute after starting prplmesh.
