### PR TITLE
Feature/add support for nl80211 standard commands to BWL

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BWL_TYPE STREQUAL "DWPAL")
 
     file(GLOB bwl_platform_sources
         ${bwl_platform_sources}
+        ${MODULE_PATH}/shared/*.c*
         ${MODULE_PATH}/dwpal/*.c*
     )
 
@@ -75,6 +76,7 @@ if(BWL_TYPE STREQUAL "DWPAL")
 elseif(BWL_TYPE STREQUAL "NL80211")
 
     file(GLOB bwl_platform_sources
+        ${MODULE_PATH}/shared/*.c*
         ${MODULE_PATH}/nl80211/*.c*
 
         # WPA Control Interface
@@ -103,6 +105,18 @@ elseif(BWL_TYPE STREQUAL "NL80211")
 
     list(APPEND BWL_LIBS nl-tiny)
 
+elseif(BWL_TYPE STREQUAL "DUMMY")
+
+    set(bwl_platform_sources
+        ${bwl_platform_sources}
+        ${MODULE_PATH}/dummy/nl80211_client_dummy.cpp
+        ${MODULE_PATH}/dummy/nl80211_client_factory_dummy.cpp
+        ${MODULE_PATH}/dummy/mon_wlan_hal_dummy.cpp
+        ${MODULE_PATH}/dummy/ap_wlan_hal_dummy.cpp
+        ${MODULE_PATH}/dummy/base_wlan_hal_dummy.cpp
+        ${MODULE_PATH}/dummy/sta_wlan_hal_dummy.cpp
+    )
+    
 else()
 
     string(TOLOWER ${BWL_TYPE} BWL_PATH)

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "nl80211_client_dummy.h"
+
+namespace bwl {
+
+nl80211_client_dummy::nl80211_client_dummy() {}
+
+nl80211_client_dummy::~nl80211_client_dummy() {}
+
+bool nl80211_client_dummy::get_sta_info(const std::string &local_interface_name,
+                                        const sMacAddr &sta_mac_address, sStaInfo &sta_info)
+{
+    // Suppress "unused parameter" warning
+    (void)local_interface_name;
+    (void)sta_mac_address;
+
+    static int inactive_time_ms        = 0;
+    static int rx_bytes                = 0;
+    static int rx_packets              = 0;
+    static uint32_t tx_bytes           = 0;
+    static uint32_t tx_packets         = 0;
+    static uint32_t tx_retries         = 0;
+    static uint32_t tx_failed          = 0;
+    static uint8_t signal_dBm          = 0;
+    static uint8_t signal_avg_dBm      = 0;
+    static uint16_t tx_bitrate_100kbps = 0;
+    static uint16_t rx_bitrate_100kbps = 0;
+
+    sta_info.inactive_time_ms   = inactive_time_ms++;
+    sta_info.rx_bytes           = rx_bytes++;
+    sta_info.rx_packets         = rx_packets++;
+    sta_info.tx_bytes           = tx_bytes++;
+    sta_info.tx_packets         = tx_packets++;
+    sta_info.tx_retries         = tx_retries++;
+    sta_info.tx_failed          = tx_failed++;
+    sta_info.signal_dBm         = signal_dBm++;
+    sta_info.signal_avg_dBm     = signal_avg_dBm++;
+    sta_info.tx_bitrate_100kbps = tx_bitrate_100kbps++;
+    sta_info.rx_bitrate_100kbps = rx_bitrate_100kbps++;
+
+    return true;
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.h
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NL80211_CLIENT_DUMMY_H__
+#define __BWL_NL80211_CLIENT_DUMMY_H__
+
+#include <bwl/nl80211_client.h>
+
+namespace bwl {
+
+/**
+ * @brief NL80211 client dummy implementation.
+ *
+ * This class is used by the dummy flavor of the BWL library and it is intended for testing
+ * purposes only.
+ */
+class nl80211_client_dummy : public nl80211_client {
+
+public:
+    /**
+     * @brief Class constructor.
+     */
+    nl80211_client_dummy();
+
+    /**
+     * @brief Class destructor.
+     */
+    virtual ~nl80211_client_dummy();
+
+    /**
+     * @brief Gets station information.
+     *
+     * Fills station information with dummy data.
+     *
+     * @param[in] local_interface_name Virtual AP (VAP) interface name.
+     * @param[in] sta_mac_address MAC address of a station connected to the local interface.
+     * @param[out] sta_info Station information.
+     *
+     * @return Dummy implementation returns always true.
+     */
+    virtual bool get_sta_info(const std::string &local_interface_name,
+                              const sMacAddr &sta_mac_address, sStaInfo &sta_info) override;
+};
+
+} // namespace bwl
+
+#endif

