### PR TITLE
Bugfix/add relay indicator to capi commads

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1667,7 +1667,7 @@ bool backhaul_manager::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_r
         } else { // Forward the data (cmdu) to bus
             // LOG(DEBUG) << "forwarding slave->master message, controller_bridge_mac=" << controller_bridge_mac;
             cmdu_rx.swap(); //swap back before forwarding
-            send_cmdu_to_bus(cmdu_rx, controller_bridge_mac, bridge_info.mac, length);
+            send_cmdu_to_bus(cmdu_rx, dst_mac, bridge_info.mac, length);
         }
     }
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -484,7 +484,8 @@ bool backhaul_manager::socket_disconnected(Socket *sd)
                     LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
                     return false;
                 }
-                send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+
+                send_cmdu_to_bus(cmdu_tx, network_utils::MULTICAST_1905_MAC_ADDR, bridge_info.mac);
             }
             return false;
         } else {
@@ -596,7 +597,7 @@ void backhaul_manager::after_select(bool timeout)
             LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
             return;
         }
-        send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+        send_cmdu_to_bus(cmdu_tx, network_utils::MULTICAST_1905_MAC_ADDR, bridge_info.mac);
     }
 }
 
@@ -1136,7 +1137,7 @@ bool backhaul_manager::send_1905_topology_discovery_message()
     tlvMac->mac() = network_utils::mac_from_string(bridge_info.mac);
 
     LOG(DEBUG) << "send_1905_topology_discovery_message, bridge_mac=" << bridge_info.mac;
-    return send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+    return send_cmdu_to_bus(cmdu_tx, network_utils::MULTICAST_1905_MAC_ADDR, bridge_info.mac);
 }
 
 bool backhaul_manager::send_autoconfig_search_message(std::shared_ptr<SSlaveSockets> soc)
@@ -1226,7 +1227,7 @@ bool backhaul_manager::send_autoconfig_search_message(std::shared_ptr<SSlaveSock
     auto beerocks_header                      = message_com::get_beerocks_header(cmdu_tx);
     beerocks_header->actionhdr()->direction() = beerocks::BEEROCKS_DIRECTION_CONTROLLER;
     LOG(DEBUG) << "sending autoconfig search message, bridge_mac=" << bridge_info.mac;
-    return send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+    return send_cmdu_to_bus(cmdu_tx, network_utils::MULTICAST_1905_MAC_ADDR, bridge_info.mac);
 }
 
 bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
@@ -1611,7 +1612,7 @@ bool backhaul_manager::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_r
     if (from_bus(sd)) {
 
         // Filter messages which are not destined to this agent
-        if (dst_mac != MULTICAST_MAC_ADDR && dst_mac != bridge_info.mac) {
+        if (dst_mac != network_utils::MULTICAST_1905_MAC_ADDR && dst_mac != bridge_info.mac) {
             LOG(DEBUG) << "handle_cmdu() - dropping msg, dst_mac=" << dst_mac
                        << ", local_bridge_mac=" << bridge_info.mac;
             return true;
@@ -1790,7 +1791,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
                 LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
                 return false;
             }
-            send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+            send_cmdu_to_bus(cmdu_tx, network_utils::MULTICAST_1905_MAC_ADDR, bridge_info.mac);
         }
 
         // If we're already connected, send a notification to the slave
@@ -2744,7 +2745,7 @@ bool backhaul_manager::handle_1905_topology_discovery(const std::string &src_mac
             LOG(ERROR) << "cmdu creation of type TOPOLOGY_NOTIFICATION_MESSAGE, has failed";
             return false;
         }
-        send_cmdu_to_bus(cmdu_tx, MULTICAST_MAC_ADDR, bridge_info.mac);
+        send_cmdu_to_bus(cmdu_tx, network_utils::MULTICAST_1905_MAC_ADDR, bridge_info.mac);
     }
     return true;
 }

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3751,8 +3751,12 @@ bool slave_thread::send_cmdu_to_controller(ieee1905_1::CmduMessageTx &cmdu_tx)
         beerocks_header->actionhdr()->radio_mac() = hostap_params.iface_mac;
         beerocks_header->actionhdr()->direction() = beerocks::BEEROCKS_DIRECTION_CONTROLLER;
     }
