### PR TITLE
tests: convert test_flows.sh to python (test_flows.py)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,28 @@ run-tests:
   needs:
     - job: build-in-docker
 
+run-tests-py:
+  stage: test
+  image: $CI_REGISTRY_IMAGE/tests-runner:18.09.7-dind
+  script:
+    # Try to pull from dockerhub, if it fails, the run should fail
+    - tools/docker/image-pull.sh
+    - tests/test_flows.py -v -u $RANDOM
+
+  artifacts:
+    paths:
+      - logs
+    when: always
+
+  tags:
+    - docker
+    - docker-build
+
+  after_script:
+    - tools/docker/stop.sh -k -r
+  needs:
+    - job: build-in-docker
+
 .build-for-openwrt:
   stage: build
   script:

--- a/tests/send_CAPI_command.py
+++ b/tests/send_CAPI_command.py
@@ -100,6 +100,11 @@ class UCCSocket:
                 else:
                     raise ValueError("Received an unknown reply from the server:\n {}".format(r))
 
+    def cmd_reply(self, command: str, verbose: bool = False) -> str:
+        """Open the connection, send a command and wait for the reply."""
+        with self:
+            self.send_cmd(command)
+            return self.get_reply(verbose)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Simulated UCC")
@@ -109,6 +114,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
     socket.gethostbyname(args.host)
 
-    with UCCSocket(args.host, args.port) as sock:
-        sock.send_cmd(args.command)
-        sock.get_reply(True)
+    UCCSocket(args.host, args.port).cmd_reply(args.command, True)

--- a/tests/send_CAPI_command.py
+++ b/tests/send_CAPI_command.py
@@ -60,12 +60,17 @@ class UCCSocket:
             command += "\n"
         self.conn.send(command.encode("utf-8"))
 
