### PR TITLE
.gitignore: add __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _GO_KW
 .kwlp
 .kwps
 kw_reports
+__pycache__/
 # ignore artifacts for building w/ openwrt USE_SOURCE_DIR
 .built
 .built_check


### PR DESCRIPTION
With python3, the cached bytecode files are created in a __pycache__
directory. Since test_flows.py uses python3, we should ignore that.
Ignore the entire directory instead of *.pyc so optimised files are also
ignored.

Although this could replace the *.pyc ignore in tools/.gitignore, we
can't really do that (yet) at this point because maptools still supports
python2 (which doesn't have a __pycache__ directory).