### PR TITLE
tests: send_CAPI_command: add tlv class

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -15,6 +15,7 @@ import time
 import json
 
 import send_CAPI_command
+from send_CAPI_command import tlv
 
 '''Regular expression to match a MAC address in a bytes string.'''
 RE_MAC = rb"(?P<mac>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})"
@@ -259,7 +260,7 @@ class test_flows:
     def test_combined_infra_metrics(self):
         self.debug("Send AP Metrics query message to agent 1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x800B,
-                                       (0x93,0x0007,"0x01 {%s}" % (self.mac_repeater1_wlan0)))
+                                       tlv(0x93,0x0007,"0x01 {%s}" % (self.mac_repeater1_wlan0)))
         self.check_log(self.repeater1, "agent_wlan0", "Received AP_METRICS_QUERY_MESSAGE")
         # TODO agent should send response autonomously, with same MID.
         # tlv1 == AP metrics TLV
@@ -267,36 +268,36 @@ class test_flows:
         # tlv3 == STA metrics TLV for STA connected to this BSS
         # tlv4 == STA traffic stats TLV for same STA
         self.repeater1_ucc.dev_send_1905(self.mac_gateway, 0x800C,
-            (0x94,0x000d,"{%s} 0x01 0x0002 0x01 0x1f2f3f" % (self.mac_repeater1_wlan0)),
-            (0x96,0x0007,"{55:44:33:22:11:00} 0x00"),
-            (0x96,0x001a,"{66:44:33:22:11:00} 0x01 {%s} 0x11223344 0x1a2a3a4a 0x1b2b3b4b 0x55" %
+            tlv(0x94,0x000d,"{%s} 0x01 0x0002 0x01 0x1f2f3f" % (self.mac_repeater1_wlan0)),
+            tlv(0x96,0x0007,"{55:44:33:22:11:00} 0x00"),
+            tlv(0x96,0x001a,"{66:44:33:22:11:00} 0x01 {%s} 0x11223344 0x1a2a3a4a 0x1b2b3b4b 0x55" %
                 self.mac_repeater1_wlan0),
-            (0xa2,0x0022,"{55:44:33:22:11:00} 0x10203040 0x11213141 0x12223242 0x13233343 "
+            tlv(0xa2,0x0022,"{55:44:33:22:11:00} 0x10203040 0x11213141 0x12223242 0x13233343 "
                 "0x14243444 0x15253545 0x16263646"))
         self.check_log(self.gateway, "controller", "Received AP_METRICS_RESPONSE_MESSAGE")
 
         self.debug("Send AP Metrics query message to agent 2")
         self.gateway_ucc.dev_send_1905(self.mac_repeater2, 0x800B,
-                                       (0x93,0x0007,"0x01 {%s}" % self.mac_repeater2_wlan2))
+                                       tlv(0x93,0x0007,"0x01 {%s}" % self.mac_repeater2_wlan2))
         self.check_log(self.repeater2, "agent_wlan2", "Received AP_METRICS_QUERY_MESSAGE")
         # TODO agent should send response autonomously
         # Same as above but with different STA MAC addresses, different values and skipping the empty one
         self.repeater2_ucc.dev_send_1905(self.mac_gateway, 0x800C,
-            (0x94,0x0010,"{%s} 0x11 0x1002 0x90 0x1c2c3c 0x1d2d3d" % self.mac_repeater2_wlan2),
-            (0x96,0x001a,"{77:44:33:22:11:00} 0x01 {%s} 0x19293949 0x10203040 0x11213141 0x99" % self.mac_repeater2_wlan2),
-            (0xa2,0x0022,"{77:44:33:22:11:00} 0xa0203040 0xa1213141 0xa2223242 0xa3233343 "
+            tlv(0x94,0x0010,"{%s} 0x11 0x1002 0x90 0x1c2c3c 0x1d2d3d" % self.mac_repeater2_wlan2),
+            tlv(0x96,0x001a,"{77:44:33:22:11:00} 0x01 {%s} 0x19293949 0x10203040 0x11213141 0x99" % self.mac_repeater2_wlan2),
+            tlv(0xa2,0x0022,"{77:44:33:22:11:00} 0xa0203040 0xa1213141 0xa2223242 0xa3233343 "
                          "0xa4243444 0xa5253545 0xa6263646"))
         self.check_log(self.gateway, "controller", "Received AP_METRICS_RESPONSE_MESSAGE")
 
         self.debug("Send 1905 Link metric query to agent 1 (neighbor agent 2)")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0005,
-                                       (0x08,0x0008,"0x01 {%s} 0x02" % self.mac_repeater2))
+                                       tlv(0x08,0x0008,"0x01 {%s} 0x02" % self.mac_repeater2))
         self.check_log(self.repeater1, "agent_wlan0", "Received LINK_METRIC_QUERY_MESSAGE")
         # TODO agent should send response autonomously
         self.repeater1_ucc.dev_send_1905(self.mac_gateway, 0x6,
-            (0x09,0x0029,"{%s} {%s} {%s} {%s} 0x0100 0x01 0x00000000 0x0000e300 0x4230 0x0064 0x0300" %
+            tlv(0x09,0x0029,"{%s} {%s} {%s} {%s} 0x0100 0x01 0x00000000 0x0000e300 0x4230 0x0064 0x0300" %
                 (self.mac_repeater1, self.mac_repeater2, self.mac_repeater1_wlan0, self.mac_repeater2_wlan2)),
-            (0x0a,0x0023,"{%s} {%s} {%s} {%s} 0x0100 0x00000007 0x00020000 0x31" %
+            tlv(0x0a,0x0023,"{%s} {%s} {%s} {%s} 0x0100 0x00000007 0x00020000 0x31" %
                 (self.mac_repeater1, self.mac_repeater2, self.mac_repeater1, self.mac_repeater2)))
         self.check_log(self.gateway, "controller", "Received LINK_METRIC_RESPONSE_MESSAGE")
 
@@ -322,7 +323,7 @@ class test_flows:
 
         self.debug("Send Client Steering Request message for Steering Mandate to CTT Agent1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8014,
-            (0x9B, 0x001b, "{%s 0xe0 0x0000 0x1388 0x01 {0x000000110022} 0x01 {%s 0x73 0x24}}" %
+            tlv(0x9B, 0x001b, "{%s 0xe0 0x0000 0x1388 0x01 {0x000000110022} 0x01 {%s 0x73 0x24}}" %
                 (self.mac_repeater1_wlan0, self.mac_repeater2_wlan0)))
         time.sleep(1)
         self.debug("Confirming Client Steering Request message was received - mandate")
@@ -335,7 +336,7 @@ class test_flows:
         self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
 
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8014,
-            (0x9B, 0x000C, "{%s 0x00 0x000A 0x0000 0x00}" % self.mac_repeater1_wlan0))
+            tlv(0x9B, 0x000C, "{%s 0x00 0x000A 0x0000 0x00}" % self.mac_repeater1_wlan0))
         time.sleep(1)
         self.debug("Confirming Client Steering Request message was received - Opportunity")
         self.check_log(self.repeater1, "agent_wlan0", "CLIENT_STEERING_REQUEST_MESSAGE")


### PR DESCRIPTION
The dev_send_1905 function needs a list of TLVs as arguments. Up to now,
they were given as tuples, which is a bit hard to understand for the
developer.

Create a tlv class and use that as the arguments to dev_send_1905. It
allows us to move the format_tlv local function to the tlv class.

Update test_flows.py accordingly. It's just a matter of calling the tlv
constructor instead of a simple tuple.

This was requested in https://github.com/prplfoundation/prplMesh/pull/859#discussion_r386341137