### PR TITLE
fix master to build on rdkb

### DIFF
--- a/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg_uci.h
@@ -39,11 +39,6 @@
 #define DUMMY_VAP_OFFSET 100
 #define MAX_NUM_OF_RADIOS 3
 
-#define RETURN_ERR_PARSE -3
-#define RETURN_ERR_NOT_FOUND -2
-#define RETURN_ERR -1
-#define RETURN_OK 0
-
 /* use only even phy numbers since odd phy's are used for station interfaces */
 #define RADIO_INDEX_SKIP 2
 #define VAP_RPC_IDX_OFFSET 10
@@ -78,6 +73,11 @@ extern "C" {
 }
 
 #endif
+
+#define RETURN_ERR_PARSE -3
+#define RETURN_ERR_NOT_FOUND -2
+#define RETURN_ERR -1
+#define RETURN_OK 0
 
 namespace beerocks {
 namespace bpl {


### PR DESCRIPTION
RDKB fails to build on master since commit e908e4742f86517564d45789c897fe9c7c826a6e

"Error codes" are defined under UGW flag but they are
used now in all platform common code.
As a result RDKB build started to fail.

Solution is not to restrict error code defines under
any specific  platform.
