### PR TITLE
hotfix/Fix missing client RSSI on multiple reconnects

### DIFF
--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -336,6 +336,12 @@ void son_actions::handle_dead_node(std::string mac, std::string hostap_mac, db &
                     tasks.kill_task(prev_task_id);
                 }
             }
+
+            // If there is an instance of association handling task, kill it
+            int association_handling_task_id = database.get_association_handling_task_id(mac);
+            if (tasks.is_task_running(association_handling_task_id)) {
+                tasks.kill_task(association_handling_task_id);
+            }
         }
 
         // close slave socket


### PR DESCRIPTION
It is observed that when a client has very low RSSI, it tend to do multiple reconnects:
connect-disconnect-connect in a very short time.
In such a case, the association handling task is running upon the first client connection.
Then the client is rapidly disconnected and connect again.
The disconnect triggers a STOP_MONITORING command, and when the client connects
again, the new association handling task is not being triggered since there is already
a running task that should be finished. So the final result is that the client is stopped being
monitored and not starting the monitoring again.
