### PR TITLE
HW Supported Channels for channel pool validation

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -34,9 +34,12 @@ using namespace beerocks::net;
 //////////////////////////////////////////////////////////////////////////////
 
 static void copy_radio_supported_channels(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal,
-                                          beerocks::message::sWifiChannel supported_channels[])
+                                          beerocks::message::sWifiChannel supported_channels[],
+                                          bool use_hw_supported_channels = false)
 {
-    auto radio_channels = ap_wlan_hal->get_radio_info().supported_channels;
+    auto radio_channels = use_hw_supported_channels
+                              ? ap_wlan_hal->get_hw_supported_channels()
+                              : ap_wlan_hal->get_radio_info().supported_channels;
 
     // Copy the channels
     for (uint i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH && i < radio_channels.size();
@@ -67,10 +70,15 @@ static int8_t get_tx_power(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal)
 }
 
 static std::string
-get_radio_supported_channels_string(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal)
+get_radio_supported_channels_string(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal,
+                                    bool use_hw_supported_channels = false )
 {
+    auto supported_channels = use_hw_supported_channels
+                                  ? ap_wlan_hal->get_hw_supported_channels()
+                                  : ap_wlan_hal->get_radio_info().supported_channels;
     std::ostringstream os;
-    for (auto val : ap_wlan_hal->get_radio_info().supported_channels) {
+    os << " Count: " << supported_channels.size();
+    for (auto val : supported_channels) {
         if (val.channel > 0) {
             os << " ch = " << int(val.channel) << " | dfs = " << int(val.tx_pow)
                << " | tx_pow = " << int(val.is_dfs) << " | noise = " << int(val.noise)

--- a/common/beerocks/bwl/common/base_wlan_hal.cpp
+++ b/common/beerocks/bwl/common/base_wlan_hal.cpp
@@ -32,6 +32,7 @@ base_wlan_hal::base_wlan_hal(HALType type, std::string iface_name, IfaceType ifa
 
     // Initialize complex containers of the radio_info structure
     m_radio_info.supported_channels.resize(128 /* TODO: Get real value */);
+    m_hw_supported_channels.resize(128 /* TODO: Get real value */);
 }
 
 base_wlan_hal::~base_wlan_hal()

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1550,7 +1550,7 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
     FieldsToParse fieldsToParse[] = {
         {(void *)&chan, &numOfValidArgs[0], DWPAL_INT_PARAM, "chan=", 0},
         {(void *)dfs_state, &numOfValidArgs[1], DWPAL_STR_PARAM,
-         "(DFS state = ", sizeof(dfs_state)},
+        "(DFS state = ", sizeof(dfs_state)},
         /* Must be at the end */
         {NULL, NULL, DWPAL_NUM_OF_PARSING_TYPES, NULL, 0}};
 
@@ -1569,9 +1569,14 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
             return false;
         }
 
-        // LOG(DEBUG) << "numOfValidArgs[0]= " << numOfValidArgs[0] << " chan= " << chan;
-        // LOG(DEBUG) << "numOfValidArgs[1]= " << numOfValidArgs[1] << " dfs_state= " << dfs_state;
-
+        LOG(DEBUG) << "numOfValidArgs[0]= " << numOfValidArgs[0] << " chan= " << chan;
+        LOG(DEBUG) << "numOfValidArgs[1]= " << numOfValidArgs[1] << " dfs_state= " << dfs_state;
+        
+        m_hw_supported_channels[i].bandwidth   = 20;
+        m_hw_supported_channels[i].channel     = chan;
+        m_hw_supported_channels[i].bss_overlap = 0;
+        m_hw_supported_channels[i].is_dfs      = numOfValidArgs[1];
+        
         m_radio_info.supported_channels[i].bandwidth   = 20;
         m_radio_info.supported_channels[i].channel     = chan;
         m_radio_info.supported_channels[i].bss_overlap = 0;

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal.h
@@ -168,6 +168,13 @@ public:
      */
     virtual std::string get_radio_mac() = 0;
 
+    /*!
+     * Returns the Radio's Hardware supported channels;
+     */
+    const std::vector<WiFiChannel> get_hw_supported_channels() const {
+        return m_hw_supported_channels;
+    }
+
     // Protected methods
 protected:
     /*!
@@ -209,6 +216,7 @@ protected:
     // Protected data-members:
 protected:
     RadioInfo m_radio_info;
+    std::vector<WiFiChannel> m_hw_supported_channels;
 
     HALState m_hal_state = HALState::Uninitialized;
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -371,16 +371,23 @@ typedef struct sNodeHostap {
     uint8_t conducted_power;
     char driver_version[beerocks::message::WIFI_DRIVER_VER_LENGTH];
     beerocks::message::sWifiChannel supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+    beerocks::message::sWifiChannel hw_supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
     void struct_swap(){
         iface_mac.struct_swap();
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
             (supported_channels[i]).struct_swap();
+        }
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+            (hw_supported_channels[i]).struct_swap();
         }
     }
     void struct_init(){
         iface_mac.struct_init();
             for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
                 (supported_channels[i]).struct_init();
+            }
+            for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+                (hw_supported_channels[i]).struct_init();
             }
     }
 } __attribute__((packed)) sNodeHostap;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -271,6 +271,9 @@ sNodeHostap:
   supported_channels:
     _type: beerocks::message::sWifiChannel 
     _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]          
+  hw_supported_channels:
+    _type: beerocks::message::sWifiChannel 
+    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]          
 
 sVapsList:
   _type: struct

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -295,11 +295,12 @@ public:
 
     bool set_hostap_supported_channels(std::string mac,
                                        beerocks::message::sWifiChannel *supported_channels,
-                                       int length);
+                                       int length, bool use_hw_supported_channels = false);
     const std::vector<beerocks::message::sWifiChannel>
-    get_hostap_supported_channels(std::string mac);
-    std::string get_hostap_supported_channels_string(const std::string &radio_mac);
-
+    get_hostap_supported_channels(std::string mac, bool use_hw_supported_channels = false);
+    std::string get_hostap_supported_channels_string(const std::string &radio_mac,
+                                                     bool use_hw_supported_channels = false);
+    
     bool add_hostap_supported_operating_class(const std::string &radio_mac, uint8_t operating_class,
                                               uint8_t tx_power,
                                               const std::vector<uint8_t> &non_operable_channels);

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -147,6 +147,7 @@ public:
         beerocks::eIfaceType iface_type;
         std::string driver_version;
         std::vector<beerocks::message::sWifiChannel> supported_channels;
+        std::vector<beerocks::message::sWifiChannel> hw_supported_channels;
         uint8_t operating_class    = 0;
         int ant_gain               = 0;
         int conducted_power        = 0;

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1958,6 +1958,9 @@ bool master_thread::handle_intel_slave_join(
 
     database.set_hostap_supported_channels(radio_mac, notification->hostap().supported_channels,
                                            message::SUPPORTED_CHANNELS_LENGTH);
+    database.set_hostap_supported_channels(radio_mac,
+                                           notification->hostap().hw_supported_channels,
+                                           message::SUPPORTED_CHANNELS_LENGTH, true);
 
     if (database.get_node_5ghz_support(radio_mac)) {
         if (notification->low_pass_filter_on()) {


### PR DESCRIPTION
currently channel pool validated by static table supported_channels_array[] of channels in db::set_dcs_channel_pool()

This is  incorrect  since radio setup could vary with different country configuration.

We need permanent prplmesh solution:

create  new structure  in node.h     std::vector<beerocks_message::sWifiChannel> phy_supported_channels
save GET_HW_FEATURES report during in slave_join to DB.
see ap_manager_thread::handle_hostapd_attached

ap_wlan_hal->read_supported_channels();

use it to Validate new dcs channel pool in db::set_dcs_channel_pool()
remove static table supported_channels_array[]  from db::set_dcs_channel_pool()

Task #686 
Fixes #961 