### PR TITLE
BPL: cfg_get_no_vendor_specific: move no_vendor_specific to UCI

### DIFF
--- a/agent/config/beerocks_agent.conf.in
+++ b/agent/config/beerocks_agent.conf.in
@@ -18,7 +18,6 @@ bridge_iface=@BEEROCKS_BRIDGE_IFACE@
 enable_system_hang_test=0 # 0 - disabled
 enable_son_slaves_watchdog=0 # 0 - disabled
 debug_disable_arp=@BEEROCKS_ENABLE_ARP_MONITOR@
-no_vendor_specific=0 # 0 - disabled
 
 [backhaul]
 backhaul_preferred_bssid=

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -168,7 +168,6 @@ static void fill_son_slave_config(beerocks::config_file::sConfigSlave &beerocks_
     son_slave_conf.backhaul_wireless_iface_filter_low =
         beerocks::string_utils::stoi(beerocks_slave_conf.sta_iface_filter_low[slave_num]);
     son_slave_conf.backhaul_wireless_iface_type = son_slave_conf.hostap_iface_type;
-    son_slave_conf.no_vendor_specific           = beerocks_slave_conf.no_vendor_specific == "1";
 
     // disable stopping on failure initially. Later on, it will be read from BPL as part of
     // cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -161,6 +161,10 @@ static bool fill_platform_settings(
         LOG(ERROR) << "Failed reading 'stop_on_failure_attempts'";
         return false;
     }
