### PR TITLE
.mergify.yml: add mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,22 @@
+pull_request_rules:
+  - name: Automatic rebase and merge on approval
+    conditions:
+      - "#approved-reviews-by>=2" # Require at least two approving reviewers
+      - "#changes-requested-reviews-by=0" # Changes requested blocks the merge
+      - "label!=don't merge" # Don't merge label blocks the merge
+      # All status checks must pass. Since mergify itself is a status check, this is a bit
+      # recursive... So, explicitly say that there should be no unfinished (= neutral) status
+      # check, no failures obviously, and that at least two status checks are successful.
+      - "#status-neutral=0"
+      - "#status-failure=0"
+      - "#status-success>=2"
+    actions:
+      merge:
+        method: rebase # Merge with rebase
+        rebase_fallback: null # Manual intervention needed if that doesn't work
+        # If not up-to-date with master, bring it up-to-date first.
+        # Use rebase for bringing up-to-date
+        # Use "smart" to do the rebase one-by-one, in case multiple PRs need to be
+        # rebased.
+        strict: smart
+        strict_method: rebase


### PR DESCRIPTION
Supposedly, the configuration can be tested at
https://dashboard.mergify.io/installation/6872982/simulator?repositoryName=prplMesh&pullRequestNumber=808
but I have had no success with it.

This configuration:
 - replicates the merge conditions we have now:
   - at least two approving reviews;
   - no changes requested;
   - no don't merge tag;
   - CI has finished successfully.
 - automatically rebases on master when master is updated ("strict"
   merge policy).

As far as I understand, the automatic rebase will only happen if all the
merge conditions are met. That's a bit unfortunate, since it means that
CI has to run first, then the rebase happens, and then CI has to run
again. The "smart" option of strict merges alleviates this problem
somewhat, by queueing the rebases if there is more than one.