### PR TITLE
Feature - Packet capture using TShark in test_flows.py

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -17,6 +17,7 @@ import json
 
 import send_CAPI_command
 from send_CAPI_command import tlv
+from datetime import datetime
 
 '''Regular expression to match a MAC address in a bytes string.'''
 RE_MAC = rb"(?P<mac>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})"
@@ -96,6 +97,15 @@ class test_flows:
             bridge_id = prplmesh_net['Id']
             bridge = 'br-' + bridge_id[:12]
         return bridge
+
+    def check_time_in_bounds(self, timestamp, end=time.time(), start=None):
+        if start:
+            return start < timestamp and timestamp < end
+        return timestamp < end
+
+    def get_time_for_packet(self, packet):
+        return float(packet['_source']['layers']['frame']['frame.time_epoch'])
+        # return datetime.fromtimestamp(float(packet_time))
 
     def message(self, message: str, color: int = 0):
         '''Print a message, optionally in a color, preceded by the currently running test.'''

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -525,9 +525,12 @@ class test_flows:
         # self.check_log(self.repeater1, "agent_wlan2", "ACK_MESSAGE")
 
     def test_ap_capability_query(self):
+        start_time = time.time()
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8001)
-        time.sleep(1)
-
+        time.sleep(2)
+        captured = self.check_tshark()
+        found = self.check_tlv_name('ap capability', captured)
+        self.status(f"AP Capability captured? {found}")
         self.debug("Confirming ap capability query has been received on agent")
         self.check_log(self.repeater1, "agent", "AP_CAPABILITY_QUERY_MESSAGE")
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -19,6 +19,7 @@ import send_CAPI_command
 from send_CAPI_command import tlv
 import signal
 from datetime import datetime
+import atexit
 
 '''Regular expression to match a MAC address in a bytes string.'''
 RE_MAC = rb"(?P<mac>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})"
@@ -872,8 +873,17 @@ class test_flows:
         self.debug("Confirming topology query was received")
         self.check_log(self.repeater1, "agent", r"TOPOLOGY_QUERY_MESSAGE")
 
+    def on_exit(self):
+        for name, thr in self.tshark_instances.items():
+            try:
+                os.kill(thr.proc.pid, signal.SIGTERM)
+            finally:
+                pass
+
+
 if __name__ == '__main__':
     t = test_flows()
+    atexit.register(t.on_exit)
     t.init()
     if t.run_tests():
         sys.exit(1)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -134,6 +134,13 @@ class test_flows:
                     tshark_args+['-a', 'duration:900'], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             self.err(f'test {self.run_tests} failed, output: {e.output}')
+
+    def check_tlv_name(self, st: str, packets):
+        try:
+            return any([st.lower() in map(lambda x: x.lower(), packet['_source']['layers']['ieee1905']) for packet in filter(lambda y: 'ieee1905' in y['_source']['layers'], packets)])
+        except KeyError:
+            return False
+
     def check_tshark(self, target_thread_name=None, end=time.time(), start=None, file_output=False):
         '''
         ### Description

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -83,6 +83,19 @@ class test_flows:
         self.tcpdump_proc = None
         self.bridge_name = 'br-lan'
 
+    def get_bridge_mac(self):
+        inspect = json.loads(subprocess.check_output(('docker', 'network', 'inspect',
+                                                      'prplMesh-net-{}'.format(self.opts.unique_id))))
+        prplmesh_net = inspect[0]
+        # podman adds a 'plugins' indirection that docker doesn't have.
+        if 'plugins' in prplmesh_net:
+            bridge = prplmesh_net['plugins'][0]['bridge']
+        else:
+            # docker doesn't report the interface name of the bridge. So format it based on the
+            # ID.
+            bridge_id = prplmesh_net['Id']
+            bridge = 'br-' + bridge_id[:12]
+        return bridge
 
     def message(self, message: str, color: int = 0):
         '''Print a message, optionally in a color, preceded by the currently running test.'''

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -98,6 +98,24 @@ class test_flows:
             bridge = 'br-' + bridge_id[:12]
         return bridge
 
+    def __capture(self, test_index, test_name, bridge, duration=None):
+        
+        # `test_index` currently unused, but might be useful for file output
+        
+        # for optional file output
+        # self.outputfile = os.path.join(
+        #     self.rootdir, 'logs', f'tshark_log_{test_name}.json')
+        
+        try:
+            tshark_args = ['tshark', '-Q', '-i', bridge, '-T', 'json']
+            if duration:
+                self.tshark_instances[test_name].proc = subprocess.Popen(
+                    tshark_args+['-a', f'duration:{duration}'], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            else:
+                self.tshark_instances[test_name].proc = subprocess.Popen(
+                    tshark_args+['-a', 'duration:900'], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            self.err(f'test {self.run_tests} failed, output: {e.output}')
     def check_time_in_bounds(self, timestamp, end=time.time(), start=None):
         if start:
             return start < timestamp and timestamp < end


### PR DESCRIPTION
I'll go into more detail on the description later, but for now I've created a draft PR with sorted commits.
Consistency needs some work, and I assume that for slower computers, the `sleep()` timers might need to be adjusted.
Will close #942 

### To Do:

- [ ] Check if it's possible (and if it matters, performance-wise) to call tshark without starting it in a different thread, this is a workaround from older methodologies I've tried and might be unnecessary.
 Only requires editing 84286ef50838a619d907af832d080ccd549cff38, 8c982bfbcdf7b4bd61862d974d5ed3e323580c56 and calls to `self.tshark_instances`.

- [ ] Consistency - the capture fails sometimes, find out why, and if it depends on whether or not 
`--skip-init` argument is given.

### Relevant GIF:

<img src="https://media.giphy.com/media/D8ACgZ9WK50nS/giphy.gif" width=100>