### PR TITLE
scripts: use start-stop-daemon for killall_program

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -6,8 +6,7 @@
 # See LICENSE file for more details.
 ###############################################################
 
-SIG_TERM=-15
-SIG_KILL=-9
+PRPLMESH_BIN_DIR="@INSTALL_PATH@/@CMAKE_INSTALL_BINDIR@"
 
 dbg() {
     [ "$VERBOSE" = "true" ] && echo "$@"
@@ -28,17 +27,9 @@ run() {
 
 killall_program() {
     PROGRAM_NAME=$1
-    if [ "$#" -eq 2 ]; then
-        KILL_SIG=$2
-    else
-        KILL_SIG=$SIG_KILL
-    fi
-    for PID in $(pgrep -f "$PROGRAM_NAME"); do
-        if [ "$(basename "$(readlink /proc/"$PID"/exe)")" = "$PROGRAM_NAME" ]; then
-            echo "kill $KILL_SIG $PID $PROGRAM_NAME";
-            kill $KILL_SIG "$PID" > /dev/null 2>&1;
-        fi
-    done
+    KILL_SIG=${2:-KILL}
+    echo "killing $PROGRAM_NAME ($KILL_SIG)"
+    start-stop-daemon -K -s "$KILL_SIG" -x "$PRPLMESH_BIN_DIR"/"$PROGRAM_NAME" > /dev/null 2>&1
 }
 
 platform_init() {
@@ -182,9 +173,9 @@ roll_logs_function()
     logFilesCountPreRoll=$(find ./*.*.log | wc -l)
         
     # Send USR1 signals to the beerocks processes to trigger log rolling
-    killall_program beerocks_controller  -USR1
-    killall_program beerocks_agent   -USR1
-    killall_program beerocks_monitor -USR1
+    killall_program beerocks_controller USR1
+    killall_program beerocks_agent USR1
+    killall_program beerocks_monitor USR1
 
     # Wait for all the modules to create a new file
     rollTimeout=0


### PR DESCRIPTION
As pointed out correctly in
https://github.com/prplfoundation/prplMesh/pull/855#pullrequestreview-361763302,
our killall_program() implementation is doing exactly what
start-stop-daemon utility is doing.

However, there are cases where our implementation is buggy and results
with the processes not being killed.
One such case is when we deploy a new prplmesh package to the target,
which results with the original binary replaced, so /proc/$PID/exe is
suffixed with "(deleted" string, which causes the comparison to fail and
the process not to be killed.

For this reason, and future bugs we may have, we better not invent the
wheel and use standard tools whenever possible.
Since start-stop-daemon is pretty standard and is available in OpenWRT,
prplWrt, UGW and RDKB - there is no reason not to use it.

This commit changes killall_program() implementation in
prplmesh_utils.sh to use start-stop-daemon.
Options used:
	-K - kills all matching processes
	-x <path> - path to binary
	-s <sig> - signal to use, default is SIGKILL (-9)

Also, while at it, remove unused parameter SIG_TERM.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>