### PR TITLE
framework: check the destination mac when looking for duplicates

### DIFF
--- a/framework/transport/ieee1905_transport/ieee1905_transport_packet_processing.cpp
+++ b/framework/transport/ieee1905_transport/ieee1905_transport_packet_processing.cpp
@@ -121,9 +121,10 @@ bool Ieee1905Transport::de_duplicate_packet(Packet &packet)
     // search for entry matching packet
     DeDuplicationKey key;
     std::copy_n(packet.src, ETH_ALEN, key.src);
-    key.messageType = ((Ieee1905CmduHeader *)packet.payload.iov_base)->messageType;
-    key.messageId   = ((Ieee1905CmduHeader *)packet.payload.iov_base)->messageId;
-    key.fragmentId  = ((Ieee1905CmduHeader *)packet.payload.iov_base)->fragmentId;
+    std::copy_n(packet.dst, ETH_ALEN, key.dst);
+    key.messageType = static_cast<Ieee1905CmduHeader *>(packet.payload.iov_base)->messageType;
+    key.messageId   = static_cast<Ieee1905CmduHeader *>(packet.payload.iov_base)->messageId;
+    key.fragmentId  = static_cast<Ieee1905CmduHeader *>(packet.payload.iov_base)->fragmentId;
 
     auto it           = de_duplication_map_.find(key);
     bool is_duplicate = (it != de_duplication_map_.end());

--- a/framework/transport/ieee1905_transport/include/mapf/transport/ieee1905_transport.h
+++ b/framework/transport/ieee1905_transport/include/mapf/transport/ieee1905_transport.h
@@ -152,6 +152,7 @@ private:
 
     struct DeDuplicationKey {
         uint8_t src[ETH_ALEN];
+        uint8_t dst[ETH_ALEN];
         uint16_t
             messageType; // required to distinguish the case of Request / Reply (when the reply carries an out of sync MID)
         uint16_t messageId;
@@ -161,10 +162,13 @@ private:
         // implement Compare for the std::map template
         bool operator()(const DeDuplicationKey &lhs, const DeDuplicationKey &rhs) const
         {
-            // compare based on src address first then messageId, then fragmentId
+            // compare based on src and dst address first then messageId, then fragmentId
             int srccmp = memcmp(lhs.src, rhs.src, ETH_ALEN);
             if (srccmp)
                 return srccmp < 0;
+            int dstcmp = memcmp(lhs.dst, rhs.dst, ETH_ALEN);
+            if (dstcmp)
+                return dstcmp < 0;
             else if (lhs.messageType != rhs.messageType)
                 return lhs.messageType < rhs.messageType;
             else if (lhs.messageId != rhs.messageId)


### PR DESCRIPTION
When an ACK message is sent to different destination MACs
successively, the packet might be marked as duplicate and not sent,
resulting in some targets not receiving the packet.

This was discovered as part of issue #945:
https://github.com/prplfoundation/prplMesh/issues/945

Add the destination to the keys that are compared when looking for
duplicates, so that the same packets with a different destination are
not marked as duplicates.

While we're at it, replace 3 C-style casts with static casts.

Fixes #945.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>