### PR TITLE
beerocks_ucc_listener.cpp: Controller drops first CHANNEL_SELECTION...

### DIFF
--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -696,7 +696,7 @@ void beerocks_ucc_listener::handle_wfa_ca_command(const std::string &command)
         }
 
         // Check if CMDU message type has preprepared CMDU which can be loaded
-        if (m_cmdu_tx.is_finalized() &&
+        if (tlv_hex_list.empty() && m_cmdu_tx.is_finalized() &&
             m_cmdu_tx.getMessageType() == ieee1905_1::eMessageType(message_type)) {
             m_cmdu_tx.setMessageId(g_mid); // force mid
             LOG(DEBUG) << "Send preset cmdu with mid " << std::hex << g_mid;
@@ -710,7 +710,7 @@ void beerocks_ucc_listener::handle_wfa_ca_command(const std::string &command)
         } else {
             // CMDU was not loaded from preprepared buffer, and need to be created manually, and
             // use TLV data from the command (if exists)
-
+            m_cmdu_tx.reset();
             if (!cmdu_tx.create(g_mid, ieee1905_1::eMessageType(message_type))) {
                 LOG(ERROR) << "cmdu creation of type 0x" << message_type_str << ", has failed";
                 reply_ucc(eWfaCaStatus::ERROR, err_internal);


### PR DESCRIPTION
The channel selection test flow uses a fully specified Channel
Selection Request message. However, current implemenation has a
predefined channel selection buffer with empty tlv paylod and
sends it instead preparing new CMDU message with full tlv payload.

For solving issue added one more check in CMDU mesage type condition from
case eWfaCaCommand::DEV_SEND_1905 - checking tlv_hex_list variable it should
be empty for sending predefined message. If tlv_hex_list variable has a data
clear CMDU buffer for erasing predefined message, create and send new CMDU
message.

Signed-off-by: Vladyslav Tupikin <v.tupikin@inango-systems.com>