### PR TITLE
tools: make "map" default build module

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -45,14 +45,9 @@ subcommand help:
 ./maptools.py <subcommand> --help
 ```
 ### Examples
-build all (default):
+build map (default):
 ```
-./maptools.py build all
-```
-
-build only map modules:
-```
-./maptools.py build map
+./maptools.py build
 ```
 
 build only dep modules(nng, safeclib, dwpal):
@@ -60,24 +55,24 @@ build only dep modules(nng, safeclib, dwpal):
 ./maptools.py build dep -n
 ```
 
-Build all with nng messaging library (needs to have nng installed):
+Build map with nng messaging library (needs to have nng installed):
 ```
-./maptools.py build all -f MSGLIB=nng
+./maptools.py build map -f MSGLIB=nng
 ```
 
 Clean and rebuild controller only:
 ```
-./maptools.py build controller -c clean make
+./maptools.py build map -c clean make
 ```
 
 Distclean (removes ../build folder):
 ```
-./maptools.py build all -c distclean
+./maptools.py build map -c clean
 ```
 
 To build with ninja (need to install the ninja tool in your distro first):
 ```
-./maptools.py build all -G Ninja
+./maptools.py build map -G Ninja
 ```
 Other generators (eclipse, codeblocks, ...) are available as well. Use
 `cmake -G` to list them. Note that the `--make-verbose` option only works with

--- a/tools/commands/build.py
+++ b/tools/commands/build.py
@@ -219,7 +219,7 @@ class mapbuild(object):
     @staticmethod
     def configure_parser(parser=argparse.ArgumentParser(prog='build')):
         parser.help = "multiap_sw standalone build module"
-        parser.add_argument('modules', choices=['all', 'map', 'dep'] + dep_modules, nargs='+', help='module[s] to build')
+        parser.add_argument('modules', choices=['all', 'map', 'dep'] + dep_modules, nargs='*', default='map', help='module[s] to build')
         parser.add_argument('-c', '--commands', choices=build_targets, nargs='+', default=['make'], help="build command (default is clean+make)")
         parser.add_argument("--verbose", "-v", action="store_true", help="verbosity on")
         parser.add_argument("--native", "-n", action="store_true", help="Build native (not cross compile - ignore external_toolchain.cfg)")


### PR DESCRIPTION
### Description
Originally raised in https://github.com/prplfoundation/prplMesh/pull/907

When no arguments specified, build.sh reports error.
As result, newcommer may try to build unsupported 'all' or 'dep' targets.
Root cause is located in 'build.py', where modules is positional argument with no default value.
This leads to a confusion.

3 options to resolve:
1. Add check for no args in build.sh, add "map" in case no args given. Which adds more logic to Docker launcher script.
2. Append "map" inside maptools.py (if no args except build are  given), more complicated due to mismatch of object types.
3. Set map as default value in build.py and allow empty arg case which is most minimal change with no additional logic added.

### Changes
Set map as default value to modules argument of build.py.
Change modules nargs to allow no argument case.