-    def get_reply(self) -> str:
+    def get_reply(self, verbose: bool = False) -> str:
         """Wait until the server replies with a `CAPIReply` message other than `CAPIReply.RUNNING`.
 
         The replies from the server will be printed as they are received.
         Note that this method only returns once a `CAPIReply.COMPLETE`, `CAPIReply.INVALID`,
         or `CAPIReply.ERROR` message has been received from the server.
+
+        Parameters
+        ----------
+        verbose : bool
+            If True, print out the valid replies (RUNNING and COMPLETE) as they arrive.
 
         Returns
         -------
@@ -84,9 +89,11 @@ class UCCSocket:
                 if not r:
                     pass  # server replied with an empty line
                 elif CAPIReply.RUNNING.value in r:
-                    print(r)
+                    if verbose:
+                        print(r)
                 elif CAPIReply.COMPLETE.value in r:
-                    print(r)
+                    if verbose:
+                        print(r)
                     return r
                 elif CAPIReply.INVALID.value in r or CAPIReply.ERROR.value in r:
                     raise ValueError("Server replied with {}".format(r))
@@ -104,4 +111,4 @@ if __name__ == "__main__":
 
     with UCCSocket(args.host, args.port) as sock:
         sock.send_cmd(args.command)
-        sock.get_reply()
+        sock.get_reply(True)

--- a/tests/send_CAPI_command.py
+++ b/tests/send_CAPI_command.py
@@ -110,6 +110,11 @@ class UCCSocket:
             self.send_cmd(command)
             return self.get_reply(verbose)
 
+    def dev_get_parameter(self, parameter: str) -> str:
+        """Call dev_get_parameter and return the parameter, or raise KeyError if it is missing."""
+        reply = self.cmd_reply("dev_get_parameter,program,map,parameter,{}".format(parameter))
+        return reply[parameter]
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Simulated UCC")
     parser.add_argument("host", help="The device hostname or IP.", type=str)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,0 +1,134 @@
+#! /usr/bin/env python3
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2020 Arnout Vandecappelle (Essensium/Mind)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+import argparse
+import os
+import re
+import sys
+
+
+class test_flows:
+    def __init__(self):
+        self.tests = [attr[len('test_'):] for attr in dir(self) if attr.startswith('test_')]
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--tcpdump", "-t", action='store_true', default=False,
+                            help="capture the packets during each test - UNINMPLEMENTED")
+        parser.add_argument("--verbose", "-v", action='store_true', default=False,
+                            help="report each action")
+        parser.add_argument("--stop-on-failure", "-s", action='store_true', default=False,
+                            help="exit on the first failure")
+        user = os.getenv("SUDO_USER", os.getenv("USER", ""))
+        parser.add_argument("--unique-id", "-u", type=str, default=user,
+                            help="append UNIQUE_ID to all container names, e.g. gateway-<UNIQUE_ID>; "
+                                 "defaults to {}".format(user))
+        parser.add_argument("--skip-init", action='store_true', default=False,
+                            help="don't start up the containers - UNINMPLEMENTED")
+        parser.add_argument("tests", nargs='*',
+                            help="tests to run; if not specified, run all tests: " + ", ".join(self.tests))
+        self.opts = parser.parse_args()
+
+        if not self.opts.tests:
+            self.opts.tests = self.tests
+
+        unknown_tests = [test for test in self.opts.tests if test not in self.tests]
+        if unknown_tests:
+            parser.error("Unknown tests: {}".format(', '.join(unknown_tests)))
+
+        self.rootdir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+        self.running = ''
+
+    def message(self, message: str, color: int = 0):
+        '''Print a message, optionally in a color, preceded by the currently running test.'''
+        full_message = '{:20} {}'.format(self.running, message)
+        if color:
+            print('\x1b[1;{}m{}\x1b[0m'.format(color, full_message))
+        else:
+            print(full_message)
+
+    def debug(self, message: str):
+        '''Print a debug message if verbose is enabled.'''
+        if self.opts.verbose:
+            self.message(message)
+
+    def status(self, message: str):
+        '''Print a purple status message.'''
+        self.message(message, 35)
+
+    def err(self, message: str):
+        '''Print a red error message.'''
+        self.message(message, 31)
+
+    def ok(self):
+        '''Print a green OK message.'''
+        self.message("OK", 32)
+
+    def fail(self, message: str) -> bool:
+        '''Print a red error message, increment failure count and return False.'''
+        self.check_error += 1
+        self.err('FAIL: {}'.format(message))
+        if self.opts.stop_on_failure:
+            sys.exit(1)
+        return False
+
+    def start_test(self, test: str):
+        '''Call this at the beginning of a test.'''
+        self.running = test
+        self.status("starting")
+
+    def init(self):
+        '''Initialize the tests.'''
+        self.start_test('init')
+        self.gateway = 'gateway-' + self.opts.unique_id
+        self.repeater1 = 'repeater1-' + self.opts.unique_id
+        self.repeater2 = 'repeater2-' + self.opts.unique_id
+
+    def check_log(self, device: str, program: str, regex: str) -> bool:
+        '''Verify that on "device" the logfile for "program" matches "regex", fail if not.'''
+        logfilename = os.path.join(self.rootdir, 'logs', device, 'beerocks_{}.log'.format(program))
+        try:
+            with open(logfilename) as logfile:
+                for line in logfile.readlines():
+                    if re.search(regex, line):
+                        self.debug("Found '{}'\n\tin {}".format(regex, logfilename))
+                        return True
+        except OSError:
+            return self.fail("Can't read {}".format(logfilename))
+        return self.fail("'{}'\n\tin log of {} on {}".format(regex, program, device))
+
+    def run_tests(self):
+        '''Run all tests as specified on the command line.'''
+        total_errors = 0
+        for test in self.opts.tests:
+            self.start_test(test)
+            self.check_error = 0
+            getattr(self, 'test_' + test)()
+            if self.check_error != 0:
+                self.err("failed")
+            else:
+                self.ok()
+            total_errors += self.check_error
+        return total_errors
+
+    # TEST DEFINITIONS #
+
+    def test_initial_ap_config(self):
+        '''Check initial configuration on repeater1.'''
+        self.check_log(self.repeater1, "agent_wlan0", r"WSC Global authentication success")
+        self.check_log(self.repeater1, "agent_wlan2", r"WSC Global authentication success")
+        self.check_log(self.repeater1, "agent_wlan0", r"KWA \(Key Wrap Auth\) success")
+        self.check_log(self.repeater1, "agent_wlan2", r"KWA \(Key Wrap Auth\) success")
+        self.check_log(self.repeater1, "agent_wlan0", r".* Controller configuration \(WSC M2 Encrypted Settings\)")
+        self.check_log(self.repeater1, "agent_wlan2", r".* Controller configuration \(WSC M2 Encrypted Settings\)")
+
+
+if __name__ == '__main__':
+    t = test_flows()
+    t.init()
+    if t.run_tests():
+        sys.exit(1)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -15,6 +15,9 @@ import json
 
 import send_CAPI_command
 
+'''Regular expression to match a MAC address in a bytes string.'''
+RE_MAC = rb"(?P<mac>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})"
+
 class test_flows:
     def __init__(self):
         self.tests = [attr[len('test_'):] for attr in dir(self) if attr.startswith('test_')]
@@ -159,6 +162,20 @@ class test_flows:
         self.debug('mac_repeater1: {}'.format(self.mac_repeater1))
         self.mac_repeater2 = self.repeater2_ucc.dev_get_parameter('ALid')
         self.debug('mac_repeater2: {}'.format(self.mac_repeater2))
+
+        mac_repeater1_wlan0_output = self.docker_command(self.repeater1, "ip", "-o",  "link", "list", "dev", "wlan0")
+        self.mac_repeater1_wlan0 = re.search(rb"link/ether " + RE_MAC, mac_repeater1_wlan0_output).group('mac').decode()
+        self.debug("Repeater1 wl0: {}".format(self.mac_repeater1_wlan0))
+        mac_repeater1_wlan2_output = self.docker_command(self.repeater1, "ip", "-o",  "link", "list", "dev", "wlan2")
+        self.mac_repeater1_wlan2 = re.search(rb"link/ether " + RE_MAC, mac_repeater1_wlan2_output).group('mac').decode()
+        self.debug("Repeater1 wl2: {}".format(self.mac_repeater1_wlan2))
+
+        mac_repeater2_wlan0_output = self.docker_command(self.repeater2, "ip", "-o",  "link", "list", "dev", "wlan0")
+        self.mac_repeater2_wlan0 = re.search(rb"link/ether " + RE_MAC, mac_repeater2_wlan0_output).group('mac').decode()
+        self.debug("Repeater2 wl0: {}".format(self.mac_repeater2_wlan0))
+        mac_repeater2_wlan2_output = self.docker_command(self.repeater2, "ip", "-o",  "link", "list", "dev", "wlan2")
+        self.mac_repeater2_wlan2 = re.search(rb"link/ether " + RE_MAC, mac_repeater2_wlan2_output).group('mac').decode()
+        self.debug("Repeater2 wl2: {}".format(self.mac_repeater2_wlan2))
 
     def check_log(self, device: str, program: str, regex: str) -> bool:
         '''Verify that on "device" the logfile for "program" matches "regex", fail if not.'''

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -9,6 +9,7 @@
 import argparse
 import os
 import re
+import subprocess
 import sys
 
 
@@ -28,7 +29,7 @@ class test_flows:
                             help="append UNIQUE_ID to all container names, e.g. gateway-<UNIQUE_ID>; "
                                  "defaults to {}".format(user))
         parser.add_argument("--skip-init", action='store_true', default=False,
-                            help="don't start up the containers - UNINMPLEMENTED")
+                            help="don't start up the containers")
         parser.add_argument("tests", nargs='*',
                             help="tests to run; if not specified, run all tests: " + ", ".join(self.tests))
         self.opts = parser.parse_args()
@@ -87,6 +88,11 @@ class test_flows:
         self.gateway = 'gateway-' + self.opts.unique_id
         self.repeater1 = 'repeater1-' + self.opts.unique_id
         self.repeater2 = 'repeater2-' + self.opts.unique_id
+        if not self.opts.skip_init:
+            subprocess.check_call((os.path.join(self.rootdir, "tests", "test_gw_repeater.sh"),
+                                   "-f", "-u", self.opts.unique_id, "-g", self.gateway,
+                                   "-r", self.repeater1, "-r", self.repeater2, "-d", "7"))
+
 
     def check_log(self, device: str, program: str, regex: str) -> bool:
         '''Verify that on "device" the logfile for "program" matches "regex", fail if not.'''

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -182,6 +182,11 @@ class test_flows:
         '''Verify that on "device" the logfile for "program" matches "regex", fail if not.'''
         logfilename = os.path.join(self.rootdir, 'logs', device, 'beerocks_{}.log'.format(program))
         try:
+            # HACK check_log is often used immediately after triggering a message on the other side.
+            # That message needs some time to arrive on the receiver. Since our python script is pretty fast,
+            # we tend to check it too quickly. As a simple workaround, add a small sleep here.
+            # The good solution is to retry with a small timeout.
+            time.sleep(.1)
             with open(logfilename) as logfile:
                 for line in logfile.readlines():
                     if re.search(regex, line):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import json
 
 import send_CAPI_command
@@ -219,6 +220,129 @@ class test_flows:
         self.check_log(self.repeater1, "agent_wlan0", r".* Controller configuration \(WSC M2 Encrypted Settings\)")
         self.check_log(self.repeater1, "agent_wlan2", r".* Controller configuration \(WSC M2 Encrypted Settings\)")
 
+    def test_channel_selection(self):
+        self.debug("Send channel preference query")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8004)
+        time.sleep(1)
+        self.debug("Confirming channel preference query has been received on agent")
+        self.check_log(self.repeater1, "agent_wlan0", "CHANNEL_PREFERENCE_QUERY_MESSAGE")
+        self.check_log(self.repeater1, "agent_wlan2", "CHANNEL_PREFERENCE_QUERY_MESSAGE")
+
+        self.debug("Send channel selection request")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8006)
+        time.sleep(1)
+        self.debug("Confirming channel selection request has been received on agent")
+        self.check_log(self.repeater1, "agent_wlan0", "CHANNEL_SELECTION_REQUEST_MESSAGE")
+        self.check_log(self.repeater1, "agent_wlan2", "CHANNEL_SELECTION_REQUEST_MESSAGE")
+
+        #self.debug("Confirming 1905.1 Ack Message request was received on agent")
+        # TODO: When creating handler for the ACK message on the agent, replace lookup of this string
+        # TODO: currently controller sends empty channel selection request, so no switch is performed
+        # self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
+        # self.check_log(self.repeater1, "agent_wlan2", "ACK_MESSAGE")
+
+    def test_ap_capability_query(self):
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8001)
+        time.sleep(1)
+
+        self.debug("Confirming ap capability query has been received on agent")
+        self.check_log(self.repeater1, "agent", "AP_CAPABILITY_QUERY_MESSAGE")
+
+        self.debug("Confirming ap capability report has been received on controller")
+        self.check_log(self.gateway, "controller", "AP_CAPABILITY_REPORT_MESSAGE")
+
+    def test_combined_infra_metrics(self):
+        self.debug("Send AP Metrics query message to agent 1")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x800B,
+                                       (0x93,0x0007,"0x01 {%s}" % (self.mac_repeater1_wlan0)))
+        self.check_log(self.repeater1, "agent_wlan0", "Received AP_METRICS_QUERY_MESSAGE")
+        # TODO agent should send response autonomously, with same MID.
+        # tlv1 == AP metrics TLV
+        # tlv2 == STA metrics TLV with no metrics
+        # tlv3 == STA metrics TLV for STA connected to this BSS
+        # tlv4 == STA traffic stats TLV for same STA
+        self.repeater1_ucc.dev_send_1905(self.mac_gateway, 0x800C,
+            (0x94,0x000d,"{%s} 0x01 0x0002 0x01 0x1f2f3f" % (self.mac_repeater1_wlan0)),
+            (0x96,0x0007,"{55:44:33:22:11:00} 0x00"),
+            (0x96,0x001a,"{66:44:33:22:11:00} 0x01 {%s} 0x11223344 0x1a2a3a4a 0x1b2b3b4b 0x55" %
+                self.mac_repeater1_wlan0),
+            (0xa2,0x0022,"{55:44:33:22:11:00} 0x10203040 0x11213141 0x12223242 0x13233343 "
+                "0x14243444 0x15253545 0x16263646"))
+        self.check_log(self.gateway, "controller", "Received AP_METRICS_RESPONSE_MESSAGE")
+
+        self.debug("Send AP Metrics query message to agent 2")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater2, 0x800B,
+                                       (0x93,0x0007,"0x01 {%s}" % self.mac_repeater2_wlan2))
+        self.check_log(self.repeater2, "agent_wlan2", "Received AP_METRICS_QUERY_MESSAGE")
+        # TODO agent should send response autonomously
+        # Same as above but with different STA MAC addresses, different values and skipping the empty one
+        self.repeater2_ucc.dev_send_1905(self.mac_gateway, 0x800C,
+            (0x94,0x0010,"{%s} 0x11 0x1002 0x90 0x1c2c3c 0x1d2d3d" % self.mac_repeater2_wlan2),
+            (0x96,0x001a,"{77:44:33:22:11:00} 0x01 {%s} 0x19293949 0x10203040 0x11213141 0x99" % self.mac_repeater2_wlan2),
+            (0xa2,0x0022,"{77:44:33:22:11:00} 0xa0203040 0xa1213141 0xa2223242 0xa3233343 "
+                         "0xa4243444 0xa5253545 0xa6263646"))
+        self.check_log(self.gateway, "controller", "Received AP_METRICS_RESPONSE_MESSAGE")
+
+        self.debug("Send 1905 Link metric query to agent 1 (neighbor agent 2)")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0005,
+                                       (0x08,0x0008,"0x01 {%s} 0x02" % self.mac_repeater2))
+        self.check_log(self.repeater1, "agent_wlan0", "Received LINK_METRIC_QUERY_MESSAGE")
+        # TODO agent should send response autonomously
+        self.repeater1_ucc.dev_send_1905(self.mac_gateway, 0x6,
+            (0x09,0x0029,"{%s} {%s} {%s} {%s} 0x0100 0x01 0x00000000 0x0000e300 0x4230 0x0064 0x0300" %
+                (self.mac_repeater1, self.mac_repeater2, self.mac_repeater1_wlan0, self.mac_repeater2_wlan2)),
+            (0x0a,0x0023,"{%s} {%s} {%s} {%s} 0x0100 0x00000007 0x00020000 0x31" %
+                (self.mac_repeater1, self.mac_repeater2, self.mac_repeater1, self.mac_repeater2)))
+        self.check_log(self.gateway, "controller", "Received LINK_METRIC_RESPONSE_MESSAGE")
+
+        # Trigger combined infra metrics
+        self.debug("Send Combined infrastructure metrics message to agent 1")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8013)
+        self.check_log(self.repeater1, "agent", "Received COMBINED_INFRASTRUCTURE_METRICS")
+        self.check_log(self.repeater1, "agent", "Received TLV_TRANSMITTER_LINK_METRIC")
+        self.check_log(self.repeater1, "agent", "Received TLV_RECEIVER_LINK_METRIC")
+
+    def test_client_steering_mandate(self):
+        self.debug("Send topology request to agent 1")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0002)
+        time.sleep(1)
+        self.debug("Confirming topology query was received")
+        self.check_log(self.repeater1, "agent", "TOPOLOGY_QUERY_MESSAGE")
+
+        self.debug("Send topology request to agent 2")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater2, 0x0002)
+        time.sleep(1)
+        self.debug("Confirming topology query was received")
+        self.check_log(self.repeater2, "agent", "TOPOLOGY_QUERY_MESSAGE")
+
+        self.debug("Send Client Steering Request message for Steering Mandate to CTT Agent1")
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8014,
+            (0x9B, 0x001b, "{%s 0xe0 0x0000 0x1388 0x01 {0x000000110022} 0x01 {%s 0x73 0x24}}" %
+                (self.mac_repeater1_wlan0, self.mac_repeater2_wlan0)))
+        time.sleep(1)
+        self.debug("Confirming Client Steering Request message was received - mandate")
+        self.check_log(self.repeater1, "agent_wlan0", "Got steer request")
+
+        self.debug("Confirming BTM Report message was received")
+        self.check_log(self.gateway, "controller", "CLIENT_STEERING_BTM_REPORT_MESSAGE")
+
+        self.debug("Confirming ACK message was received")
+        self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
+
+        self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8014,
+            (0x9B, 0x000C, "{%s 0x00 0x000A 0x0000 0x00}" % self.mac_repeater1_wlan0))
+        time.sleep(1)
+        self.debug("Confirming Client Steering Request message was received - Opportunity")
+        self.check_log(self.repeater1, "agent_wlan0", "CLIENT_STEERING_REQUEST_MESSAGE")
+
+        self.debug("Confirming ACK message was received")
+        self.check_log(self.gateway, "controller", "ACK_MESSAGE")
+
+        self.debug("Confirming steering completed message was received")
+        self.check_log(self.gateway, "controller", "STEERING_COMPLETED_MESSAGE")
+
+        self.debug("Confirming ACK message was received")
+        self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
 
 if __name__ == '__main__':
     t = test_flows()

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -115,20 +115,6 @@ send_bwl_event() {
     check docker exec $1 sh -c 'echo '"$3"' > /tmp/$USER/beerocks/'$2'/EVENT'
 }
 
-test_initial_ap_config() {
-    status "test initial autoconfig"
-
-    check_error=0
-    check_log ${REPEATER1} agent_wlan0 "WSC Global authentication success"
-    check_log ${REPEATER1} agent_wlan2 "WSC Global authentication success"
-    check_log ${REPEATER1} agent_wlan0 "KWA (Key Wrap Auth) success"
-    check_log ${REPEATER1} agent_wlan2 "KWA (Key Wrap Auth) success"
-    check_log ${REPEATER1} agent_wlan0 ".* Controller configuration (WSC M2 Encrypted Settings)"
-    check_log ${REPEATER1} agent_wlan2 ".* Controller configuration (WSC M2 Encrypted Settings)"
-
-    return $check_error
-}
-
 test_ap_config_renew() {
     status "test autoconfig renew"
 

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -82,6 +82,7 @@ main() {
     docker network inspect ${NETWORK} >/dev/null 2>&1 || {
         dbg "Network $NETWORK does not exist, creating..."
         run docker network create ${NETWORK} >/dev/null 2>&1
+        echo "network $NETWORK" >> "${scriptdir}/.test_containers"
     }
 
     [ -z "$IPADDR" -a -n "$NETWORK" ] && {

--- a/tools/docker/stop.sh
+++ b/tools/docker/stop.sh
@@ -45,15 +45,15 @@ main() {
 
     grep -v '^network ' "$containers_file" |\
         while read -r container; do
-            docker "$stop_cmd" "${container}" >/dev/null 2>&1
+            docker "$stop_cmd" "${container}" >/dev/null 2>&1 || true
             if [ "$remove" = true ] ; then
-                docker rm "${container}" >/dev/null 2>&1
+                docker rm "${container}" >/dev/null 2>&1 || true
             fi
         done
 
     sed -n '/^network \(.*\)$/s//\1/p' "$containers_file" |\
         while read -r network; do
-            docker network rm "${network}" >/dev/null 2>&1
+            docker network rm "${network}" >/dev/null 2>&1 || true
         done
 }
 

--- a/tools/docker/stop.sh
+++ b/tools/docker/stop.sh
@@ -43,13 +43,18 @@ main() {
         esac
     done
 
-    while read -r container; do
-        docker "$stop_cmd" "${container}" >/dev/null 2>&1
-        if [ "$remove" = true ] ; then
-            docker rm "${container}" >/dev/null 2>&1
-        fi
-    done <"$containers_file"
+    grep -v '^network ' "$containers_file" |\
+        while read -r container; do
+            docker "$stop_cmd" "${container}" >/dev/null 2>&1
+            if [ "$remove" = true ] ; then
+                docker rm "${container}" >/dev/null 2>&1
+            fi
+        done
 
+    sed -n '/^network \(.*\)$/s//\1/p' "$containers_file" |\
+        while read -r network; do
+            docker network rm "${network}" >/dev/null 2>&1
+        done
 }
 
 main "$@"


### PR DESCRIPTION
test_flows.py is a drop-in replacement for test_flows.sh.
This PR ports it directly without any changes or refactorings, except for a few things which are easier to do differently in Python.
E.g. searching in the log file is done directly in Python, not by calling grep.

Fixes #894 