### PR TITLE
ci: update run_easymesh_cert.sh to support upload to owncloud (Patch 2)

### DIFF
--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -22,9 +22,10 @@ usage() {
     echo "      -b|--branch - prplmesh branch to use (default master latest)"
     echo "      -o|--log-folder - path to put the logs to (make sure it does not contain previous logs)."
     echo "      -e|--easymesh-cert - path to easymesh_cert repository (default ../easymesh_cert)"
-    echo "      -u|--upload - upload results"
+    echo "      --owncloud-upload - whether or not to upload results to owncloud. (default: false)"
+    echo "      --owncloud-path - relative path in the owncloud server to upload results to. (default: $OWNCLOUD_PATH)"
     echo "      -v|--verbose - set verbosity (ucc logs also redirected to stdout)"
-    echo "      -s|--ssh - target device ssh name (defined in ~/.ssh/config). Default is $TARGET_DEVICE_SSH"
+    echo "      -s|--ssh - target device ssh name (defined in ~/.ssh/config). (default: $TARGET_DEVICE_SSH)"
     echo "'test' can either be a test name, or the path to a file containing"
     echo " test names (newline-separated)."
     echo
@@ -34,10 +35,15 @@ usage() {
     echo "$(basename "$0") MAP-5.3.1 tests/all_controller_test.txt"
     echo ""
     echo "The default is to run all agent certification tests."
+    echo ""
+    echo "Credentials for uploading to owncloud are taken from $HOME/.netrc"
+    echo "Make sure it has a line like this:"
+    echo "  machine ftp.essensium.com login <user> password <password>"
+    echo ""
 }
 
 main() {
-     OPTS=$(getopt -o 'hb:o:e:u:s:v' --long help,branch:,log-folder:,easymesh-cert:,upload:,ssh:verbose -n 'parse-options' -- "$@")
+    OPTS=$(getopt -o 'hb:o:e:s:v' --long help,branch:,log-folder:,easymesh-cert:,owncloud-upload,owncloud-path:,ssh:,verbose -n 'parse-options' -- "$@")
 
     if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -50,7 +56,8 @@ main() {
             -o | --log-folder)      LOG_FOLDER="$2"; shift 2;;
             -v | --verbose)         VERBOSE=true; VERBOSE_OPT="-v"; shift;;
             -e | --easymesh-cert)   EASYMESH_CERT_PATH="$2"; shift 2;;
-            -u | --upload)          UPLOAD_PATH="$2"; shift 2;;
+            --owncloud-upload)      OWNCLOUD_UPLOAD=true; shift;;
+            --owncloud-path)        OWNCLOUD_PATH="$2"; shift 2;;
             -s | --ssh)             TARGET_DEVICE_SSH="$2"; shift 2;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1;;
@@ -75,19 +82,12 @@ main() {
 
     info "Start running tests"
     run "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" "$VERBOSE_OPT"
+    mv prplmesh.{ipk,buildinfo} "$LOG_FOLDER"
 
-    passed=$(find "$LOG_FOLDER"/PASS/ -maxdepth 1 -type d -printf x | wc -c)
-    failed=$(find "$LOG_FOLDER"/FAIL/ -maxdepth 1 -type d -printf x | wc -c)
-    total=$((failed+passed))
-    if [ "$VERBOSE" = "true" ]; then
-        info "Passed tests:"
-        ls "$LOG_FOLDER/PASS"
-        info "Failed tests:"
-        ls "$LOG_FOLDER/FAIL"
+    if [ -n "$OWNCLOUD_UPLOAD" ]; then
+        info "Uploading $LOG_FOLDER to $OWNCLOUD_PATH"
+        "$scriptdir"/upload_to_owncloud.sh "$OWNCLOUD_PATH" "$LOG_FOLDER"
     fi
-    info "Passed $passed/$total"
-    info "Uploading results to $UPLOAD_PATH not supported yet"
-    # TODO upload results
     info "done"
 }
 
