### PR TITLE
tools: clang-format: run only on tracked files

### DIFF
--- a/clang-format.sh
+++ b/clang-format.sh
@@ -1,5 +1,6 @@
 #! /bin/sh
-cd ${0%/*}
+# cd to the script directory:
+cd "${0%/*}" || { echo "Couldn't cd to ${0%/*}!"; exit 1; }
 CLANG_FORMAT="clang-format"
 if ! [ -x "$(command -v ${CLANG_FORMAT})" ]; then
   echo "{$CLANG_FORMAT} not found. skipping..."
@@ -14,6 +15,4 @@ else
     filter="grep ."
 fi
 
-find */ -type f -name \*.[ch] -o -name \*.[ch]pp -o -name *.cc | \
-    $filter | \
-    xargs clang-format -i -style=file
+git ls-files -- '*.c' '*.cpp' '*.h' '*.hpp' '*.cc' | $filter | xargs clang-format -i -style=file


### PR DESCRIPTION
This one has been bugging me for so long that I finally decided to look at it.
There is a bug in clang-format, but it only occurs on a specific generated file.

This PR makes clang-format run on tracked files only.

---

When running clang-format (both in docker and natively), it would
segfault under certain circumstances which made it impossible to run
it locally (it never failed this way in CI).

After a short investigation, it turns out it would always segfault on
the same (generated) file:
CMakeFiles/3.15.5/CompilerIdC/CMakeCCompilerId.c

We could adapt the find command used in the top-level clang-format to
exclude CMakeFiles directories. However, it would still potentially
run on many other generated files, while we're really only interested
in formatting the files we track with git.

Use git-ls-files to get the list of tracked files, filter it to keep
only the file extensions we're interested in, and run clang-format on
them.

Since the prplmesh-runner image does not include git, we have to adapt
tools/docker/clang-format.sh to run with the prplmesh-builder
image. Note that the clang-format job that runs in CI was already
using the prplmesh-builder image.

While we're at it, fix shellcheck issues in both clang-format.sh
scripts.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>