### PR TITLE
Feature/detect agent down with topology flow

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -511,7 +511,6 @@ bool backhaul_manager::socket_disconnected(Socket *sd)
                     LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
                     return false;
                 }
-                cmdu_header->flags().relay_indicator = true;
                 send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
             }
             return false;
@@ -624,7 +623,6 @@ void backhaul_manager::after_select(bool timeout)
             LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
             return;
         }
-        cmdu_header->flags().relay_indicator = true;
         send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
     }
 }
@@ -1813,7 +1811,6 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
                 LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
                 return false;
             }
-            cmdu_header->flags().relay_indicator = true;
             send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
         }
 
@@ -2771,7 +2768,6 @@ bool backhaul_manager::handle_1905_topology_discovery(const std::string &src_mac
             LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
             return false;
         }
-        cmdu_header->flags().relay_indicator = true;
         send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
     }
     return true;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -13,6 +13,7 @@
 
 #include <bcl/beerocks_backport.h>
 #include <bcl/beerocks_config_file.h>
+#include <bcl/beerocks_defines.h>
 #include <bcl/beerocks_socket_thread.h>
 #include <bcl/network/network_utils.h>
 #include <btl/btl.h>
@@ -210,9 +211,8 @@ private:
     const int DEAUTH_REASON_PASSPHRASE_MISMACH        = 2;
     const int AUTOCONFIG_DISCOVERY_TIMEOUT_SECONDS    = 1;
     const int MAX_FAILED_AUTOCONFIG_SEARCH_ATTEMPTS   = 20;
-    const int DISCOVERY_NOTIFICATION_TIMEOUT_SEC      = 60; // According to specification
     const int DISCOVERY_NEIGHBOUR_REMOVAL_TIMEOUT =
-        DISCOVERY_NOTIFICATION_TIMEOUT_SEC + 3; // 3 seconds grace period
+        ieee1905_1_consts::DISCOVERY_NOTIFICATION_TIMEOUT_SEC + 3; // 3 seconds grace period
 
     std::chrono::steady_clock::time_point state_time_stamp_timeout;
     int state_attempts;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -286,6 +286,16 @@ private:
      */
     bool get_neighbor_links(const sMacAddr &neighbor_mac_filter,
                             std::map<std::string, std::vector<sMacAddr>> &neighbor_links_map);
