### PR TITLE
Bugfix: Fix AL-MAC getter inconsistencies in test_flows.sh

### DIFF
--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -130,7 +130,7 @@ test_initial_ap_config() {
 }
 
 test_ap_config_renew() {
-    status "test initial autoconfig"
+    status "test autoconfig renew"
 
     # Regression test: MAC address should be case insensitive
     MAC_AGENT1=$(echo $mac_agent1 | tr a-z A-Z)

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -618,13 +618,11 @@ test_init() {
     [ -z "$connmap" ] && { err "Failed to create temp file"; exit 1; }
     trap "rm -f $connmap" EXIT
     docker exec ${GATEWAY} ${installdir}/bin/beerocks_cli -c bml_conn_map > "$connmap"
-
-    mac_gateway=$(grep "GW_BRIDGE" "$connmap" | head -1 | awk '{print $5}' | cut -d ',' -f 1)
+    mac_gateway=$(get_alid ${GATEWAY})
+    mac_agent1=$(get_alid ${REPEATER1})
+    mac_agent2=$(get_alid ${REPEATER2})
     dbg "mac_gateway = ${mac_gateway}"
-
-    mac_agent1=$(grep "IRE_BRIDGE" "$connmap" | head -1 | awk '{print $5}' | cut -d ',' -f 1)
     dbg "mac_agent1 = ${mac_agent1}"
-    mac_agent2=$(grep "IRE_BRIDGE" "$connmap" | sed -n 2p | awk '{print $5}' | cut -d ',' -f 1)
     dbg "mac_agent2 = ${mac_agent2}"
 
     mac_agent1_wlan0=$(docker exec ${REPEATER1} ip -o l list dev wlan0 | sed 's%.*link/ether \([0-9a-f:]*\).*%\1%')

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -596,6 +596,10 @@ test_topology() {
     return $check_error
 }
 
+get_alid(){
+    send_CAPI_command $1 "dev_get_parameter,program,map,parameter,ALid"> /dev/null 2>&1
+    echo ${capi_command_reply#*'ALid,'}
+}
 test_init() {
     status "test initialization"
 


### PR DESCRIPTION
## Overview

Running `test_flows.sh` tests with the argument `-- skip-init` revealed a flaw in the mechanism for getting different bridges' AL-MAC addresses, this was due to the fact `bml_conn_map` often scrambled the order of repeaters.

As a result of this behavior, some tests would fail or show inconsistent results, for example, 
The teardown test would tear down the wrong repeater. When ran, it would try to update **repeater 1**, but repeater 1 would appear **_second_** in the `conn_map` therefore it would try to perform a teardown on **repeater 2**, obviously failing the test as repeater 1 would still hold an unmodified configuration.
This is merely one example.
## Fix

Implement a function that gets a bridge's al mac using dev_get_parameter, and the relevant docker **container's** ipv4 address, using the same protocol utilized in the UCC testbed.
This assures consistency and accuracy, and no false positives or false negatives. <img src="https://cultofthepartyparrot.com/parrots/hd/mardigrasparrot.gif" width=25 title="maybe we should also update bml_conn_map but this is for a different PR I guess">