### PR TITLE
bpl: cfg_get_prplmesh_param_int: add default value

### DIFF
--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -84,6 +84,13 @@ namespace bpl {
 #define BPL_GW_DB_MANAGE_MODE_LEN (127 + 1) /* Maximal length of MANAGEMENT MODE string */
 #define BPL_GW_DB_OPER_MODE_LEN (127 + 1)   /* Maximal length of OPERATING MODE string */
 
+/* Default values */
+#define DEFAULT_STOP_ON_FAILURE_ATTEMPTS 1
+#define DEFAULT_RDKB_EXTENSIONS 0
+#define DEFAULT_BAND_STEERING 1
+#define DEFAULT_DFS_REENTRY 1
+#define DEFAULT_CLIENT_ROAMING 1
+
 /****************************************************************************/
 /******************************* Structures *********************************/
 /****************************************************************************/

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -113,9 +113,11 @@ int cfg_get_certification_mode()
 int cfg_get_stop_on_failure_attempts()
 {
     int retVal = -1;
-    if (cfg_get_prplmesh_param_int("stop_on_failure_attempts", &retVal) == RETURN_ERR) {
-        MAPF_ERR("cfg_get_stop_on_failure_attempts: Failed to read stop_on_failure_attempts "
-                 "parameter\n");
+    if (cfg_get_prplmesh_param_int_default("stop_on_failure_attempts", &retVal,
+                                           DEFAULT_STOP_ON_FAILURE_ATTEMPTS) == RETURN_ERR) {
+
+        MAPF_INFO("cfg_get_stop_on_failure_attempts: Failed to read stop_on_failure_attempts "
+                  "parameter\n");
         return RETURN_ERR;
     }
     return retVal;
@@ -134,8 +136,9 @@ int cfg_is_onboarding()
 int cfg_get_rdkb_extensions()
 {
     int retVal = -1;
-    if (cfg_get_prplmesh_param_int("rdkb_extensions", &retVal) == RETURN_ERR) {
-        printf("cfg_get_rdkb_extensions: Failed to read RDKB Extensions parameter\n");
+    if (cfg_get_prplmesh_param_int_default("rdkb_extensions", &retVal, DEFAULT_RDKB_EXTENSIONS) ==
+        RETURN_ERR) {
+        MAPF_INFO("cfg_get_rdkb_extensions: Failed to read RDKB Extensions parameter\n");
         return RETURN_ERR;
     }
     return retVal;
@@ -144,8 +147,9 @@ int cfg_get_rdkb_extensions()
 int cfg_get_band_steering()
 {
     int retVal = -1;
-    if (cfg_get_prplmesh_param_int("band_steering", &retVal) == RETURN_ERR) {
-        MAPF_ERR("cfg_get_band_steering: Failed to read BandSteering parameter\n");
+    if (cfg_get_prplmesh_param_int_default("band_steering", &retVal, DEFAULT_BAND_STEERING) ==
+        RETURN_ERR) {
+        MAPF_INFO("cfg_get_band_steering: Failed to read BandSteering parameter\n");
         return RETURN_ERR;
     }
     return retVal;
@@ -154,8 +158,9 @@ int cfg_get_band_steering()
 int cfg_get_dfs_reentry()
 {
     int retVal = -1;
-    if (cfg_get_prplmesh_param_int("dfs_reentry", &retVal) == RETURN_ERR) {
-        printf("cfg_get_dfs_reentry: Failed to read DfsReentry parameter\n");
+    if (cfg_get_prplmesh_param_int_default("dfs_reentry", &retVal, DEFAULT_DFS_REENTRY) ==
+        RETURN_ERR) {
+        MAPF_INFO("cfg_get_dfs_reentry: Failed to read DfsReentry parameter\n");
         return RETURN_ERR;
     }
     return retVal;
@@ -164,8 +169,10 @@ int cfg_get_dfs_reentry()
 int cfg_get_client_roaming()
 {
     int retVal = -1;
-    if (cfg_get_prplmesh_param_int("client_roaming", &retVal) == RETURN_ERR) {
-        MAPF_ERR("cfg_get_client_roaming: Failed to read ClientRoaming parameter\n");
+    if (cfg_get_prplmesh_param_int_default("client_roaming", &retVal, DEFAULT_CLIENT_ROAMING) ==
+        RETURN_ERR) {
+
+        MAPF_INFO("cfg_get_client_roaming: Failed to read ClientRoaming parameter\n");
         return RETURN_ERR;
     }
     return retVal;

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_helper.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_helper.h
@@ -61,6 +61,17 @@ int cfg_get_prplmesh_radio_param(int radio_id, const std::string &radio_param, c
 int cfg_get_prplmesh_param_int(const std::string &param, int *buf);
 
 /**
+ * Returns the value of requested integer type param from DB
+ *
+ * @param [in] param prplmesh param key string
+ * @param [in] default_value value to return if parameter is missing in DB
+ * @param [out] buf buffer to get value of requested param
+ *
+ * @return 0 on success or -1 on error.
+ **/
+int cfg_get_prplmesh_param_int_default(const std::string &param, int *buf, int default_value);
+
+/**
  * Returns the value of ACS from DB
  *
  * @param [in] interface_name interface name string

--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -39,6 +39,7 @@
 #define DUMMY_VAP_OFFSET 100
 #define MAX_NUM_OF_RADIOS 3
 
+#define RETURN_ERR_PARSE -3
 #define RETURN_ERR_NOT_FOUND -2
 #define RETURN_ERR -1
 #define RETURN_OK 0


### PR DESCRIPTION
Currently BPL subsystem returns error code if a configuration parameter is missing in the DB.
This error is usually propagated by its clients and it ends up shutting down the whole system.
This effect is undesired for non-critical parameters.

One approach is to keep configuration updated for every supported platform.
Forcing developers to explicitly set all the parameters can potentially lead to better tuned firmware.
The downside is higher maintanance time/cost.

Another approach is to use default values for missing configuration parametes.
Falling back to a default value will keep FW running thus making it more robust.
It also allows to configure smaller fraction of available parameters in order to decrese time to market for new platforms.

This commit provides API for integer parameters for the second approach.
It adds a default parameter to a bunch of cfg_get_* functions that is used if the parameter is missing in the DB.
Error is still returned in case of syntax error (non-integer value).

The affected code in Linux and UCI implementation is reorganized in a similar manner in order to facilitate their code merge in the future.

Signed-off-by: Vitalii Komisarenko <vitalii.komisarenko@essensium.com>