### PR TITLE
Add code snippets for debug and error logging

### DIFF
--- a/.vscode/prplmesh-snippets.code-snippets
+++ b/.vscode/prplmesh-snippets.code-snippets
@@ -25,5 +25,21 @@
 			"}"
 		],
 		"description": "Create and check a variable that might be null, name is short for 'may be null'"
+	  },
+	"Log DEBUG": {
+		"prefix": "dbg",
+		"body": [
+		  "LOG(DEBUG) << ${1:your code here};"
+		],
+		"description": "Log DEBUG",
+		"scope": "cpp"
+	  },
+	  "Log ERROR": {
+		"prefix": "err",
+		"body": [
+		  "LOG(ERROR) << ${1:your code here};"
+		],
+		"description": "Log DEBUG",
+		"scope": "cpp"
 	  }
 }


### PR DESCRIPTION
### Summary
This should make logging (a bit) shorter, not that it's terribly long at the moment, but sometimes it acts funny when holding the shift key, it's definitely a nice to have.
Either way, typing `err` or `dbg` then hitting your autocomplete button and then `return`/`enter` is definitely faster.
These should only show on cpp-associated files.
If they don't appear in your vscode editor, try creating a cpp language snippet config file using F1&rarr;`Preferences: Configure Code Snippets` and selecting `cpp`

#### Example snippet:
`dbg` yields:
```c++
LOG(DEBUG) << {your code here};
```
<img src="https://media.giphy.com/media/a5MFvAwc6GPf2/giphy.gif" height=100>