### PR TITLE
[Patch 2/2] Feature/client capability response [Test 4.6.2]

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1169,10 +1169,10 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
             return false;
         }
 
-        notification->params().mac          = msg->params.mac;
-        notification->params().vap_id       = msg->params.vap_id;
-        notification->params().bssid        = network_utils::mac_from_string(vap_node->second.mac);
-        notification->params().capabilities = msg->params.capabilities;
+        notification->mac()          = msg->params.mac;
+        notification->vap_id()       = msg->params.vap_id;
+        notification->bssid()        = network_utils::mac_from_string(vap_node->second.mac);
+        notification->capabilities() = msg->params.capabilities;
 
         message_com::send_cmdu(slave_socket, cmdu_tx);
 

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1173,6 +1173,12 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
         notification->vap_id()       = msg->params.vap_id;
         notification->bssid()        = network_utils::mac_from_string(vap_node->second.mac);
         notification->capabilities() = msg->params.capabilities;
+        if (!msg->params.association_frame) {
+            LOG(DEBUG) << "no association frame";
+        } else {
+            notification->set_association_frame(msg->params.association_frame,
+                                                msg->params.association_frame_length);
+        }
 
         message_com::send_cmdu(slave_socket, cmdu_tx);
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2033,8 +2033,19 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
         }
 
         // Set client association information for associated client
-        auto &associated_clients              = soc->associated_clients_map[msg->bssid()];
-        associated_clients[msg->client_mac()] = std::chrono::steady_clock::now();
+        //remove this client from other radios
+        remove_client_from_all_radios(msg->client_mac());
+
+        auto &associated_clients = soc->associated_clients_map[msg->bssid()];
+
+        sClientInfo client_info;
+        client_info.client_mac = msg->client_mac();
+        client_info.bssid      = msg->bssid();
+        client_info.time_stamp = std::chrono::steady_clock::now();
+        client_info.asso_len   = msg->association_frame_length();
+        memcpy(client_info.assoc_req, msg->association_frame(), client_info.asso_len);
+        associated_clients[msg->client_mac()] = client_info;
+
         break;
     }
     case beerocks_message::ACTION_BACKHAUL_CLIENT_DISCONNECTED_NOTIFICATION: {

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2930,6 +2930,18 @@ bool backhaul_manager::send_slaves_enable()
     return true;
 }
 
