### PR TITLE
Feature/4.8.1 client steering mandate

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1219,6 +1219,8 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
 
         response->params().mac         = msg->params.mac;
         response->params().status_code = msg->params.status_code;
+        response->params().source_bssid = msg->params.source_bssid;
+        // TODO: add the optional target BSSID
 
         message_com::send_cmdu(slave_socket, cmdu_tx);
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1982,11 +1982,13 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             LOG(ERROR) << "addClass wfa_map::tlvSteeringBTMReport failed";
             return false;
         }
-        //TODO Add target/source BSSID
+        //TODO Add target BSSID
         steering_btm_report_tlv->sta_mac()         = response_in->params().mac;
         steering_btm_report_tlv->btm_status_code() = response_in->params().status_code;
+        steering_btm_report_tlv->bssid() = response_in->params().source_bssid;
 
         LOG(DEBUG) << "sending CLIENT_STEERING_BTM_REPORT_MESSAGE back to controller";
+        LOG(DEBUG) << "BTM report source bssid: " << steering_btm_report_tlv->bssid();
         send_cmdu_to_controller(cmdu_tx);
         break;
     }

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -166,6 +166,9 @@ bool ap_wlan_hal_dummy::sta_bss_steer(const std::string &mac, const std::string 
 
     msg->params.mac         = beerocks::net::network_utils::mac_from_string(mac);
     msg->params.status_code = 0;
+    // source_bssid should be the vap bssid and not radio_mac, but
+    // dummy mode doesn't use vaps yet
+    msg->params.source_bssid = beerocks::net::network_utils::mac_from_string(get_radio_mac());
 
     // Add the message to the queue
     event_queue_push(Event::BSS_TM_Response, msg_buff);

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -210,10 +210,9 @@ typedef struct {
 
 typedef struct {
     sMacAddr mac;
+    sMacAddr source_bssid;
+    sMacAddr target_bssid;
     uint8_t status_code;
-    uint8_t reserved1;
-    uint8_t reserved2;
-    uint8_t reserved3;
 } sNodeBssSteerResponse;
 
 typedef struct {

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -463,12 +463,18 @@ typedef struct sNodeBssSteerRequest {
 
 typedef struct sNodeBssSteerResponse {
     sMacAddr mac;
+    sMacAddr source_bssid;
+    sMacAddr target_bssid;
     uint8_t status_code;
     void struct_swap(){
         mac.struct_swap();
+        source_bssid.struct_swap();
+        target_bssid.struct_swap();
     }
     void struct_init(){
         mac.struct_init();
+        source_bssid.struct_init();
+        target_bssid.struct_init();
     }
 } __attribute__((packed)) sNodeBssSteerResponse;
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -309,7 +309,9 @@ sNodeBssSteerRequest:
 sNodeBssSteerResponse:
   _type: struct
   mac: sMacAddr
-  status_code: uint8_t 
+  source_bssid: sMacAddr
+  target_bssid: sMacAddr
+  status_code: uint8_t
 
 sNeighborSetParams11k:
   _type: struct

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1025,11 +1025,11 @@ bool master_thread::handle_cmdu_1905_client_steering_btm_report_message(
     std::string client_mac = network_utils::mac_to_string(steering_btm_report->sta_mac());
     uint8_t status_code    = steering_btm_report->btm_status_code();
 
-    LOG(DEBUG) << "BSS_TM_RESP from client_mac=" << client_mac
+    LOG(DEBUG) << "BTM_REPORT from source bssid " << steering_btm_report->bssid() <<  " for client_mac=" << client_mac
                << " status_code=" << (int)status_code;
 
     int steering_task_id = database.get_steering_task_id(client_mac);
-    tasks.push_event(steering_task_id, client_steering_task::BSS_TM_RESPONSE_RECEIVED);
+    tasks.push_event(steering_task_id, client_steering_task::BTM_REPORT_RECEIVED);
     database.update_node_11v_responsiveness(client_mac, true);
 
     if (status_code != 0) {

--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -263,14 +263,14 @@ void client_steering_task::handle_event(int event_type, void *obj)
             TASK_LOG(DEBUG) << "aborting task";
             finish();
         }
-    } else if (event_type == BSS_TM_RESPONSE_RECEIVED) {
-        bss_tm_response_received = true;
+    } else if (event_type == BTM_REPORT_RECEIVED) {
+        btm_report_received = true;
     }
 }
 
 void client_steering_task::handle_task_end()
 {
-    if (!bss_tm_response_received) {
+    if (!btm_report_received) {
         TASK_LOG(DEBUG) << "node didn't respond to 11v request, updating failed attempt";
         database.update_node_11v_responsiveness(sta_mac, false);
     }

--- a/controller/src/beerocks/master/tasks/client_steering_task.h
+++ b/controller/src/beerocks/master/tasks/client_steering_task.h
@@ -19,7 +19,7 @@ public:
     enum events {
         STA_CONNECTED,
         STA_DISCONNECTED,
-        BSS_TM_RESPONSE_RECEIVED,
+        BTM_REPORT_RECEIVED,
         BSS_TM_REQUEST_REJECTED,
     };
 
@@ -48,7 +48,7 @@ private:
     bool steering_success  = false;
     bool disassoc_imminent = true;
     const int disassoc_timer_ms;
-    bool bss_tm_response_received = false;
+    bool btm_report_received = false;
     bool steer_restricted         = false;
 
     const static int steering_wait_time_ms = 25000;

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -331,6 +331,9 @@ class test_flows:
         self.debug("Confirming BTM Report message was received")
         self.check_log(self.gateway, "controller", "CLIENT_STEERING_BTM_REPORT_MESSAGE")
 
+        self.debug("Checking BTM Report source bssid")
+        self.check_log(self.gateway, "controller", "BTM_REPORT from source bssid %s" % self.mac_repeater1_wlan0)
+
         self.debug("Confirming ACK message was received")
         self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
 


### PR DESCRIPTION
The source BSSID was missing from the BTM report, which made test 4.8.1 fail.

Add it to the internal BTM responses so that it can also be added to the BTM report.

Fixes #429  