### PR TITLE
common: match based on process names when using killall

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -33,7 +33,7 @@ killall_program() {
     else
         KILL_SIG=$SIG_KILL
     fi
-    for PID in $(pgrep -f $PROGRAM_NAME[[:blank:][:alpha:]]); do
+    for PID in $(pgrep "$PROGRAM_NAME"); do
         echo "kill $KILL_SIG $PID $PROGRAM_NAME";
         kill $KILL_SIG $PID > /dev/null 2>&1;
     done


### PR DESCRIPTION
Commit '47278ea280a9c15f93cc4d13b4f76350f960787a' changed the regexp
used with killall to not match any process that doesn't have either a
blank character or an alphabetical character at the end. Because of
this, running the stop function does not kill any process that doesn't
have a space at the end of its full command line (i.e., nothing except
the slaves is killed).

Remove "[[:blank:][:alpha:]]" because:
- we do not have any command name matching "$PROGRAM_NAME[:alpha:]",
  so the "[:alpha:]" part is useless.
- most of the processes we want to kill do not have any character
  matching [:blank:] at their end.

Remove the "-f" option to match on the process name only and not the
full command line, so that a "tail" process does not match.

While we're at it, quote PROGRAM_NAME to prevent any possibility of
globing or word splitting.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>