+    /*
+     * @brief List of known 1905 neighbor devices
+     * 
+     * key:     1905.1 device AL-MAC
+     * value:   Last timestam receiving discovery message from AL-MAC
+     * Devices are being added to the list when receiving a 1905.1 Topology Discovery message from
+     * an unknown 1905.1 device. Every 1905.1 device shall send this message every 60 seconds, and
+     * we update the time stamp in which the message is received.
+     */
+    std::unordered_map<sMacAddr, std::chrono::steady_clock::time_point> m_1905_neighbor_devices;
 
     /*
  * State Machines

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -75,6 +75,8 @@ private:
     bool handle_1905_1_message(ieee1905_1::CmduMessageRx &cmdu_rx, const std::string &src_mac);
 
     // 1905 messages handlers
+    bool handle_1905_topology_discovery(const std::string &src_mac,
+                                        ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_1905_autoconfiguration_response(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                 const std::string &src_mac);
     bool handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmdu_rx, const std::string &src_mac);
@@ -208,6 +210,9 @@ private:
     const int DEAUTH_REASON_PASSPHRASE_MISMACH        = 2;
     const int AUTOCONFIG_DISCOVERY_TIMEOUT_SECONDS    = 1;
     const int MAX_FAILED_AUTOCONFIG_SEARCH_ATTEMPTS   = 20;
+    const int DISCOVERY_NOTIFICATION_TIMEOUT_SEC      = 60; // According to specification
+    const int DISCOVERY_NEIGHBOUR_REMOVAL_TIMEOUT =
+        DISCOVERY_NOTIFICATION_TIMEOUT_SEC + 3; // 3 seconds grace period
 
     std::chrono::steady_clock::time_point state_time_stamp_timeout;
     int state_attempts;

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -33,6 +33,10 @@ namespace beerocks {
 // clang-format on
 #endif
 
+namespace ieee1905_1_consts {
+static constexpr int DISCOVERY_NOTIFICATION_TIMEOUT_SEC = 60;
+}
+
 namespace message {
 
 enum eStructsConsts {

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -271,6 +271,7 @@ public:
     std::set<std::string> get_node_siblings(std::string mac, int type = beerocks::TYPE_ANY);
     std::set<std::string> get_node_children(std::string mac, int type = beerocks::TYPE_ANY,
                                             int state = beerocks::STATE_ANY);
+    std::list<sMacAddr> get_1905_1_neighbors(const sMacAddr &al_mac);
     std::string get_node_key(const std::string &al_mac, const std::string &ruid);
 
     //

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1482,7 +1482,8 @@ bool master_thread::handle_cmdu_1905_topology_notification(const std::string &sr
                                                            ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto mid = cmdu_rx.getMessageId();
-    LOG(DEBUG) << "Received TOPOLOGY_NOTIFICATION_MESSAGE, mid=" << std::hex << int(mid);
+    LOG(DEBUG) << "Received TOPOLOGY_NOTIFICATION_MESSAGE, from " << src_mac << ", mid=" << std::hex
+               << int(mid);
 
     // IEEE 1905.1 defines that TOPOLOGY_NOTIFICATION_MESSAGE must containt one 1905.1 AL MAC
     // address type TLV, and MultiAp standard extend it with zero or one Client Association Event
@@ -1603,7 +1604,8 @@ bool master_thread::handle_cmdu_1905_topology_response(const std::string &src_ma
                                                        ieee1905_1::CmduMessageRx &cmdu_rx)
 {
     auto mid = cmdu_rx.getMessageId();
-    LOG(DEBUG) << "Received TOPOLOGY_RESPONSE_MESSAGE, mid=" << std::hex << int(mid);
+    LOG(DEBUG) << "Received TOPOLOGY_RESPONSE_MESSAGE from " << src_mac << ", mid=" << std::hex
+               << int(mid);
 
     auto tlvDeviceInformation = cmdu_rx.getClass<ieee1905_1::tlvDeviceInformation>();
     if (!tlvDeviceInformation) {

--- a/controller/src/beerocks/master/son_master_thread.h
+++ b/controller/src/beerocks/master/son_master_thread.h
@@ -85,8 +85,6 @@ private:
                                                      ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_operating_channel_report(const std::string &src_mac,
                                                    ieee1905_1::CmduMessageRx &cmdu_rx);
-    bool handle_cmdu_1905_topology_discovery(const std::string &src_mac,
-                                             ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_ack_message(const std::string &src_mac,
                                       ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_cmdu_1905_higher_layer_data_message(const std::string &src_mac,


### PR DESCRIPTION
This PR removed the Topology Discovery handler from the controller and move it to the Agent.
The Agent now uses it to store newly discovered 1905 Devices on a list, and notify the Controller about any change on that list.
If the Controller detects that the Agent did not report a neighbor device that appears on the Controller database, it removed this node.
This whole mechanism purpose it to detect Agent that went down like power off for example.

Currently, there is a problem with this PR. It is observed that running `tests/test_gw_repeater.sh -f -v` is failing since the repeater so_slaves get a timeout on waiting for "JOINED_RESPONSE" multiple times until they get it (takes 60 seconds).
After some debugging I did, it seems that if the controller sends the Topology Notification with the relay flag set, it causes the problem.
Also, I checked on Wireshark and I saw all the messages from the repeater that the controller did not receive.

HELP!

Edit:
For some reason test flows fully passed now. 😱 

Created a pipeline that checks the following: 
```
MAP-4.2.1
MAP-4.3.1_ETH
MAP-4.3.2_ETH_FH24G
MAP-4.3.2_ETH_FH5GL
MAP-4.3.2_ETH_FH5GH
```
https://gitlab.com/prpl-foundation/prplMesh/pipelines/129730277

#925 