### PR TITLE
agent: skip keep alive for non prplmesh controller

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -260,7 +260,8 @@ bool slave_thread::work()
 
 void slave_thread::process_keep_alive()
 {
-    if (!config.enable_keep_alive || !son_config.slave_keep_alive_retries) {
+    if (!config.enable_keep_alive || !son_config.slave_keep_alive_retries ||
+        !backhaul_params.is_prplmesh_controller) {
         return;
     }
 


### PR DESCRIPTION
Commit 430ab6ecd92473bc3a238fe3dbd6a42332ab1c10 removed sending of VS
messages to non prplmesh controllers, but did not handle the
process_keep_alive() logic which still waited for the PING response from
the controller.
The response obviousely will never arrive which will result with slave
reset after 20 seconds (KEEP_ALIVE_INTERVAL_MSC).
Fix it by skipping the whole keep alive process in the agent when the
controller is not prplmesh.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>