### PR TITLE
easylogging: Remove sticky std::hex configuration and add showbase and boolalpha flags to logs

### DIFF
--- a/common/beerocks/bcl/source/beerocks_logging.cpp
+++ b/common/beerocks/bcl/source/beerocks_logging.cpp
@@ -513,6 +513,9 @@ void logging::apply_settings()
     el::Loggers::addFlag(el::LoggingFlag::LogDetailedCrashReason);
     el::Loggers::addFlag(el::LoggingFlag::DisableApplicationAbortOnFatalLog);
     el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
+    el::Loggers::addFlag(el::LoggingFlag::ForceDecBase);
+    el::Loggers::addFlag(el::LoggingFlag::ShowBase);
+    el::Loggers::addFlag(el::LoggingFlag::BoolAlpha);
 
     auto logger = el::Loggers::getLogger("default");
     if (!logger) {

--- a/framework/external/easylogging/easylogging++.cc
+++ b/framework/external/easylogging/easylogging++.cc
@@ -2543,6 +2543,15 @@ void MessageBuilder::initialize(Logger* logger) {
   m_logger = logger;
   m_containerLogSeperator = ELPP->hasFlag(LoggingFlag::NewLineForContainer) ?
                             ELPP_LITERAL("\n    ") : ELPP_LITERAL(", ");
+  if (ELPP->hasFlag(LoggingFlag::ForceDecBase)) {
+    m_logger->stream().setf(std::ios::dec);
+  }
+  if (ELPP->hasFlag(LoggingFlag::ShowBase)) {
+    m_logger->stream().setf(std::ios::showbase);
+  }
+  if (ELPP->hasFlag(LoggingFlag::BoolAlpha)) {
+    m_logger->stream().setf(std::ios::boolalpha);
+  }
 }
 
 MessageBuilder& MessageBuilder::operator<<(const wchar_t* msg) {

--- a/framework/external/easylogging/easylogging++.h
+++ b/framework/external/easylogging/easylogging++.h
@@ -725,8 +725,14 @@ enum class LoggingFlag : base::type::EnumType {
   AutoSpacing = 8192,
   /// @brief Preserves time format and does not convert it to sec, hour etc (performance tracking only)
   FixedTimeFormat = 16384,
-  // @brief Ignore SIGINT or crash
+  /// @brief Ignore SIGINT or crash
   IgnoreSigInt = 32768,
+  /// @brief Set the log to print integer on decimal format with every log-entry
+  ForceDecBase = 65536,
+  /// @brief Set the log to print the base of integer value according to iostream base flag
+  ShowBase = 131072,
+  /// @brief Set the log to print the booleans as "true" or "false" instead of "1" or "0"
+  BoolAlpha = 262144,
 };
 namespace base {
 /// @brief Namespace containing constants used internally.

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -527,7 +527,7 @@ test_client_steering_policy() {
     check_log ${REPEATER1} agent_wlan0 "MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE"
     sleep 1
     dbg "Confirming client steering policy ack message has been received on the controller"
-    check_log ${GATEWAY} controller "ACK_MESSAGE, mid=$MID1_STR"
+    check_log ${GATEWAY} controller "ACK_MESSAGE, mid=0x$MID1_STR"
 
     return $check_error
 }
@@ -580,7 +580,7 @@ test_higher_layer_data_payload_trigger() {
     dbg "Confirming matching protocol and payload length"
 
     check_log ${REPEATER1} agent "protocol: 0"
-    check_log ${REPEATER1} agent "payload_length: 4b0"
+    check_log ${REPEATER1} agent "payload_length: 0x4b0"
 
     dbg "Confirming ACK message was received in the controller"
     check_log ${GATEWAY} controller "ACK_MESSAGE"


### PR DESCRIPTION
Add to LoggingFlag on easylogging 3 new flags:
ForceDecBase - Set the log to print integer on decimal format with every log-entry.
ShowBase - Set the log to print the base of integer value according to iostream base flag.
BoolAlpha - Set the log to print the booleans as "true" or "false" instead of "1" or "0".

Set these configurations by default on all processes.
Now  the log will look like this:

LOG(DEBUG) << std::hex << "num_hex=" << 32 << ", bool=" << bool(false);
LOG(DEBUG) << "num_dec=" << 32 << ", bool=" << bool(true);

output:
```
DEBUG 16:33:21:731 <Some file> --> num_hex=0x20, bool=false
DEBUG 16:33:21:731 <Some file> --> num_dec=32, bool=true
```

#879