### PR TITLE
common: prplmesh_utils.sh: always stop controller and agent on stop()

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -237,8 +237,8 @@ stop_function() {
 
     [ "@BWL_TYPE@" = "DUMMY" -a "$PLATFORM_INIT" = "true" ] && platform_deinit
     [ "@BTL_TYPE@" = "LOCAL_BUS" ] && prplmesh_framework_deinit
-    [ "$PRPLMESH_MODE" = "CA" -o "$PRPLMESH_MODE" = "C" ] && prplmesh_controller_stop
-    [ "$PRPLMESH_MODE" = "CA" -o "$PRPLMESH_MODE" = "A" ] && prplmesh_agent_stop
+    prplmesh_controller_stop
+    prplmesh_agent_stop
     [ "$DELETE_LOGS" = "true" ] && prplmesh_delete_logs
 }
 


### PR DESCRIPTION
When prplMesh is first started in controller mode then, restarted in
agent mode using 'prplmesh_utils.sh restart -m A', the controller
process doesn't stop because stop_function() is called with
$PRPLMESH_MODE set to "A".

Fix it by always stopping both the controller and agent when
stop_function() is called.

Calling the script with 'stop' and '-m CA' although only the agent was
started is not a problem, since the output is anyway redirected to
/dev/null.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>