### PR TITLE
agent: channel sel: skip non-operable op classes

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4434,7 +4434,10 @@ bool slave_thread::handle_channel_preference_query(Socket *sd, ieee1905_1::CmduM
 beerocks::message::sWifiChannel slave_thread::channel_selection_select_channel()
 {
     for (const auto &preference : channel_preferences) {
-        LOG(DEBUG) << "Preference operating class: " << int(preference.oper_class);
+        // Skip non-operable operating classes
+        if (preference.channels.empty()) {
+            continue;
+        }
         for (uint8_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
             auto channel         = hostap_params.supported_channels[i];
             auto operating_class = wireless_utils::get_operating_class_by_channel(

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4479,7 +4479,7 @@ bool slave_thread::channel_selection_current_channel_restricted()
     auto operating_class = wireless_utils::get_operating_class_by_channel(channel, bw);
 
     LOG(DEBUG) << "Current channel " << int(channel) << " bw " << int(bw) << " oper_class "
-              << int(operating_class);
+               << int(operating_class);
     for (const auto &preference : channel_preferences) {
         // for now we handle only non-operable preference
         // TODO - handle as part of https://github.com/prplfoundation/prplMesh/issues/725

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4478,6 +4478,8 @@ bool slave_thread::channel_selection_current_channel_restricted()
     auto bw              = static_cast<beerocks::eWiFiBandwidth>(hostap_cs_params.bandwidth);
     auto operating_class = wireless_utils::get_operating_class_by_channel(channel, bw);
 
+    LOG(DEBUG) << "Current channel " << int(channel) << " bw " << int(bw) << " oper_class "
+              << int(operating_class);
     for (const auto &preference : channel_preferences) {
         // for now we handle only non-operable preference
         // TODO - handle as part of https://github.com/prplfoundation/prplMesh/issues/725

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -43,9 +43,11 @@ static const std::map<uint8_t, sOperatingClass> operating_classes_list = {
     {125,       {{149, 153, 157, 161, 165, 169},                               beerocks::BANDWIDTH_20}},
     {126,       {{149, 157},                                                   beerocks::BANDWIDTH_40}},
     {127,       {{153, 161},                                                   beerocks::BANDWIDTH_40}},
-    {128,       {{36,  40,  44,  48,  52,  56,  60,  64,  100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161}, beerocks::BANDWIDTH_80}},
-    {129,       {{50, 66, 82, 98, 114},                                        beerocks::BANDWIDTH_160}},
-    {130,       {{36,  40,  44,  48,  52,  56,  60,  64,  100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161}, beerocks::BANDWIDTH_160}}};
+//  {OP Class   {Channel center Frequency index},                              Bandwidth              }}
+    {128,       {{42, 58, 106, 122, 138, 155},                                 beerocks::BANDWIDTH_80}},
+    {129,       {{50, 114},                                                    beerocks::BANDWIDTH_160}},
+    {130,       {{42, 58, 106, 122, 138, 155},                                 beerocks::BANDWIDTH_80}}
+};
 // clang-format on
 
 constexpr beerocks::eWiFiAntNum
@@ -652,6 +654,14 @@ uint8_t wireless_utils::get_operating_class_max_tx_power(
 uint8_t wireless_utils::get_operating_class_by_channel(uint8_t channel,
                                                        beerocks::eWiFiBandwidth channel_bandwidth)
 {
+    // operating classes 128,129,130 use center channel **unlike the other classes**,
+    // so convert channel and bandwidth to center channel.
+    // For more info, refer to Table E-4 in the 802.11 specification.
+    if (channel_bandwidth >= beerocks::eWiFiBandwidth::BANDWIDTH_80) {
+        auto bw              = beerocks::utils::convert_bandwidth_to_int(channel_bandwidth);
+        auto vht_center_freq = beerocks::utils::wifi_channel_to_vht_center_freq(channel, bw, true);
+        channel              = beerocks::utils::wifi_freq_to_channel(vht_center_freq);
+    }
     for (auto oper_class : operating_classes_list) {
         if (oper_class.second.band == channel_bandwidth &&
             oper_class.second.channels.find(channel) != oper_class.second.channels.end()) {


### PR DESCRIPTION
Commit 82fe3c5785216af08e2b90737cb5228c436fffeb fixed the channel selection logic to ignore non-operable channels, but missed an important case where the channel preference channel list is empty, which means that all channels in that operating class are non-operable.

We missed it because the UCC is using op class 115 channel 36 in 4.2.1 test case, which is the first operating class we iterate on in channel_selection_select_channel loop when we try to find out if a specific channel from that operating class is non-operable.
Since channel 36 is the only channel which is not present in the preference channel list, it was selected as it should have.

In case of channel 149 however, the UCC marks the entire 115 operating class as non-operable, by having an empty channel list (according to Table 23 in the MultiAP Specification, an empty channel list field indicates that the indicated preference applies to all channels in the operating class).

The current channel selection logic iterates through all supported channels, and for each channel it checks if it is marked as non-operable by checking if it is part of the channel preference channel list.
Since the channel list for operating class 115 is empty, the first channel in that operating class is selected.

The solution is to simply skip the entire preference if the channel list is empty and is introduced in the first commit.

Another bug we have is that operating classes 128,129,130 defined in the `operating_classes_list` are wrong, these operating classes use center channels instead of starting channels and are using bandwidths 80 and 160.
However, hostapd reports the starting channel, for example, 36 instead of 42. This collides with the UCC command which is also following the 80211 specification and marks center channels as non-operable, which results with the agent concluding that the current channel (36 for that manner) is not restricted.

The solution for this is added in the third commit, which updates the channels for operating classes 128,129 and 130 to use center channels, and use the center channel when checking if the current channel is restricted if the bandwidth is 80MHz or 160MHz.

Fixes #937

MAP-4.8.1_ETH_ETH5GH status: https://gitlab.com/prpl-foundation/prplMesh/pipelines/124908827

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>