### PR TITLE
Feature/add method to obtain radio information

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -675,7 +675,7 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
 
                         notification->params().backhaul_bssid =
                             network_utils::mac_from_string(soc->sta_wlan_hal->get_bssid());
-                        // notification->params().backhaul_freq          = utils::wifi_channel_to_freq(soc->sta_wlan_hal->get_channel()); // HACK temp disabled because of a bug on endian converter
+                        // notification->params().backhaul_freq          = son::wireless_utils::channel_to_freq(soc->sta_wlan_hal->get_channel()); // HACK temp disabled because of a bug on endian converter
                         notification->params().backhaul_channel = soc->sta_wlan_hal->get_channel();
                         // TODO - Specify true WiFi model from config (safe to derive from hostap_iface_type?)
                         notification->params().backhaul_iface_type  = IFACE_TYPE_WIFI_INTEL;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4761,8 +4761,8 @@ bool slave_thread::send_operating_channel_report()
     beerocks::message::sWifiChannel channel;
     channel.channel_bandwidth = hostap_cs_params.bandwidth;
     channel.channel           = hostap_cs_params.channel;
-    auto center_channel       = utils::wifi_freq_to_channel(hostap_cs_params.vht_center_frequency);
-    auto operating_class      = wireless_utils::get_operating_class_by_channel(channel);
+    auto center_channel  = wireless_utils::freq_to_channel(hostap_cs_params.vht_center_frequency);
+    auto operating_class = wireless_utils::get_operating_class_by_channel(channel);
 
     operating_class_entry.operating_class = operating_class;
     // operating classes 128,129,130 use center channel **unlike the other classes** (See Table E-4 in 802.11 spec)

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -164,9 +164,11 @@ enum eProtocolPorts {
 };
 
 enum eWiFiBandwidth : uint8_t {
-    BANDWIDTH_20 = 0,
+    BANDWIDTH_UNKNOWN = 0,
+    BANDWIDTH_20,
     BANDWIDTH_40,
     BANDWIDTH_80,
+    BANDWIDTH_80_80,
     BANDWIDTH_160,
     BANDWIDTH_MAX,
 };

--- a/common/beerocks/bcl/include/bcl/beerocks_utils.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_utils.h
@@ -66,10 +66,6 @@ public:
     static int convert_bandwidth_to_int(beerocks::eWiFiBandwidth bw);
     static std::string convert_channel_ext_above_to_string(bool channel_ext_above_secondary,
                                                            beerocks::eWiFiBandwidth bandwidth);
-    static int wifi_channel_to_freq(int channel);
-    static int wifi_freq_to_channel(int freq);
-    static uint16_t wifi_channel_to_vht_center_freq(int channel, int bandwidth,
-                                                    bool channel_ext_above_secondary);
     static void merge_list(std::vector<uint8_t> &ret, std::vector<uint8_t> &list);
     static void hex_dump(const std::string &description, uint8_t *addr, int len,
                          const char *calling_file = __builtin_FILE(),

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -122,6 +122,13 @@ public:
                                   uint8_t &short_gi);
 
     static int channel_to_freq(int channel);
+
+    /**
+     * @brief Obtains the channel number that corresponds to given frequency value.
+     *
+     * @param freq frequency value in MHz.
+     * @return channel number.
+     */
     static int freq_to_channel(int freq);
     static uint16_t channel_to_vht_center_freq(int channel, int bandwidth,
                                                bool channel_ext_above_secondary);

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -121,6 +121,10 @@ public:
                                   const beerocks::eWiFiBandwidth bw, uint8_t &mcs,
                                   uint8_t &short_gi);
 
+    static int channel_to_freq(int channel);
+    static int freq_to_channel(int freq);
+    static uint16_t channel_to_vht_center_freq(int channel, int bandwidth,
+                                               bool channel_ext_above_secondary);
     static beerocks::eFreqType which_freq(uint32_t chn);
     static bool is_same_freq_band(int chn1, int chn2);
     static beerocks::eSubbandType which_subband(uint32_t chn);

--- a/common/beerocks/bcl/source/beerocks_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_utils.cpp
@@ -212,54 +212,6 @@ std::string utils::convert_channel_ext_above_to_string(bool channel_ext_above_se
     }
 }
 
