### PR TITLE
Dev/client steering optimization

### DIFF
--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -78,7 +78,7 @@ enum eGlobals {
     PHY_RATE_100KB_MAX                      = 8666,
     PHY_RATE_100KB_MIN                      = 72,
     PHY_RATE_100KB_INVALID                  = 0,
-    BSS_STEER_DISASSOC_TIMER_MS             = 15000, // ~15sec
+    BSS_STEER_DISASSOC_TIMER_MS             = 200, // ~200ms
     BSS_STEER_IMMINENT_VALID_INT            = 100,
     BSS_STEER_VALID_INT                     = 50,
     SON_SLAVE_WATCHDOG_INTERVAL_MSC         = 5000,

--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -250,8 +250,15 @@ void client_steering_task::steer_sta()
 void client_steering_task::handle_event(int event_type, void *obj)
 {
     if (event_type == STA_CONNECTED) {
-        TASK_LOG(DEBUG) << "steering successful for sta " << sta_mac;
-        steering_success = true;
+        auto connected_bssid = database.get_node_parent(sta_mac);
+        if (target_bssid == connected_bssid) {
+            TASK_LOG(DEBUG) << "steering successful for sta " << sta_mac << " to bssid "
+                            << connected_bssid;
+            steering_success = true;
+        } else {
+            TASK_LOG(ERROR) << "sta " << sta_mac << " steered to bssid " << connected_bssid
+                            << " ,target bssid was " << target_bssid;
+        }
     } else if (event_type == STA_DISCONNECTED) {
         TASK_LOG(DEBUG) << "sta " << sta_mac
                         << " disconnected after successful steering, proceeding to unblock";

--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -267,8 +267,7 @@ void client_steering_task::handle_event(int event_type, void *obj)
                             << " ,target bssid was " << target_bssid;
         }
     } else if (event_type == STA_DISCONNECTED) {
-        TASK_LOG(DEBUG) << "sta " << sta_mac
-                        << " disconnected after successful steering, proceeding to unblock";
+        TASK_LOG(DEBUG) << "sta " << sta_mac << " disconnected due to steering request";
     } else if (event_type == BSS_TM_REQUEST_REJECTED) {
         TASK_LOG(DEBUG) << "sta " << sta_mac << " rejected BSS_TM request";
         if (disassoc_imminent) {

--- a/controller/src/beerocks/master/tasks/client_steering_task.h
+++ b/controller/src/beerocks/master/tasks/client_steering_task.h
@@ -25,7 +25,7 @@ public:
 
 public:
     client_steering_task(db &database_, ieee1905_1::CmduMessageTx &cmdu_tx_, task_pool &tasks_,
-                         std::string sta_mac_, std::string hostap_mac, bool disassoc_imminent_,
+                         std::string sta_mac_, std::string target_bssid_, bool disassoc_imminent_,
                          int disassoc_timer_ms_ = beerocks::BSS_STEER_DISASSOC_TIMER_MS,
                          bool steer_restricted_ = false,
                          std::string task_name_ = std::string("client_steering_task"));
@@ -43,8 +43,8 @@ private:
     ieee1905_1::CmduMessageTx &cmdu_tx;
     task_pool &tasks;
     const std::string sta_mac;
-    const std::string hostap_mac;
-    std::string original_hostap_mac;
+    const std::string target_bssid;
+    std::string original_bssid;
     bool steering_success  = false;
     bool disassoc_imminent = true;
     const int disassoc_timer_ms;

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -1191,10 +1191,8 @@ void optimal_path_task::work()
                             << sta_mac << " steer from AP " << current_hostap_vap << " to AP "
                             << chosen_hostap;
             bool disassoc_imminent = true;
-            int disassoc_timer_ms  = 100;
-            steering_task_id =
-                son_actions::steer_sta(database, cmdu_tx, tasks, sta_mac, chosen_hostap,
-                                       disassoc_imminent, disassoc_timer_ms);
+            steering_task_id       = son_actions::steer_sta(database, cmdu_tx, tasks, sta_mac,
+                                                      chosen_hostap, disassoc_imminent);
         }
 
         wait_for_task_end(steering_task_id, 30000);

--- a/tests/test_flows.sh
+++ b/tests/test_flows.sh
@@ -363,7 +363,7 @@ test_client_steering_dummy() {
     send_bwl_event ${REPEATER1} wlan2 "EVENT AP-STA-CONNECTED ${sta_mac}"
     dbg "Confirm steering success by client connected"
     check_log ${GATEWAY} controller "steering successful for sta ${sta_mac}"
-    check_log ${GATEWAY} controller "sta ${sta_mac} disconnected after successful steering"
+    check_log ${GATEWAY} controller "sta ${sta_mac} disconnected due to steering request"
     return $check_error
 }
 


### PR DESCRIPTION
This PR fixes client steering bugs and performance issues.

Found:
while performing client steering basic validation on RDKB platform.

- [x] Disassociate timer is too long– change default from 15sec to 200ms (use in all cases in optimal path task)

- [x] client_steering_task wrong “success” criteria – add check if we steered to the requested bssid.

- [x] [bug] Disallow message not sent  – controller should send VAP mac instead of AP mac in bssid field . disallow message should be sent per VAP.