@@ -98,5 +98,6 @@ TOOLS_PATH="$rootdir/tools"
 EASYMESH_CERT_PATH=$(realpath "$rootdir/../easymesh_cert")
 TARGET_DEVICE="netgear-rax40"
 TARGET_DEVICE_SSH="$TARGET_DEVICE-1"
+OWNCLOUD_PATH=Nightly/agent_certification
 
 main "$@"

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -78,11 +78,12 @@ main() {
     cat "$PRPLMESH_BUILDINFO"
 
     info "deploy latest ipk to $TARGET_DEVICE_SSH"
-    run "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$IPK"
+    run "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$PRPLMESH_IPK"
 
     info "Start running tests"
     run "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" "$VERBOSE_OPT"
-    mv prplmesh.{ipk,buildinfo} "$LOG_FOLDER"
+    mv "$PRPLMESH_IPK" "$LOG_FOLDER"
+    mv "$PRPLMESH_BUILDINFO" "$LOG_FOLDER"
 
     if [ -n "$OWNCLOUD_UPLOAD" ]; then
         info "Uploading $LOG_FOLDER to $OWNCLOUD_PATH"
@@ -92,8 +93,8 @@ main() {
 }
 
 BRANCH=master
-IPK=prplmesh.ipk
-PRPLMESH_BUILDINFO=prplmesh.buildinfo
+PRPLMESH_IPK=prplmesh.ipk
+PRPLMESH_BUILDINFO=prplmesh_buildinfo.txt
 TOOLS_PATH="$rootdir/tools"
 EASYMESH_CERT_PATH=$(realpath "$rootdir/../easymesh_cert")
 TARGET_DEVICE="netgear-rax40"

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -72,13 +72,19 @@ main() {
     info "Tests to run: $TESTS"
 
     info "download latest ipk from branch $BRANCH"
-    run "$TOOLS_PATH"/download_ipk.sh --branch "$BRANCH"
+    "$TOOLS_PATH"/download_ipk.sh --branch "$BRANCH" || {
+        err "Failed to download prplmesh.ipk, abort"
+        exit 1
+    }
     
     info "prplmesh build info:"
     cat "$PRPLMESH_BUILDINFO"
 
     info "deploy latest ipk to $TARGET_DEVICE_SSH"
-    run "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$PRPLMESH_IPK"
+    "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$PRPLMESH_IPK" || {
+        err "Failed to deploy prplmesh.ipk, abort"
+        exit 1
+    }
 
     info "Start running tests"
     "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" "$VERBOSE_OPT"
@@ -87,7 +93,10 @@ main() {
 
     if [ -n "$OWNCLOUD_UPLOAD" ]; then
         info "Uploading $LOG_FOLDER to $OWNCLOUD_PATH"
-        "$scriptdir"/upload_to_owncloud.sh "$OWNCLOUD_PATH" "$LOG_FOLDER"
+        "$scriptdir"/upload_to_owncloud.sh "$OWNCLOUD_PATH" "$LOG_FOLDER" || {
+            err "Failed to upload $LOG_FOLDER"
+            exit 1
+        }
     fi
     info "done"
 }

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -72,7 +72,7 @@ main() {
     info "Tests to run: $TESTS"
 
     info "download latest ipk from branch $BRANCH"
-    "$TOOLS_PATH"/download_ipk.sh --branch "$BRANCH" || {
+    "$TOOLS_PATH"/download_ipk.sh --branch "$BRANCH" ${VERBOSE:+ -v} || {
         err "Failed to download prplmesh.ipk, abort"
         exit 1
     }
@@ -87,7 +87,7 @@ main() {
     }
 
     info "Start running tests"
-    "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" "$VERBOSE_OPT"
+    "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" ${VERBOSE:+ -v}
     mv "$PRPLMESH_IPK" "$LOG_FOLDER"
     mv "$PRPLMESH_BUILDINFO" "$LOG_FOLDER"
 

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -81,7 +81,7 @@ main() {
     run "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$PRPLMESH_IPK"
 
     info "Start running tests"
-    run "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" "$VERBOSE_OPT"
+    "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" "$VERBOSE_OPT"
     mv "$PRPLMESH_IPK" "$LOG_FOLDER"
     mv "$PRPLMESH_BUILDINFO" "$LOG_FOLDER"
 

--- a/ci/upload_to_owncloud.sh
+++ b/ci/upload_to_owncloud.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2020 Tomer Eliyahu (Intel)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+scriptdir="$(cd "${0%/*}" && pwd)"
+rootdir=$(realpath "$scriptdir/../")
+
+# shellcheck source=../tools/functions.sh
+. "$rootdir/tools/functions.sh"
+
+usage() {
+    echo "usage: $(basename "$0") [-hv] <user> <password> <remote-path> <local-path>"
+    echo "  options:"
+    echo "      -h|--help - display this help."
+    echo "      -v|--verbose - enable verbosity"
+    echo "      -u|--url - webDAV URL (default https://ftp.essensium.com/owncloud/remote.php/dav/files/USERNAME)"
+    echo
+    echo "  positional arguments:"
+    echo "      remote-path - path in the cloud, relative to the user home to upload"
+    echo "      local-path - local file or folder to upload"
+    echo ""
+    echo "  Credentials are taken from $HOME/.netrc"
+    echo "  Make sure it has a line like this:"
+    echo "    machine ftp.essensium.com login <user> password <password>"
+    echo ""
+}
+
+main() {
+    if ! OPTS=$(getopt -o 'hvu:' --long help,verbose,url: -n 'parse-options' -- "$@"); then
+        echo echo "Failed parsing options." >&2; usage; exit 1
+    fi
+
+    eval set -- "$OPTS"
+
+    while true; do
+        case "$1" in
+            -h | --help)            usage; exit 0;;
+            -v | --verbose)         export VERBOSE=true; QUIET=; shift;;
+            -u | --owncloud-url)    OWNCLOUD_URL="$2"; shift 2;;
+            -- ) shift; break ;;
+            * ) err "unsupported argument $1"; usage; exit 1;;
+        esac
+    done
+
+    [ -n "$1" ] || { usage; err "Missing remote-path"; exit 1; }
+    remote_path="$1"; shift
+    [ -n "$1" ] || { usage; err "Missing local-path"; exit 1; }
+    local_path="$1"; shift
+
+    info "upload $local_path to $OWNCLOUD_BROWSE_URL/$remote_path/$(basename "$local_path") (using user $user)"
+    if ! find "$local_path" -type d -exec \
+            realpath {} --relative-to="$(dirname "$local_path")" \; | \
+                while read -r -s dir; do
+                    printf . # show progress
+                    dbg "Create directory: $dir"
+                    curl ${QUIET:+ -s -S} -f -n -X MKCOL "$OWNCLOUD_URL/$user/$remote_path/$dir"
+                    printf . # show progress
+                    # get the list of files to upload in the format <file>,<file>,...,<file>
+                    files=$(find "$(dirname "$local_path")/$dir/" -type f -maxdepth 1 -print0 | tr '\0' ',' | sed 's/,$//')
+                    dbg "$files"
+                    [ -n "$files" ] && {
+                        curl ${QUIET:+ -s -S} -f -n -T "{$files}" "$OWNCLOUD_URL/$user/$remote_path/$dir/" || {
+                            error="$?"
+                            err "Failed to upload files to $remote_path/$dir/ (error $error)"
+                            exit $error
+                        }
+                    }
+                done
+    then
+        echo
+        err "Upload failed"
+        return 1
+    fi
+    echo
+    success "Upload success"
+}
+
+OWNCLOUD_URL="https://ftp.essensium.com/owncloud/remote.php/dav/files"
+OWNCLOUD_BROWSE_URL="https://ftp.essensium.com/owncloud/index.php/apps/files/?dir=/prplmesh/certification"
+QUIET=true
+user=$(awk '/ftp.essensium.com/{getline; print $4}' ~/.netrc)
+
+main "$@"

--- a/tools/download_ipk.sh
+++ b/tools/download_ipk.sh
@@ -23,7 +23,7 @@ download() {
     BUILDINFO_URL="https://gitlab.com/prpl-foundation/prplmesh/-/jobs/artifacts/$BRANCH/raw/build/$DEVICE/prplmesh.buildinfo?job=build-for-$DEVICE"
     # curl options - fail on error (-f), follow redirect (-L)
     curl -f -L "$IPK_URL" --output "$IPK_PATH"/prplmesh.ipk
-    curl -f -L "$BUILDINFO_URL" --output "$IPK_PATH"/prplmesh.buildinfo
+    curl -f -L "$BUILDINFO_URL" --output "$IPK_PATH"/prplmesh_buildinfo.txt
 }
 
 main() {

--- a/tools/download_ipk.sh
+++ b/tools/download_ipk.sh
@@ -10,6 +10,7 @@ usage() {
     echo "usage: $(basename "$0") [-hbd]"
     echo "  options:"
     echo "      -h|--help - show this help menu"
+    echo "      -v|--verbose - add verbosity"
     echo "      --branch  - branch to use (default master)"
     echo "      --device  - device to use (default netgear-rax40)"
     echo "      --path    - path to copy ipk to (default .)"
@@ -22,12 +23,12 @@ download() {
     IPK_URL="https://gitlab.com/prpl-foundation/prplmesh/-/jobs/artifacts/$BRANCH/raw/build/$DEVICE/prplmesh.ipk?job=build-for-$DEVICE"
     BUILDINFO_URL="https://gitlab.com/prpl-foundation/prplmesh/-/jobs/artifacts/$BRANCH/raw/build/$DEVICE/prplmesh.buildinfo?job=build-for-$DEVICE"
     # curl options - fail on error (-f), follow redirect (-L)
-    curl -f -L "$IPK_URL" --output "$IPK_PATH"/prplmesh.ipk
-    curl -f -L "$BUILDINFO_URL" --output "$IPK_PATH"/prplmesh_buildinfo.txt
+    curl ${QUIET:+ -s -S} -f -L "$IPK_URL" --output "$IPK_PATH"/prplmesh.ipk
+    curl ${QUIET:+ -s -S} -f -L "$BUILDINFO_URL" --output "$IPK_PATH"/prplmesh_buildinfo.txt
 }
 
 main() {
-    if ! OPTS=$(getopt -o 'h' --long help,branch:,device:,path: -n 'parse-options' -- "$@"); then
+    if ! OPTS=$(getopt -o 'hv' --long help,verbose,branch:,device:,path: -n 'parse-options' -- "$@"); then
         echo "Failed parsing options." >&2
         usage
         exit 1
@@ -40,6 +41,11 @@ main() {
             -h|--help)
                 usage
                 exit 0
+                ;;
+            -v|--verbose)
+                QUIET=
+                VERBOSE=true
+                shift
                 ;;
             --branch)
                 BRANCH="$2"
@@ -64,5 +70,7 @@ main() {
 DEVICE=netgear-rax40
 BRANCH=master
 IPK_PATH=.
+VERBOSE=false
+QUIET=true
 
 main "$@"


### PR DESCRIPTION
Add a script for uploading file[s] / folders to owncloud via curl.
(based on https://doc.owncloud.com/server/user_manual/files/access_webdav.html#accessing-files-using-curl) and update `run_easymesh_cert.sh` to support uploading to owncloud.

Example logs uploaded by the script:
https://ftp.essensium.com/owncloud/index.php/apps/files/?dir=/Nightly/agent_certification/2020-03-25_19-19-40&fileid=712397