+void backhaul_manager::remove_client_from_all_radios(sMacAddr &client_mac)
+{
+    for (const auto &slave : slaves_sockets) {
+        const auto &associated_clients_map = slave->associated_clients_map;
+        for (const auto &client : associated_clients_map) {
+            if (client.second.find(client_mac) != client.second.end()) {
+                slaves_sockets.remove(slave);
+            }
+        }
+    }
+}
+
 bool backhaul_manager::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr,
                                          std::string iface)
 {

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2145,11 +2145,14 @@ bool backhaul_manager::handle_client_capability_query(ieee1905_1::CmduMessageRx 
     //with any of the BSS operated by the Multi-AP Agent [ though the TLV does contain a BSSID, the specification
     // says that we should answer if the client is associated with any BSS on this agent.]
     bool associated_client_found = false;
+    sClientInfo client_info;
     for (const auto &slave : slaves_sockets) {
         auto associated_clients_map = slave->associated_clients_map;
         for (const auto &vap : associated_clients_map) {
-            if (vap.second.find(client_info_tlv_r->client_mac()) != vap.second.end()) {
+            auto it = vap.second.find(client_info_tlv_r->client_mac());
+            if (it != vap.second.end()) {
                 associated_client_found = true;
+                client_info             = it->second;
                 break;
             }
         }
@@ -2175,18 +2178,22 @@ bool backhaul_manager::handle_client_capability_query(ieee1905_1::CmduMessageRx 
         return false;
     }
 
-    //if it is an error scenario, set Success status to 0x01 = Failure and do nothing after it.
+    // if it is an error scenario, set Success status to 0x01 = Failure and do nothing after it.
     if (associated_client_found) {
         client_capability_report_tlv->result_code() = wfa_map::tlvClientCapabilityReport::SUCCESS;
         LOG(DEBUG) << "Result Code: SUCCESS";
-        //TODO: Add frame body of the most recently received (Re)Association Request frame from this client
+        // Add frame body of the most recently received (Re)Association Request frame from this client
+
+        client_capability_report_tlv->set_association_frame(client_info.assoc_req,
+                                                            client_info.asso_len);
+
     } else {
         client_capability_report_tlv->result_code() = wfa_map::tlvClientCapabilityReport::FAILURE;
 
         LOG(DEBUG) << "Result Code: FAILURE";
         LOG(DEBUG) << "STA specified in the Client Capability Query message is not associated with "
                       "any of the BSS operated by the Multi-AP Agent ";
-        //Add an Error Code TLV
+        // Add an Error Code TLV
         auto error_code_tlv = cmdu_tx.addClass<wfa_map::tlvErrorCode>();
         if (!error_code_tlv) {
             LOG(ERROR) << "addClass wfa_map::tlvErrorCode has failed";

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2530,7 +2530,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
                     // the timestamp of its last association.
                     for (const auto &associated_client : associated_clients) {
                         auto client_mac       = associated_client.first;
-                        auto association_time = associated_client.second;
+                        auto association_time = associated_client.second.time_stamp;
 
                         auto elapsed =
                             std::chrono::duration_cast<std::chrono::seconds>(now - association_time)

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -225,6 +225,14 @@ private:
 
     std::unique_ptr<beerocks::agent_ucc_listener> m_agent_ucc_listener;
 
+    struct sClientInfo {
+        sMacAddr client_mac;
+        sMacAddr bssid; // VAP mac
+        std::chrono::steady_clock::time_point time_stamp;
+        size_t asso_len;
+        uint8_t assoc_req[ASSOCIATION_FRAME_SIZE];
+    };
+
     /**
      * @brief Type definition for associated clients information.
      *

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -236,18 +236,21 @@ private:
     /**
      * @brief Type definition for associated clients information.
      *
-     * Associated client information consists of:
+     * Associated client information consists of sClientInfo strucrt, which has the 
+     * following fields:
      * - The MAC address of the 802.11 client that associates to a BSS.
      * - Timestamp of the 802.11 client's last association to this Multi-AP device.
+     * - The length of the association frame.
+     * - the association frame itself.
      *
      * Associated client information is gathered from
      * ACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION events received from slave threads.
      *
      * Associated client information is later used to fill in the Associated Clients TLV
-     * in the Topology Response message.
+     * in the Topology Response message and Client Capability Response message.
      */
-    typedef std::unordered_map<sMacAddr, std::chrono::steady_clock::time_point>
-        associated_clients_t;
+
+    typedef std::unordered_map<sMacAddr, sClientInfo> associated_clients_t;
 
     /**
      * @brief Information gathered about a radio (= slave).

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -102,6 +102,8 @@ private:
     void platform_notify_error(bpl::eErrorCode code, const std::string &error_data);
     bool send_slaves_enable();
 
+    void remove_client_from_all_radios(sMacAddr &client_mac);
+
     std::shared_ptr<bwl::sta_wlan_hal> get_wireless_hal(std::string iface = "");
 
 private:

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2097,9 +2097,14 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             break;
         }
 
-        notification_out->iface_mac()  = hostap_params.iface_mac;
         notification_out->client_mac() = notification_in->mac();
         notification_out->bssid()      = notification_in->bssid();
+        if (!notification_in->association_frame_length()) {
+            LOG(DEBUG) << "no association frame";
+        } else {
+            notification_out->set_association_frame(notification_in->association_frame(),
+                                                    notification_in->association_frame_length());
+        }
 
         // Send the message
         LOG(DEBUG) << "send ACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION for client "

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2081,7 +2081,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             return false;
         }
         LOG(TRACE) << "received ACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION";
-        std::string client_mac = network_utils::mac_to_string(notification_in->params().mac);
+        std::string client_mac = network_utils::mac_to_string(notification_in->mac());
         LOG(INFO) << "client associated sta_mac=" << client_mac;
 
         if (!master_socket) {
@@ -2097,8 +2097,9 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             break;
         }
 
-        notification_out->client_mac() = notification_in->params().mac;
-        notification_out->bssid()      = notification_in->params().bssid;
+        notification_out->iface_mac()  = hostap_params.iface_mac;
+        notification_out->client_mac() = notification_in->mac();
+        notification_out->bssid()      = notification_in->bssid();
 
         // Send the message
         LOG(DEBUG) << "send ACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION for client "
@@ -2118,8 +2119,8 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             LOG(ERROR) << "addClass tlvClientAssociationEvent failed";
             return false;
         }
-        client_association_event_tlv->client_mac() = notification_in->params().mac;
-        client_association_event_tlv->bssid()      = notification_in->params().bssid;
+        client_association_event_tlv->client_mac() = notification_in->mac();
+        client_association_event_tlv->bssid()      = notification_in->bssid();
         client_association_event_tlv->association_event() =
             wfa_map::tlvClientAssociationEvent::CLIENT_HAS_JOINED_THE_BSS;
 
@@ -2135,10 +2136,10 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
                 return false;
             }
 
-            vs_tlv->mac()          = notification_in->params().mac;
-            vs_tlv->bssid()        = notification_in->params().bssid;
-            vs_tlv->vap_id()       = notification_in->params().vap_id;
-            vs_tlv->capabilities() = notification_in->params().capabilities;
+            vs_tlv->mac()          = notification_in->mac();
+            vs_tlv->bssid()        = notification_in->bssid();
+            vs_tlv->vap_id()       = notification_in->vap_id();
+            vs_tlv->capabilities() = notification_in->capabilities();
         }
 
         send_cmdu_to_controller(cmdu_tx);

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -40,13 +40,18 @@ static constexpr int DISCOVERY_NOTIFICATION_TIMEOUT_SEC = 60;
 namespace message {
 
 enum eStructsConsts {
-    VERSION_LENGTH                = 16,
-    NODE_NAME_LENGTH              = 32,
-    IFACE_NAME_LENGTH             = 32 + 4, //need extra 1 byte for null termination + alignment
-    SUPPORTED_CHANNELS_LENGTH     = 64,     //support upto # channels, every channel item is 32-bit
-    HOSTAP_ERR_MSG_LENGTH         = 64,
-    WIFI_DRIVER_VER_LENGTH        = 32 + 4,
-    WIFI_SSID_MAX_LENGTH          = 32 + 1 + 3, //need extra 1 byte for null termination + alignment
+    VERSION_LENGTH            = 16,
+    NODE_NAME_LENGTH          = 32,
+    IFACE_NAME_LENGTH         = 32 + 4, //need extra 1 byte for null termination + alignment
+    SUPPORTED_CHANNELS_LENGTH = 64,     //support upto # channels, every channel item is 32-bit
+    HOSTAP_ERR_MSG_LENGTH     = 64,
+    WIFI_DRIVER_VER_LENGTH    = 32 + 4,
+    WIFI_SSID_MAX_LENGTH      = 32 + 1 + 3, //need extra 1 byte for null termination + alignment
+    // The absolute maximum size of any frame according to the 802.11 specification
+    // is MMPDU size of 2304 bytes. The actual size of an (re)association frame
+    // should be in the range of a couple of hundreds of bytes, so be on the safe side
+    // and set the maximum size to 2KB
+    ASSOCIATION_MAX_LENGTH        = 2048,
     WIFI_PASS_MAX_LENGTH          = 64 + 1 + 3, //need extra 1 byte for null termination + alignment
     USER_PASS_LEN                 = 64 + 1 + 3, //need extra 1 byte for null termination + alignment
     DEV_INFO_STR_MAX_LEN          = 32,

--- a/common/beerocks/bcl/include/bcl/beerocks_string_utils.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_string_utils.h
@@ -79,6 +79,8 @@ public:
     static int64_t stoi(const std::string &str, const char *calling_file = __builtin_FILE(),
                         int calling_line = __builtin_LINE());
 
+    static std::string hex_to_char_string(std::string hex);
+
     static std::string int_to_hex_string(const unsigned int integer,
                                          const uint8_t number_of_digits);
 };

--- a/common/beerocks/bcl/source/beerocks_string_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_string_utils.cpp
@@ -106,6 +106,18 @@ int64_t string_utils::stoi(const std::string &str, const char *calling_file, int
     return val;
 }
 
+std::string string_utils::hex_to_char_string(std::string hex)
+{
+    auto len = hex.length();
+    std::string charStr;
+    for (size_t i = 0; i < len; i += 2) {
+        auto byte = hex.substr(i, 2);
+        char chr  = (char)(int)strtol(byte.c_str(), nullptr, 16);
+        charStr.push_back(chr);
+    }
+    return charStr;
+}
+
 std::string string_utils::int_to_hex_string(const unsigned int integer,
                                             const uint8_t number_of_digits)
 {

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -380,9 +380,20 @@ bool ap_wlan_hal_dummy::process_dummy_event(parsed_obj_map_t &parsed_obj)
             LOG(ERROR) << "Failed reading mac parameter!";
             return false;
         }
-
         msg->params.mac = beerocks::net::network_utils::mac_from_string(tmp_str);
+        const char assoc_req[] =
+            "00003A01029A96FB591100504322565F029A96FB591110E431141400000E4D756C74692D41502D3234472D"
+            "31010802040B0C121618242102001430140100000FAC040100000FAC040100000FAC02000032043048606C"
+            "3B10515153547374757677787C7D7E7F80823B160C01020304050C161718191A1B1C1D1E1F202180818246"
+            "057000000000460571505000047F0A04000A82214000408000DD070050F2020001002D1A2D1103FFFF0000"
+            "000000000000000000000000000018E6E10900BF0CB079D133FAFF0C03FAFF0C03C70110DD07506F9A1603"
+            "0103";
 
+        //convert the hex string to binary
+        auto binary_str                      = get_binary_association_frame(assoc_req);
+        msg->params.association_frame_length = binary_str.length();
+
+        std::copy_n(&binary_str[0], binary_str.length(), msg->params.association_frame);
         bool caps_valid = true;
         SRadioCapabilitiesStrings caps_strings;
         if (!dummy_obj_read_str("SupportedRates", parsed_obj, &tmp_str)) {

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1782,15 +1782,16 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         memset(msg_buff.get(), 0, sizeof(sACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION));
         memset((char *)&msg->params.capabilities, 0, sizeof(msg->params.capabilities));
 
-        char VAP[SSID_MAX_SIZE]        = {0};
-        char MACAddress[MAC_ADDR_SIZE] = {0};
-        int supported_rates[16]        = {0};
-        int RRM_CAP[8]                 = {0};
-        int HT_MCS[16]                 = {0};
-        int16_t VHT_MCS[16]            = {0};
-        char ht_cap[8]                 = {0};
-        char vht_cap[16]               = {0};
-        size_t numOfValidArgs[20]      = {0};
+        char VAP[SSID_MAX_SIZE]                = {0};
+        char MACAddress[MAC_ADDR_SIZE]         = {0};
+        int supported_rates[16]                = {0};
+        int RRM_CAP[8]                         = {0};
+        int HT_MCS[16]                         = {0};
+        int16_t VHT_MCS[16]                    = {0};
+        char ht_cap[8]                         = {0};
+        char vht_cap[16]                       = {0};
+        size_t numOfValidArgs[20]              = {0};
+        char assoc_req[ASSOCIATION_FRAME_SIZE] = {0};
 
         FieldsToParse fieldsToParse[] = {
             {NULL /*opCode*/, &numOfValidArgs[0], DWPAL_STR_PARAM, NULL, 0},
@@ -1806,6 +1807,8 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
              "VHT_MCS=", sizeof(VHT_MCS)},
             {(void *)ht_cap, &numOfValidArgs[7], DWPAL_STR_PARAM, "HT_CAP=", sizeof(ht_cap)},
             {(void *)vht_cap, &numOfValidArgs[8], DWPAL_STR_PARAM, "VHT_CAP=", sizeof(vht_cap)},
+            {(void *)assoc_req, &numOfValidArgs[9], DWPAL_STR_PARAM,
+             "assoc_req=", sizeof(assoc_req)},
             {(void *)&msg->params.capabilities.btm_supported, &numOfValidArgs[9], DWPAL_CHAR_PARAM,
              "btm_supported=", 0},
             {(void *)&msg->params.capabilities.cell_capa, &numOfValidArgs[10], DWPAL_CHAR_PARAM,
@@ -1857,6 +1860,7 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         LOG(DEBUG) << "max_mcs          : " << (int)msg->params.capabilities.max_mcs;
         LOG(DEBUG) << "max_tx_power     : " << (int)msg->params.capabilities.max_tx_power;
         LOG(DEBUG) << "mumimo_supported : " << (int)msg->params.capabilities.mumimo_supported;
+        LOG(DEBUG) << "assoc_req: " << assoc_req;
 
         for (uint8_t i = 0; i < (sizeof(numOfValidArgs) / sizeof(size_t)); i++) {
             if (numOfValidArgs[i] == 0) {

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1873,6 +1873,12 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         msg->params.mac          = beerocks::net::network_utils::mac_from_string(MACAddress);
         msg->params.capabilities = {};
 
+        //convert the hex string to binary
+        auto binary_str                      = get_binary_association_frame(assoc_req);
+        msg->params.association_frame_length = binary_str.length();
+
+        std::copy_n(&binary_str[0], binary_str.length(), msg->params.association_frame);
+
         std::string ht_cap_str(ht_cap);
         get_ht_mcs_capabilities(HT_MCS, ht_cap_str, msg->params.capabilities);
 

--- a/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
@@ -346,6 +346,11 @@ public:
      * @return true on success or false on error.
      */
     virtual bool generate_connected_clients_events() = 0;
+
+private:
+    static const int tagged_patameters_idx = 56;
+    static const int wifi_alliance_tag_len = 18;
+
 };
 
 // AP HAL factory types

--- a/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
@@ -10,6 +10,7 @@
 #define _BWL_AP_WLAN_HAL_H_
 
 #include "base_wlan_hal.h"
+#include <bcl/beerocks_string_utils.h>
 
 namespace bwl {
 
@@ -351,6 +352,16 @@ private:
     static const int tagged_patameters_idx = 56;
     static const int wifi_alliance_tag_len = 18;
 
+protected:
+    std::string get_binary_association_frame(const char assoc_req[])
+    {
+        auto sub_str_len = strnlen(assoc_req, ASSOCIATION_FRAME_SIZE) -
+                           ap_wlan_hal::tagged_patameters_idx - ap_wlan_hal::wifi_alliance_tag_len;
+        auto sub_str = std::string(&assoc_req[ap_wlan_hal::tagged_patameters_idx], sub_str_len);
+
+        //convert the hex string to binary
+        return beerocks::string_utils::hex_to_char_string(sub_str);
+    };
 };
 
 // AP HAL factory types

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -196,6 +196,7 @@ typedef struct {
 
 typedef struct {
     sMacAddr mac;
+    sMacAddr bssid;
     beerocks::message::sRadioCapabilities capabilities;
     int8_t vap_id;
     uint8_t reserved1;

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -201,6 +201,8 @@ typedef struct {
     uint8_t reserved1;
     uint8_t reserved2;
     uint8_t reserved3;
+    size_t association_frame_length;
+    uint8_t association_frame[beerocks::message::ASSOCIATION_MAX_LENGTH];
 } sClientAssociationParams;
 
 typedef struct {

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -263,6 +263,9 @@ typedef struct {
 } sHOSTAP_ENABLED_NOTIFICATION;
 
 #define SSID_MAX_SIZE beerocks::message::WIFI_SSID_MAX_LENGTH
+// ASSOCIATION_MAX_LENGTH is defined to be the maximum of the binary frame
+// but since it is represented as hex here. we need two hex characters per byte + a terminating \0.
+#define ASSOCIATION_FRAME_SIZE (2 * beerocks::message::ASSOCIATION_MAX_LENGTH + 1)
 #define MAC_ADDR_SIZE 18
 #define MAX_SUPPORTED_20M_CHANNELS beerocks::message::SUPPORTED_CHANNELS_LENGTH
 #define MAX_SUPPORTED_CHANNELS                                                                     \

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -533,7 +533,10 @@ class cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION);
         }
-        sClientAssociationParams& params();
+        sMacAddr& mac();
+        sMacAddr& bssid();
+        beerocks::message::sRadioCapabilities& capabilities();
+        int8_t& vap_id();
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -541,7 +544,10 @@ class cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        sClientAssociationParams* m_params = nullptr;
+        sMacAddr* m_mac = nullptr;
+        sMacAddr* m_bssid = nullptr;
+        beerocks::message::sRadioCapabilities* m_capabilities = nullptr;
+        int8_t* m_vap_id = nullptr;
 };
 
 class cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -537,6 +537,10 @@ class cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
         sMacAddr& bssid();
         beerocks::message::sRadioCapabilities& capabilities();
         int8_t& vap_id();
+        size_t association_frame_length() { return m_association_frame_idx__ * sizeof(uint8_t); }
+        uint8_t* association_frame(size_t idx = 0);
+        bool set_association_frame(const void* buffer, size_t size);
+        bool alloc_association_frame(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -548,6 +552,9 @@ class cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
         sMacAddr* m_bssid = nullptr;
         beerocks::message::sRadioCapabilities* m_capabilities = nullptr;
         int8_t* m_vap_id = nullptr;
+        uint8_t* m_association_frame = nullptr;
+        size_t m_association_frame_idx__ = 0;
+        int m_lock_order_counter__ = 0;
 };
 
 class cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -496,6 +496,10 @@ class cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
         }
         sMacAddr& client_mac();
         sMacAddr& bssid();
+        size_t association_frame_length() { return m_association_frame_idx__ * sizeof(uint8_t); }
+        uint8_t* association_frame(size_t idx = 0);
+        bool set_association_frame(const void* buffer, size_t size);
+        bool alloc_association_frame(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -505,6 +509,9 @@ class cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION : public BaseClass
         eActionOp_BACKHAUL* m_action_op = nullptr;
         sMacAddr* m_client_mac = nullptr;
         sMacAddr* m_bssid = nullptr;
+        uint8_t* m_association_frame = nullptr;
+        size_t m_association_frame_idx__ = 0;
+        int m_lock_order_counter__ = 0;
 };
 
 class cACTION_BACKHAUL_CLIENT_DISCONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -174,23 +174,6 @@ typedef struct sDfsChannelAvailable {
     }
 } __attribute__((packed)) sDfsChannelAvailable;
 
-typedef struct sClientAssociationParams {
-    sMacAddr mac;
-    sMacAddr bssid;
-    beerocks::message::sRadioCapabilities capabilities;
-    int8_t vap_id;
-    void struct_swap(){
-        mac.struct_swap();
-        bssid.struct_swap();
-        capabilities.struct_swap();
-    }
-    void struct_init(){
-        mac.struct_init();
-        bssid.struct_init();
-        capabilities.struct_init();
-    }
-} __attribute__((packed)) sClientAssociationParams;
-
 typedef struct sClientDisconnectionParams {
     sMacAddr mac;
     sMacAddr bssid;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1704,6 +1704,48 @@ int8_t& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::vap_id() {
     return (int8_t&)(*m_vap_id);
 }
 
+uint8_t* cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::association_frame(size_t idx) {
+    if ( (m_association_frame_idx__ == 0) || (m_association_frame_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_association_frame[idx]);
+}
+
+bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::set_association_frame(const void* buffer, size_t size) {
+    if (buffer == nullptr) {
+        TLVF_LOG(WARNING) << "set_association_frame received a null pointer.";
+        return false;
+    }
+    if (!alloc_association_frame(size)) { return false; }
+    std::copy_n(reinterpret_cast<const uint8_t *>(buffer), size, m_association_frame);
+    return true;
+}
+bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::alloc_association_frame(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list association_frame, abort!";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_association_frame;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_association_frame_idx__ += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    return true;
+}
+
 void cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
@@ -1778,6 +1820,8 @@ bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
         return false;
     }
+    m_association_frame = (uint8_t*)m_buff_ptr__;
+    m_association_frame_idx__ = getBuffRemainingBytes();
     if (m_parse__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1688,14 +1688,28 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::~cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION() {
 }
-sClientAssociationParams& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::params() {
-    return (sClientAssociationParams&)(*m_params);
+sMacAddr& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::mac() {
+    return (sMacAddr&)(*m_mac);
+}
+
+sMacAddr& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::bssid() {
+    return (sMacAddr&)(*m_bssid);
+}
+
+beerocks::message::sRadioCapabilities& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::capabilities() {
+    return (beerocks::message::sRadioCapabilities&)(*m_capabilities);
+}
+
+int8_t& cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::vap_id() {
+    return (int8_t&)(*m_vap_id);
 }
 
 void cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
-    m_params->struct_swap();
+    m_mac->struct_swap();
+    m_bssid->struct_swap();
+    m_capabilities->struct_swap();
 }
 
 bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::finalize()
@@ -1728,7 +1742,10 @@ bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::finalize()
 size_t cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(sClientAssociationParams); // params
+    class_size += sizeof(sMacAddr); // mac
+    class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(beerocks::message::sRadioCapabilities); // capabilities
+    class_size += sizeof(int8_t); // vap_id
     return class_size;
 }
 
@@ -1738,12 +1755,29 @@ bool cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_params = (sClientAssociationParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sClientAssociationParams))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sClientAssociationParams) << ") Failed!";
+    m_mac = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
         return false;
     }
-    if (!m_parse__) { m_params->struct_init(); }
+    if (!m_parse__) { m_mac->struct_init(); }
+    m_bssid = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { m_bssid->struct_init(); }
+    m_capabilities = (beerocks::message::sRadioCapabilities*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sRadioCapabilities))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sRadioCapabilities) << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { m_capabilities->struct_init(); }
+    m_vap_id = (int8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(int8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(int8_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -1714,6 +1714,48 @@ sMacAddr& cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::bssid() {
     return (sMacAddr&)(*m_bssid);
 }
 
+uint8_t* cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::association_frame(size_t idx) {
+    if ( (m_association_frame_idx__ == 0) || (m_association_frame_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_association_frame[idx]);
+}
+
+bool cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::set_association_frame(const void* buffer, size_t size) {
+    if (buffer == nullptr) {
+        TLVF_LOG(WARNING) << "set_association_frame received a null pointer.";
+        return false;
+    }
+    if (!alloc_association_frame(size)) { return false; }
+    std::copy_n(reinterpret_cast<const uint8_t *>(buffer), size, m_association_frame);
+    return true;
+}
+bool cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::alloc_association_frame(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list association_frame, abort!";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)m_association_frame;
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_association_frame_idx__ += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    return true;
+}
+
 void cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
@@ -1774,6 +1816,8 @@ bool cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_bssid->struct_init(); }
+    m_association_frame = (uint8_t*)m_buff_ptr__;
+    m_association_frame_idx__ = getBuffRemainingBytes();
     if (m_parse__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -119,7 +119,10 @@ cACTION_APMANAGER_HOSTAP_REMOVE_NEIGHBOR_11K_REQUEST:
 
 cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION:
   _type: class
-  params: sClientAssociationParams
+  mac: sMacAddr
+  bssid: sMacAddr
+  capabilities: beerocks::message::sRadioCapabilities
+  vap_id: int8_t
 
 cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -123,6 +123,9 @@ cACTION_APMANAGER_CLIENT_ASSOCIATED_NOTIFICATION:
   bssid: sMacAddr
   capabilities: beerocks::message::sRadioCapabilities
   vap_id: int8_t
+  association_frame:
+    _type: uint8_t
+    _length: [] 
 
 cACTION_APMANAGER_CLIENT_DISCONNECTED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -130,6 +130,9 @@ cACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION:
   _type: class
   client_mac: sMacAddr
   bssid: sMacAddr
+  association_frame:
+    _type: uint8_t 
+    _length: [] 
 
 cACTION_BACKHAUL_CLIENT_DISCONNECTED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -140,12 +140,6 @@ sDfsChannelAvailable:
   bandwidth: uint8_t      #beerocks::eWiFiBandwidth
   vht_center_frequency: uint16_t  
 
-sClientAssociationParams:
-  _type: struct
-  mac: sMacAddr
-  bssid: sMacAddr
-  capabilities: beerocks::message::sRadioCapabilities
-  vap_id: int8_t
 
 sClientDisconnectionParams:
   _type: struct

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1029,11 +1029,19 @@ bool master_thread::handle_cmdu_1905_client_capability_report_message(
         return false;
     }
 
-    //TODO: log the details so it can be checked in the test_flows
+    //log the details so it can be checked in the test_flows
     LOG(INFO) << "Received CLIENT_CAPABILITY_REPORT_MESSAGE, mid=" << std::hex << int(mid)
               << ", Result Code= " << result_code
               << ", client MAC= " << network_utils::mac_to_string(client_info_tlv->client_mac())
               << ", BSSID= " << network_utils::mac_to_string(client_info_tlv->bssid());
+
+    LOG_IF(client_capability_report_tlv->result_code() ==
+               wfa_map::tlvClientCapabilityReport::SUCCESS,
+           DEBUG)
+        << "(Re)Association Request frame= "
+        << utils::dump_buffer(client_capability_report_tlv->association_frame(),
+                              client_capability_report_tlv->association_frame_length());
+
     return true;
 }
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1568,7 +1568,7 @@ bool master_thread::handle_cmdu_1905_topology_notification(const std::string &sr
 #ifdef BEEROCKS_RDKB
         //push event to rdkb_wlan_hal task
         if (vs_tlv && database.settings_rdkb_extensions()) {
-            beerocks_message::sClientAssociationParams new_event = {};
+            bwl::sClientAssociationParams new_event = {};
 
             new_event.mac          = client_mac;
             new_event.bssid        = bssid;

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -14,6 +14,7 @@
 #include "tasks/optimal_path_task.h"
 #include "tasks/task_pool.h"
 
+#include "../../../common/beerocks/bwl/include/bwl/base_wlan_hal.h"
 #include <bcl/beerocks_defines.h>
 #include <bcl/beerocks_logging.h>
 #include <bcl/beerocks_message_structs.h>

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
@@ -678,7 +678,7 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
     case STEERING_EVENT_CLIENT_CONNECT_AVAILABLE: {
 
         if (obj) {
-            auto event_obj   = (beerocks_message::sClientAssociationParams *)obj;
+            auto event_obj   = (bwl::sClientAssociationParams *)obj;
             auto client_mac  = net::network_utils::mac_to_string(event_obj->mac);
             auto bssid       = net::network_utils::mac_to_string(event_obj->bssid);
             auto group_index = rdkb_db.get_group_index(client_mac, bssid);

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientCapabilityReport.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvClientCapabilityReport.h
@@ -41,7 +41,7 @@ class tlvClientCapabilityReport : public BaseClass
         const eTlvTypeMap& type();
         const uint16_t& length();
         eResultCode& result_code();
-        uint8_t& association_frame_length();
+        size_t association_frame_length() { return m_association_frame_idx__ * sizeof(uint8_t); }
         uint8_t* association_frame(size_t idx = 0);
         bool set_association_frame(const void* buffer, size_t size);
         bool alloc_association_frame(size_t count = 1);
@@ -54,7 +54,6 @@ class tlvClientCapabilityReport : public BaseClass
         eTlvTypeMap* m_type = nullptr;
         uint16_t* m_length = nullptr;
         eResultCode* m_result_code = nullptr;
-        uint8_t* m_association_frame_length = nullptr;
         uint8_t* m_association_frame = nullptr;
         size_t m_association_frame_idx__ = 0;
         int m_lock_order_counter__ = 0;

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvClientCapabilityReport.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvClientCapabilityReport.yaml
@@ -10,12 +10,9 @@ tlvClientCapabilityReport:
     _value_const: TLV_CLIENT_CAPABILITY_REPORT
   length: uint16_t
   result_code: eResultCode
-  association_frame_length:
-    _type: uint8_t
-    _length_var: True
   association_frame:
     _type: uint8_t
-    _length: [ association_frame_length ] 
+    _length: [] 
 
 eResultCode:
   _type: enum

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -477,6 +477,19 @@ class TestFlows:
         sta1 = env.Station.create()
         sta2 = env.Station.create()
 
+        association_frame = """00 0e 4d 75 6c 74 69 2d 41 50 2d 32 34 47 2d 31
+01 08 02 04 0b 0c 12 16 18 24 21 02 00 14 30 14
+01 00 00 0f ac 04 01 00 00 0f ac 04 01 00 00 0f
+ac 02 00 00 32 04 30 48 60 6c 3b 10 51 51 53 54
+73 74 75 76 77 78 7c 7d 7e 7f 80 82 3b 16 0c 01
+02 03 04 05 0c 16 17 18 19 1a 1b 1c 1d 1e 1f 20
+21 80 81 82 46 05 70 00 00 00 00 46 05 71 50 50
+00 04 7f 0a 04 00 0a 82 21 40 00 40 80 00 dd 07
+00 50 f2 02 00 01 00 2d 1a 2d 11 03 ff ff 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 18 e6
+e1 09 00 bf 0c b0 79 d1 33 fa ff 0c 03 fa ff 0c
+03 c7 01 10 """
+
         debug("Send client capability query for unconnected STA")
         env.controller.dev_send_1905(env.agents[0].mac, 0x8009,
                                      tlv(0x90, 0x000C,
@@ -507,6 +520,9 @@ class TestFlows:
         self.check_log(env.controller,
                        r"Result Code= SUCCESS, client MAC= {}, BSSID= {}"
                        .format(sta2.mac, env.agents[0].radios[0].mac))
+
+        for line in association_frame.splitlines():
+            self.check_log(env.controller, r"{}".format(line))
 
     def test_client_association_dummy(self):
         sta = env.Station.create()


### PR DESCRIPTION
### Description
According to Multi-AP Specification, If a Multi-AP Agent receives a
Client Capability Query message, then within one second it shall respond
with a Client Capability Report message.

If the STA specified in the Client Capability Query message is not
associated with any of the BSS operated by the Multi-AP Agent (an error
scenario), the Multi-AP Agent shall set the result code in the Client
Capability Report TLV to 0x01 and include an Error Code TLV.
If it is not an error scenario, the Client Capability Report TLV should
include the frame body of the most recently received (Re)Association
Request frame from this client.

### Changes

- Parse the association request frame from the AP-STA-CONNECTED event.

- Save in the associated_clients_t map the frame body of the most recently 
received (Re)Association Request frame from each client.

- Add  the frame body of the most recently received (Re)Association
Request frame from the client to the Client Capability Report TLV

### Testbed status
Passed, you can check out the logs:https://gitlab.com/prpl-foundation/prplMesh/pipelines/133224675

there is a bug in the master version #1097, the logs above are before rebasing with the master which causes the bug---solved !

latest logs : https://gitlab.com/prpl-foundation/prplMesh/pipelines/135801475

### Next steps

- [x] Add an association frame in dummy mode.
- [x] Add a test to check it [dummy mode].
- [x] Currently, I'm facing a strange issue that the association frame is not delivered from son slave to backhaul manager, need to debug it. -----> Solved! an issue with the TLVF, thanks to @LiorAmram 
- [x] Solve the issue on the testbed

<img src="https://media.giphy.com/media/AUGqun7QALo0o/giphy.gif" width=144>
Signed-off-by: Coral Malachi coral.malachi@intel.com
