### PR TITLE
bwl: dwpal: set empty ssids when tearing down vaps

### DIFF
--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1061,6 +1061,8 @@ bool ap_wlan_hal_dwpal::update_vap_credentials(
             entry_mode != "ap") {
             continue;
         }
+        // SSID
+        hostapd_config_set_value(vap_hostapd_config, "ssid", std::string());
         // Disable the VAP
         hostapd_config_set_value(vap_hostapd_config, "start_disabled", "1");
     }


### PR DESCRIPTION
Currently, tear down is implemented with setting start_disabled=1 for
each tore down VAP in the hostapd conf.
The backhaul manager uses the VAPs SSIDs when building the AP operational
BSS TLV in the topology response message by testing for empty string to
determine if the VAP is enabled and should be reported or not.
Fix that by setting the SSID to empty string in the BWL DWPAL
implementation when tearing down a VAP.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>