### PR TITLE
Bugfix/channel switch wrong bandwidth

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -241,6 +241,11 @@ private:
     bool handle_link_metrics_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool channel_selection_get_channel_preference(ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool channel_selection_get_transmit_power_limit(ieee1905_1::CmduMessageRx &cmdu_rx,
+                                                    int &power_limit);
+    bool channel_selection_current_channel_restricted();
+    beerocks::message::sWifiChannel channel_selection_select_channel();
     bool handle_multi_ap_policy_config_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_association_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_client_steering_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -458,6 +458,30 @@ enum class eChannelScanOpErrCode : uint8_t {
 
 #define CHANNEL_SCAN_INVALID_PARAM -1
 
+/**
+ * @brief channel preference values
+ * 
+ * Based on Multi-AP specification 2.0 Table 23 - channel preference TLV format bits 7-4
+ */
+enum class eChannelPreference : uint8_t {
+    NON_OPERABLE = 0,
+    PREFERRED1,
+    PREFERRED2,
+    PREFERRED3,
+    PREFERRED4,
+    PREFERRED5,
+    PREFERRED6,
+    PREFERRED7,
+    PREFERRED8,
+    PREFERRED9,
+    PREFERRED10,
+    PREFERRED11,
+    PREFERRED12,
+    PREFERRED13,
+    PREFERRED14,
+    INVALID // 0b1111 is reserved
+};
+
 } // namespace beerocks
 
 #endif //_BEEROCKS_DEFINES_H_

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -458,30 +458,6 @@ enum class eChannelScanOpErrCode : uint8_t {
 
 #define CHANNEL_SCAN_INVALID_PARAM -1
 
-/**
- * @brief channel preference values
- * 
- * Based on Multi-AP specification 2.0 Table 23 - channel preference TLV format bits 7-4
- */
-enum class eChannelPreference : uint8_t {
-    NON_OPERABLE = 0,
-    PREFERRED1,
-    PREFERRED2,
-    PREFERRED3,
-    PREFERRED4,
-    PREFERRED5,
-    PREFERRED6,
-    PREFERRED7,
-    PREFERRED8,
-    PREFERRED9,
-    PREFERRED10,
-    PREFERRED11,
-    PREFERRED12,
-    PREFERRED13,
-    PREFERRED14,
-    INVALID // 0b1111 is reserved
-};
-
 } // namespace beerocks
 
 #endif //_BEEROCKS_DEFINES_H_

--- a/common/beerocks/bcl/include/bcl/beerocks_message_structs.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_message_structs.h
@@ -92,26 +92,6 @@ typedef struct sRadioCapabilities {
     }
 } __attribute__((packed)) sRadioCapabilities;
 
-typedef struct sPreference {
-    uint8_t oper_class = 0;
-    uint8_t preference = 0;
-    uint8_t reason     = 0;
-    sPreference(){};
-    sPreference(uint8_t oper_class_, uint8_t preference_, uint8_t reason_)
-    {
-        oper_class = oper_class_;
-        preference = preference_;
-        reason     = reason_;
-    }
-    void struct_swap() {}
-    void struct_init()
-    {
-        oper_class = 0;
-        preference = 0;
-        reason     = 0;
-    }
-} __attribute__((packed)) sPreference;
-
 typedef struct sWifiChannel {
     uint8_t channel           = 0;
     int8_t noise              = 0;

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -15,6 +15,7 @@
 #include <tlvf/WSC/eWscAuth.h>
 #include <tlvf/WSC/eWscEncr.h>
 #include <tlvf/WSC/eWscVendorExt.h>
+#include <tlvf/wfa_map/tlvChannelPreference.h>
 
 #include <iostream>
 #include <list>
@@ -100,7 +101,9 @@ public:
     } sPhyRateBitRateEntry;
 
     typedef struct {
-        beerocks::message::sPreference preference;
+        uint8_t oper_class = 0;
+        uint8_t preference = wfa_map::cPreferenceOperatingClasses::ePreference::NON_OPERABLE;
+        uint8_t reason     = wfa_map::cPreferenceOperatingClasses::eReasonCode::UNSPECIFIED;
         std::vector<beerocks::message::sWifiChannel> channels;
     } sChannelPreference;
 

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -587,13 +587,11 @@ wireless_utils::get_channel_preferences(const beerocks::message::sWifiChannel su
                 radar_affected_channels.push_back(supported_channels[i]);
             }
         }