-int utils::wifi_channel_to_freq(int channel)
-{
-    if (channel == 14)
-        return 2484;
-
-    if (channel < 14)
-        return (channel * 5) + 2407;
-
-    return (channel + 1000) * 5;
-}
-
-uint16_t utils::wifi_channel_to_vht_center_freq(int channel, int bandwidth,
-                                                bool channel_ext_above_secondary)
-{
-    int freq = wifi_channel_to_freq(channel);
-    uint16_t vht_center_freq;
-    switch (bandwidth) {
-    case 20:
-        vht_center_freq = freq;
-        break;
-    case 40:
-        vht_center_freq = freq + (channel_ext_above_secondary ? 10 : -10);
-        break;
-    case 80:
-        vht_center_freq = freq + (channel_ext_above_secondary ? 30 : -30);
-        break;
-    case 160:
-        vht_center_freq = freq + (channel_ext_above_secondary ? 70 : -70);
-        break;
-    default:
-        LOG(ERROR) << "invalid bandwidth!";
-        return -1;
-    }
-    return vht_center_freq;
-}
-
-int utils::wifi_freq_to_channel(int freq)
-{
-    if (freq == 2484)
-        return 14;
-
-    if (freq < 2484)
-        return (freq - 2407) / 5;
-
-    /* FIXME: dot11ChannelStartingFactor (802.11-2007 17.3.8.3.2) */
-    return freq / 5 - 1000;
-}
-
 void utils::merge_list(std::vector<uint8_t> &ret, std::vector<uint8_t> &list)
 {
     std::vector<uint8_t>::iterator it;

--- a/common/beerocks/bcl/source/beerocks_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_utils.cpp
@@ -180,6 +180,7 @@ int utils::convert_bandwidth_to_int(beerocks::eWiFiBandwidth bandwidth)
     case beerocks::BANDWIDTH_80:
         bandwidth_int = 80;
         break;
+    case beerocks::BANDWIDTH_80_80:
     case beerocks::BANDWIDTH_160:
         bandwidth_int = 160;
         break;
@@ -199,6 +200,7 @@ std::string utils::convert_channel_ext_above_to_string(bool channel_ext_above_se
         break;
     case beerocks::BANDWIDTH_40:
     case beerocks::BANDWIDTH_80:
+    case beerocks::BANDWIDTH_80_80:
     case beerocks::BANDWIDTH_160:
         if (channel_ext_above_secondary) {
             return "H";

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -366,14 +366,20 @@ int wireless_utils::channel_to_freq(int channel)
 
 int wireless_utils::freq_to_channel(int freq)
 {
-    if (freq == 2484)
+    /* see 802.11-2007 17.3.8.3.2 and Annex J */
+    if (freq == 2484) {
         return 14;
-
-    if (freq < 2484)
+    } else if (freq < 2484) {
         return (freq - 2407) / 5;
-
-    /* FIXME: dot11ChannelStartingFactor (802.11-2007 17.3.8.3.2) */
-    return freq / 5 - 1000;
+    } else if (freq >= 4910 && freq <= 4980) {
+        return (freq - 4000) / 5;
+    } else if (freq <= 45000) { /* DMG band lower limit */
+        return (freq - 5000) / 5;
+    } else if (freq >= 58320 && freq <= 64800) {
+        return (freq - 56160) / 2160;
+    } else {
+        return 0;
+    }
 }
 
 uint16_t wireless_utils::channel_to_vht_center_freq(int channel, int bandwidth,
@@ -575,10 +581,10 @@ std::vector<uint8_t> wireless_utils::get_5g_20MHz_channels(beerocks::eWiFiBandwi
         LOG(ERROR) << "INVALID BW:" << bw;
     }
     }
-        std::for_each(std::begin(channels), std::end(channels),
-                      [](uint8_t channel) { LOG(DEBUG) << "channel:" << int(channel); });
-        return channels;
-    }
+    std::for_each(std::begin(channels), std::end(channels),
+                  [](uint8_t channel) { LOG(DEBUG) << "channel:" << int(channel); });
+    return channels;
+}
 
 uint8_t wireless_utils::channel_step_multiply(bool channel_ext_above_secondary,
                                               bool channel_ext_above_primary)

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -511,6 +511,7 @@ std::vector<uint8_t> wireless_utils::get_5g_20MHz_channels(beerocks::eWiFiBandwi
         channels.push_back(beerocks::utils::wifi_freq_to_channel(vht_center_frequency + 30));
         break;
     }
+    case beerocks::BANDWIDTH_80_80:
     case beerocks::BANDWIDTH_160: {
         channels.push_back(beerocks::utils::wifi_freq_to_channel(vht_center_frequency - 70));
         channels.push_back(beerocks::utils::wifi_freq_to_channel(vht_center_frequency - 50));

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
@@ -8,17 +8,69 @@
 
 #include "nl80211_client_dummy.h"
 
+#include <bcl/beerocks_utils.h>
+
 namespace bwl {
 
 nl80211_client_dummy::nl80211_client_dummy() {}
 
 nl80211_client_dummy::~nl80211_client_dummy() {}
 
-bool nl80211_client_dummy::get_sta_info(const std::string &local_interface_name,
-                                        const sMacAddr &sta_mac_address, sStaInfo &sta_info)
+bool nl80211_client_dummy::get_radio_info(const std::string &interface_name, radio_info &radio_info)
 {
     // Suppress "unused parameter" warning
-    (void)local_interface_name;
+    (void)interface_name;
+
+    band_info band{};
+
+    // 5GHz simulated report
+    for (uint16_t ch = 36; ch <= 64; ch += 4) {
+        for (uint16_t step = 0; step < 3; step++) {
+            channel_info channel;
+
+            channel.number = ch;
+            channel.supported_bandwidths.push_back(
+                beerocks::utils::convert_bandwidth_to_enum(20 + step * 20));
+            channel.is_dfs = (ch > 48);
+
+            band.supported_channels[channel.number] = channel;
+        }
+    }
+    for (uint16_t ch = 100; ch <= 144; ch += 4) {
+        for (uint16_t step = 0; step < 3; step++) {
+            channel_info channel;
+
+            channel.number = ch;
+            channel.supported_bandwidths.push_back(
+                beerocks::utils::convert_bandwidth_to_enum(20 + step * 20));
+            channel.is_dfs = true;
+
+            band.supported_channels[channel.number] = channel;
+        }
+    }
+    for (uint16_t ch = 149; ch <= 165; ch += 4) {
+        for (uint16_t step = 0; step < 3; step++) {
+            channel_info channel;
+
+            channel.number = ch;
+            channel.supported_bandwidths.push_back(
+                beerocks::utils::convert_bandwidth_to_enum(20 + step * 20));
+            channel.is_dfs = false;
+
+            band.supported_channels[channel.number] = channel;
+        }
+    }
+
+    radio_info.bands.push_back(band);
+
+    return true;
+}
+
+bool nl80211_client_dummy::get_sta_info(const std::string &interface_name,
+                                        const sMacAddr &sta_mac_address, sta_info &sta_info)
+{
+    // Suppress "unused parameter" warning
+    (void)interface_name;
     (void)sta_mac_address;
 
     static int inactive_time_ms        = 0;
@@ -28,8 +80,8 @@ bool nl80211_client_dummy::get_sta_info(const std::string &local_interface_name,
     static uint32_t tx_packets         = 0;
     static uint32_t tx_retries         = 0;
     static uint32_t tx_failed          = 0;
-    static uint8_t signal_dBm          = 0;
-    static uint8_t signal_avg_dBm      = 0;
+    static uint8_t signal_dbm          = 0;
+    static uint8_t signal_avg_dbm      = 0;
     static uint16_t tx_bitrate_100kbps = 0;
     static uint16_t rx_bitrate_100kbps = 0;
 
@@ -40,16 +92,15 @@ bool nl80211_client_dummy::get_sta_info(const std::string &local_interface_name,
     sta_info.tx_packets         = tx_packets++;
     sta_info.tx_retries         = tx_retries++;
     sta_info.tx_failed          = tx_failed++;
-    sta_info.signal_dBm         = signal_dBm++;
-    sta_info.signal_avg_dBm     = signal_avg_dBm++;
+    sta_info.signal_dbm         = signal_dbm++;
+    sta_info.signal_avg_dbm     = signal_avg_dbm++;
     sta_info.tx_bitrate_100kbps = tx_bitrate_100kbps++;
     sta_info.rx_bitrate_100kbps = rx_bitrate_100kbps++;
 
     return true;
 }
 
-bool nl80211_client_dummy::set_tx_power_limit(const std::string &local_interface_name,
-                                              uint32_t limit)
+bool nl80211_client_dummy::set_tx_power_limit(const std::string &interface_name, uint32_t limit)
 {
     return true;
 }

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.h
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.h
@@ -32,30 +32,41 @@ public:
     virtual ~nl80211_client_dummy();
 
     /**
+     * @brief Gets radio information.
+     *
+     * Radio information contains HT/VHT capabilities and the list of supported channels.
+     *
+     * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
+     * @param[out] radio_info Radio information.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_radio_info(const std::string &interface_name, radio_info &radio_info) override;
+
+    /**
      * @brief Gets station information.
      *
      * Fills station information with dummy data.
      *
-     * @param[in] local_interface_name Virtual AP (VAP) interface name.
+     * @param[in] interface_name Virtual AP (VAP) interface name.
      * @param[in] sta_mac_address MAC address of a station connected to the local interface.
      * @param[out] sta_info Station information.
      *
      * @return Dummy implementation returns always true.
      */
-    virtual bool get_sta_info(const std::string &local_interface_name,
-                              const sMacAddr &sta_mac_address, sStaInfo &sta_info) override;
+    bool get_sta_info(const std::string &interface_name, const sMacAddr &sta_mac_address,
+                      sta_info &sta_info) override;
 
     /**
      * @brief Set the tx power limit
      *
      * Set tx power limit for a radio
      *
-     * @param[in] local_interface_name radio interface name.
-     * @param[in] limit tx power limit in dBM to set 
+     * @param[in] interface_name radio interface name.
+     * @param[in] limit tx power limit in dBm to set
      * @return true success and false otherwise
      */
-    virtual bool set_tx_power_limit(const std::string &local_interface_name,
-                                    uint32_t limit) override;
+    bool set_tx_power_limit(const std::string &interface_name, uint32_t limit) override;
 };
 
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1110,7 +1110,7 @@ bool ap_wlan_hal_dwpal::sta_unassoc_rssi_measurement(const std::string &mac, int
 {
     // Convert values to strings
     std::string chanBandwidth     = std::to_string(bw);
-    std::string centerFreq        = std::to_string(beerocks::utils::wifi_channel_to_freq(chan));
+    std::string centerFreq        = std::to_string(son::wireless_utils::channel_to_freq(chan));
     std::string waveVhtCenterFreq = std::to_string(vht_center_frequency);
 
     // Build command string
@@ -1183,7 +1183,7 @@ bool ap_wlan_hal_dwpal::switch_channel(int chan, int bw, int vht_center_frequenc
     } else {
         m_drop_csa = false;
 
-        int freq                              = beerocks::utils::wifi_channel_to_freq(chan);
+        int freq                              = son::wireless_utils::channel_to_freq(chan);
         std::string freq_str                  = std::to_string(freq);
         std::string wave_vht_center_frequency = std::to_string(vht_center_frequency);
 
@@ -1298,7 +1298,7 @@ bool ap_wlan_hal_dwpal::failsafe_channel_set(int chan, int bw, int vht_center_fr
     // Build command string
     if (chan) {
         std::string bw_str   = std::to_string(bw);
-        std::string chan_str = std::to_string(beerocks::utils::wifi_channel_to_freq(chan));
+        std::string chan_str = std::to_string(son::wireless_utils::channel_to_freq(chan));
         std::string freq_str = std::to_string(vht_center_frequency);
         LOG(DEBUG) << "chan_str = " << chan_str << " bw_str = " << bw_str
                    << " vht_freq_str = " << freq_str;
@@ -1363,7 +1363,7 @@ bool ap_wlan_hal_dwpal::failsafe_channel_get(int &chan, int &bw)
     } else if (!strncmp(freq, "ACS", 3)) {
         chan = bw = 0;
     } else {
-        chan = beerocks::utils::wifi_freq_to_channel(beerocks::string_utils::stoi(freq));
+        chan = son::wireless_utils::freq_to_channel(beerocks::string_utils::stoi(freq));
     }
 
     return true;
@@ -2370,7 +2370,7 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
             }
         }
 
-        msg->params.channel   = beerocks::utils::wifi_freq_to_channel(msg->params.frequency);
+        msg->params.channel   = son::wireless_utils::freq_to_channel(msg->params.frequency);
         msg->params.bandwidth = dwpal_bw_to_beerocks_bw(chan_width);
 
         // Add the message to the queue
@@ -2423,7 +2423,7 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
             }
         }
 
-        msg->params.channel   = beerocks::utils::wifi_freq_to_channel(msg->params.frequency);
+        msg->params.channel   = son::wireless_utils::freq_to_channel(msg->params.frequency);
         msg->params.bandwidth = dwpal_bw_to_beerocks_bw(chan_width);
 
         // Add the message to the queue

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
@@ -132,7 +132,7 @@ static bool dwpal_get_channel_scan_freq(const std::vector<unsigned int> &channel
             return false;
         }
 
-        scan_params.freq[freq_index] = beerocks::utils::wifi_channel_to_freq(int(channel));
+        scan_params.freq[freq_index] = son::wireless_utils::channel_to_freq(int(channel));
         LOG(DEBUG) << "channel scan pool add center frequency=" << scan_params.freq[freq_index];
         freq_index++;
     }
@@ -376,7 +376,7 @@ static bool translate_nl_data_to_bwl_results(sChannelScanResults &results,
         } else {
             results.operating_frequency_band = eOperating_Freq_Band_2_4GHz;
         }
-        results.channel = beerocks::utils::wifi_freq_to_channel(freq);
+        results.channel = son::wireless_utils::freq_to_channel(freq);
     }
 
     // get beacon period

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
@@ -176,7 +176,7 @@ int sta_wlan_hal_dwpal::get_scan_results(const std::string &ssid, std::vector<SS
 
         SScanResult ap;
         ap.bssid   = beerocks::net::network_utils::mac_from_string(scan_results[i].bssid);
-        ap.channel = beerocks::utils::wifi_freq_to_channel(scan_results[i].frequency);
+        ap.channel = son::wireless_utils::freq_to_channel(scan_results[i].frequency);
         ap.rssi    = scan_results[i].rssi;
 
         list.insert(list.begin(), ap);
@@ -213,7 +213,7 @@ bool sta_wlan_hal_dwpal::connect(const std::string &ssid, const std::string &pas
         return false;
     }
 
-    auto freq = beerocks::utils::wifi_channel_to_freq(int(channel));
+    auto freq = son::wireless_utils::channel_to_freq(int(channel));
 
     // Update network parameters
     if (!set_network_params(network_id, ssid, bssid, sec, mem_only_psk, pass, hidden_ssid, freq)) {
@@ -306,7 +306,7 @@ bool sta_wlan_hal_dwpal::roam(const std::string &bssid, uint8_t channel)
         return false;
     }
 
-    auto freq = beerocks::utils::wifi_channel_to_freq(int(channel));
+    auto freq = son::wireless_utils::channel_to_freq(int(channel));
     if (!set_network(m_active_network_id, "freq_list", std::to_string(freq))) {
         LOG(ERROR) << "Failed setting frequency on iface " << get_iface_name();
         return false;
@@ -363,7 +363,7 @@ bool sta_wlan_hal_dwpal::unassoc_rssi_measurement(const std::string &mac, int ch
 
     // Convert values to strings
     std::string chanBandwidth       = std::to_string(bw);
-    std::string centerFreq          = std::to_string(beerocks::utils::wifi_channel_to_freq(chan));
+    std::string centerFreq          = std::to_string(son::wireless_utils::channel_to_freq(chan));
     std::string waveVhtCenterFreq   = std::to_string(vht_center_frequency);
 
     // Create a new object
@@ -729,7 +729,7 @@ void sta_wlan_hal_dwpal::update_status(const ConnectionStatus &connection_status
 {
     m_active_network_id = connection_status.id;
     m_active_bssid      = connection_status.bssid;
-    m_active_channel    = beerocks::utils::wifi_freq_to_channel(connection_status.freq);
+    m_active_channel    = son::wireless_utils::freq_to_channel(connection_status.freq);
     m_active_ssid       = connection_status.ssid;
 
     LOG(DEBUG) << "m_active_network_id= " << m_active_network_id;

--- a/common/beerocks/bwl/include/bwl/nl80211_client.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client.h
@@ -8,9 +8,31 @@
 #ifndef __BWL_NL80211_CLIENT_H__
 #define __BWL_NL80211_CLIENT_H__
 
+#include <bcl/beerocks_defines.h>
+#include <bcl/beerocks_message_structs.h>
+#include <bcl/son/son_wireless_utils.h>
 #include <tlvf/common/sMacAddr.h>
 
+#include <algorithm>
 #include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @brief Length of HT MCS set.
+ *
+ * According to <linux/nl80211.h>, NL80211_BAND_ATTR_HT_MCS_SET is a 16-byte attribute containing
+ * the MCS set as defined in 802.11n
+ */
+static constexpr size_t ht_mcs_set_size = 16;
+
+/**
+ * @brief Length of VHT MCS set.
+ *
+ * According to <linux/nl80211.h>, NL80211_BAND_ATTR_VHT_MCS_SET is a 32-byte attribute containing
+ * the MCS set as defined in 802.11ac
+ */
+static constexpr size_t vht_mcs_set_size = 32;
 
 namespace bwl {
 
@@ -34,12 +56,144 @@ class nl80211_client {
 
 public:
     /**
+     * @brief Channel information
+     *
+     * Used in band_info structure as each band contains a map of supported channels.
+     *
+     * Information obtained with NL80211_CMD_GET_WIPHY command through a NL80211 socket.
+     * See NL80211_FREQUENCY_ATTR_* in <linux/nl80211.h> for a description of each field.
+     */
+    struct channel_info {
+
+        /**
+         * Channel number.
+         * Obtained from NL80211_FREQUENCY_ATTR_FREQ (see 802.11-2007 17.3.8.3.2 and Annex J)
+         */
+        uint8_t number = 0;
+
+        /**
+         * Supported channel bandwidths.
+         */
+        std::vector<beerocks::eWiFiBandwidth> supported_bandwidths;
+
+        /**
+         * Maximum transmission power in dBm.
+         * Obtained as 0.01 * NL80211_FREQUENCY_ATTR_MAX_TX_POWER
+         */
+        uint8_t tx_power = 0;
+
+        /**
+         * Radar detection is mandatory on this channel in current regulatory domain.
+         * Set to true if attribute NL80211_FREQUENCY_ATTR_RADAR is present.
+         */
+        bool is_dfs = false;
+
+        /**
+         * True if current state for DFS is NL80211_DFS_UNAVAILABLE.
+         * Obtained from NL80211_FREQUENCY_ATTR_DFS_STATE
+         */
+        bool radar_affected = false;
+
+        /**
+         * @brief Gets the maximum supported bandwidth by the channel.
+         *
+         * @return Maximum supported bandwidth
+         */
+        beerocks::eWiFiBandwidth get_max_bandwidth() const
+        {
+            if (supported_bandwidths.empty()) {
+                return beerocks::eWiFiBandwidth::BANDWIDTH_UNKNOWN;
+            }
+
+            return *std::max_element(supported_bandwidths.begin(), supported_bandwidths.end());
+        }
+    };
+
+    /**
+     * @brief Band information
+     *
+     * Used in radio_info structure as each radio contains a list of bands.
+     *
+     * Information obtained with NL80211_CMD_GET_WIPHY command through a NL80211 socket.
+     * See NL80211_BAND_ATTR_* in <linux/nl80211.h> for a description of each field.
+     */
+    struct band_info {
+
+        /**
+         * Value of NL80211_BAND_ATTR_HT_CAPA, see iw/util.c print_ht_capability() as a bit
+         * interpretation example.
+         */
+        uint16_t ht_capability = 0;
+
+        /**
+         * Value of NL80211_BAND_ATTR_HT_MCS_SET, see iw/util.c print_ht_mcs() as a byte
+         * interpretation example.
+         */
+        uint8_t ht_mcs_set[ht_mcs_set_size];
+
+        /**
+         * Value of NL80211_BAND_ATTR_VHT_CAPA, see iw/util.c print_vht_info() as a bit
+         * interpretation example.
+         */
+        uint32_t vht_capability = 0;
+
+        /**
+         * Value of NL80211_BAND_ATTR_VHT_MCS_SET, see iw/util.c print_vht_info() as a byte
+         * interpretation example.
+         */
+        uint8_t vht_mcs_set[vht_mcs_set_size];
+
+        /**
+         * Channels supported in this band (obtained from NL80211_BAND_ATTR_FREQS).
+         * Map key is the channel number and map value is the channel information.
+         */
+        std::unordered_map<uint8_t, channel_info> supported_channels;
+
+        /**
+         * @brief Gets the frequency band of this band.
+         *
+         * Return value can be obtained from whatever of the supported channels.
+         *
+         * @return Frequency band
+         */
+        beerocks::eFreqType get_frequency_band() const
+        {
+            if (supported_channels.empty()) {
+                return beerocks::eFreqType::FREQ_UNKNOWN;
+            }
+
+            return son::wireless_utils::which_freq(supported_channels.begin()->first);
+        }
+
+        /**
+         * @brief Checks if this band is the 5GHz band.
+         *
+         * @return True if this band is the 5GHz band and false otherwise.
+         */
+        bool is_5ghz_band() const { return beerocks::eFreqType::FREQ_5G == get_frequency_band(); }
+    };
+
+    /**
+     * @brief Radio information
+     *
+     * Information obtained with NL80211_CMD_GET_WIPHY command through a NL80211 socket.
+     * See <linux/nl80211.h> for a description of each field.
+     */
+    struct radio_info {
+
+        /**
+         * Bands included in this radio (obtained from NL80211_ATTR_WIPHY_BANDS)
+         */
+        std::vector<band_info> bands;
+    };
+
+    /**
      * @brief Station information
      *
      * Information obtained with NL80211_CMD_GET_STATION command through a NL80211 socket.
      * See NL80211_STA_INFO_* in <linux/nl80211.h> for a description of each field.
      */
-    struct sStaInfo {
+    struct sta_info {
         uint32_t inactive_time_ms   = 0;
         uint32_t rx_bytes           = 0;
         uint32_t rx_packets         = 0;
@@ -47,8 +201,8 @@ public:
         uint32_t tx_packets         = 0;
         uint32_t tx_retries         = 0;
         uint32_t tx_failed          = 0;
-        uint8_t signal_dBm          = 0;
-        uint8_t signal_avg_dBm      = 0;
+        uint8_t signal_dbm          = 0;
+        uint8_t signal_avg_dbm      = 0;
         uint16_t tx_bitrate_100kbps = 0;
         uint16_t rx_bitrate_100kbps = 0;
     };
@@ -59,31 +213,42 @@ public:
     virtual ~nl80211_client() = default;
 
     /**
+     * @brief Gets radio information.
+     *
+     * Radio information contains HT/VHT capabilities and the list of supported channels.
+     *
+     * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
+     * @param[out] radio_info Radio information.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_radio_info(const std::string &interface_name, radio_info &radio_info) = 0;
+
+    /**
      * @brief Gets station information.
      *
      * Station information contains basically metrics associated to the link between given local
      * interface and a the interface of a station whose MAC address is 'sta_mac_address'.
      *
-     * @param[in] local_interface_name Virtual AP (VAP) interface name.
+     * @param[in] interface_name Virtual AP (VAP) interface name.
      * @param[in] sta_mac_address MAC address of a station connected to the local interface.
      * @param[out] sta_info Station information.
      *
      * @return True on success and false otherwise.
      */
-    virtual bool get_sta_info(const std::string &local_interface_name,
-                              const sMacAddr &sta_mac_address, sStaInfo &sta_info) = 0;
+    virtual bool get_sta_info(const std::string &interface_name, const sMacAddr &sta_mac_address,
+                              sta_info &sta_info) = 0;
+
     /**
      * @brief Set the tx power limit
      *
      * Set tx power limit for a radio
      *
-     * @param[in] local_interface_name radio interface name.
-     * @param[in] limit tx power limit in dBM to set 
+     * @param[in] interface_name radio interface name.
+     * @param[in] limit tx power limit in dBm to set
      * @return true success and false otherwise
      */
-    virtual bool set_tx_power_limit(const std::string &local_interface_name, uint32_t limit) = 0;
-
-    // TODO: add remaining methods
+    virtual bool set_tx_power_limit(const std::string &interface_name, uint32_t limit) = 0;
 };
 
 } // namespace bwl

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -306,7 +306,7 @@ bool ap_wlan_hal_nl80211::switch_channel(int chan, int bw, int vht_center_freque
         return false;
     }
 
-    int freq                              = beerocks::utils::wifi_channel_to_freq(chan);
+    int freq                              = son::wireless_utils::channel_to_freq(chan);
     std::string freq_str                  = std::to_string(freq);
     std::string wave_vht_center_frequency = std::to_string(vht_center_frequency);
 
@@ -416,7 +416,7 @@ bool ap_wlan_hal_nl80211::failsafe_channel_get(int &chan, int &bw)
             return false;
         }
         bw   = beerocks::string_utils::stoi(tmp_vec[1]);
-        chan = beerocks::utils::wifi_freq_to_channel(freq);
+        chan = son::wireless_utils::freq_to_channel(freq);
     }
 
     return true;
@@ -529,7 +529,7 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
 
                             freq = nla_get_u32(tb_freq[NL80211_FREQUENCY_ATTR_FREQ]);
                             m_radio_info.supported_channels[idx].channel =
-                                beerocks::utils::wifi_freq_to_channel(freq);
+                                son::wireless_utils::freq_to_channel(freq);
 
                             if (tb_freq[NL80211_FREQUENCY_ATTR_MAX_TX_POWER]) {
                                 m_radio_info.supported_channels[idx].tx_pow =
@@ -680,7 +680,7 @@ bool ap_wlan_hal_nl80211::process_nl80211_event(parsed_obj_map_t &parsed_obj)
             return false;
         }
         m_radio_info.channel =
-            beerocks::utils::wifi_freq_to_channel(beerocks::string_utils::stoi(parsed_obj["freq"]));
+            son::wireless_utils::freq_to_channel(beerocks::string_utils::stoi(parsed_obj["freq"]));
         m_radio_info.bandwidth          = wpa_bw_to_beerocks_bw(bandwidth);
         m_radio_info.channel_ext_above  = beerocks::string_utils::stoi(parsed_obj["ch_offset"]);
         m_radio_info.vht_center_freq    = beerocks::string_utils::stoi(parsed_obj["cf1"]);

--- a/common/beerocks/bwl/shared/nl80211_client_impl.h
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.h
@@ -43,31 +43,42 @@ public:
     virtual ~nl80211_client_impl() = default;
 
     /**
+     * @brief Gets radio information.
+     *
+     * Radio information contains HT/VHT capabilities and the list of supported channels.
+     *
+     * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
+     * @param[out] radio_info Radio information.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_radio_info(const std::string &interface_name, radio_info &radio_info) override;
+
+    /**
      * @brief Gets station information.
      *
      * Station information contains basic metrics associated to the link between given local
      * interface and the interface of a station with MAC address 'sta_mac_address'.
      *
-     * @param[in] local_interface_name Virtual AP (VAP) interface name.
+     * @param[in] interface_name Virtual AP (VAP) interface name.
      * @param[in] sta_mac_address MAC address of a station connected to the local interface.
      * @param[out] sta_info Station information.
      *
      * @return True on success and false otherwise.
      */
-    virtual bool get_sta_info(const std::string &local_interface_name,
-                              const sMacAddr &sta_mac_address, sStaInfo &sta_info) override;
+    virtual bool get_sta_info(const std::string &interface_name, const sMacAddr &sta_mac_address,
+                              sta_info &sta_info) override;
 
     /**
      * @brief Set the tx power limit
      *
      * Set tx power limit for a radio
      *
-     * @param[in] local_interface_name radio interface name.
-     * @param[in] limit tx power limit in dBM to set 
+     * @param[in] interface_name radio interface name.
+     * @param[in] limit tx power limit in dBm to set
      * @return true success and false otherwise
      */
-    virtual bool set_tx_power_limit(const std::string &local_interface_name,
-                                    uint32_t limit) override;
+    virtual bool set_tx_power_limit(const std::string &interface_name, uint32_t limit) override;
 
 private:
     /**

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -190,7 +190,7 @@ static void bml_utils_dump_conn_map(
                    << utils::convert_channel_ext_above_to_string(
                           radio->channel_ext_above_secondary, (beerocks::eWiFiBandwidth)radio->bw)
                    << ", freq: "
-                   << std::to_string(beerocks::utils::wifi_channel_to_freq(radio->channel)) << "MHz"
+                   << std::to_string(son::wireless_utils::channel_to_freq(radio->channel)) << "MHz"
                    << std::endl;
 
                 // VAP

--- a/controller/src/beerocks/cli/beerocks_cli_socket.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_socket.cpp
@@ -10,6 +10,8 @@
 
 #include <bcl/beerocks_string_utils.h>
 #include <bcl/beerocks_utils.h>
+#include <bcl/son/son_wireless_utils.h>
+
 #include <easylogging++.h>
 
 #include <beerocks/tlvf/beerocks_message.h>
@@ -656,9 +658,9 @@ int cli_socket::ap_channel_switch(std::string ap_mac, uint8_t channel, uint8_t b
     request->cs_params().channel   = channel;
     request->cs_params().bandwidth = utils::convert_bandwidth_to_enum(bw);
     request->cs_params().vht_center_frequency =
-        vht_center_frequency
-            ? vht_center_frequency
-            : utils::wifi_channel_to_vht_center_freq(channel, bw, channel_ext_above_secondary);
+        vht_center_frequency ? vht_center_frequency
+                             : son::wireless_utils::channel_to_vht_center_freq(
+                                   channel, bw, channel_ext_above_secondary);
     wait_response = true;
     message_com::send_cmdu(master_socket, cmdu_tx);
     waitResponseReady();

--- a/controller/src/beerocks/master/tasks/channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.cpp
@@ -11,7 +11,6 @@
 #include "bml_task.h"
 #include "ire_network_optimization_task.h"
 
-#include <bcl/beerocks_utils.h>
 #include <bcl/network/network_utils.h>
 #include <bcl/son/son_wireless_utils.h>
 #include <easylogging++.h>
@@ -333,8 +332,8 @@ void channel_selection_task::work()
     }
     case eState::ON_SLAVE_JOINED: {
 
-        auto freq                      = utils::wifi_channel_to_freq(slave_joined_event->channel);
-        auto vht_center_frequency      = slave_joined_event->cs_params.vht_center_frequency;
+        auto freq                 = wireless_utils::channel_to_freq(slave_joined_event->channel);
+        auto vht_center_frequency = slave_joined_event->cs_params.vht_center_frequency;
         auto channel_ext_above_primary = slave_joined_event->cs_params.channel_ext_above_primary;
 
         auto channel_ext_above_secondary = (freq < vht_center_frequency) ? true : false;
@@ -511,7 +510,7 @@ void channel_selection_task::work()
             return;
         }
         request->params().failsafe_channel =
-            beerocks::utils::wifi_freq_to_channel(database.config.fail_safe_5G_frequency);
+            wireless_utils::freq_to_channel(database.config.fail_safe_5G_frequency);
         request->params().failsafe_channel_bandwidth = database.config.fail_safe_5G_bw;
         request->params().vht_center_frequency       = database.config.fail_safe_5G_vht_frequency;
         memset(request->params().restricted_channels, 0, message::RESTRICTED_CHANNEL_LENGTH);
@@ -537,7 +536,7 @@ void channel_selection_task::work()
         request->params().failsafe_channel =
             hostap_params.is_2G
                 ? 0
-                : beerocks::utils::wifi_freq_to_channel(database.config.fail_safe_5G_frequency);
+                : wireless_utils::freq_to_channel(database.config.fail_safe_5G_frequency);
         request->params().failsafe_channel_bandwidth =
             hostap_params.is_2G ? 0 : database.config.fail_safe_5G_bw;
         request->params().vht_center_frequency =
@@ -596,7 +595,7 @@ void channel_selection_task::work()
         request->params().failsafe_channel =
             hostap_params.is_2G
                 ? 0
-                : beerocks::utils::wifi_freq_to_channel(database.config.fail_safe_5G_frequency);
+                : wireless_utils::freq_to_channel(database.config.fail_safe_5G_frequency);
         ;
         request->params().failsafe_channel_bandwidth =
             hostap_params.is_2G ? 0 : database.config.fail_safe_5G_bw;
@@ -718,7 +717,7 @@ void channel_selection_task::work()
                        << " vht_center_frequency = "
                        << uint16_t(csa_event->cs_params.vht_center_frequency);
 
-        auto freq                 = utils::wifi_channel_to_freq(csa_event->cs_params.channel);
+        auto freq                 = wireless_utils::channel_to_freq(csa_event->cs_params.channel);
         auto vht_center_frequency = csa_event->cs_params.vht_center_frequency;
 
         auto channel_ext_above_secondary = (freq < vht_center_frequency) ? true : false;
@@ -891,7 +890,7 @@ void channel_selection_task::work()
                        << " channel = " << int(csa_event->cs_params.channel)
                        << " channel_ext_above_primary = "
                        << int(csa_event->cs_params.channel_ext_above_primary);
-        auto freq                      = utils::wifi_channel_to_freq(csa_event->cs_params.channel);
+        auto freq = wireless_utils::channel_to_freq(csa_event->cs_params.channel);
         auto prev_vht_center_frequency = database.get_hostap_vht_center_frequency(hostap_mac);
         auto prev_channel              = database.get_node_channel(hostap_mac);
         auto prev_bandwidth            = database.get_node_bw(hostap_mac);
@@ -1532,7 +1531,7 @@ bool channel_selection_task::ccl_fill_channel_switch_request_with_least_used_cha
         channel_switch_request.channel   = min_channels.begin()->first;
         channel_switch_request.bandwidth = beerocks::BANDWIDTH_80;
         align_channel_to_80Mhz();
-        channel_switch_request.vht_center_frequency = utils::wifi_channel_to_vht_center_freq(
+        channel_switch_request.vht_center_frequency = wireless_utils::channel_to_vht_center_freq(
             channel_switch_request.channel,
             beerocks::utils::convert_bandwidth_to_int(
                 beerocks::eWiFiBandwidth(channel_switch_request.bandwidth)),
@@ -1576,7 +1575,7 @@ bool channel_selection_task::ccl_fill_channel_switch_request_with_least_used_cha
         channel_switch_request.channel   = it_res->first;
         channel_switch_request.bandwidth = beerocks::BANDWIDTH_80;
         align_channel_to_80Mhz();
-        channel_switch_request.vht_center_frequency = utils::wifi_channel_to_vht_center_freq(
+        channel_switch_request.vht_center_frequency = wireless_utils::channel_to_vht_center_freq(
             channel_switch_request.channel,
             utils::convert_bandwidth_to_int(
                 beerocks::eWiFiBandwidth(channel_switch_request.bandwidth)),
@@ -1717,7 +1716,7 @@ bool channel_selection_task::fill_restricted_channels_from_ccl_busy_bands(uint8_
     int channel_step = CHANNEL_20MHZ_STEP;
 
     auto channel                     = channel_switch_request.channel;
-    auto freq                        = utils::wifi_channel_to_freq(channel);
+    auto freq                        = wireless_utils::channel_to_freq(channel);
     auto vht_center_frequency        = channel_switch_request.vht_center_frequency;
     auto channel_ext_above_secondary = (freq < vht_center_frequency) ? true : false;
 
@@ -1763,7 +1762,7 @@ bool channel_selection_task::acs_result_match()
 {
     TASK_LOG(DEBUG) << "*****************acs_result_match**************************** :";
     auto channel                     = channel_switch_request.channel;
-    auto freq                        = utils::wifi_channel_to_freq(channel);
+    auto freq                        = wireless_utils::channel_to_freq(channel);
     auto vht_center_frequency        = channel_switch_request.vht_center_frequency;
     auto channel_ext_above_secondary = (freq < vht_center_frequency) ? true : false;
     TASK_LOG(DEBUG) << "channel_ext_above_secondary  = " << int(channel_ext_above_secondary)


### PR DESCRIPTION
Add method to obtain radio information by issuing command
NL80211_CMD_GET_WIPHY.

This method will later be used to compute MediaType field required by
several TLVs and to fill in the HT/VHT capabilities TLVs.