### PR TITLE
tools/docker: Dockerfile for prplwrt RAX40 build

### DIFF
--- a/tools/docker/builder/openwrt/toolchains/Dockerfile
+++ b/tools/docker/builder/openwrt/toolchains/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386
+
+RUN apt-get -y update && apt-get install --no-install-recommends -y sudo git-core \
+gawk wget unzip make uml-utilities bridge-utils debootstrap gcc-multilib \
+perl automake autoconf fakeroot build-essential crash makedumpfile \
+kernel-wedge git-core libncurses5 libncurses5-dev libelf-dev asciidoc binutils-dev \
+bison imagemagick openssl cmake git-core expect xutils-dev genext2fs m4 qemu \
+libqt4-dev qt4-dev-tools python-setuptools \
+python-pip python3.5 python3.5-dev apt-file gcc gcc-multilib \
+libstdc++6:i386 python-zope.interface python-bjsonrpc \
+python-crypto python-openssl python-twisted curl libcurl3 libcurl4-openssl-dev libjson0-dev \
+fuse libfuse2 libfuse-dev libpcre3 libpcre3-dev zlib1g zlib1g-dev \
+libidn2-0 libxml2-dev unzip subversion nmap python-qt4 cflow lua5.1 libssl1.0.0 libssl-dev
+
+RUN pip install --upgrade pip && pip install pyyaml
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/bin/bash","/usr/local/bin/entrypoint.sh"]

--- a/tools/docker/builder/openwrt/toolchains/README.txt
+++ b/tools/docker/builder/openwrt/toolchains/README.txt
@@ -1,0 +1,42 @@
+Building prplwrt for Nighthawk RAX40
+
+# First execution:
+
+1. Download prplmesh
+
+    git clone https://github.com/prplfoundation/prplMesh.git
+
+2. Enter in openwrt/toolchains directory
+
+    cd prplMesh/tools/docker/builder/openwrt/toolchains
+
+3. Build docker image
+
+    docker build -t prplwrt-build .
+
+4. Put prplwrt-env in /usr/bin/
+
+    mv prplwrt-env /usr/bin/
+
+5. Retrieve prplwrt in new empty folder
+
+    git clone https://git.prpl.dev/prplmesh/prplwrt.git|
+
+6. From new folder run prplwrt-env script
+
+    prplwrt-env bash
+
+7. After entering in docker container shell start building
+
+    make world -j4 V=99
+
+# Next executions:
+
+1. Enter in directory with prplwrt folder
+2. Run prplwrt-env script
+
+     prplwrt-env bash
+
+3. After entering in docker container shell start building
+
+     make world -j4 V=99

--- a/tools/docker/builder/openwrt/toolchains/entrypoint.sh
+++ b/tools/docker/builder/openwrt/toolchains/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+cmd="$@"
+
+# Check if the command argument is a service command
+if [ "${cmd}" = "show-launch-script" ] ; then
+    cat /usr/local/bin/openwrt-env
+    exit
+fi
+
+FILE_SYSTEM_OUTPUT=/fs-output
+ROOT=/workspace
+WORK_DIR=${ROOT}
+
+# Create a user and his primary group that match a host's user inside a Docker
+# container.
+# Note: We don't create a user's home directory because it is already created by
+# mounting a host's user .ssh directory in 'docker run' command.
+groupadd -g ${GROUP_ID} ${GROUP_NAME}
+useradd -g ${GROUP_ID} -s "/bin/bash" -u ${USER_ID} ${USER_NAME}
+
+# Prepare user's home directory
+cp -pr /etc/skel/. /home/${USER_NAME}
+
+cat <<EOF >> /home/${USER_NAME}/.profile
+PS1='OPENWRT-ENV:\w\$ '
+export FILE_SYSTEM_OUTPUT=${FILE_SYSTEM_OUTPUT}
+export ROOT=${ROOT}
+cd ${WORK_DIR}
+
+./scripts/feeds setup "src-git,packages,https://git.openwrt.org/feed/packages.git;openwrt-19.07" "src-git,intel_feed,https://git.prpl.dev/prplmesh/feed-intel.git;intel-19.07" "src-git,iwlwav,https://git.prpl.dev/prplmesh/iwlwav.git;iwlwav-19.07" "src-git,routing,https://github.com/openwrt-routing/packages.git" "src-git,luci,https://git.openwrt.org/project/luci.git^c0e73d3f9567f227cbe36ba12af53efbfdd4343d" "src-git,prpl_feed,https://git.prpl.dev/prplwrt/feed-prpl.git"
+./scripts/feeds update
+./scripts/feeds install -a -p intel_feed
+./scripts/feeds install -a -p prpl_feed
+./scripts/feeds install -a -p iwlwav
+./scripts/feeds install -a -p luci
+./scripts/feeds install intel_mips
+./scripts/feeds install zmq
+./scripts/gen_config.sh rax40 luci
+
+EOF
+
+chown -R ${USER_NAME}:${GROUP_NAME} /home/${USER_NAME}
+
+# Run!
+if [ $# -eq 0 ] ; then
+    # No arguments were passed (interactive mode)
+    sudo -i -u ${USER_NAME}
+else
+    # Some arguments were passed (non-interactive mode)
+    sudo -i -u ${USER_NAME} -- "/bin/bash" -c "${cmd}"
+fi
+

--- a/tools/docker/builder/openwrt/toolchains/prplwrt-env
+++ b/tools/docker/builder/openwrt/toolchains/prplwrt-env
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+ROOT=$(pwd)/prplwrt
+
+echo "ROOT: ${ROOT}"
+
+#
+# Run Docker container
+#
+envvars="
+-e USER_ID=$(id -u)
+-e USER_NAME=$(id -un)
+-e GROUP_ID=$(id -g)
+-e GROUP_NAME=$(id -gn)
+"
+
+volumes="
+-v ${ROOT}:/workspace
+-v /srv/Packages:/srv/Packages
+-v ${HOME}/.ssh:/home/${USER}/.ssh
+"
+if [ -r ${HOME}/.gitconfig ] ; then
+    volumes="${volumes} -v ${HOME}/.gitconfig:/home/${USER}/.gitconfig"
+fi
+
+# Use 'sudo' to run docker container if the host's user is not in 'docker' group
+if [ $(groups | grep -cw docker) = "0" ] ; then
+    sudo="sudo "
+fi
+
+cmd="${sudo}docker run ${envvars} ${volumes} -it --rm prplwrt-build $@"
+echo ${cmd}
+echo
+exec ${cmd}


### PR DESCRIPTION
Currently, we do not have dockerfile for building prplwrt for RAX40.
Without dockerfile developer must find and install all depednencies
in own environment. Eeach developer has own non-standard environment.
Which can cause hard-to-debug hard-to-reproduce build runtime errors.

Create new dockerfile and entrypoint script to prepare clear and unified
build environment for all developers.