### PR TITLE
Bugfix/fix channel selection

### DIFF
--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -153,8 +153,7 @@ public:
     static uint8_t get_5g_center_channel(uint8_t channel,
                                          beerocks::eWiFiBandwidth channel_bandwidth,
                                          bool channel_ext_above_secondary);
-    static uint8_t get_operating_class_by_channel(uint8_t channel, uint8_t center_channel,
-                                                  beerocks::eWiFiBandwidth channel_bandwidth);
+    static uint8_t get_operating_class_by_channel(const beerocks::message::sWifiChannel &channel);
     static std::list<sChannelPreference>
     get_channel_preferences(const beerocks::message::sWifiChannel supported_channels[]);
 

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -153,7 +153,7 @@ public:
     static uint8_t get_5g_center_channel(uint8_t channel,
                                          beerocks::eWiFiBandwidth channel_bandwidth,
                                          bool channel_ext_above_secondary);
-    static uint8_t get_operating_class_by_channel(uint8_t channel,
+    static uint8_t get_operating_class_by_channel(uint8_t channel, uint8_t center_channel,
                                                   beerocks::eWiFiBandwidth channel_bandwidth);
     static std::list<sChannelPreference>
     get_channel_preferences(const beerocks::message::sWifiChannel supported_channels[]);

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -150,6 +150,9 @@ public:
                                      uint8_t operating_class);
     static std::vector<uint8_t> get_operating_class_non_oper_channels(
         const beerocks::message::sWifiChannel supported_channels[], uint8_t operating_class);
+    static uint8_t get_5g_center_channel(uint8_t channel,
+                                         beerocks::eWiFiBandwidth channel_bandwidth,
+                                         bool channel_ext_above_secondary);
     static uint8_t get_operating_class_by_channel(uint8_t channel,
                                                   beerocks::eWiFiBandwidth channel_bandwidth);
     static std::list<sChannelPreference>

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -658,19 +658,18 @@ uint8_t wireless_utils::get_5g_center_channel(uint8_t start_channel,
  * @brief get operating class number by channel and channel bandwidth 
  *
  * @param channel current channel
+ * @param center_channel vht center channel
  * @param channel_bandwidth current channel bandwidth
  * @return operating class number
  */
-uint8_t wireless_utils::get_operating_class_by_channel(uint8_t channel,
+uint8_t wireless_utils::get_operating_class_by_channel(uint8_t channel, uint8_t center_channel,
                                                        beerocks::eWiFiBandwidth channel_bandwidth)
 {
     // operating classes 128,129,130 use center channel **unlike the other classes**,
     // so convert channel and bandwidth to center channel.
     // For more info, refer to Table E-4 in the 802.11 specification.
     if (channel_bandwidth >= beerocks::eWiFiBandwidth::BANDWIDTH_80) {
-        auto bw              = beerocks::utils::convert_bandwidth_to_int(channel_bandwidth);
-        auto vht_center_freq = beerocks::utils::wifi_channel_to_vht_center_freq(channel, bw, true);
-        channel              = beerocks::utils::wifi_freq_to_channel(vht_center_freq);
+        channel = center_channel;
     }
     for (auto oper_class : operating_classes_list) {
         if (oper_class.second.band == channel_bandwidth &&

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -644,6 +644,16 @@ uint8_t wireless_utils::get_operating_class_max_tx_power(
     return max_tx_power;
 }
 
+uint8_t wireless_utils::get_5g_center_channel(uint8_t start_channel,
+                                              beerocks::eWiFiBandwidth channel_bandwidth,
+                                              bool channel_ext_above_secondary)
+{
+    auto bw              = beerocks::utils::convert_bandwidth_to_int(channel_bandwidth);
+    auto vht_center_freq = beerocks::utils::wifi_channel_to_vht_center_freq(
+        start_channel, bw, channel_ext_above_secondary);
+    return beerocks::utils::wifi_freq_to_channel(vht_center_freq);
+}
+
 /**
  * @brief get operating class number by channel and channel bandwidth 
  *

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -657,23 +657,23 @@ uint8_t wireless_utils::get_5g_center_channel(uint8_t start_channel,
 /**
  * @brief get operating class number by channel and channel bandwidth 
  *
- * @param channel current channel
- * @param center_channel vht center channel
- * @param channel_bandwidth current channel bandwidth
+ * @param channel current channel parameters
  * @return operating class number
  */
-uint8_t wireless_utils::get_operating_class_by_channel(uint8_t channel, uint8_t center_channel,
-                                                       beerocks::eWiFiBandwidth channel_bandwidth)
+uint8_t
+wireless_utils::get_operating_class_by_channel(const beerocks::message::sWifiChannel &channel)
 {
     // operating classes 128,129,130 use center channel **unlike the other classes**,
     // so convert channel and bandwidth to center channel.
     // For more info, refer to Table E-4 in the 802.11 specification.
-    if (channel_bandwidth >= beerocks::eWiFiBandwidth::BANDWIDTH_80) {
-        channel = center_channel;
+    auto ch = channel.channel;
+    auto bw = static_cast<beerocks::eWiFiBandwidth>(channel.channel_bandwidth);
+    if (bw >= beerocks::eWiFiBandwidth::BANDWIDTH_80) {
+        ch = wireless_utils::get_5g_center_channel(ch, bw, true);
     }
     for (auto oper_class : operating_classes_list) {
-        if (oper_class.second.band == channel_bandwidth &&
-            oper_class.second.channels.find(channel) != oper_class.second.channels.end()) {
+        if (oper_class.second.band == channel.channel_bandwidth &&
+            oper_class.second.channels.find(ch) != oper_class.second.channels.end()) {
             return oper_class.first;
         }
     }


### PR DESCRIPTION
agent: channel_sel: restrict correct channels for op class 128,129,130 …
03ba771

Commit 23de848 tried to fix a bug in the channel selection where
operating classes 128,129,130 which use a center channel instead of
start channel, but it broke in the last code review iteration since the
center channel was used correctly to get the operating class, but the
start channel was wrongly used to check if the channel is restricted
later on.

Fix that by explicitely adding center channel to the
get_operating_class_by_channel API, then explicitely use the center
channel for operating classes 128,129 and 130.

Tests run: https://gitlab.com/prpl-foundation/prplMesh/-/jobs/467558322

Fixes #937 

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>