### PR TITLE
[BUG] agent: autoconfig renew with broadcom controller

### DIFF
--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -156,7 +156,7 @@ private:
 private:
     const int SELECT_TIMEOUT_MSEC                                     = 200;
     const int SLAVE_INIT_DELAY_SEC                                    = 4;
-    const int WAIT_FOR_JOINED_RESPONSE_TIMEOUT_SEC                    = 30;
+    const int WAIT_FOR_JOINED_RESPONSE_TIMEOUT_SEC                    = 5;
     const int WAIT_BEFORE_SEND_SLAVE_JOINED_NOTIFICATION_SEC          = 1;
     const int WAIT_BEFORE_SEND_BH_ENABLE_NOTIFICATION_SEC             = 1;
     const int WAIT_FOR_PLATFORM_MANAGER_REGISTER_RESPONSE_TIMEOUT_SEC = 600;


### PR DESCRIPTION
**Describe the bug** -
Currently, there is an issue in the testbed where all tests involving Broadcom controller sometimes fail on "MSG: No AP-Autoconfiguration WSC message with M2 found" after the autoconfig renew step in the 4.4.3 tests.

Reproduces 8/10 tries.

## Steps to reproduce

Run any of the 4.4.3 tests in the testbed which involve the Broadcom controller. For example, 4.4.3_ETH_FH5GL.

## Expected behavior

The test should pass 100% of the times.

## Target

PTK1 testbed

## Logs

https://ftp.essensium.com/owncloud/index.php/s/ketl3eFhIgwcweZ?path=%2Fprpl%20agent%20tests%2FFAIL%2FMAP-4.4.3_ETH_FH24G%202020-03-16%2FMAP-4.4.3_ETH_FH24G_Mar-16-2020__03-09-48

https://ftp.essensium.com/owncloud/index.php/s/ketl3eFhIgwcweZ?path=%2Fprpl%20agent%20tests%2FFAIL%2FMAP-4.4.3_ETH_FH5GL%202020-03-16%2FMAP-4.4.3_ETH_FH5GL_Mar-16-2020__03-15-06