### PR TITLE
gitlab-ci: clang-format: properly exit on failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ clang-format:
         ret=$?
         echo "Inconsistent formatting, please apply patch from artifacts"
         git diff > correct-formatting.patch
-        exit $?
+        exit $ret
       }
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ clang-format:
   artifacts:
     paths:
       - correct-formatting.patch
+    when: on_failure
 
 build-in-docker:
   extends: .in-prplmesh-builder

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1217,8 +1217,8 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
             return false;
         }
 
-        response->params().mac         = msg->params.mac;
-        response->params().status_code = msg->params.status_code;
+        response->params().mac          = msg->params.mac;
+        response->params().status_code  = msg->params.status_code;
         response->params().source_bssid = msg->params.source_bssid;
         // TODO: add the optional target BSSID
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1985,7 +1985,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         //TODO Add target BSSID
         steering_btm_report_tlv->sta_mac()         = response_in->params().mac;
         steering_btm_report_tlv->btm_status_code() = response_in->params().status_code;
-        steering_btm_report_tlv->bssid() = response_in->params().source_bssid;
+        steering_btm_report_tlv->bssid()           = response_in->params().source_bssid;
 
         LOG(DEBUG) << "sending CLIENT_STEERING_BTM_REPORT_MESSAGE back to controller";
         LOG(DEBUG) << "BTM report source bssid: " << steering_btm_report_tlv->bssid();

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -2274,13 +2274,13 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         // Initialize the message
         memset(msg_buff.get(), 0, sizeof(sACTION_APMANAGER_CLIENT_BSS_STEER_RESPONSE));
 
-        char MACAddress[MAC_ADDR_SIZE] = {0};
-        int status_code                = 0;
+        char MACAddress[MAC_ADDR_SIZE]                      = {0};
+        int status_code                                     = 0;
         char vap_name[beerocks::message::IFACE_NAME_LENGTH] = {0};