-    return message_com::send_cmdu(master_socket, cmdu_tx, backhaul_params.controller_bridge_mac,
-                                  backhaul_params.bridge_mac);
+
+    auto dst_addr =
+        cmdu_tx.getMessageType() == ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE
+            ? network_utils::MULTICAST_1905_MAC_ADDR
+            : backhaul_params.controller_bridge_mac;
+    return message_com::send_cmdu(master_socket, cmdu_tx, dst_addr, backhaul_params.bridge_mac);
 }
 
 /**

--- a/common/beerocks/bcl/include/bcl/network/network_utils.h
+++ b/common/beerocks/bcl/include/bcl/network/network_utils.h
@@ -39,6 +39,7 @@ public:
     static const std::string ZERO_MAC_STRING;
     static const sMacAddr ZERO_MAC;
     static const std::string WILD_MAC_STRING;
+    static const std::string MULTICAST_1905_MAC_ADDR;
 
     typedef struct {
         uint16_t htype;

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -76,6 +76,7 @@ const std::string network_utils::ZERO_IP_STRING("0.0.0.0");
 const std::string network_utils::ZERO_MAC_STRING("00:00:00:00:00:00");
 const sMacAddr network_utils::ZERO_MAC{.oct = {0}};
 const std::string network_utils::WILD_MAC_STRING("ff:ff:ff:ff:ff:ff");
+const std::string network_utils::MULTICAST_1905_MAC_ADDR("01:80:c2:00:00:13");
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Implementation ///////////////////////////////

--- a/common/beerocks/btl/btl.cpp
+++ b/common/beerocks/btl/btl.cpp
@@ -13,8 +13,6 @@
 using namespace beerocks::btl;
 using namespace beerocks::net;
 
-const std::string transport_socket_thread::MULTICAST_MAC_ADDR = "01:80:c2:00:00:13";
-
 transport_socket_thread::transport_socket_thread(const std::string &unix_socket_path_)
     : socket_thread(unix_socket_path_)
 {

--- a/common/beerocks/btl/include/btl/btl.h
+++ b/common/beerocks/btl/include/btl/btl.h
@@ -51,8 +51,6 @@ protected:
     bool send_cmdu_to_bus(ieee1905_1::CmduMessage &cmdu, const std::string &dst_mac,
                           const std::string &src_mac, uint16_t length);
 
-    static const std::string MULTICAST_MAC_ADDR;
-
 private:
     bool bus_init();
     bool bus_send(ieee1905_1::CmduMessage &cmdu, const std::string &dst_mac,

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -91,12 +91,17 @@ prplmesh_framework_init() {
     echo "prplmesh_framework_init - starting local_bus and ieee1905_transport processes..."
     @INSTALL_PATH@/bin/local_bus &
     @INSTALL_PATH@/bin/ieee1905_transport &
+
+    # This is required for solveing issue which causing meesges not geeting to their destination.
+    # For more information see: https://github.com/prplfoundation/prplMesh/pull/1029#issuecomment-608353274
+    ebtables -A FORWARD -d 01:80:c2:00:00:13 -j DROP
 }
 
 prplmesh_framework_deinit() {
     echo "prplmesh_framework_deinit - killing local_bus and ieee1905_transport processes..."
     killall_program local_bus
     killall_program ieee1905_transport
+    ebtables -D FORWARD -d 01:80:c2:00:00:13 -j DROP
 }
 
 prplmesh_controller_start() {

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -231,7 +231,8 @@ bool master_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
         }
 
         // Filter messages which are not destined to the controller
-        if (dst_mac != MULTICAST_MAC_ADDR && dst_mac != database.get_local_bridge_mac()) {
+        if (dst_mac != network_utils::MULTICAST_1905_MAC_ADDR &&
+            dst_mac != database.get_local_bridge_mac()) {
             return true;
         }
 

--- a/framework/tlvf/src/src/CmduMessageTx.cpp
+++ b/framework/tlvf/src/src/CmduMessageTx.cpp
@@ -11,7 +11,26 @@
 
 #include <tlvf/tlvflogging.h>
 
+#include <set>
+
 using namespace ieee1905_1;
+
+static void set_relay_indicator(std::shared_ptr<ieee1905_1::cCmduHeader> &cmdu_header)
+{
+    // Taken from Table 6-4 on IEEE 1905.1-2013
+    auto message_type                                         = cmdu_header->message_type();
+    const std::set<ieee1905_1::eMessageType> relayed_messages = {
+        ieee1905_1::eMessageType::TOPOLOGY_NOTIFICATION_MESSAGE,
+        ieee1905_1::eMessageType::AP_AUTOCONFIGURATION_SEARCH_MESSAGE,
+        ieee1905_1::eMessageType::AP_AUTOCONFIGURATION_RENEW_MESSAGE,
+        ieee1905_1::eMessageType::PUSH_BUTTON_EVENT_NOTIFICATION_MESSAGE,
+        ieee1905_1::eMessageType::PUSH_BUTTON_JOIN_NOTIFICATION_MESSAGE,
+    };
+
+    if (relayed_messages.find(message_type) != relayed_messages.end()) {
+        cmdu_header->flags().relay_indicator = true;
+    }
+}
 
 CmduMessageTx::CmduMessageTx(uint8_t *buff, size_t buff_len) : CmduMessage(buff, buff_len) {}
 
@@ -27,6 +46,9 @@ std::shared_ptr<cCmduHeader> CmduMessageTx::create(uint16_t id, eMessageType mes
 
     cmduhdr->message_type() = message_type;
     cmduhdr->message_id()   = id;
+
+    set_relay_indicator(cmduhdr);
+
     return cmduhdr;
 }
 

--- a/tools/docker/runner/Dockerfile
+++ b/tools/docker/runner/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
 	iproute2 \
 	psmisc \
 	clang-format \
+	ebtables \
 	netcat \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add relay indicator to CAPI commands with message types that require it according to Table 6-4 on IEEE 1905.1-2013, to solve #1011.

As part of this PR, changed also other messages that should have been sent as relayed multicast, to relayed multicast.  

**Help Needed!**
For some reason sending messages with relay indicator casing to some other message to not be received. For example, when the repeater sends an auto-config search message (relay=1), the controller response to it (relay=0) but the response is not being received on the repeater side.