### PR TITLE
Hotfix/dynamic channel selection task: increase timeout

### DIFF
--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -12,8 +12,8 @@
 #include <bcl/network/network_utils.h>
 #include <easylogging++.h>
 
-#define SCAN_TRIGGERED_WAIT_TIME_MSEC 20000
-#define SCAN_RESULTS_DUMP_WAIT_TIME_MSEC 40000
+#define SCAN_TRIGGERED_WAIT_TIME_MSEC 20000     //20 Sec
+#define SCAN_RESULTS_DUMP_WAIT_TIME_MSEC 210000 //3.5 Min
 
 std::string s_ar_states[] = {FOREACH_DCS_STATE(GENERATE_STRING)};
 std::string s_ar_events[] = {FOREACH_DCS_EVENT(GENERATE_STRING)};


### PR DESCRIPTION
In the Dynamic Channel Selection (DCS) task, the task reads the channel
pool avaliable for the current radio (and scan type) then sents that
pool the the monitor to trigger a channel scan.
The task then waits for events sent from the monitor and acts
accordingly.

If the sent pool is very large and/or contains DFS channels the task
might read the abnormaly losg wait time as too long thus resultig in
a "CHANNEL_SCAN_RESULTS_READY_EVENT_TIMEOUT" or a similer timeout
event\status, even if the scan eventually finishes.

Issue: #992 