-        size_t numOfValidArgs[4]       = {0};
-        FieldsToParse fieldsToParse[]  = {
+        size_t numOfValidArgs[4]                            = {0};
+        FieldsToParse fieldsToParse[]                       = {
             {NULL /*opCode*/, &numOfValidArgs[0], DWPAL_STR_PARAM, NULL, 0},
-            {(void*) vap_name, &numOfValidArgs[1], DWPAL_STR_PARAM, NULL,
+            {(void *)vap_name, &numOfValidArgs[1], DWPAL_STR_PARAM, NULL,
              beerocks::message::IFACE_NAME_LENGTH},
             {(void *)MACAddress, &numOfValidArgs[2], DWPAL_STR_PARAM, NULL, sizeof(MACAddress)},
             {(void *)&status_code, &numOfValidArgs[3], DWPAL_INT_PARAM, "status_code=", 0},
@@ -2288,7 +2288,8 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
             {NULL, NULL, DWPAL_NUM_OF_PARSING_TYPES, NULL, 0}};
 
         if (dwpal_string_to_struct_parse(buffer, bufLen, fieldsToParse,
-                                         sizeof(vap_name) + sizeof(MACAddress) + sizeof(status_code)) == DWPAL_FAILURE) {
+                                         sizeof(vap_name) + sizeof(MACAddress) +
+                                             sizeof(status_code)) == DWPAL_FAILURE) {
             LOG(ERROR) << "DWPAL parse error ==> Abort";
             return false;
         }

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
@@ -387,12 +387,10 @@ static bool translate_nl_data_to_bwl_results(sChannelScanResults &results,
     // get signal strength, signal strength units not specified, scaled to 0-100
     if (bss[NL80211_BSS_SIGNAL_UNSPEC]) {
         //signal strength of the probe response/beacon in unspecified units, scaled to 0..100 <u8>
-        results.signal_strength_dBm =
-            int32_t(nla_get_u8(bss[NL80211_BSS_SIGNAL_UNSPEC]));
+        results.signal_strength_dBm = int32_t(nla_get_u8(bss[NL80211_BSS_SIGNAL_UNSPEC]));
     } else if (bss[NL80211_BSS_SIGNAL_MBM]) {
         //signal strength of probe response/beacon in mBm (100 * dBm) <s32>
-        results.signal_strength_dBm =
-            int32_t(nla_get_u32(bss[NL80211_BSS_SIGNAL_MBM])) / 100;
+        results.signal_strength_dBm = int32_t(nla_get_u32(bss[NL80211_BSS_SIGNAL_MBM])) / 100;
     }
 
     //get information elements from information-elements-buffer or from beacon

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -1005,8 +1005,7 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
                     LOG(DEBUG) << "Received response ["
                                << "opt code: " << int(op_error_code)
                                << ", status: " << int(*m_scan_results_status)
-                               << ", size: " << int(scan_results_size)
-                               << "].";
+                               << ", size: " << int(scan_results_size) << "].";
 
                     if (scan_results_size > 0) {
                         LOG(TRACE) << "currently " << m_scan_results->size() << " cached results, "

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -2012,8 +2012,8 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
 
     uint8_t status             = 0;
     unsigned int results_count = max_results_size;
-    int ret                    = bml_get_dcs_scan_results(ctx, radio_mac.c_str(), results,
-                                                          &results_count, &status, is_single_scan);
+    int ret = bml_get_dcs_scan_results(ctx, radio_mac.c_str(), results, &results_count, &status,
+                                       is_single_scan);
 
     if (ret == BML_RET_OK) {
         if (results_count > max_results_size) {
@@ -2066,8 +2066,7 @@ int cli_bml::get_dcs_scan_results(const std::string &radio_mac, uint32_t max_res
     return 0;
 }
 
-template <typename T>
-const std::string cli_bml::string_from_int_array(T *arr, size_t arr_max_size)
+template <typename T> const std::string cli_bml::string_from_int_array(T *arr, size_t arr_max_size)
 {
     std::stringstream ss;
     if (arr) {

--- a/controller/src/beerocks/cli/beerocks_cli_bml.h
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.h
@@ -205,8 +205,7 @@ private:
                               const std::string &channel_pool);
     int get_dcs_scan_results(const std::string &radio_mac, uint32_t max_results_size,
                              bool is_single_scan = false);
-    template <typename T>
-    const std::string string_from_int_array(T *arr, size_t arr_max_size);
+    template <typename T> const std::string string_from_int_array(T *arr, size_t arr_max_size);
     // Variable
     std::string beerocks_conf_path;
     BML_CTX ctx = nullptr;

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -1957,7 +1957,7 @@ void son_management::handle_bml_message(Socket *sd,
         // Clear flags
         auto result_status = eChannelScanErrCode::CHANNEL_SCAN_SUCCESS;
         auto op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_SUCCESS;
-        
+
         // Get scan statuses
         auto scan_in_progress = database.get_channel_scan_in_progress(radio_mac, is_single_scan);
         if (scan_in_progress) {
@@ -2003,7 +2003,7 @@ void son_management::handle_bml_message(Socket *sd,
             LOG(ERROR) << "Something went wrong, sending CMDU with error code: ["
                        << (int)op_error_code << "] & result status [" << (int)result_status << "].";
             auto response = gen_new_results_response();
-            send_results_response(response,result_status,op_error_code);
+            send_results_response(response, result_status, op_error_code);
 
             break;
         }
@@ -2012,7 +2012,8 @@ void son_management::handle_bml_message(Socket *sd,
         if (scan_results_size == 0) {
             LOG(DEBUG) << "no scan results are available";
             auto response = gen_new_results_response();
-            send_results_response(response,eChannelScanErrCode::CHANNEL_SCAN_RESULTS_EMPTY,op_error_code);
+            send_results_response(response, eChannelScanErrCode::CHANNEL_SCAN_RESULTS_EMPTY,
+                                  op_error_code);
             break;
         }
 
@@ -2025,13 +2026,13 @@ void son_management::handle_bml_message(Socket *sd,
             if (max_size < sizeof(dump)) {
 
                 LOG(DEBUG) << "Reached limit on CMDU, Sending..";
-                send_results_response(response,result_status,op_error_code, false);
+                send_results_response(response, result_status, op_error_code, false);
                 LOG(DEBUG) << "Creating new CMDU";
                 response = gen_new_results_response();
                 max_size = cmdu_tx.getMessageBuffLength() - reserved_size;
-            } 
+            }
             //LOG(DEBUG) << "Allocating space";
-            if(!response->alloc_results()) {
+            if (!response->alloc_results()) {
                 LOG(ERROR) << "Failed buffer allocation";
                 op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
                 break;
@@ -2039,17 +2040,17 @@ void son_management::handle_bml_message(Socket *sd,
             max_size -= sizeof(dump);
 
             auto num_of_res = response->results_size();
-            if(!std::get<0>(response->results(num_of_res - 1))) {
+            if (!std::get<0>(response->results(num_of_res - 1))) {
                 LOG(ERROR) << "Failed accessing results buffer";
                 op_error_code = eChannelScanOpErrCode::CHANNEL_SCAN_OP_ERROR;
                 break;
             }
             auto &dump_msg = std::get<1>(response->results(num_of_res - 1));
 
-            dump_msg = dump;         
+            dump_msg = dump;
         }
         LOG(DEBUG) << "Finished all results, Sending final CMDU";
-        send_results_response(response,result_status,op_error_code, true);
+        send_results_response(response, result_status, op_error_code, true);
         break;
     }
     case beerocks_message::ACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST: {

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1025,8 +1025,8 @@ bool master_thread::handle_cmdu_1905_client_steering_btm_report_message(
     std::string client_mac = network_utils::mac_to_string(steering_btm_report->sta_mac());
     uint8_t status_code    = steering_btm_report->btm_status_code();
 
-    LOG(DEBUG) << "BTM_REPORT from source bssid " << steering_btm_report->bssid() <<  " for client_mac=" << client_mac
-               << " status_code=" << (int)status_code;
+    LOG(DEBUG) << "BTM_REPORT from source bssid " << steering_btm_report->bssid()
+               << " for client_mac=" << client_mac << " status_code=" << (int)status_code;
 
     int steering_task_id = database.get_steering_task_id(client_mac);
     tasks.push_event(steering_task_id, client_steering_task::BTM_REPORT_RECEIVED);

--- a/controller/src/beerocks/master/tasks/client_steering_task.h
+++ b/controller/src/beerocks/master/tasks/client_steering_task.h
@@ -49,7 +49,7 @@ private:
     bool disassoc_imminent = true;
     const int disassoc_timer_ms;
     bool btm_report_received = false;
-    bool steer_restricted         = false;
+    bool steer_restricted    = false;
 
     const static int steering_wait_time_ms = 25000;
 

--- a/framework/common/zmq/socket.cpp
+++ b/framework/common/zmq/socket.cpp
@@ -9,11 +9,11 @@
 #include "msglib.h"
 #include <algorithm>
 #include <chrono>
-#include <thread>
 #include <mapf/common/err.h>
 #include <mapf/common/logger.h>
 #include <mapf/common/message_factory.h>
 #include <mapf/common/socket.h>
+#include <thread>
 #include <zmq.h>
 
 //#define MAPF_DEBUG


### PR DESCRIPTION
When clang-format fails (that is, when it leads to differences), the job
doesn't fail. That's because `git diff` doesn't exit failure when there
are differences. In fact, we saved the exit code in $ret specifically
for this purpose, but the `exit` command uses $? instead of $ret.

Fix that now.

Failing job on master that doesn't report failure: https://gitlab.com/prpl-foundation/prplMesh/-/jobs/458965322