### PR TITLE
easylogging: resolveFilename: use same file for all debug levels

### DIFF
--- a/framework/external/easylogging/easylogging++.h
+++ b/framework/external/easylogging/easylogging++.h
@@ -1943,6 +1943,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   base::FileStreamPtr sharedFileStream(Level level);
   std::size_t maxLogFileSize(Level level);
   std::size_t logFlushThreshold(Level level);
+  std::string getDateTimeForFilename(const std::string &fmt);
 
  private:
   Configurations* m_configurations;
@@ -1958,6 +1959,9 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   std::unordered_map<Level, std::size_t> m_maxLogFileSizeMap;
   std::unordered_map<Level, std::size_t> m_logFlushThresholdMap;
   LogStreamsReferenceMapPtr m_logStreamsReference = nullptr;
+
+  base::threading::Mutex m_dateTimeMutex;
+  std::string m_dateTimeNow;
 
   friend class el::Helpers;
   friend class el::base::MessageBuilder;


### PR DESCRIPTION
For each debug level the log file name is calculated separately. Normally, it's always the same name, so the log file will be opened only once. However, if the second happens to tick by in the middle of the initialisation of the logging, we will have two different log files with 1 second difference, and half the log ends up in one log file, the other half in the other log file.

In the case of that CI job, it lead to a failure because we grep the log file to check the status of the agent, and we were grepping the wrong log file.

This commit ensures that all file name calculations use the same time stamp.