### PR TITLE
tools: add download_ipk.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ run-tests:
     # kill prplmesh on each target to make sure they don't interfere with the test
     - for i in $ALL_TARGETS ; do ssh "$i" 'pgrep -f beerocks | xargs kill -9 2>/dev/null' || true ; done
   script:
-    - tools/deploy_ipk.sh $TARGET_DEVICE_NAME "build/$TARGET_DEVICE/"*.ipk
+    - tools/deploy_ipk.sh $TARGET_DEVICE_NAME "build/$TARGET_DEVICE/"prplmesh.ipk
     - tests/openwrt/test_status.sh $TARGET_DEVICE_NAME
   artifacts:
     paths:
@@ -181,7 +181,7 @@ run-certification-tests:
       - |
         if [ "$DEVICE_UNDER_TEST" != prplmesh ] ; then
             echo "Deploying to $DEVICE_UNDER_TEST"
-            tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/*.ipk
+            tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
         fi
       - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
   artifacts:

--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -63,6 +63,7 @@ main() {
 
     while true; do
         case "$1" in
+            -h|--help) usage; exit 0 ;;
             --certification-mode)
                 CERTIFICATION_MODE=true
                 shift
@@ -72,7 +73,7 @@ main() {
                 shift 2
                 ;;
             -- ) shift; break ;;
-            * ) err "unsupported argument $1"; usage; exit 1 ;;
+            * ) echo "unsupported argument $1"; usage; exit 1 ;;
         esac
     done
 

--- a/tools/docker/builder/openwrt/scripts/build.sh
+++ b/tools/docker/builder/openwrt/scripts/build.sh
@@ -9,6 +9,10 @@ rm -rf /home/openwrt/prplMesh/build
 make package/feeds/prpl/prplmesh/prepare USE_SOURCE_DIR="/home/openwrt/prplMesh" V=s
 make package/feeds/prpl/prplmesh/compile V=sc -j"$(nproc)"
 mkdir -p artifacts
-find bin -name 'prplmesh*.ipk' -exec cp -v {} "artifacts/prplmesh-${TARGET_PROFILE}-${OPENWRT_VERSION}-${PRPLMESH_VERSION}.ipk" \;
-
+cat << EOT >> artifacts/prplmesh.buildinfo
+TARGET_PROFILE=${TARGET_PROFILE}
+OPENWRT_VERSION=${OPENWRT_VERSION}
+PRPLMESH_VERSION=${PRPLMESH_VERSION}
+EOT
+find bin -name 'prplmesh*.ipk' -exec cp -v {} "artifacts/prplmesh.ipk" \;
 find bin/targets/"$TARGET_SYSTEM"/"$SUBTARGET"/ -type f -maxdepth 1 -exec cp -v {} "artifacts/" \;

--- a/tools/download_ipk.sh
+++ b/tools/download_ipk.sh
@@ -1,0 +1,66 @@
+#!/bin/sh -e
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2020 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+usage() {
+    echo "usage: $(basename "$0") [-hbd]"
+    echo "  options:"
+    echo "      -h|--help - show this help menu"
+    echo "      --branch  - branch to use (default master)"
+    echo "      --device  - device to use (default netgear-rax40)"
+    echo "      --path    - path to copy ipk to (default .)"
+    
+}
+
+download() {
+    # URL for downloading the prplmesh.ipk according to
+    # https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html#downloading-the-latest-artifacts
+    URL="https://gitlab.com/prpl-foundation/prplmesh/-/jobs/artifacts/$BRANCH/raw/build/$DEVICE/prplmesh.ipk?job=build-for-$DEVICE"
+    # curl options - fail on error (-f), follow redirect (-L)
+    curl -f -L "$URL" --output "$IPK_PATH"/prplmesh.ipk
+}
+
+main() {
+    if ! OPTS=$(getopt -o 'h' --long help,branch:,device:,path: -n 'parse-options' -- "$@"); then
+        echo "Failed parsing options." >&2
+        usage
+        exit 1
+    fi
+
+    eval set -- "$OPTS"
+
+    while true; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            --branch)
+                BRANCH="$2"
+                shift 2
+                ;;
+            --device)
+                DEVICE="$2"
+                shift 2
+                ;;
+            --path)
+                IPK_PATH="$2"
+                shift 2
+                ;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1 ;;
+        esac
+    done
+
+    download "$@"
+}
+
+DEVICE=netgear-rax40
+BRANCH=master
+IPK_PATH=.
+
+main "$@"


### PR DESCRIPTION
Add a helper script which can be used to download latest ipks from a
specific branch in gitlab.

This will be used by a cron job in each testbed setup not connected to gitlab CI which will allow for a simple script to deploy latest prplmesh master IPK to the RAX40.

This can also be used for Broadfarm, or any other testing framework which uses real devices.