--- a/common/beerocks/bwl/dummy/nl80211_client_factory_dummy.cpp
+++ b/common/beerocks/bwl/dummy/nl80211_client_factory_dummy.cpp
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <bwl/nl80211_client_factory.h>
+
+#include "nl80211_client_dummy.h"
+
+#include <bcl/beerocks_backport.h>
+
+namespace bwl {
+
+std::unique_ptr<nl80211_client> nl80211_client_factory::create_instance()
+{
+    return std::make_unique<nl80211_client_dummy>();
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/include/bwl/nl80211_client.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client.h
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NL80211_CLIENT_H__
+#define __BWL_NL80211_CLIENT_H__
+
+#include <tlvf/common/sMacAddr.h>
+
+#include <string>
+
+namespace bwl {
+
+/**
+ * @brief NL80211 client interface.
+ *
+ * This interface lists the methods to read and write wireless hardware status and configuration
+ * through a NL80211 socket.
+ *
+ * Programming to an interface allows dependent classes to remain unaware of the different
+ * implementations of the interface as well as facilitates the creation of mock implementations for
+ * unit testing.
+ *
+ * This is a C++ interface: an abstract class that is designed to be specifically used as a base
+ * class and which derived classes (implementations) will override each pure virtual function.
+ *
+ * Known implementations: nl80211_client_impl (uses NL80211 socket), nl80211_client_dummy (fake
+ * implementation that returns dummy data).
+ */
+class nl80211_client {
+
+public:
+    /**
+     * @brief Station information
+     *
+     * Information obtained with NL80211_CMD_GET_STATION command through a NL80211 socket.
+     * See NL80211_STA_INFO_* in <linux/nl80211.h> for a description of each field.
+     */
+    struct sStaInfo {
+        uint32_t inactive_time_ms   = 0;
+        uint32_t rx_bytes           = 0;
+        uint32_t rx_packets         = 0;
+        uint32_t tx_bytes           = 0;
+        uint32_t tx_packets         = 0;
+        uint32_t tx_retries         = 0;
+        uint32_t tx_failed          = 0;
+        uint8_t signal_dBm          = 0;
+        uint8_t signal_avg_dBm      = 0;
+        uint16_t tx_bitrate_100kbps = 0;
+        uint16_t rx_bitrate_100kbps = 0;
+    };
+
+    /**
+     * @brief Class destructor.
+     */
+    virtual ~nl80211_client() = default;
+
+    /**
+     * @brief Gets station information.
+     *
+     * Station information contains basically metrics associated to the link between given local
+     * interface and a the interface of a station whose MAC address is 'sta_mac_address'.
+     *
+     * @param[in] local_interface_name Virtual AP (VAP) interface name.
+     * @param[in] sta_mac_address MAC address of a station connected to the local interface.
+     * @param[out] sta_info Station information.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_sta_info(const std::string &local_interface_name,
+                              const sMacAddr &sta_mac_address, sStaInfo &sta_info) = 0;
+
+    // TODO: add remaining methods
+};
+
+} // namespace bwl
+
+#endif

--- a/common/beerocks/bwl/include/bwl/nl80211_client_factory.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client_factory.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NL80211_CLIENT_FACTORY_H__
+#define __BWL_NL80211_CLIENT_FACTORY_H__
+
+#include "nl80211_client.h"
+
+#include <memory>
+
+namespace bwl {
+
+/**
+ * @brief NL80211 client factory.
+ *
+ * Factory to create NL80211 client instances. Each BWL implementation should define one.
+ */
+class nl80211_client_factory {
+
+public:
+    /**
+     * @brief Creates a new NL80211 client instance.
+     *
+     * @return NL80211 client instance.
+     */
+    static std::unique_ptr<nl80211_client> create_instance();
+};
+
+} // namespace bwl
+
+#endif

--- a/common/beerocks/bwl/shared/README.md
+++ b/common/beerocks/bwl/shared/README.md
@@ -1,0 +1,6 @@
+# Shared files directory
+
+The `shared` directory contains classes shared among all the implementations that use actual WiFi radios (i.e.: the DWPAL and NL80211 flavors but not the Dummy one).
+
+Currently, these classes provide the following functionality:
+- Support for NL80211 standard commands through a NL80211 socket. 

--- a/common/beerocks/bwl/shared/netlink_socket.cpp
+++ b/common/beerocks/bwl/shared/netlink_socket.cpp
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "netlink_socket.h"
+
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
+
+#include <easylogging++.h>
+
+namespace bwl {
+
+netlink_socket::netlink_socket(int protocol)
+    : m_nl_socket(nl_socket_alloc(), nl_socket_free), m_protocol(protocol)
+{
+    LOG_IF(!m_nl_socket, ERROR) << "Failed to allocate netlink socket!";
+}
+
+bool netlink_socket::connect()
+{
+    if (!m_nl_socket) {
+        LOG(ERROR) << "Cannot use unallocated socket!";
+        return false;
+    }
+
+    // Connect the socket
+    if (nl_connect(m_nl_socket.get(), m_protocol) != 0) {
+        LOG(ERROR) << "Failed to connect netlink socket!";
+        return false;
+    }
+
+    return true;
+}
+
+void netlink_socket::close()
+{
+    if (!m_nl_socket) {
+        LOG(ERROR) << "Cannot use unallocated socket!";
+    }
+
+    // Terminate connection and close socket
+    nl_close(m_nl_socket.get());
+}
+
+bool netlink_socket::send_receive_msg(std::function<bool(struct nl_msg *msg)> msg_create,
+                                      std::function<bool(struct nl_msg *msg)> msg_handle)
+{
+    if (!m_nl_socket) {
+        LOG(ERROR) << "Cannot use unallocated socket!";
+        return false;
+    }
+
+    // The Netlink message to send
+    std::unique_ptr<nl_msg, void (*)(nl_msg *)> nl_message(nlmsg_alloc(), nlmsg_free);
+    if (!nl_message) {
+        LOG(ERROR) << "Failed creating netlink message!";
+        return false;
+    }
+
+    // The Netlink callback set
+    std::unique_ptr<nl_cb, void (*)(nl_cb *)> nl_callback(nl_cb_alloc(NL_CB_DEFAULT), nl_cb_put);
+    if (!nl_callback) {
+        LOG(ERROR) << "Failed creating netlink callback!";
+        return false;
+    }
+
+    // Termination flag for the loop that receives the response messages. Possible values are:
+    // error == 1: initial value, request message has not be sent yet
+    // error == 0: response has been successfully received
+    // error < 0: some error occurred while receiving response
+    // Final value is used to compute the result code of this method.
+    int error = 1;
+
+    // Create standard callbacks
+    static auto nl_err_cb = [](struct sockaddr_nl *nla, struct nlmsgerr *err, void *arg) -> int {
+        int *error = (int *)arg;
+        *error     = err->error;
+        LOG(ERROR) << "Failed to process netlink message! Error: " << *error;
+        return NL_STOP;
+    };
+
+    static auto nl_finish_cb = [](struct nl_msg *msg, void *arg) -> int {
+        int *error = (int *)arg;
+        *error     = 0;
+        return NL_SKIP;
+    };
+
+    static auto nl_ack_cb = [](struct nl_msg *msg, void *arg) -> int {
+        int *error = (int *)arg;
+        *error     = 0;
+        return NL_STOP;
+    };
+
+    // Passing a lambda with capture is not supported for standard C function
+    // pointers. As a workaround, we create a static (but thread local) wrapper
+    // function that calls the capturing lambda function.
+    static thread_local std::function<int(struct nl_msg * msg, void *arg)> nl_handler_cb_wrapper;
+    nl_handler_cb_wrapper = [&](struct nl_msg *msg, void *arg) -> int {
+        if (!msg_handle(msg)) {
+            LOG(ERROR) << "User's netlink handler function failed!";
+        }
+        return NL_SKIP;
+    };
+    auto nl_handler_cb = [](struct nl_msg *msg, void *arg) -> int {
+        return nl_handler_cb_wrapper(msg, arg);
+    };
+
+    // Call the user's message create function
+    if (!msg_create(nl_message.get())) {
+        LOG(ERROR) << "User's netlink create function failed!";
+        return false;
+    }
+
+    // Set the callbacks
+    nl_cb_err(nl_callback.get(), NL_CB_CUSTOM, nl_err_cb, &error); // error
+    nl_cb_set(nl_callback.get(), NL_CB_FINISH, NL_CB_CUSTOM, nl_finish_cb,
+              &error);                                                        // finish
+    nl_cb_set(nl_callback.get(), NL_CB_ACK, NL_CB_CUSTOM, nl_ack_cb, &error); // ack
+    nl_cb_set(nl_callback.get(), NL_CB_VALID, NL_CB_CUSTOM, nl_handler_cb,
+              nullptr); // response handler
+
+    // Send the netlink message
+    int rc = nl_send_auto_complete(m_nl_socket.get(), nl_message.get());
+    if (rc < 0) {
+        LOG(ERROR) << "Failed to send netlink message! Error: " << rc;
+        return false;
+    }
+
+    // Receive the response messages
+    // Note that call to nl_recvmsgs() is blocking and loop terminates when one of these
+    // conditions is met:
+    // - nl_recvmsgs() fails (because internal call to nl_recv() in turn fails)
+    // - One of the callback functions sets error to 0 (ok)
+    // - One of the callback functions sets error to a value lower than 0 (error)
+    // Loop is required just in case more than one message is received. Handling callback must
+    // process them all.
+    while (error > 0) {
+        int rc = nl_recvmsgs(m_nl_socket.get(), nl_callback.get());
+        if (rc < 0) {
+            LOG(ERROR) << "Failed to receive netlink messages! Error: " << rc;
+            return false;
+        }
+    }
+
+    // Return true on success and false otherwise
+    return (0 == error);
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/shared/netlink_socket.h
+++ b/common/beerocks/bwl/shared/netlink_socket.h
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NETLINK_SOCKET_H__
+#define __BWL_NETLINK_SOCKET_H__
+
+#include <functional>
+#include <memory>
+
+/**
+ * Forward declarations
+ */
+struct nl_sock;
+struct nl_msg;
+
+namespace bwl {
+
+/**
+ * @brief C++ wrapper class around the core library of the Netlink Protocol Library Suite (libnl).
+ *
+ * The Netlink socket is Linux kernel interface used for inter-process communication (IPC) between
+ * both the kernel and userspace processes.
+ *
+ * The Netlink core library contains C functions implementing the fundamentals required to use the
+ * Netlink protocol such as socket handling, message construction and parsing, and sending and
+ * receiving of data.
+ *
+ * This is a very simple C++ wrapper class around the Netlink core library. Its aim is to
+ * facilitate the use of the library from C++ applications. The class can be used as is or extended
+ * by derived classes to support extended versions of the netlink protocol like, for example, the
+ * generic netlink protocol.
+ *
+ * Known derived classes: nl_genl_socket.
+ */
+class netlink_socket {
+
+public:
+    /**
+     * @brief Class constructor.
+     *
+     * Allocates the Netlink socket structure.
+     *
+     * @param protocol Netlink protocol to use. Possible values are listed in <linux/netlink.h>
+     */
+    explicit netlink_socket(int protocol);
+
+    /**
+     * @brief Class destructor.
+     *
+     * Deallocates the Netlink socket structure.
+     */
+    virtual ~netlink_socket() = default;
+
+    /**
+     * @brief Connects the Netlink socket.
+     *
+     * Creates a new Netlink socket and binds it to the protocol specified in class constructor.
+     *
+     * @return True on success and false otherwise (e.g.: socket is already connected).
+     */
+    virtual bool connect();
+
+    /**
+     * @brief Closes the Netlink socket.
+     *
+     * Call this method to terminate connection and free resources.
+     */
+    virtual void close();
+
+    /**
+     * @brief Performs a request/response transaction.
+     *
+     * Requires Netlink socket to be connected.
+     *
+     * Creates a new Netlink message and sends it over the previously connected Netlink socket.
+     * Then waits until response message is received and handles it.
+     *
+     * Message to send is created using provided creation callback function and received message
+     * is parsed using provided handling callback function.
+     *
+     * @param[in] msg_create Message creation callback function (called on message to be sent).
+     * @param[in] msg_handle Message handling callback function (called on received message).
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool send_receive_msg(std::function<bool(struct nl_msg *msg)> msg_create,
+                                  std::function<bool(struct nl_msg *msg)> msg_handle);
+
+protected:
+    /**
+     * Netlink socket structure containing the netlink socket and all related attributes,
+     * including the actual file descriptor.
+     *
+     * This member is protected so derived classes can use it to extend or refine the
+     * functionality provided by this class.
+     */
+    std::unique_ptr<struct nl_sock, void (*)(struct nl_sock *)> m_nl_socket;
+
+private:
+    /**
+     * Netlink protocol to use. Possible values are listed in <linux/netlink.h>
+     */
+    int m_protocol;
+};
+
+} // namespace bwl
+
+#endif

--- a/common/beerocks/bwl/shared/nl80211_client_factory.cpp
+++ b/common/beerocks/bwl/shared/nl80211_client_factory.cpp
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <bwl/nl80211_client_factory.h>
+
+#include "nl80211_client_impl.h"
+
+#include <bcl/beerocks_backport.h>
+
+#include <easylogging++.h>
+
+namespace bwl {
+
+std::unique_ptr<nl80211_client> nl80211_client_factory::create_instance()
+{
+    // Create NL80211 socket to communicate with WiFi driver
+    auto socket = std::make_unique<bwl::nl80211_socket>();
+
+    // Connect NL80211 socket (it will be automatically closed when it is not needed any more)
+    if (!socket->connect()) {
+        LOG(ERROR) << "Failed to connect nl80211 socket!";
+        return nullptr;
+    }
+
+    // Create NL80211 client to send standard NL80211 commands to WiFi driver using NL80211 socket
+    return std::make_unique<nl80211_client_impl>(std::move(socket));
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/shared/nl80211_client_impl.cpp
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.cpp
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "nl80211_client_impl.h"
+
+#include <easylogging++.h>
+
+#include <linux/if_ether.h>
+#include <linux/nl80211.h>
+#include <net/if.h>
+#include <netlink/genl/genl.h>
+
+#include <math.h>
+
+namespace bwl {
+
+nl80211_client_impl::nl80211_client_impl(std::unique_ptr<nl80211_socket> socket)
+    : m_socket(std::move(socket))
+{
+}
+
+bool nl80211_client_impl::get_sta_info(const std::string &local_interface_name,
+                                       const sMacAddr &sta_mac_address, sStaInfo &sta_info)
+{
+    static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1];
+    stats_policy[NL80211_STA_INFO_INACTIVE_TIME] = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_RX_BYTES]      = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_RX_PACKETS]    = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_TX_BYTES]      = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_TX_PACKETS]    = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_TX_RETRIES]    = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_TX_FAILED]     = {NLA_U32, 0, 0};
+    stats_policy[NL80211_STA_INFO_SIGNAL]        = {NLA_U8, 0, 0};
+    stats_policy[NL80211_STA_INFO_SIGNAL_AVG]    = {NLA_U8, 0, 0};
+    stats_policy[NL80211_STA_INFO_TX_BITRATE]    = {NLA_NESTED, 0, 0};
+    stats_policy[NL80211_STA_INFO_RX_BITRATE]    = {NLA_NESTED, 0, 0};
+
+    static struct nla_policy rate_policy[NL80211_RATE_INFO_MAX + 1];
+    rate_policy[NL80211_RATE_INFO_BITRATE]   = {NLA_U16, 0, 0};
+    rate_policy[NL80211_RATE_INFO_BITRATE32] = {NLA_U32, 0, 0};
+
+    sta_info = {};
+
+    if (!m_socket) {
+        LOG(ERROR) << "Socket is NULL!";
+        return false;
+    }
+
+    // Get the interface index for given interface name
+    int iface_index = if_nametoindex(local_interface_name.c_str());
+    if (0 == iface_index) {
+        LOG(ERROR) << "Failed to read the index of interface " << local_interface_name << ": "
+                   << strerror(errno);
+
+        return false;
+    }
+
+    return m_socket.get()->send_receive_msg(
+        NL80211_CMD_GET_STATION, NLM_F_DUMP,
+        [&](struct nl_msg *msg) -> bool {
+            nla_put_u32(msg, NL80211_ATTR_IFINDEX, iface_index);
+            nla_put(msg, NL80211_ATTR_MAC, ETH_ALEN, sta_mac_address.oct);
+
+            return true;
+        },
+        [&](struct nl_msg *msg) -> bool {
+            struct nlattr *tb[NL80211_ATTR_MAX + 1];
+            struct genlmsghdr *gnlh = (struct genlmsghdr *)nlmsg_data(nlmsg_hdr(msg));
+            struct nlattr *sinfo[NL80211_STA_INFO_MAX + 1];
+
+            // Parse the netlink message
+            if (nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0),
+                          NULL)) {
+                LOG(ERROR) << "Failed to parse netlink message!";
+                return false;
+            }
+
+            if (!tb[NL80211_ATTR_STA_INFO]) {
+                LOG(ERROR) << "STA stats missing!";
+                return false;
+            }
+
+            // Parse nested station stats
+            if (nla_parse_nested(sinfo, NL80211_STA_INFO_MAX, tb[NL80211_ATTR_STA_INFO],
+                                 stats_policy)) {
+                LOG(ERROR) << "Failed to parse nested STA attributes!";
+                return false;
+            }
+
+            if (sinfo[NL80211_STA_INFO_INACTIVE_TIME]) {
+                sta_info.inactive_time_ms = nla_get_u32(sinfo[NL80211_STA_INFO_INACTIVE_TIME]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_INACTIVE_TIME attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_RX_BYTES]) {
+                sta_info.rx_bytes = nla_get_u32(sinfo[NL80211_STA_INFO_RX_BYTES]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_RX_BYTES attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_RX_PACKETS]) {
+                sta_info.rx_packets = nla_get_u32(sinfo[NL80211_STA_INFO_RX_PACKETS]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_RX_PACKETS attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_TX_BYTES]) {
+                sta_info.tx_bytes = nla_get_u32(sinfo[NL80211_STA_INFO_TX_BYTES]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_TX_BYTES attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_TX_PACKETS]) {
+                sta_info.tx_packets = nla_get_u32(sinfo[NL80211_STA_INFO_TX_PACKETS]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_TX_PACKETS attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_TX_RETRIES]) {
+                sta_info.tx_retries = nla_get_u32(sinfo[NL80211_STA_INFO_TX_RETRIES]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_TX_RETRIES attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_TX_FAILED]) {
+                sta_info.tx_failed = nla_get_u32(sinfo[NL80211_STA_INFO_TX_FAILED]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_TX_FAILED attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_SIGNAL]) {
+                sta_info.signal_dBm = nla_get_u8(sinfo[NL80211_STA_INFO_SIGNAL]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_SIGNAL attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_SIGNAL_AVG]) {
+                sta_info.signal_avg_dBm = nla_get_u8(sinfo[NL80211_STA_INFO_SIGNAL_AVG]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_SIGNAL_AVG attribute is missing";
+            }
+
+            // Bit rate parsing helper function
+            auto parse_bitrate_func = [&](struct nlattr *bitrate_attr) -> int {
+                struct nlattr *rinfo[NL80211_RATE_INFO_MAX + 1];
+
+                int rate = 0;
+                if (nla_parse_nested(rinfo, NL80211_RATE_INFO_MAX, bitrate_attr, rate_policy)) {
+                    LOG(ERROR) << "Failed to parse nested rate attributes!";
+                } else if (rinfo[NL80211_RATE_INFO_BITRATE32]) {
+                    rate = nla_get_u32(rinfo[NL80211_RATE_INFO_BITRATE32]);
+                } else if (rinfo[NL80211_RATE_INFO_BITRATE]) {
+                    rate = nla_get_u16(rinfo[NL80211_RATE_INFO_BITRATE]);
+                } else {
+                    LOG(DEBUG) << "NL80211_RATE_INFO_BITRATE attribute is missing";
+                }
+
+                return rate;
+            };
+
+            if (sinfo[NL80211_STA_INFO_TX_BITRATE]) {
+                sta_info.tx_bitrate_100kbps =
+                    parse_bitrate_func(sinfo[NL80211_STA_INFO_TX_BITRATE]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_TX_BITRATE attribute is missing";
+            }
+
+            if (sinfo[NL80211_STA_INFO_RX_BITRATE]) {
+                sta_info.rx_bitrate_100kbps =
+                    parse_bitrate_func(sinfo[NL80211_STA_INFO_RX_BITRATE]);
+            } else {
+                LOG(DEBUG) << "NL80211_STA_INFO_RX_BITRATE attribute is missing";
+            }
+
+            return true;
+        });
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/shared/nl80211_client_impl.h
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NL80211_CLIENT_IMPL_H__
+#define __BWL_NL80211_CLIENT_IMPL_H__
+
+#include "bwl/nl80211_client.h"
+#include "nl80211_socket.h"
+
+#include <memory>
+
+namespace bwl {
+
+/**
+ * @brief NL80211 client implementation.
+ *
+ * This class implements the NL80211 client interface. Communication with the WiFi driver is
+ * performed with a NL80211 socket injected in the class constructor.
+ *
+ * Both the DWPAL and the NL80211 flavors of the BWL library use this implementation to send
+ * standard NL80211 commands to the WiFi driver.
+ */
+class nl80211_client_impl : public nl80211_client {
+
+public:
+    /**
+     * @brief Class constructor.
+     *
+     * Note: provided socket must be connected before calling any of the methods in this class.
+     *
+     * @param[in] socket NL80211 socket to send messages and receive responses to/from the WiFi
+     * driver.
+     */
+    explicit nl80211_client_impl(std::unique_ptr<nl80211_socket> socket);
+
+    /**
+     * @brief Class destructor.
+     */
+    virtual ~nl80211_client_impl() = default;
+
+    /**
+     * @brief Gets station information.
+     *
+     * Station information contains basic metrics associated to the link between given local
+     * interface and the interface of a station with MAC address 'sta_mac_address'.
+     *
+     * @param[in] local_interface_name Virtual AP (VAP) interface name.
+     * @param[in] sta_mac_address MAC address of a station connected to the local interface.
+     * @param[out] sta_info Station information.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_sta_info(const std::string &local_interface_name,
+                              const sMacAddr &sta_mac_address, sStaInfo &sta_info) override;
+
+private:
+    /**
+     * NL80211 socket to send messages and receive responses to/from the WiFi driver.
+     */
+    std::unique_ptr<nl80211_socket> m_socket;
+};
+
+} // namespace bwl
+
+#endif

--- a/common/beerocks/bwl/shared/nl80211_socket.cpp
+++ b/common/beerocks/bwl/shared/nl80211_socket.cpp
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "nl80211_socket.h"
+
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/family.h>
+#include <netlink/genl/genl.h>
+
+#include <easylogging++.h>
+
+/**
+ * Receive and transmit socket buffer size in bytes.
+ */
+static constexpr int netlink_buffer_size = 8192;
+
+/**
+ * Will cause the netlink port to be set to the port assigned to the netlink socket just before
+ * sending the message off.
+ *
+ * This macro is already defined in <netlink/msg.h> for some platforms, but not for others maybe
+ * because it was introduced at a later version of the library being used. Thus we define the macro
+ * if it's not already being defined.
+ */
+#ifndef NL_AUTO_PORT
+#define NL_AUTO_PORT 0
+#endif
+
+namespace bwl {
+
+bool nl80211_socket::connect()
+{
+    // Connect the socket
+    bool result = netlink_socket::connect();
+
+    // Increase the socket's internal buffer size
+    if (result) {
+        int rc =
+            nl_socket_set_buffer_size(m_nl_socket.get(), netlink_buffer_size, netlink_buffer_size);
+        if (rc < 0) {
+            LOG(ERROR) << "Failed to set buffer size! Error: " << rc;
+        }
+    }
+
+    // Resolve the generic nl80211 family id
+    if (result) {
+        const char *family_name = "nl80211";
+
+        m_family_id = genl_ctrl_resolve(m_nl_socket.get(), family_name);
+        if (0 > m_family_id) {
+            LOG(ERROR) << "'" << family_name << "' family not found!";
+            result = false;
+
+            close();
+        }
+    }
+
+    return result;
+}
+
+bool nl80211_socket::send_receive_msg(int command, int flags,
+                                      std::function<bool(struct nl_msg *msg)> msg_create,
+                                      std::function<bool(struct nl_msg *msg)> msg_handle)
+{
+    return netlink_socket::send_receive_msg(
+        [&](struct nl_msg *msg) -> bool {
+            // Initialize the netlink message
+            if (!genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, m_family_id, 0, flags, command, 0)) {
+                LOG(ERROR) << "Failed initializing the netlink message!";
+                return false;
+            }
+
+            // Call the user's message create function
+            return msg_create(msg);
+        },
+        msg_handle);
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/shared/nl80211_socket.h
+++ b/common/beerocks/bwl/shared/nl80211_socket.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NL80211_SOCKET_H__
+#define __BWL_NL80211_SOCKET_H__
+
+#include "nl_genl_socket.h"
+
+namespace bwl {
+
+/**
+ * @brief Extension to the generic Netlink protocol class for NL80211.
+ *
+ * The NL80211 is the 802.11 Netlink-based userspace interface for the cfg80211 configuration
+ * system for wireless hardware.
+ */
+class nl80211_socket : public nl_genl_socket {
+
+public:
+    /**
+     * @brief Class destructor.
+     */
+    virtual ~nl80211_socket() = default;
+
+    /**
+     * @brief Connects the Netlink socket.
+     *
+     * Calls base class method with the same name and then, after connection has been established,
+     * increases the internal buffer size of the socket and obtains the "nl80211" family id, which
+     * will later be used to create NL80211 messages.
+     *
+     * @return True on success and false otherwise (e.g.: socket is already connected or family
+     * not found).
+     */
+    virtual bool connect() override;
+
+    /**
+     * @brief Performs a request/response transaction.
+     *
+     * Requires Netlink socket to be connected.
+     *
+     * Installs a hook on the message creation callback to add generic Netlink headers to Netlink
+     * message before calling provided callback. Uses numeric family identifier obtained right
+     * after socket is connected as well as provided command identifier and optional message flags.
+     * Then calls base class method with the same name.
+     *
+     * @param[in] command Numeric command identifier. Possible values are listed in <linux/nl80211.h>
+     * @param[in] flags Additional Netlink message flags (optional).
+     * @param[in] msg_create Message creation callback function (called on message to be sent).
+     * @param[in] msg_handle Message handling callback function (called on received message).
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool send_receive_msg(int command, int flags,
+                                  std::function<bool(struct nl_msg *msg)> msg_create,
+                                  std::function<bool(struct nl_msg *msg)> msg_handle);
+
+private:
+    /**
+     * NL80211 family id
+     * We ask the Kernel to resolve family name "nl80211" to family id (using genl_ctrl_resolve).
+     * Family id is used during netlink message initialization, when we add generic netlink
+     * headers to it (using genlmsg_put).
+     */
+    int m_family_id = 0;
+};
+
+} // namespace bwl
+
+#endif

--- a/common/beerocks/bwl/shared/nl_genl_socket.cpp
+++ b/common/beerocks/bwl/shared/nl_genl_socket.cpp
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "nl_genl_socket.h"
+
+#include <linux/netlink.h>
+
+namespace bwl {
+
+nl_genl_socket::nl_genl_socket() : netlink_socket(NETLINK_GENERIC) {}
+
+} // namespace bwl

--- a/common/beerocks/bwl/shared/nl_genl_socket.h
+++ b/common/beerocks/bwl/shared/nl_genl_socket.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * Copyright (c) 2020 MaxLinear
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+#ifndef __BWL_NL_GENL_SOCKET_H__
+#define __BWL_NL_GENL_SOCKET_H__
+
+#include "netlink_socket.h"
+
+namespace bwl {
+
+/**
+ * @brief C++ wrapper class around the generic Netlink protocol library (libnl-genl).
+ *
+ * This is a very simple C++ wrapper class around the generic Netlink protocol library. Its aim is
+ * to facilitate the use of the library from C++ applications. This class extends the
+ * netlink_socket base class for the generic Netlink protocol (NETLINK_GENERIC).
+ *
+ * Known derived classes: nl80211_socket.
+ */
+class nl_genl_socket : public netlink_socket {
+
+public:
+    /**
+     * @brief Class constructor.
+     *
+     * Calls base class constructor with protocol NETLINK_GENERIC.
+     */
+    nl_genl_socket();
+
+    /**
+     * @brief Class destructor.
+     */
+    virtual ~nl_genl_socket() = default;
+};
+
+} // namespace bwl
+
+#endif


### PR DESCRIPTION
Create C++ wrappers around libnl and libnl-genl to facilitate sending
NL80211 commands through a NL80211 netlink socket.

Classes have been created in bwl/shared so NL80211 standard commands
will be available to all flavours of the BWL library except the Dummy one.

Add NL80211_CMD_GET_STATION command implementation as an example of
how standard commands are to be implemented.

Once this design had been validated, the rest of standard commands will
be added. Also we will do a code refactoring to use the new classes and
eliminate duplicated code.
