### PR TITLE
use validity period in client disallow

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -693,6 +693,17 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
         std::string sta_mac = network_utils::mac_to_string(request->mac());
         std::string bssid   = network_utils::mac_to_string(request->bssid());
+
+        const auto &vap_unordered_map = ap_wlan_hal->get_radio_info().available_vaps;
+        auto it = std::find_if(vap_unordered_map.begin(), vap_unordered_map.end(),
+                               [&](const std::pair<int, bwl::VAPElement> &element) {
+                                   return element.second.mac == bssid;
+                               });
+
+        if (it == vap_unordered_map.end()) {
+            //AP does not have the requested vap, probably will be handled on the other AP
+            return true;
+        }
         LOG(DEBUG) << "CLIENT_DISALLOW: mac = " << sta_mac << ", bssid = " << bssid;
 
         ap_wlan_hal->sta_deny(sta_mac, bssid);
@@ -708,6 +719,18 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
         std::string sta_mac = network_utils::mac_to_string(request->mac());
         std::string bssid   = network_utils::mac_to_string(request->bssid());
+
+        const auto &vap_unordered_map = ap_wlan_hal->get_radio_info().available_vaps;
+        auto it = std::find_if(vap_unordered_map.begin(), vap_unordered_map.end(),
+                               [&](const std::pair<int, bwl::VAPElement> &element) {
+                                   return element.second.mac == bssid;
+                               });
+
+        if (it == vap_unordered_map.end()) {
+            //AP does not have the requested vap, probably will be handled on the other AP
+            return true;
+        }
+
         LOG(DEBUG) << "CLIENT_ALLOW: mac = " << sta_mac << ", bssid = " << bssid;
 
         ap_wlan_hal->sta_allow(sta_mac, bssid);

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1667,3 +1667,17 @@ void ap_manager_thread::send_steering_return_status(beerocks_message::eActionOp_
     }
     return;
 }
+
+void ap_manager_thread::remove_client_from_disallowed_list(const sMacAddr &mac,
+                                                           const sMacAddr &bssid)
+{
+    auto it = std::find_if(m_disallowed_clients.begin(), m_disallowed_clients.end(),
+                           [&](const son::ap_manager_thread::disallowed_client_t &element) {
+                               return ((element.mac == mac) && (element.bssid == bssid));
+                           });
+
+    if (it != m_disallowed_clients.end()) {
+        // remove client from the disallow list
+        m_disallowed_clients.erase(it);
+    }
+}

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -766,9 +766,11 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             return true;
         }
 
-        LOG(DEBUG) << "CLIENT_ALLOW: mac = " << sta_mac << ", bssid = " << bssid;
+        remove_client_from_disallowed_list(request->mac(), request->bssid());
 
+        LOG(DEBUG) << "CLIENT_ALLOW: mac = " << sta_mac << ", bssid = " << bssid;
         ap_wlan_hal->sta_allow(sta_mac, bssid);
+
         break;
     }
     case beerocks_message::ACTION_APMANAGER_READ_ACS_REPORT_REQUEST: {

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1681,3 +1681,18 @@ void ap_manager_thread::remove_client_from_disallowed_list(const sMacAddr &mac,
         m_disallowed_clients.erase(it);
     }
 }
+
+void ap_manager_thread::allow_expired_clients()
+{
+    // check if any client disallow period has expired and allow it.
+    for (auto it = m_disallowed_clients.begin(); it != m_disallowed_clients.end();) {
+        if (std::chrono::steady_clock::now() > it->timeout) {
+            LOG(DEBUG) << "CLIENT_ALLOW: mac = " << it->mac << ", bssid = " << it->bssid;
+            ap_wlan_hal->sta_allow(network_utils::mac_to_string(it->mac),
+                                   network_utils::mac_to_string(it->bssid));
+            m_disallowed_clients.erase(it);
+        } else {
+            it++;
+        }
+    }
+}

--- a/agent/src/beerocks/slave/ap_manager_thread.h
+++ b/agent/src/beerocks/slave/ap_manager_thread.h
@@ -47,6 +47,18 @@ public:
         eBackhaulVapType type;
     };
 
