### PR TITLE
.mergify.yml: remove redundant labels on merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,3 +21,11 @@ pull_request_rules:
         # rebased.
         strict: smart
         strict_method: rebase
+
+  - name: Remove redundant labels
+    conditions:
+      - "merged"
+    actions:
+      label:
+        # These labels are potentially confusing for merged PRs, so remove them
+        remove: ["ready for merge", "help wanted", "don't merge", "wait for platform test"]


### PR DESCRIPTION
Labels like "ready for merge" or "help wanted" are meaningless and can
even lead to confusion once the PR has been approved and merged. Remove
them when a PR is merged. Do it in a separate rule, so it applies not
just to automatic merges, but also to manual merges.

Fixes: #1021