### PR TITLE
beerocks_ucc_listener.h: remove unused create_cmdu

### DIFF
--- a/common/beerocks/bcl/include/bcl/beerocks_ucc_listener.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_ucc_listener.h
@@ -86,8 +86,6 @@ private:
     static bool parse_params(const std::vector<std::string> &command_tokens,
                              std::unordered_map<std::string, std::string> &params,
                              std::string &err_string);
-    static bool create_cmdu(ieee1905_1::CmduMessageTx &cmdu_tx,
-                            ieee1905_1::eMessageType message_type, std::string &err_string);
 
     struct tlv_hex_t {
         std::string *type   = nullptr;


### PR DESCRIPTION
Method beerocks_ucc_listener::create_cmdu was removed in
commit eeaac3210bef8 by Tomer Eliyahu from cpp file, but in
header method prototype still exist. Link on previous PR: https://github.com/prplfoundation/prplMesh/pull/651

We remove unused method from prototype.

Signed-off-by: Vladyslav Tupikin <v.tupikin@inango-systems.com>