### PR TITLE
easylogging: Fix syslog out of memory

### DIFF
--- a/framework/external/easylogging/easylogging++.cc
+++ b/framework/external/easylogging/easylogging++.cc
@@ -2231,8 +2231,10 @@ void DefaultLogDispatchCallback::handle(const LogDispatchData* data) {
   {
 	  LogDispatchData syslogData;
 	  syslogData.setDispatchAction(base::DispatchAction::SysLog);
-	  syslogData.setLogMessage(new LogMessage(data->logMessage()->level(), data->logMessage()->file(), data->logMessage()->line(),
-		data->logMessage()->func(), data->logMessage()->verboseLevel(), Loggers::getLogger(base::consts::kSysLogLoggerId), data->logMessage()->message()));
+	  LogMessage log_message(data->logMessage()->level(), data->logMessage()->file(),
+			   data->logMessage()->line(), data->logMessage()->func(), data->logMessage()->verboseLevel(),
+			   Loggers::getLogger(base::consts::kSysLogLoggerId), data->logMessage()->message());
+	  syslogData.setLogMessage(&log_message);
 
 	  dispatch(m_data->logMessage()->logger()->logBuilder()->build(m_data->logMessage(),
 			   m_data->dispatchAction() == base::DispatchAction::NormalLog), syslogData .logMessage()->logger()->logBuilder()->build(syslogData.logMessage(),


### PR DESCRIPTION
It has been observed that on RDKB where easylogging works on syslog mode,
after ~24 hours, the system gets  kernel panic error and reboots:
"Kernel panic - not syncing: Out of memory: system-wide panic_on_oom is enabled"
When running "top" command on memory mode, right before it happens, it is
possible to see that prplMesh process consumption of allocated memory (RSS)
reached to hundreds of MBs.

Debugging the issue pointed out that the source of the issue is log printing.
To validate that the log is really what causing it, I added temporary (not included
on this commit) 10000 lines print on son_master work function and indeed the
controller memory consumption has raised to 100 MB in less than 2 minutes.

The root cause of the issue is a dynamic allocation of "LogMessage" object in
DefaultLogDispatchCallback function which is called only when syslog is enabled,
without freeing the object after the function ends.

Replace the dynamic allocation with a stack allocation.

#879