### PR TITLE
Hotfix/fix reconnect of son slave on topology flow

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1725,18 +1725,6 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
             }
         }
 
-        if (m_eFSMState >= EState::CONNECT_TO_MASTER) {
-            LOG(INFO) << "Sending topology notification on reconnected son_slave";
-            auto cmdu_header =
-                cmdu_tx.create(0, ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE);
-            if (!cmdu_header) {
-                LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
-                return false;
-            }
-            cmdu_header->flags().relay_indicator = true;
-            return send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
-        }
-
         LOG(DEBUG) << "ACTION_BACKHAUL_REGISTER_REQUEST sta_iface=" << soc->sta_iface
                    << " local_master=" << int(local_master) << " local_gw=" << int(local_gw)
                    << " hostap_iface=" << soc->hostap_iface;
@@ -1783,6 +1771,18 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
         LOG(DEBUG) << "ACTION_BACKHAUL_ENABLE hostap_iface=" << soc->hostap_iface
                    << " sta_iface=" << soc->sta_iface << " mac=" << mac
                    << " is_5ghz=" << int(request->iface_is_5ghz());
+
+        if (m_eFSMState >= EState::CONNECT_TO_MASTER) {
+            LOG(INFO) << "Sending topology notification on reconnected son_slave";
+            auto cmdu_header =
+                cmdu_tx.create(0, ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE);
+            if (!cmdu_header) {
+                LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
+                return false;
+            }
+            cmdu_header->flags().relay_indicator = true;
+            send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+        }
 
         // If we're already connected, send a notification to the slave
         if (FSM_IS_IN_STATE(OPERATIONAL)) {

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2323,13 +2323,13 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
         if (!fill_radio_iface_info(true)) {
             LOG(DEBUG) << "filling interface information on radio=" << soc->radio_mac
                        << " has failed!";
-            return false;
+            return true;
         }
 
         if (!fill_radio_iface_info(false)) {
             LOG(DEBUG) << "filling interface information on radio=" << soc->radio_mac
                        << " backhaul has failed!";
-            return false;
+            return true;
         }
     }
 


### PR DESCRIPTION
When a son_slave reconnects to the backhaul manager after it disconnection, the Backhaul Manager
sends topology notification that results in getting Topology Query message.
Filling the device information on the Topology Response message might fail because of
a race condition. The radio_mac and the freq_type are being updated on the BACKHAUL_ENABLE message,
but we trigger the Topology notification on BACKHAUL REGISTER message, so if the Topology Query
message would get before getting the BACKHAUL ENABLE, the filling of the device information
will fail.

Moved the sending of the Topology Notification from BACKHAUL REGISTER to BACKHAUL ENABLE.

Created a pipeline that checks the following: 
```
MAP-4.2.1
MAP-4.3.1_ETH
MAP-4.3.2_ETH_FH24G
MAP-4.3.2_ETH_FH5GL
MAP-4.3.2_ETH_FH5GH
```

https://gitlab.com/prpl-foundation/prplMesh/pipelines/128752410