### PR TITLE
openwrt build.sh use TARGET_DEVICE for default

### DIFF
--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -141,7 +141,7 @@ main() {
     if [ -n "$TAG" ] ; then
         image_tag="$TAG"
     else
-        image_tag="prplmesh-builder-${TARGET}:${OPENWRT_VERSION}"
+        image_tag="prplmesh-builder-${TARGET_DEVICE}:${OPENWRT_VERSION}"
         dbg "image tag not set, using default value $image_tag"
     fi
 


### PR DESCRIPTION
Fix bug when building without specifying the tag fails since TARGET is
undefined, instead use:
image_tag="prplmesh-builder-${TARGET_DEVICE}:${OPENWRT_VERSION}"