### PR TITLE
.gitlab-ci.yml: add missing "docker" tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ cppcheck:
     paths:
       - cppcheck_results.txt
     when: always
+  tags:
+    - docker
 
 clang-format:
   extends: .in-prplmesh-builder


### PR DESCRIPTION
The cppcheck job didn't have any tag, so it was only picked up by
runners configured to run untagged jobs.
Worse, it could have been picked by a runner on which docker is not
available.

Since the cppcheck job uses docker, add the "docker" tag like we do
for the other jobs.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>