### PR TITLE
controller: task: simplify event_received

### DIFF
--- a/controller/src/beerocks/master/tasks/task.cpp
+++ b/controller/src/beerocks/master/tasks/task.cpp
@@ -45,14 +45,11 @@ void task::response_received(std::string mac,
 
 void task::event_received(int event_type, void *obj)
 {
-    auto range = pending_events.equal_range(event_type);
-    for (auto it = range.first; it != range.second;) {
-        if (*it == event_type) {
-            it = pending_events.erase(it);
-            break;
-        } else {
-            it++;
-        }
+    auto it = pending_events.find(event_type);
+    if (it == pending_events.end()) {
+        TASK_LOG(DEBUG) << "received non-pending event " << event_type;
+    } else {
+        pending_events.erase(it);
     }
 
     handle_event(event_type, obj);


### PR DESCRIPTION
event_received() removes the incoming event from pending_events and then
calls the pure virtual handle_event() callback. However, the way the
incoming event is removed is more than a little weird:
- first a range is created over all pending events of that type;
- we iterate over the range but break at the first iteration;
- we only erase it if the iterator matches event_type, but since the
range is already matching event_type, this will always be true.

So simplify this logic by using find() instead.

While we're at it, log a message if an event received that was not
pending - it's either an unexpected event, or it should have been added
to pending_events.

This PR was previously #658, but that was closed without a way of reopening it so I had to make a new PR.