+    /**
+     * disallowed client parameters
+     * Used to save clients mac, bssid that the client is disallowed from and 
+     * validity period of time (blocking) 
+     * so we could unblock it when the period expires
+     */
+    struct disallowed_client_t {
+        sMacAddr mac;
+        sMacAddr bssid;
+        std::chrono::steady_clock::time_point timeout;
+    };
+
     enum eThreadErrors : uint32_t {
         APMANAGER_THREAD_ERROR_NO_ERROR            = 0,
         APMANAGER_THREAD_ERROR_HOSTAP_DISABLED     = 1,
@@ -82,6 +94,7 @@ private:
     bool low_filter;
     int bss_steer_valid_int;
     int bss_steer_imminent_valid_int;
+    std::vector<disallowed_client_t> m_disallowed_clients;
 
     std::list<backhaul_vap_list_element_t> backhaul_vaps_list;
 

--- a/agent/src/beerocks/slave/ap_manager_thread.h
+++ b/agent/src/beerocks/slave/ap_manager_thread.h
@@ -88,6 +88,7 @@ private:
     void send_steering_return_status(beerocks_message::eActionOp_APMANAGER ActionOp,
                                      int32_t status);
     void remove_client_from_disallowed_list(const sMacAddr &mac, const sMacAddr &bssid);
+    void allow_expired_clients();
 
     std::string slave_uds;
     uint8_t wifi_channel;

--- a/agent/src/beerocks/slave/ap_manager_thread.h
+++ b/agent/src/beerocks/slave/ap_manager_thread.h
@@ -87,6 +87,7 @@ private:
     void send_heartbeat();
     void send_steering_return_status(beerocks_message::eActionOp_APMANAGER ActionOp,
                                      int32_t status);
+    void remove_client_from_disallowed_list(const sMacAddr &mac, const sMacAddr &bssid);
 
     std::string slave_uds;
     uint8_t wifi_channel;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -4305,8 +4305,9 @@ bool slave_thread::handle_client_association_request(Socket *sd, ieee1905_1::Cmd
             return false;
         }
 
-        request_out->mac()   = sta_mac;
-        request_out->bssid() = bssid;
+        request_out->mac()                 = sta_mac;
+        request_out->bssid()               = bssid;
+        request_out->validity_period_sec() = association_control_request_tlv->validity_period_sec();
     }
 
     message_com::send_cmdu(ap_manager_socket, cmdu_tx);

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -625,6 +625,7 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
         }
         sMacAddr& mac();
         sMacAddr& bssid();
+        uint16_t& validity_period_sec();
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -634,6 +635,7 @@ class cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST : public BaseClass
         eActionOp_APMANAGER* m_action_op = nullptr;
         sMacAddr* m_mac = nullptr;
         sMacAddr* m_bssid = nullptr;
+        uint16_t* m_validity_period_sec = nullptr;
 };
 
 class cACTION_APMANAGER_CLIENT_ALLOW_REQUEST : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -2008,11 +2008,16 @@ sMacAddr& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::bssid() {
     return (sMacAddr&)(*m_bssid);
 }
 
+uint16_t& cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::validity_period_sec() {
+    return (uint16_t&)(*m_validity_period_sec);
+}
+
 void cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_mac->struct_swap();
     m_bssid->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_validity_period_sec));
 }
 
 bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::finalize()
@@ -2047,6 +2052,7 @@ size_t cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::get_initial_size()
     size_t class_size = 0;
     class_size += sizeof(sMacAddr); // mac
     class_size += sizeof(sMacAddr); // bssid
+    class_size += sizeof(uint16_t); // validity_period_sec
     return class_size;
 }
 
@@ -2068,6 +2074,11 @@ bool cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST::init()
         return false;
     }
     if (!m_parse__) { m_bssid->struct_init(); }
