### PR TITLE
build: change CMAKE REVISION variable to PRPLMESH_REVISION

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions(-DBEEROCKS_VERSION="${prplmesh_VERSION}")
 add_definitions(-DBEEROCKS_BUILD_DATE="${BUILD_DATE}")
-add_definitions(-DBEEROCKS_REVISION="${REVISION}")
+add_definitions(-DBEEROCKS_REVISION="${PRPLMESH_REVISION}")
 
 add_definitions(-DBEEROCKS_BIN_PATH="${INSTALL_PATH}/bin/")
 add_definitions(-DBEEROCKS_CONF_PATH="${INSTALL_PATH}/config/")

--- a/cmake/multiap-helpers.cmake
+++ b/cmake/multiap-helpers.cmake
@@ -29,12 +29,12 @@ if (${FORCE_COLORED_OUTPUT})
     endif ()
 endif ()
 
-if (NOT REVISION)
+if (NOT PRPLMESH_REVISION)
     execute_process(
         COMMAND "git" "rev-parse" "--short" "HEAD"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_STRIP_TRAILING_WHITESPACE 
-        OUTPUT_VARIABLE REVISION
+        OUTPUT_VARIABLE PRPLMESH_REVISION
     )
 endif()
 
@@ -44,4 +44,4 @@ endif()
 
 message(STATUS "prplmesh Version: ${prplmesh_VERSION}")
 message(STATUS "prplmesh Build Date: ${BUILD_DATE}")
-message(STATUS "prplmesh Revision: ${REVISION}")
+message(STATUS "prplmesh Revision: ${PRPLMESH_REVISION}")

--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions(-DBEEROCKS_VERSION="${prplmesh_VERSION}")
 add_definitions(-DBEEROCKS_BUILD_DATE="${BUILD_DATE}")
-add_definitions(-DBEEROCKS_REVISION="${REVISION}")
+add_definitions(-DBEEROCKS_REVISION="${PRPLMESH_REVISION}")
 
 add_definitions(-DBEEROCKS_BIN_PATH="${INSTALL_PATH}/bin/")
 add_definitions(-DBEEROCKS_CONF_PATH="${INSTALL_PATH}/config/")

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -110,7 +110,7 @@ main() {
             SUBTARGET=xrx500
             TARGET_PROFILE=DEVICE_NETGEAR_RAX40
             PRPLMESH_VARIANT="-dwpal"
-            PRPL_FEED="https://git.prpl.dev/prplmesh/iwlwav.git^129d4450f9780c957859c78ea44c2d8c4171152e"
+            PRPL_FEED="https://git.prpl.dev/prplmesh/iwlwav.git^6265989f2c47f7b42f64d25f455443b87902582e"
             INTEL_FEED="https://git.prpl.dev/prplmesh/feed-intel.git^e3eca4e93286eb4346f0196b2816a3be97287482"
             BASE_CONFIG=gcc8
             ;;

--- a/version.in
+++ b/version.in
@@ -1,4 +1,4 @@
 prplmesh_version=@prplmesh_VERSION@
-prplmesh_revision=@REVISION@
+prplmesh_revision=@PRPLMESH_REVISION@
 prplmesh_build_date=@BUILD_DATE@
 


### PR DESCRIPTION
Building IPK from tools/builder/openwrt/scripts/build.sh is done as
follows:
make package/feeds/prpl/prplmesh/prepare USE_SOURCE_DIR="/home/openwrt/prplMesh" V=s
make package/feeds/prpl/prplmesh/compile V=sc -j"$(nproc)"

The prplMesh revision comes out wrong since the REVISION variable is
passed from the OpenWRT package Makefile AND is exported by the OpenWRT
build system anyway.
This is simply confusing since the revision showing in the logs, and in
the config/version file, are wrong.

In order to fix this, the feed Makefile needs to be modified not to pass
REVISION when USE_SOURCE_DIR is defined, but in addition, prplmesh build
system should use a unique variable for the revision otherwise it will get
the REVISION exported by the OpenWRT build system.

This commit changes REVISION to PRPLMESH_REVISION so that it will use
the revision passed from the OpenWRT feed Makefile.
Also, since this commit requires a change in the feed, update it as well
in the build script - relevant commit in the feed:
https://git.prpl.dev/prplmesh/iwlwav/-/commit/6265989f2c47f7b42f64d25f455443b87902582e.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>