### PR TITLE
Agent: Variable overflow in fill_cs_params

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -983,7 +983,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
 void ap_manager_thread::fill_cs_params(beerocks_message::sApChannelSwitch &params)
 {
-    params.tx_power  = (int8_t)ap_wlan_hal->get_radio_info().tx_power;
+    params.tx_power  = static_cast<int8_t>(ap_wlan_hal->get_radio_info().tx_power);
     params.channel   = ap_wlan_hal->get_radio_info().channel;
     params.bandwidth = uint8_t(
         beerocks::utils::convert_bandwidth_to_enum(ap_wlan_hal->get_radio_info().bandwidth));

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -983,7 +983,7 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
 
 void ap_manager_thread::fill_cs_params(beerocks_message::sApChannelSwitch &params)
 {
-    params.tx_power  = ap_wlan_hal->get_radio_info().tx_power;
+    params.tx_power  = (int8_t)ap_wlan_hal->get_radio_info().tx_power;
     params.channel   = ap_wlan_hal->get_radio_info().channel;
     params.bandwidth = uint8_t(
         beerocks::utils::convert_bandwidth_to_enum(ap_wlan_hal->get_radio_info().bandwidth));

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -327,8 +327,8 @@ bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {
-    LOG(TRACE) << __func__ << " setting power limit: " << tx_pow_limit * 100 << " mBm";
-    m_radio_info.tx_power = tx_pow_limit * 100;
+    LOG(TRACE) << __func__ << " setting power limit: " << tx_pow_limit;
+    m_radio_info.tx_power = tx_pow_limit;
     return true;
 }
 

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -327,7 +327,8 @@ bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {
-    LOG(TRACE) << __func__ << " setting power limit: " << tx_pow_limit;
+    LOG(TRACE) << __func__ << " setting power limit: " << static_cast<int8_t>(tx_pow_limit)
+               << " dBm";
     m_radio_info.tx_power = tx_pow_limit;
     return true;
 }


### PR DESCRIPTION
Function set_tx_power_limit break the logic for
tx_power variable when multiple tx_pow_limit on 100
and assign it to the m_radio_info.tx_power, because in
other cases as example in the function fill_cs_params
tx_power has type int8_t, and it triggers overflow when
value in tx_power greater than 127.

Solution - remove multiplication from set_tx_power and
add type conversion from int to int8_t in fill_cs_params
for tx_power.