### PR TITLE
.gitlab-ci.yml: cppcheck: run on the framework folder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ cppcheck:
   script:
     # cppcheck runs in the alpine image because every new release brings useful improvements
     # (the versions from Ubuntu get old too quickly)
-    - tools/docker/static-analysis/cppcheck.sh common
+    - tools/docker/static-analysis/cppcheck.sh common framework
   artifacts:
     paths:
       - cppcheck_results.txt


### PR DESCRIPTION
This commit was mistakenly dropped when reworking https://github.com/prplfoundation/prplMesh/pull/959 .

---

Now that every issue of severity warning or error has been solved for
the framework folder, we can run on it in CI.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>