### PR TITLE
controller: fix compilation error on rdkb

### DIFF
--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task_db.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task_db.cpp
@@ -126,7 +126,7 @@ rdkb_wlan_task_db::get_ap_config(const std::string &bssid)
         }
     }
     LOG(ERROR) << "can't find entry for bssid=" << bssid;
-    return std::make_pair(false, {});
+    return {};
 }
 
 std::unordered_map<std::string, std::shared_ptr<beerocks_message::sSteeringClientConfig>>


### PR DESCRIPTION
Commit 372fc6eb6ff60c88988f9e0e1b306dd3f952df67 introduced a
compilation error:
rdkb_wlan_task_db.cpp:129:36: error: no matching function for call to 'make_pair(bool, <brace-enclosed initializer list>)'
|      return std::make_pair(false, {});

To fix it, we could create the pair like this:
return {false, {}};

However, since bool is value-initialized to false, we can directly do
this just as well:
return {};

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>