### PR TITLE
scripts: search full command line with pgrep -f

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -33,7 +33,7 @@ killall_program() {
     else
         KILL_SIG=$SIG_KILL
     fi
-    for PID in $(pgrep "$PROGRAM_NAME"); do
+    for PID in $(pgrep -f "$PROGRAM_NAME"); do
         echo "kill $KILL_SIG $PID $PROGRAM_NAME";
         kill $KILL_SIG $PID > /dev/null 2>&1;
     done

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -34,8 +34,10 @@ killall_program() {
         KILL_SIG=$SIG_KILL
     fi
     for PID in $(pgrep -f "$PROGRAM_NAME"); do
-        echo "kill $KILL_SIG $PID $PROGRAM_NAME";
-        kill $KILL_SIG $PID > /dev/null 2>&1;
+        if [ "$(basename "$(readlink /proc/"$PID"/exe)")" = "$PROGRAM_NAME" ]; then
+            echo "kill $KILL_SIG $PID $PROGRAM_NAME";
+            kill $KILL_SIG "$PID" > /dev/null 2>&1;
+        fi
     done
 }
 


### PR DESCRIPTION
prplmesh_utils.sh includes a `killall_program()` function which is used
to kill processes which were brought up by the script when stopping
prplmesh, and is using pgrep to search for the PID to kill.

Commit 574fe63 removed the -f for not
killing other applications which have the command line string of the
process we are killing in their command line - used when we tail the
logs.

This solved the issue where tail was also killed when we stopped
prplmesh, but it created a new bug, which was the reason -f was used in
the first place -
By default, pgrep only searches the process name,
which is a truncated version of the entire command, for example in
ubuntu16.04 LTS:
"tester@WcsTEst100:~/work/prplMesh$ cat /proc/6389/status
Name:   beerocks_contro"

This means that pgrep beerocks_controller simply will not work, which
results with processes not being killed as they should.

Fix this by bringing back -f flag for pgrep which will match the full
process name. Not that with the -f flag, pgreping the truncated name
will also work, so this will not break other cases.

The second commit fixes the "tail" issue by matching the process name with the full executable name we read from `/proc/$PID/exe`.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>