### PR TITLE
bcl: logging: abort on LOG(FATAL)

### DIFF
--- a/common/beerocks/bcl/source/beerocks_logging.cpp
+++ b/common/beerocks/bcl/source/beerocks_logging.cpp
@@ -511,7 +511,6 @@ void logging::apply_settings()
 
     el::Loggers::addFlag(el::LoggingFlag::ImmediateFlush);
     el::Loggers::addFlag(el::LoggingFlag::LogDetailedCrashReason);
-    el::Loggers::addFlag(el::LoggingFlag::DisableApplicationAbortOnFatalLog);
     el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
     el::Loggers::addFlag(el::LoggingFlag::ForceDecBase);
     el::Loggers::addFlag(el::LoggingFlag::ShowBase);


### PR DESCRIPTION
Easylogging provides multiple log levels, where the most critical one is
FATAL which results with abort() which kills the application.
This is a reasonable course of operation in cases where prplMesh gets
into unrecoverable conditions, such as memory allocation failures, and
is enabled by default in easylogging++.

However, BCL logging frameworks disables this by default for all
loggers, which allows FATAL logs to continue without crashing the
application which would most probably result with a later crash which
will be simply harder to debug.

The correct way to handle unexpected cases in c++ is using exceptions,
but since we do not use exceptions in prplMesh, the least we can do is
abort and log the last error that happened. This might cause prplMesh to
be less robust since it is possible that currently not all LOG(FATAL)
and LOG_IF(conf, FATAL) should result with abort, but we will fix the
wrong usage as we go.

Remove DisableApplicationAbortOnFatalLog from BCL logging so that any
LOG(FATAL), LOG_IF(condition, FATAL) will result with abort().

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>