### PR TITLE
Hotfix/start controller ucc listener at init

### DIFF
--- a/controller/src/beerocks/master/CMakeLists.txt
+++ b/controller/src/beerocks/master/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 add_executable(${PROJECT_NAME} ${controller_sources} ${controller_tasks_sources} ${controller_db_sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,-z,defs")
 
-target_link_libraries(${PROJECT_NAME} bcl btl tlvf elpp btlvf)
+target_link_libraries(${PROJECT_NAME} bpl bcl btl tlvf elpp btlvf)
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${MODULE_PATH}/../bml
 )

--- a/controller/src/beerocks/master/beerocks_master_main.cpp
+++ b/controller/src/beerocks/master/beerocks_master_main.cpp
@@ -10,6 +10,7 @@
 #include <bcl/beerocks_logging.h>
 #include <bcl/beerocks_version.h>
 #include <bcl/network/network_utils.h>
+#include <bpl/bpl_cfg.h>
 #include <easylogging++.h>
 
 #include "db/db.h"

--- a/controller/src/beerocks/master/beerocks_master_main.cpp
+++ b/controller/src/beerocks/master/beerocks_master_main.cpp
@@ -214,6 +214,9 @@ static void fill_master_config(son::db::sDbMasterConfig &master_conf,
     if (!s.empty()) {
         master_conf.global_restricted_channels.push_back(beerocks::string_utils::stoi(s));
     }
+
+    // platform settings
+    master_conf.certification_mode = beerocks::bpl::cfg_get_certification_mode();
 }
 
 int main(int argc, char *argv[])

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -114,7 +114,7 @@ private:
 
     db &database;
     task_pool tasks;
-    std::unique_ptr<beerocks::controller_ucc_listener> m_controller_ucc_listener;
+    beerocks::controller_ucc_listener m_controller_ucc_listener;
 };
 
 } // namespace son


### PR DESCRIPTION
Currently, the controller waits for slave join and only then starts the UCC listener.
This is an unnecessary by-product of the fact we are avoiding reading the platform DB by the controller.
Since we plan to allow the controller to read the platform DB anyway, as most configuration parameters which are shared between the controller and agent are stored in the platform DB, there is no reason to keep this separation anymore.
Update the controller to link with BPL, and read the certification mode directly at init.
Then, start the UCC listener at init instead of waiting for slave join.

We can do the same for the agent, but it is not really required since the platform manager is part of the agent and is anyway the first entity to which each agent component is registering to.