### PR TITLE
logging: change default log suffix to .txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ set(BEEROCKS_ENABLE_ARP_MONITOR 1)
 # Logging configuration
 set(BEEROCKS_LOG_FILES_ENABLED      "true")
 set(BEEROCKS_LOG_FILES_PATH         "${TMP_PATH}/logs")
-set(BEEROCKS_LOG_FILES_SUFFIX       ".log")
+set(BEEROCKS_LOG_FILES_SUFFIX       ".txt")
 set(BEEROCKS_LOG_FILES_AUTO_ROLL    "true")
 set(BEEROCKS_LOG_STDOUT_ENABLED     "false")
 set(BEEROCKS_LOG_SYSLOG_ENABLED     "false")

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -225,7 +225,7 @@ class TestFlows:
 
     def _check_log_internal(self, device: str, program: str, regex: str) -> bool:
         '''Search for regex in logfile for program on device.'''
-        logfilename = os.path.join(self.rootdir, 'logs', device, 'beerocks_{}.log'.format(program))
+        logfilename = os.path.join(self.rootdir, 'logs', device, 'beerocks_{}.txt'.format(program))
         with open(logfilename) as logfile:
             for line in logfile.readlines():
                 if re.search(regex, line):


### PR DESCRIPTION
File extention .log is not standard as .txt which is what the logs
contain, which makes default text editors not to understand that these
are regular text files.
An extremely annoying example is the ownCloud web GUI which doesn't know
how to show .log files therefore we need to download logs in order to
view them, which makes analyzing issues take much longer.
Therefore, change the default log suffix to .txt.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>