### PR TITLE
CI: run flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length=100

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,14 @@ cppcheck:
   tags:
     - docker
 
+flake8:
+  stage: build
+  image: pipelinecomponents/flake8:f087c4c
+  variables:
+      FLAKE8_FILES: "tests/capi.py"
+  script:
+    - flake8 --verbose $FLAKE8_FILES
+
 clang-format:
   extends: .in-prplmesh-builder
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,13 @@ flake8:
   script:
     - flake8 --verbose $FLAKE8_FILES
 
+flake8-diff:
+  stage: build
+  image: pipelinecomponents/flake8:f087c4c
+  script:
+    - apk add --update --no-cache git
+    - git diff -U0 origin/master | flake8 --verbose --diff
+
 clang-format:
   extends: .in-prplmesh-builder
   stage: build


### PR DESCRIPTION
We want to validate PEP8 compliance in CI.
Since we currently have one file (tests/capi.py) that actually passes flake8, add a CI job for that one file.
More can be added once they start passing flake8 as well.