+        sChannelPreference pref;
+        pref.reason = wfa_map::cPreferenceOperatingClasses::eReasonCode::
+            OPERATION_DISALLOWED_DUE_TO_RADAR_DETECTION_ON_A_DFS_CHANNEL;
         if (!radar_affected_channels.empty()) {
-            auto pref = beerocks::message::sPreference(
-                {oper_class.first, 0,
-                 wfa_map::cPreferenceOperatingClasses::eReasonCode::
-                     OPERATION_DISALLOWED_DUE_TO_RADAR_DETECTION_ON_A_DFS_CHANNEL});
-
-            preferences.push_back({pref, radar_affected_channels});
+            preferences.push_back(pref);
         }
     }
 

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1183,8 +1183,6 @@ bool ap_wlan_hal_dwpal::switch_channel(int chan, int bw, int vht_center_frequenc
     } else {
         m_drop_csa = false;
 
-        // int bandwidth_int = utils::convert_bandwidth_to_int(bandwidth);
-        std::string bandwidth_str             = std::to_string(bw);
         int freq                              = beerocks::utils::wifi_channel_to_freq(chan);
         std::string freq_str                  = std::to_string(freq);
         std::string wave_vht_center_frequency = std::to_string(vht_center_frequency);
@@ -1193,7 +1191,7 @@ bool ap_wlan_hal_dwpal::switch_channel(int chan, int bw, int vht_center_frequenc
         cmd += freq_str; // CenterFrequency
 
         // Extension Channel
-        if (bw != 20) {
+        if (bw != beerocks::BANDWIDTH_20) {
             if (freq < vht_center_frequency) {
                 cmd += " sec_channel_offset=1";
             } else {
@@ -1206,7 +1204,8 @@ bool ap_wlan_hal_dwpal::switch_channel(int chan, int bw, int vht_center_frequenc
             cmd += " center_freq1=" + wave_vht_center_frequency;
         }
 
-        cmd += " bandwidth=" + bandwidth_str;
+        cmd += " bandwidth=" + std::to_string(beerocks::utils::convert_bandwidth_to_int(
+                                   static_cast<beerocks::eWiFiBandwidth>(bw)));
 
         // Supported Standard n/ac
         if (bw == beerocks::BANDWIDTH_20 || bw == beerocks::BANDWIDTH_40) {
@@ -1217,6 +1216,7 @@ bool ap_wlan_hal_dwpal::switch_channel(int chan, int bw, int vht_center_frequenc
     }
 
     // Send command
+    LOG(DEBUG) << "switch channel command: " << cmd;
     if (!dwpal_send_cmd(cmd)) {
         LOG(ERROR) << "switch_channel() failed!";
         return false;

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvChannelPreference.h
@@ -68,6 +68,25 @@ class cPreferenceOperatingClasses : public BaseClass
         explicit cPreferenceOperatingClasses(std::shared_ptr<BaseClass> base, bool parse = false);
         ~cPreferenceOperatingClasses();
 
+        enum ePreference {
+            NON_OPERABLE = 0x0,
+            PREFERRED1 = 0x1,
+            PREFERRED2 = 0x2,
+            PREFERRED3 = 0x3,
+            PREFERRED4 = 0x4,
+            PREFERRED5 = 0x5,
+            PREFERRED6 = 0x6,
+            PREFERRED7 = 0x7,
+            PREFERRED8 = 0x8,
+            PREFERRED9 = 0x9,
+            PREFERRED10 = 0xa,
+            PREFERRED11 = 0xb,
+            PREFERRED12 = 0xc,
+            PREFERRED13 = 0xd,
+            PREFERRED14 = 0xe,
+            RESERVED = 0xf,
+        };
+        
         enum eReasonCode {
             UNSPECIFIED = 0x0,
             PROXIMATE_NON_802_11_INTERFERER_IN_LOCAL_ENVIRONMENT = 0x1,

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvChannelPreference.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvChannelPreference.yaml
@@ -29,6 +29,25 @@ cPreferenceOperatingClasses:
     _length: [ channel_list_length ]
   flags: sFlags
 
+ePreference:
+  _type: enum
+  NON_OPERABLE: 0
+  PREFERRED1: 1
+  PREFERRED2: 2
+  PREFERRED3: 3
+  PREFERRED4: 4
+  PREFERRED5: 5
+  PREFERRED6: 6
+  PREFERRED7: 7
+  PREFERRED8: 8
+  PREFERRED9: 9
+  PREFERRED10: 10
+  PREFERRED11: 11
+  PREFERRED12: 12
+  PREFERRED13: 13
+  PREFERRED14: 14
+  RESERVED: 15
+
 eReasonCode:
   _type: enum
   UNSPECIFIED: 0


### PR DESCRIPTION
Fix several bugs in the channel selection implementation:
- Fix wrong bandwidth use in DWPAL which caused chan_switch command to fail
- Fix bug in agent's channel selection which selected a restricted channel
- Fix bug in agent's channel selection which caused the agent not to send operating channel report when channel switch was not needed.
- Fix bug in agent's channel selection which did not follow the Multi-AP specification by not marking channel preference with empty channel list as non-operable

WiFi Alliance support case # 00129476 helped identify the final bug. With this, we pass 4.2.1 without any workarounds.

Fixes #344 