+    m_validity_period_sec = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
     if (m_parse__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -140,6 +140,7 @@ cACTION_APMANAGER_CLIENT_DISALLOW_REQUEST:
   _type: class
   mac: sMacAddr
   bssid: sMacAddr
+  validity_period_sec: uint16_t
 
 cACTION_APMANAGER_CLIENT_ALLOW_REQUEST:
   _type: class

--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -166,12 +166,6 @@ void son_actions::unblock_sta(db &database, ieee1905_1::CmduMessageTx &cmdu_tx, 
                 network_utils::mac_from_string(hostap_vap.second.mac);
             association_control_request_tlv->association_control() =
                 wfa_map::tlvClientAssociationControlRequest::UNBLOCK;
-            /*
-            According to section 11.6 in the Multi-AP Specification
-            The Validity Period field in a Client Association Control Request message 
-            with Association Control field set to 0x01 (Client Unblocking) is ignored
-            */
-            association_control_request_tlv->validity_period_sec() = 0;
             association_control_request_tlv->alloc_sta_list();
             auto sta_list         = association_control_request_tlv->sta_list(0);
             std::get<1>(sta_list) = network_utils::mac_from_string(sta_mac);

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -309,8 +309,6 @@ void son_management::handle_cli_message(Socket *sd,
             network_utils::mac_from_string(hostap_mac);
         association_control_request_tlv->association_control() =
             wfa_map::tlvClientAssociationControlRequest::UNBLOCK;
-        //TODO: Get real validity_period_sec
-        association_control_request_tlv->validity_period_sec() = 1;
         association_control_request_tlv->alloc_sta_list();
         auto sta_list         = association_control_request_tlv->sta_list(0);
         std::get<1>(sta_list) = network_utils::mac_from_string(client_mac);

--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -196,7 +196,9 @@ void client_steering_task::steer_sta()
             std::get<1>(sta_list_block) = network_utils::mac_from_string(sta_mac);
             son_actions::send_cmdu_to_agent(agent_mac, cmdu_tx, database, hostap);
             TASK_LOG(DEBUG) << "sending disallow request for " << sta_mac << " to bssid "
-                            << hostap_vap.second.mac << " id=" << int(id);
+                            << hostap_vap.second.mac << " with validity period = "
+                            << association_control_block_request_tlv->validity_period_sec()
+                            << "sec,  id=" << int(id);
 
             // update bml listeners
             bml_task::client_disallow_req_available_event client_disallow_event;

--- a/controller/src/beerocks/master/tasks/client_steering_task.cpp
+++ b/controller/src/beerocks/master/tasks/client_steering_task.cpp
@@ -274,6 +274,8 @@ void client_steering_task::handle_event(int event_type, void *obj)
             TASK_LOG(DEBUG) << "disassoc_imminent flag is true, proceeding as usual";
         } else {
             TASK_LOG(DEBUG) << "aborting task";
+            // need to remove client from blacklist ASAP and not wait until the disallow period ends.
+            son_actions::unblock_sta(database, cmdu_tx, sta_mac);
             finish();
         }
     } else if (event_type == BTM_REPORT_RECEIVED) {
@@ -288,7 +290,4 @@ void client_steering_task::handle_task_end()
         database.update_node_11v_responsiveness(sta_mac, false);
     }
     database.set_node_handoff_flag(sta_mac, false);
-    if (!steer_restricted) {
-        son_actions::unblock_sta(database, cmdu_tx, sta_mac);
-    }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
@@ -171,6 +171,7 @@ bool tlvClientAssociationControlRequest::init()
     }
     if(m_length && !m_parse__){ (*m_length) += sizeof(eAssociationControl); }
     m_validity_period_sec = (uint16_t*)m_buff_ptr__;
+    if (!m_parse__) *m_validity_period_sec = 0x0;
     if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
         return false;

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvClientAssociationControlRequest.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvClientAssociationControlRequest.yaml
@@ -11,7 +11,13 @@ tlvClientAssociationControlRequest:
   length: uint16_t
   bssid_to_block_client: sMacAddr
   association_control: eAssociationControl
-  validity_period_sec: uint16_t
+  validity_period_sec:
+    _type: uint16_t
+    # According to section 11.6 in the Multi-AP Specification
+    # The Validity Period field in a Client Association Control Request message 
+    # with Association Control field set to 0x01 (Client Unblocking) is ignored
+    # setting default to 0 for all cases
+    _value: 0
   sta_list_length:
     _type: uint8_t
     _length_var: True

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -917,6 +917,19 @@ class TestFlows:
         self.check_log(self.gateway, "controller", r"steering successful for sta {}".format(sta_mac))
         self.check_log(self.gateway, "controller", r"sta {} disconnected due to steering request".format(sta_mac))
 
+        # Make sure that all blocked agents send UNBLOCK messages at the end of
+        # disallow period (default 25 sec)
+        time.sleep(25)
+
+        debug("Confirming Client Association Control Request message was received (UNBLOCK)")
+        self.check_log(self.repeater1, "agent_wlan0", r"Got client allow request")
+
+        debug("Confirming Client Association Control Request message was received (UNBLOCK)")
+        self.check_log(self.repeater2, "agent_wlan0", r"Got client allow request")
+
+        debug("Confirming Client Association Control Request message was received (UNBLOCK)")
+        self.check_log(self.repeater2, "agent_wlan2", r"Got client allow request")
+
     def test_client_steering_policy(self):
         debug("Send client steering policy to agent 1")
         mid = self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8003,


### PR DESCRIPTION
check if validity period parameter is set in client_disallow message
then add it to the "disallowed client timeouts" list.
This list will be polled and when validity period is timed-out
CLIENT_ALLOW message will be sent to the bssid.

The unblocking in the client steering task FINALIZE state can
be removed since it is not really needed due to the validity period.
Unblocking will be triggered on in case client rejects the steering
request , since then there is no point of waiting till the end of the
period and we need to ALLOW all the client in all APs ASAP.

this commit will be split later on .

issue #445


Following test was performed:
platform: RDKB 
1. attach both 2 clients to 5G radio
2. steer client_1 to 2.4G radio
3. disallow client_1 from 5G message sent with validity period = 25 [sec] 
4. wait 5 sec
5. steer client_2  to 2.4G radio
6. disallow client_2 from 5G message sent with validity period = 25 [sec]

result:
->   t0: client_1 steered  successfully to 2.4G radio
->   t5: client_2 steered  successfully to 2.4G radio
-> t25: ALLOW client_1 on 5G message auto sent by the radio 
-> t30: ALLOW client_2 on 5G message auto sent by the radio 