+    if ((platform_common_conf.no_vendor_specific = bpl::cfg_get_no_vendor_specific()) < 0) {
+        LOG(ERROR) << "Failed reading 'no_vendor_specific'";
+        return false;
+    }
     if ((platform_common_conf.dfs_reentry = bpl::cfg_get_dfs_reentry()) < 0) {
         LOG(ERROR) << "Failed reading 'dfs_reentry'";
         return false;
@@ -209,6 +213,7 @@ static bool fill_platform_settings(
     msg->platform_settings().operating_mode     = uint8_t(platform_common_conf.operating_mode);
     msg->platform_settings().management_mode    = uint8_t(platform_common_conf.management_mode);
     msg->platform_settings().certification_mode = uint8_t(platform_common_conf.certification_mode);
+    msg->platform_settings().no_vendor_specific = uint8_t(platform_common_conf.no_vendor_specific);
     msg->platform_settings().stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);
     msg->platform_settings().local_master      = uint8_t(platform_common_conf.local_master);

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.h
@@ -42,6 +42,7 @@ public:
         int management_mode;
         int operating_mode;
         int certification_mode;
+        int no_vendor_specific;
         int stop_on_failure_attempts;
         int local_gw;
         int local_master;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1919,7 +1919,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         client_association_event_tlv->association_event() =
             wfa_map::tlvClientAssociationEvent::CLIENT_HAS_LEFT_THE_BSS;
 
-        if (config.no_vendor_specific) {
+        if (platform_settings.no_vendor_specific) {
             LOG(DEBUG) << "non-Intel, not adding ClientAssociationEvent VS TLV";
         } else {
             // Add vendor specific tlv
@@ -2105,7 +2105,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         client_association_event_tlv->association_event() =
             wfa_map::tlvClientAssociationEvent::CLIENT_HAS_JOINED_THE_BSS;
 
-        if (config.no_vendor_specific) {
+        if (platform_settings.no_vendor_specific) {
             LOG(DEBUG) << "non-Intel, not adding ClientAssociationEvent VS TLV";
         } else {
             // Add vendor specific tlv
@@ -3354,7 +3354,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             return false;
         }
 
-        if (config.no_vendor_specific) {
+        if (platform_settings.no_vendor_specific) {
             LOG(INFO) << "Configured as non-Intel, not sending SLAVE_JOINED_NOTIFICATION";
         } else {
             auto notification = message_com::add_vs_tlv<

--- a/common/beerocks/bcl/include/bcl/beerocks_config_file.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_config_file.h
@@ -104,7 +104,6 @@ public:
         std::string enable_system_hang_test;
         std::string enable_son_slaves_watchdog;
         std::string const_backhaul_slave;
-        std::string no_vendor_specific;
         //[slaveX]
         std::string radio_identifier[IRE_MAX_SLAVES]; // mAP RUID
         std::string enable_repeater_mode[IRE_MAX_SLAVES];

--- a/common/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/common/beerocks/bcl/source/beerocks_config_file.cpp
@@ -158,7 +158,6 @@ bool config_file::read_slave_config_file(std::string config_file_path, sConfigSl
             std::make_tuple("enable_system_hang_test=", &conf.enable_system_hang_test, 0),
             std::make_tuple("enable_son_slaves_watchdog=", &conf.enable_son_slaves_watchdog, 0),
             std::make_tuple("const_backhaul_slave=", &conf.const_backhaul_slave, 0),
-            std::make_tuple("no_vendor_specific=", &conf.no_vendor_specific, 0),
         };
         std::string config_type = "global";
         if (!read_config_file(config_file_path, slave_global_conf_args, config_type)) {

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -84,12 +84,12 @@ prplmesh_platform_db_init() {
         # In certification, agent must retry onboarding indefinitely
         echo "certification_mode=1"
         echo "stop_on_failure_attempts=0" 
+        if [ "$NO_VENDOR_SPECIFIC" = true ]; then
+            echo "no_vendor_specific=1"
+        else
+            echo "no_vendor_specific=0"
+        fi
     } > @TMP_PATH@/prplmesh_platform_db
-
-    if [ "$NO_VENDOR_SPECIFIC" = true ]; then
-        sed '/^no_vendor_specific=0/s//no_vendor_specific=1/' \
-            @CMAKE_INSTALL_PREFIX@/config/beerocks_agent.conf > /tmp/beerocks_agent.conf
-    fi
 }
 
 prplmesh_framework_init() {

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -85,6 +85,7 @@ typedef struct sPlatformSettings {
     uint8_t operating_mode;
     uint8_t management_mode;
     uint8_t mem_only_psk;
+    uint8_t no_vendor_specific;
     uint8_t certification_mode;
     uint8_t stop_on_failure_attempts;
     uint8_t client_band_steering_enabled;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -77,6 +77,7 @@ sPlatformSettings:
   operating_mode: uint8_t
   management_mode: uint8_t
   mem_only_psk: uint8_t
+  no_vendor_specific: uint8_t
 
   certification_mode: uint8_t 
   stop_on_failure_attempts: uint8_t

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -90,6 +90,7 @@ namespace bpl {
 #define DEFAULT_BAND_STEERING 1
 #define DEFAULT_DFS_REENTRY 1
 #define DEFAULT_CLIENT_ROAMING 1
+#define DEFAULT_NO_VENDOR_SPECIFIC 0
 
 /****************************************************************************/
 /******************************* Structures *********************************/
@@ -274,6 +275,14 @@ int cfg_get_certification_mode();
  * @return -1 Error.
  */
 int cfg_get_stop_on_failure_attempts();
+
+/**
+ * Returns whether the vendor specific messages are turned off
+ * @return 1 Messages are enabled
+ * @return 0 Messages are disabled
+ * @return -1 Error
+ */
+int cfg_get_no_vendor_specific();
 
 /**
  * Returns whether the platform is in onboarding state.

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -266,6 +266,17 @@ int cfg_get_hostap_iface(int32_t radio_num, char hostap_iface[BPL_IFNAME_LEN])
     return RETURN_OK;
 }
 
+int cfg_get_no_vendor_specific()
+{
+    int retVal;
+    if (cfg_get_param_int("no_vendor_specific=", retVal) == RETURN_ERR) {
+        MAPF_ERR("cfg_get_no_vendor_specific: Failed to read no_vendor_specific");
+        return DEFAULT_NO_VENDOR_SPECIFIC;
+    }
+
+    return retVal;
+}
+
 int cfg_get_all_prplmesh_wifi_interfaces(BPL_WLAN_IFACE *interfaces, int *num_of_interfaces)
 {
     if (!interfaces) {

--- a/framework/platform/bpl/linux/prplmesh_platform_db
+++ b/framework/platform/bpl/linux/prplmesh_platform_db
@@ -2,3 +2,4 @@ management_mode=Multi-AP-Controller-and-Agent
 operating_mode=Gateway
 stop_on_failure_attempts=1
 certification_mode=1
+no_vendor_specific=0

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -313,6 +313,17 @@ int cfg_get_hostap_iface(int32_t radio_num, char hostap_iface[BPL_IFNAME_LEN])
     return cfg_get_prplmesh_radio_param(radio_num, "hostap_iface", hostap_iface, BPL_IFNAME_LEN);
 }
 
+int cfg_get_no_vendor_specific()
+{
+    int retVal = -1;
+    if (cfg_get_prplmesh_param_int_default("no_vendor_specific", &retVal,
+                                           DEFAULT_NO_VENDOR_SPECIFIC) == RETURN_ERR) {
+        MAPF_INFO("cfg_get_no_vendor_specific: Failed to read no_vendor_specific parameter\n");
+        return RETURN_ERR;
+    }
+    return retVal;
+}
+
 int cfg_get_all_prplmesh_wifi_interfaces(BPL_WLAN_IFACE *interfaces, int *num_of_interfaces)
 {
     if (!interfaces) {

--- a/framework/platform/bpl/uci/db/prplmesh_db
+++ b/framework/platform/bpl/uci/db/prplmesh_db
@@ -20,6 +20,7 @@ config prplmesh 'config'
     option backhaul_band 'auto'
     option certification_mode '1'
     option stop_on_failure_attempts '1'
+    option no_vendor_specific '0'
 
 config wifi-device 'radio0'
     option hostap_iface 'wlan0'


### PR DESCRIPTION
BPL: cfg_get_no_vendor_specific: move no_vendor_specific to UCI

There is currently a setting in beerocks_agent.conf that allows to turn off the vendor specific messages in M1: no_vendor_specific.
The setting has to be turned on for agent tests, otherwise some devices from the testbed will ignore our M1.

For controller tests however, it has to be turned off, or autoconfig will fail.

Having the setting in UCI would make it easier to change, because we already change other UCI values based on the test type (management_mode, operating_mode, and so on).
