### PR TITLE
bwl: nl80211_client: add set_tx_power_limit API

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -52,20 +52,6 @@ static void copy_radio_supported_channels(std::shared_ptr<bwl::ap_wlan_hal> &ap_
     }
 }
 
-static int8_t get_tx_power(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal)
-{
-    auto radio_channels = ap_wlan_hal->get_radio_info().supported_channels;
-    uint8_t channel     = ap_wlan_hal->get_radio_info().channel;
-
-    for (uint8_t i = 0;
-         i < beerocks::message::SUPPORTED_CHANNELS_LENGTH && i < radio_channels.size(); i++) {
-        if (radio_channels[i].channel == channel)
-            return radio_channels[i].tx_pow;
-    }
-
-    return 0;
-}
-
 static std::string
 get_radio_supported_channels_string(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal)
 {
@@ -997,7 +983,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
 void ap_manager_thread::fill_cs_params(beerocks_message::sApChannelSwitch &params)
 {
-    params.tx_power  = get_tx_power(ap_wlan_hal);
+    params.tx_power  = ap_wlan_hal->get_radio_info().conducted_power;
     params.channel   = ap_wlan_hal->get_radio_info().channel;
     params.bandwidth = uint8_t(
         beerocks::utils::convert_bandwidth_to_enum(ap_wlan_hal->get_radio_info().bandwidth));

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1046,6 +1046,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
     case Event::CSA_Finished: {
 
         ap_wlan_hal->read_acs_report();
+        ap_wlan_hal->refresh_radio_info();
 
         LOG(INFO) << ((event == Event::ACS_Completed) ? "ACS_Completed" : "CSA_Finished:")
                   << " channel = " << int(ap_wlan_hal->get_radio_info().channel)

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -983,7 +983,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
 void ap_manager_thread::fill_cs_params(beerocks_message::sApChannelSwitch &params)
 {
-    params.tx_power  = ap_wlan_hal->get_radio_info().conducted_power;
+    params.tx_power  = ap_wlan_hal->get_radio_info().tx_power;
     params.channel   = ap_wlan_hal->get_radio_info().channel;
     params.bandwidth = uint8_t(
         beerocks::utils::convert_bandwidth_to_enum(ap_wlan_hal->get_radio_info().bandwidth));
@@ -1485,10 +1485,10 @@ void ap_manager_thread::handle_hostapd_attached()
 
     notification->params().iface_type = uint8_t(ap_wlan_hal->get_iface_type());
     notification->params().iface_mac = network_utils::mac_from_string(ap_wlan_hal->get_radio_mac());
-    notification->params().iface_is_5ghz   = ap_wlan_hal->get_radio_info().is_5ghz;
-    notification->params().ant_num         = ap_wlan_hal->get_radio_info().ant_num;
-    notification->params().conducted_power = ap_wlan_hal->get_radio_info().conducted_power;
-    notification->cs_params().channel      = ap_wlan_hal->get_radio_info().channel;
+    notification->params().iface_is_5ghz = ap_wlan_hal->get_radio_info().is_5ghz;
+    notification->params().ant_num       = ap_wlan_hal->get_radio_info().ant_num;
+    notification->params().tx_power      = ap_wlan_hal->get_radio_info().tx_power;
+    notification->cs_params().channel    = ap_wlan_hal->get_radio_info().channel;
     notification->cs_params().channel_ext_above_primary =
         ap_wlan_hal->get_radio_info().channel_ext_above;
     notification->cs_params().vht_center_frequency = ap_wlan_hal->get_radio_info().vht_center_freq;
@@ -1501,7 +1501,7 @@ void ap_manager_thread::handle_hostapd_attached()
     LOG(INFO) << "send ACTION_APMANAGER_JOINED_NOTIFICATION";
     LOG(INFO) << " mac = " << ap_wlan_hal->get_radio_mac();
     LOG(INFO) << " ant_num = " << ap_wlan_hal->get_radio_info().ant_num;
-    LOG(INFO) << " conducted_power = " << ap_wlan_hal->get_radio_info().conducted_power;
+    LOG(INFO) << " tx_power = " << ap_wlan_hal->get_radio_info().tx_power;
     LOG(INFO) << " current channel = " << ap_wlan_hal->get_radio_info().channel;
     LOG(INFO) << " vht_center_frequency = " << ap_wlan_hal->get_radio_info().vht_center_freq;
     LOG(INFO) << " current bw = " << ap_wlan_hal->get_radio_info().bandwidth;

--- a/agent/src/beerocks/slave/ap_manager_thread.h
+++ b/agent/src/beerocks/slave/ap_manager_thread.h
@@ -70,6 +70,7 @@ private:
     // bool hostap_handle_event(std::string& event, void* event_obj);
     void handle_hostapd_attached();
     bool handle_ap_enabled(int vap_id);
+    void fill_cs_params(beerocks_message::sApChannelSwitch &params);
     void stop_ap_manager_thread();
     void send_heartbeat();
     void send_steering_return_status(beerocks_message::eActionOp_APMANAGER ActionOp,

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4682,21 +4682,18 @@ bool slave_thread::handle_channel_selection_request(Socket *sd, ieee1905_1::Cmdu
         return false;
     }
 
-    // Currently, setting and reading tx power limit is not implemented
-    // in any or our BWL backends.
-    // Therefore, updating only the tx power limit does not result with an event
-    // which should trigger the agent to send the operating channel report
-    // with the new tx power, thus failing certification onboarding test 4.2.1.
-    // As a temporary workaround, always send the operating channel report regardless
-    // of the tx power setting.
-    // TODO - Fix as part of https://github.com/prplfoundation/prplMesh/issues/725
-    if (!switch_required) {
-        LOG(INFO) << "Channel switch not required, sending operating channel report";
+    // Normally, when a channel switch is required, a CSA notification
+    // will be received with the new channel setting which is when
+    // the agent will send the operating channel report.
+    // In case of only a tx power limit change, there will still be
+    // a CSA notification which will hold the new power limit and also
+    // trigger sending the operating channel report.
+    // If neither channel switch nor power limit change is required,
+    // we need to explicitly send the event.
+    if (!switch_required && !power_limit_received) {
+        LOG(DEBUG) << "Channel switch not required, sending operating channel report";
         send_operating_channel_report();
-        if (!power_limit_received) {
-            LOG(INFO) << "No power limit received - nothing else to do";
-            return true;
-        }
+        return true;
     }
 
     auto request_out = message_com::create_vs_message<

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -83,7 +83,7 @@ public:
         beerocks::eWiFiBandwidth bw;
         beerocks::eWiFiAntNum ant_num;
         int ant_gain;
-        int conducted_power;
+        int tx_power;
     } sPhyApParams;
 
     typedef struct {

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -205,7 +205,7 @@ wireless_utils::estimate_ul_params(int ul_rssi, uint16_t sta_phy_tx_rate_100kb,
 int wireless_utils::estimate_dl_rssi(int ul_rssi, int tx_power, const sPhyApParams &ap_params)
 {
     int eirp_sta   = tx_power;
-    int eirp_ap    = ap_params.ant_gain + ap_params.conducted_power;
+    int eirp_ap    = ap_params.ant_gain + ap_params.tx_power;
     int ant_factor = ANT_FACTOR_2X2;
     float pathloss;
     int dl_rssi;

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -327,7 +327,8 @@ bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {
-    LOG(TRACE) << __func__ << " power limit: " << tx_pow_limit;
+    LOG(TRACE) << __func__ << " setting power limit: " << tx_pow_limit * 100 << " mBm";
+    m_radio_info.conducted_power = tx_pow_limit * 100;
     return true;
 }
 

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -328,7 +328,7 @@ bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {
     LOG(TRACE) << __func__ << " setting power limit: " << tx_pow_limit * 100 << " mBm";
-    m_radio_info.conducted_power = tx_pow_limit * 100;
+    m_radio_info.tx_power = tx_pow_limit * 100;
     return true;
 }
 

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
@@ -48,4 +48,10 @@ bool nl80211_client_dummy::get_sta_info(const std::string &local_interface_name,
     return true;
 }
 
+bool nl80211_client_dummy::set_tx_power_limit(const std::string &local_interface_name,
+                                              uint32_t limit)
+{
+    return true;
+}
+
 } // namespace bwl

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.h
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.h
@@ -44,6 +44,18 @@ public:
      */
     virtual bool get_sta_info(const std::string &local_interface_name,
                               const sMacAddr &sta_mac_address, sStaInfo &sta_info) override;
+
+    /**
+     * @brief Set the tx power limit
+     *
+     * Set tx power limit for a radio
+     *
+     * @param[in] local_interface_name radio interface name.
+     * @param[in] limit tx power limit in dBM to set 
+     * @return true success and false otherwise
+     */
+    virtual bool set_tx_power_limit(const std::string &local_interface_name,
+                                    uint32_t limit) override;
 };
 
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1590,8 +1590,7 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
 
 bool ap_wlan_hal_dwpal::set_tx_power_limit(int tx_pow_limit)
 {
-    LOG(DEBUG) << "set_tx_power_limit(): missing function implementation";
-    return true;
+    return m_nl80211_client->set_tx_power_limit(m_radio_info.iface_name, tx_pow_limit);
 }
 
 bool ap_wlan_hal_dwpal::set_vap_enable(const std::string &iface_name, const bool enable)

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -12,6 +12,7 @@
 #include <bcl/beerocks_utils.h>
 #include <bcl/network/network_utils.h>
 #include <bcl/son/son_wireless_utils.h>
+#include <bwl/nl80211_client_factory.h>
 
 #include <easylogging++.h>
 
@@ -76,8 +77,10 @@ std::ostream &operator<<(std::ostream &out, const dwpal_fsm_event &value)
 base_wlan_hal_dwpal::base_wlan_hal_dwpal(HALType type, std::string iface_name,
                                          hal_event_cb_t callback, hal_conf_t hal_conf)
     : base_wlan_hal(type, iface_name, IfaceType::Intel, callback, hal_conf),
-      beerocks::beerocks_fsm<dwpal_fsm_state, dwpal_fsm_event>(dwpal_fsm_state::Delay)
+      beerocks::beerocks_fsm<dwpal_fsm_state, dwpal_fsm_event>(dwpal_fsm_state::Delay),
+      m_nl80211_client(nl80211_client_factory::create_instance())
 {
+    LOG_IF(!m_nl80211_client, FATAL) << "Failed to create nl80211_client instance";
     // Initialize the FSM
     fsm_setup();
 }

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -735,8 +735,7 @@ bool base_wlan_hal_dwpal::refresh_radio_info()
         size_t numOfValidArgs[7]      = {0};
         FieldsToParse fieldsToParse[] = {
             {(void *)&m_radio_info.ant_num, &numOfValidArgs[0], DWPAL_INT_PARAM, "TxAntennas=", 0},
-            {(void *)&m_radio_info.conducted_power, &numOfValidArgs[1], DWPAL_INT_PARAM,
-             "TxPower=", 0},
+            {(void *)&m_radio_info.tx_power, &numOfValidArgs[1], DWPAL_INT_PARAM, "TxPower=", 0},
             {(void *)&m_radio_info.bandwidth, &numOfValidArgs[2], DWPAL_INT_PARAM,
              "OperatingChannelBandwidt=", 0},
             {(void *)&m_radio_info.vht_center_freq, &numOfValidArgs[3], DWPAL_INT_PARAM, "Cf1=", 0},
@@ -757,7 +756,7 @@ bool base_wlan_hal_dwpal::refresh_radio_info()
         /* TEMP: Traces... */
         // LOG(DEBUG) << "GET_RADIO_INFO reply=\n" << reply;
         // LOG(DEBUG) << "numOfValidArgs[0]= " << numOfValidArgs[0] << " ant_num= " << m_radio_info.ant_num;
-        // LOG(DEBUG) << "numOfValidArgs[1]= " << numOfValidArgs[1] << " conducted_power= " << m_radio_info.conducted_power;
+        // LOG(DEBUG) << "numOfValidArgs[1]= " << numOfValidArgs[1] << " tx_power= " << m_radio_info.tx_power;
         // LOG(DEBUG) << "numOfValidArgs[2]= " << numOfValidArgs[2] << " bandwidth= " << m_radio_info.bandwidth;
         // LOG(DEBUG) << "numOfValidArgs[3]= " << numOfValidArgs[3] << " vht_center_freq= " << m_radio_info.vht_center_freq;
         // LOG(DEBUG) << "numOfValidArgs[4]= " << numOfValidArgs[4] << " wifi_ctrl_enabled= " << m_radio_info.wifi_ctrl_enabled;

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -10,6 +10,7 @@
 #define _BWL_BASE_WLAN_HAL_DWPAL_H_
 
 #include <bwl/base_wlan_hal.h>
+#include <bwl/nl80211_client.h>
 
 #include <bcl/beerocks_state_machine.h>
 
@@ -87,6 +88,8 @@ protected:
                           size_t vendor_data_size);
     bool dwpal_nl_cmd_scan_dump();
     void *get_dwpal_nl_ctx() const { return (m_dwpal_nl_ctx); }
+
+    std::unique_ptr<nl80211_client> m_nl80211_client;
 
     // Private data-members:
 private:

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -88,7 +88,7 @@ struct RadioInfo {
     int vht_center_freq             = 0;
     bool is_dfs_channel             = false;
     int ant_num                     = 0;
-    int conducted_power             = 0;
+    int tx_power                    = 0;
     ChanSwReason last_csa_sw_reason = ChanSwReason::Unknown;
     std::vector<WiFiChannel> supported_channels;
     std::unordered_map<int, VAPElement> available_vaps; // key = vap_id

--- a/common/beerocks/bwl/include/bwl/nl80211_client.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client.h
@@ -72,6 +72,16 @@ public:
      */
     virtual bool get_sta_info(const std::string &local_interface_name,
                               const sMacAddr &sta_mac_address, sStaInfo &sta_info) = 0;
+    /**
+     * @brief Set the tx power limit
+     *
+     * Set tx power limit for a radio
+     *
+     * @param[in] local_interface_name radio interface name.
+     * @param[in] limit tx power limit in dBM to set 
+     * @return true success and false otherwise
+     */
+    virtual bool set_tx_power_limit(const std::string &local_interface_name, uint32_t limit) = 0;
 
     // TODO: add remaining methods
 };

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -572,8 +572,7 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
 
 bool ap_wlan_hal_nl80211::set_tx_power_limit(int tx_pow_limit)
 {
-    LOG(TRACE) << __func__ << " - NOT IMPLEMENTED!";
-    return true;
+    return m_nl80211_client->set_tx_power_limit(m_radio_info.iface_name, tx_pow_limit);
 }
 
 bool ap_wlan_hal_nl80211::set_vap_enable(const std::string &iface_name, const bool enable)

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -12,6 +12,7 @@
 #include <bcl/beerocks_utils.h>
 #include <bcl/network/network_utils.h>
 #include <bcl/son/son_wireless_utils.h>
+#include <bwl/nl80211_client_factory.h>
 
 #include <easylogging++.h>
 
@@ -204,8 +205,10 @@ base_wlan_hal_nl80211::base_wlan_hal_nl80211(HALType type, std::string iface_nam
                                              hal_conf_t hal_conf)
     : base_wlan_hal(type, iface_name, IfaceType::Intel, callback, hal_conf),
       beerocks::beerocks_fsm<nl80211_fsm_state, nl80211_fsm_event>(nl80211_fsm_state::Delay),
+      m_nl80211_client(nl80211_client_factory::create_instance()),
       m_wpa_ctrl_buffer_size(wpa_ctrl_buffer_size)
 {
+    LOG_IF(!m_nl80211_client, FATAL) << "Failed to create nl80211_client instance";
     // Allocate wpa_ctrl buffer
     if (m_wpa_ctrl_buffer_size) {
         m_wpa_ctrl_buffer = std::shared_ptr<char>(new char[m_wpa_ctrl_buffer_size], [](char *obj) {

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -658,8 +658,8 @@ bool base_wlan_hal_nl80211::refresh_radio_info()
     } else {
 
         // Unavailable
-        m_radio_info.ant_num         = 0;
-        m_radio_info.conducted_power = 0;
+        m_radio_info.ant_num  = 0;
+        m_radio_info.tx_power = 0;
 
         int ieee80211ac = beerocks::string_utils::stoi(reply["ieee80211ac"]);
 

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.h
@@ -10,6 +10,7 @@
 #define _BWL_BASE_WLAN_HAL_NL80211_H_
 
 #include <bwl/base_wlan_hal.h>
+#include <bwl/nl80211_client.h>
 
 #include <bcl/beerocks_state_machine.h>
 
@@ -78,6 +79,8 @@ protected:
     bool send_nl80211_msg(uint8_t command, int flags,
                           std::function<bool(struct nl_msg *msg)> msg_create,
                           std::function<bool(struct nl_msg *msg)> msg_handle);
+
+    std::unique_ptr<nl80211_client> m_nl80211_client;
 
     // Private data-members:
 private:

--- a/common/beerocks/bwl/shared/nl80211_client_impl.cpp
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.cpp
@@ -193,8 +193,8 @@ bool nl80211_client_impl::set_tx_power_limit(const std::string &local_interface_
     // Get the interface index for given interface name
     int iface_index = if_nametoindex(local_interface_name.c_str());
     if (0 == iface_index) {
-        LOG(ERROR) << "Failed to read the index of interface '" << local_interface_name << "': "
-                   << strerror(errno);
+        LOG(ERROR) << "Failed to read the index of interface '" << local_interface_name
+                   << "': " << strerror(errno);
 
         return false;
     }

--- a/common/beerocks/bwl/shared/nl80211_client_impl.cpp
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.cpp
@@ -193,7 +193,7 @@ bool nl80211_client_impl::set_tx_power_limit(const std::string &local_interface_
     // Get the interface index for given interface name
     int iface_index = if_nametoindex(local_interface_name.c_str());
     if (0 == iface_index) {
-        LOG(ERROR) << "Failed to read the index of interface " << local_interface_name << ": "
+        LOG(ERROR) << "Failed to read the index of interface '" << local_interface_name << "': "
                    << strerror(errno);
 
         return false;

--- a/common/beerocks/bwl/shared/nl80211_client_impl.h
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.h
@@ -57,6 +57,18 @@ public:
     virtual bool get_sta_info(const std::string &local_interface_name,
                               const sMacAddr &sta_mac_address, sStaInfo &sta_info) override;
 
+    /**
+     * @brief Set the tx power limit
+     *
+     * Set tx power limit for a radio
+     *
+     * @param[in] local_interface_name radio interface name.
+     * @param[in] limit tx power limit in dBM to set 
+     * @return true success and false otherwise
+     */
+    virtual bool set_tx_power_limit(const std::string &local_interface_name,
+                                    uint32_t limit) override;
+
 private:
     /**
      * NL80211 socket to send messages and receive responses to/from the WiFi driver.

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -368,7 +368,7 @@ typedef struct sNodeHostap {
     uint8_t iface_is_5ghz;
     uint8_t ant_num;
     uint8_t ant_gain;
-    uint8_t conducted_power;
+    uint8_t tx_power;
     char driver_version[beerocks::message::WIFI_DRIVER_VER_LENGTH];
     beerocks::message::sWifiChannel supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
     void struct_swap(){

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -264,7 +264,7 @@ sNodeHostap:
   iface_is_5ghz: uint8_t
   ant_num: uint8_t 
   ant_gain: uint8_t 
-  conducted_power: uint8_t 
+  tx_power: uint8_t 
   driver_version:
     _type: char  
     _length: [ "beerocks::message::WIFI_DRIVER_VER_LENGTH" ]

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1137,7 +1137,7 @@ int db::get_hostap_ant_gain(std::string mac)
     return n->hostap->ant_gain;
 }
 
-bool db::set_hostap_conducted_power(std::string mac, int conducted_power)
+bool db::set_hostap_tx_power(std::string mac, int tx_power)
 {
     auto n = get_node(mac);
     if (!n) {
@@ -1147,11 +1147,11 @@ bool db::set_hostap_conducted_power(std::string mac, int conducted_power)
         LOG(WARNING) << __FUNCTION__ << "node " << mac << " is not a valid hostap!";
         return false;
     }
-    n->hostap->conducted_power = conducted_power;
+    n->hostap->tx_power = tx_power;
     return true;
 }
 
-int db::get_hostap_conducted_power(std::string mac)
+int db::get_hostap_tx_power(std::string mac)
 {
     auto n = get_node(mac);
     if (!n) {
@@ -1161,7 +1161,7 @@ int db::get_hostap_conducted_power(std::string mac)
         LOG(WARNING) << __FUNCTION__ << "node " << mac << " is not a valid hostap!";
         return -1;
     }
-    return n->hostap->conducted_power;
+    return n->hostap->tx_power;
 }
 
 bool db::set_hostap_supported_channels(std::string mac, beerocks::message::sWifiChannel *channels,

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -290,8 +290,8 @@ public:
     bool set_hostap_ant_gain(std::string mac, int ant_gain);
     int get_hostap_ant_gain(std::string mac);
 
-    bool set_hostap_conducted_power(std::string mac, int conducted_power);
-    int get_hostap_conducted_power(std::string mac);
+    bool set_hostap_tx_power(std::string mac, int tx_power);
+    int get_hostap_tx_power(std::string mac);
 
     bool set_hostap_supported_channels(std::string mac,
                                        beerocks::message::sWifiChannel *supported_channels,

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -148,7 +148,7 @@ std::ostream &operator<<(std::ostream &os, const node &n)
             }
         }
         os << " AntGain: " << int(n.hostap->ant_gain) << std::endl
-           << " ConductedPower: " << int(n.hostap->conducted_power) << std::endl
+           << " ConductedPower: " << int(n.hostap->tx_power) << std::endl
            << " AntNum: " << int(n.capabilities.ant_num) << std::endl
            << " Statistics:" << std::endl
            << "   LastUpdate: "

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -149,7 +149,7 @@ public:
         std::vector<beerocks::message::sWifiChannel> supported_channels;
         uint8_t operating_class    = 0;
         int ant_gain               = 0;
-        int conducted_power        = 0;
+        int tx_power               = 0;
         bool exclude_from_steering = false;
         std::string ssid;
         beerocks::eRadioBandCapability capability = beerocks::SUBBAND_CAPABILITY_UNKNOWN;

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1973,7 +1973,7 @@ bool master_thread::handle_intel_slave_join(
               << "    ant_num=" << int(notification->hostap().ant_num)
               << " ant_gain=" << int(notification->hostap().ant_gain)
               << " channel=" << int(notification->cs_params().channel)
-              << " conducted=" << int(notification->hostap().conducted_power) << std::endl
+              << " conducted=" << int(notification->hostap().tx_power) << std::endl
               << "    radio_mac=" << radio_mac << std::endl;
 
     bool local_master = (bool)notification->platform_settings().local_master;
@@ -2055,7 +2055,7 @@ bool master_thread::handle_intel_slave_join(
 
     database.set_hostap_ant_num(radio_mac, (beerocks::eWiFiAntNum)notification->hostap().ant_num);
     database.set_hostap_ant_gain(radio_mac, notification->hostap().ant_gain);
-    database.set_hostap_conducted_power(radio_mac, notification->hostap().conducted_power);
+    database.set_hostap_tx_power(radio_mac, notification->hostap().tx_power);
 
     database.set_node_name(radio_mac, slave_name + "_AP");
     database.set_node_ipv4(radio_mac, bridge_ipv4);
@@ -2343,10 +2343,10 @@ bool master_thread::handle_non_intel_slave_join(
     database.set_hostap_iface_type(radio_mac, IFACE_TYPE_WIFI_UNSPECIFIED);
 
     // TODO number of antennas comes from HT/VHT capabilities (implicit from NxM)
-    // TODO ant_gain and conducted_power will not be set
+    // TODO ant_gain and tx_power will not be set
     database.set_hostap_ant_num(radio_mac, beerocks::eWiFiAntNum::ANT_NONE);
     database.set_hostap_ant_gain(radio_mac, 0);
-    database.set_hostap_conducted_power(radio_mac, 0);
+    database.set_hostap_tx_power(radio_mac, 0);
     database.set_hostap_active(radio_mac, true);
     database.set_node_name(radio_mac, manufacturer + "_AP");
     database.set_node_manufacturer(radio_mac, manufacturer);

--- a/controller/src/beerocks/master/tasks/load_balancer_task.cpp
+++ b/controller/src/beerocks/master/tasks/load_balancer_task.cpp
@@ -300,10 +300,10 @@ void load_balancer_task::work()
                 continue;
             }
 
-            hostap_params.bw              = database.get_node_bw(hostap);
-            hostap_params.ant_num         = database.get_hostap_ant_num(hostap);
-            hostap_params.ant_gain        = database.get_hostap_ant_gain(hostap);
-            hostap_params.conducted_power = database.get_hostap_conducted_power(hostap);
+            hostap_params.bw       = database.get_node_bw(hostap);
+            hostap_params.ant_num  = database.get_hostap_ant_num(hostap);
+            hostap_params.ant_gain = database.get_hostap_ant_gain(hostap);
+            hostap_params.tx_power = database.get_hostap_tx_power(hostap);
 
             int ul_rssi;
             //int estimated_ul_rssi, hostap_dl_rssi = beerocks::RSSI_INVALID;
@@ -373,7 +373,7 @@ void load_balancer_task::work()
                     // son::wireless_utils::calculate_basic_phy_rate_100kb(database.get_node_max_supported_phy_rate_100kb(chosen_client),
                     //         database.get_hostap_ant_num(hostap),
                     //         database.get_hostap_ant_gain(hostap), 
-                    //         database.get_hostap_conducted_power(hostap), 
+                    //         database.get_hostap_tx_power(hostap), 
                     //         database.get_rssi_rx_measurement(chosen_client, hostap), 
                     //         database.get_node_rx_phy_rate_100kb(chosen_client),
                     //         sta_is_5ghz,

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -461,11 +461,11 @@ void optimal_path_task::work()
                     TASK_LOG(DEBUG) << "sta_phy_tx_rate_100kb=" << int(sta_phy_tx_rate_100kb);
 
                     son::wireless_utils::sPhyApParams hostap_params;
-                    hostap_params.is_5ghz         = hostap_is_5ghz;
-                    hostap_params.bw              = hostap_bw;
-                    hostap_params.ant_num         = database.get_hostap_ant_num(hostap);
-                    hostap_params.ant_gain        = database.get_hostap_ant_gain(hostap);
-                    hostap_params.conducted_power = database.get_hostap_conducted_power(hostap);
+                    hostap_params.is_5ghz  = hostap_is_5ghz;
+                    hostap_params.bw       = hostap_bw;
+                    hostap_params.ant_num  = database.get_hostap_ant_num(hostap);
+                    hostap_params.ant_gain = database.get_hostap_ant_gain(hostap);
+                    hostap_params.tx_power = database.get_hostap_tx_power(hostap);
 
                     current_ul_params = son::wireless_utils::estimate_ul_params(
                         rx_rssi, sta_phy_tx_rate_100kb, sta_capabilities, hostap_params.bw,
@@ -544,11 +544,11 @@ void optimal_path_task::work()
                     TASK_LOG(DEBUG) << "sta_phy_tx_rate_100kb=" << int(sta_phy_tx_rate_100kb);
 
                     son::wireless_utils::sPhyApParams hostap_params;
-                    hostap_params.is_5ghz         = database.is_node_5ghz(hostap);
-                    hostap_params.bw              = database.get_node_bw(hostap);
-                    hostap_params.ant_num         = database.get_hostap_ant_num(hostap);
-                    hostap_params.ant_gain        = database.get_hostap_ant_gain(hostap);
-                    hostap_params.conducted_power = database.get_hostap_conducted_power(hostap);
+                    hostap_params.is_5ghz  = database.is_node_5ghz(hostap);
+                    hostap_params.bw       = database.get_node_bw(hostap);
+                    hostap_params.ant_num  = database.get_hostap_ant_num(hostap);
+                    hostap_params.ant_gain = database.get_hostap_ant_gain(hostap);
+                    hostap_params.tx_power = database.get_hostap_tx_power(hostap);
 
                     sta_capabilities =
                         database.get_station_capabilities(sta_mac, hostap_params.is_5ghz);
@@ -939,10 +939,10 @@ void optimal_path_task::work()
                             << " ht_bw=" << int(sta_capabilities->ht_bw)
                             << " vht_bw=" << int(sta_capabilities->vht_bw);
 
-            hostap_params.bw              = database.get_node_bw(hostap);
-            hostap_params.ant_num         = database.get_hostap_ant_num(hostap);
-            hostap_params.ant_gain        = database.get_hostap_ant_gain(hostap);
-            hostap_params.conducted_power = database.get_hostap_conducted_power(hostap);
+            hostap_params.bw       = database.get_node_bw(hostap);
+            hostap_params.ant_num  = database.get_hostap_ant_num(hostap);
+            hostap_params.ant_gain = database.get_hostap_ant_gain(hostap);
+            hostap_params.tx_power = database.get_hostap_tx_power(hostap);
 
             if (!hostap_sibling) {
                 int8_t rx_rssi, rx_packets;


### PR DESCRIPTION
Some EasyMesh flows require setting tx power limit, which is not
supported via hostapd (tx_power is readable via radio_info command),
Add set_tx_power_limit() API to the nl80211 client implementation which
uses NL80211_CMD_SET_WIPHY to set the limit.

Currently doesn't work since set tx power is not supported by the driver, but this can be merged since we get the same status as when doing this with `iw` - so marking as ready for review.
**Tested on AXEPOINT3000 (UGW) and everything works as expected.**

Since this PR changes some channel selection handling, triggered gitlan CI pipeline to verify nothing broke, which tests the following tests and verifies autoconfig, onboarding and channel selection:
```
MAP-4.2.1
MAP-4.5.2_ETH_FH5GL
MAP-4.5.3_ETH_FH5GL
MAP-4.5.3_ETH_FH5GH
```
https://gitlab.com/prpl-foundation/prplMesh/pipelines/128634565

Fixes #983
 
Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>