### PR TITLE
agent: topology:  don't quit when bh sta is not available

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2025,7 +2025,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
             if (!front_iface && !soc->sta_wlan_hal) {
                 LOG(TRACE) << "Skip radio interface with no active STA BWL, front_radio="
                            << soc->radio_mac;
-                return false;
+                return true;
             }
 
             auto localInterfaceInfo = tlvDeviceInformation->create_local_interface_list();


### PR DESCRIPTION
Currently there is a bug (100% reproducable) which causes the agent
topology query handler to fail and never respond with a topology
response. The root cause is that the fill_radio_iface_info lambda
function declared in handle_1905_topology_query() returns false for the
backhaul interface in case there is no STA WLAN HAL interface.
This causes the calling function to return false, which means we never
get to send the topology response to the bus, and instead the message is
wrongly forwarded to the son slaves.

A quick solution this commit is adding is to return true in the lambda
function - if we don't have a station interface, we do not need to fail
the function.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>