### PR TITLE
build.sh uses wrong path to mount rootdir

### DIFF
--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -7,10 +7,9 @@
 ###############################################################
 
 scriptdir="$(cd "${0%/*}"; pwd)"
-rootdir="${scriptdir%/*/*}"
+rootdir=${scriptdir%/*/*/*}
 
-. ${rootdir}/tools/docker/functions.sh
-
+. ${scriptdir}/functions.sh
 main() {
     docker image inspect prplmesh-builder >/dev/null 2>&1 || {
         echo "Image prplmesh-build does not exist, creating..."
@@ -19,7 +18,7 @@ main() {
 
     # Default docker arguments
     docker_args="\
-    --workdir=$rootdir --user=${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)} \
+    --workdir=${rootdir}/prplMesh --user=${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)} \
     -e USER=${SUDO_USER:-${USER}} -v ${rootdir}:${rootdir} \
     --entrypoint=./tools/maptools.py \
     "


### PR DESCRIPTION
### Description

Currently,  `build.sh all` script produces next output:
```
ASSERT: Command '['cmake', '--build', '/local/workspace/prpl/sources/prplMesh/build/nng', '--target', 'install', '--', '-j', '5']' returned non-zero exit status 2
```
As result - it's impossible to build project using provided Dockerfiles and scripts.
This is caused by `rootdir` variable which mounts only `prplMesh` folder (but not `3rdparty`, `hostap` dirs which are required to` build.sh all`) in `prplmesh-builder` Docker image.

### Changes

- Currently, rootdir points to `prplMesh` folder. Substituting one more additional level makes Dockerimage to mount all repo tool projects required to `build.sh all`. 
- In order to keep path to `maptools.py`, make image `--workdir `point to `prplMesh` dir
