### PR TITLE
controller: son_management: check single scan in progress

### DIFF
--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -2071,6 +2071,18 @@ void son_management::handle_bml_message(Socket *sd,
             LOG(ERROR) << "Failed building message cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE !";
             return;
         }
+
+        // Get single scan status
+        auto single_scan_in_progress =
+            database.get_channel_scan_in_progress(request->scan_params().radio_mac, true);
+        if (single_scan_in_progress) {
+            LOG(ERROR) << "Single scan is still running!";
+            response->op_error_code() =
+                uint8_t(eChannelScanOpErrCode::CHANNEL_SCAN_OP_SCAN_IN_PROGRESS);
+            message_com::send_cmdu(sd, cmdu_tx);
+            break;
+        }
+
         auto radio_mac         = request->scan_params().radio_mac;
         auto dwell_time_ms     = request->scan_params().dwell_time_ms;
         auto channel_pool_size = request->scan_params().channel_pool_size;


### PR DESCRIPTION
The son_management is responsible to send a
`dynamic_channel_selection_task::eEvent::TRIGGER_SINGLE_SCAN` request to
the Dynamic Channel Selection task, when a
`beerocks_message::cACTION_BML_CHANNEL_SCAN_START_SCAN_REQUEST` event
is received.
Before triggering the request, the son_management must verify that a
a scan is not in progress since the task supports one single-scan
request at a time.
The above-mentioned check is not performed and the scan parameters of
the already triggered single-scan can be overridden.

Added a check of single-scan in progress. If a scan is in progress a
`CHANNEL_SCAN_OP_SCAN_IN_PROGRESS` error code is returned and the scan request is not passed to the task.

Fixes #990 

Signed-off-by: Adam Dov <adamx.dov@intel.com>