### PR TITLE
Run tests with tcpdump in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ run-tests:
   script:
     # Try to pull from dockerhub, if it fails, the run should fail
     - tools/docker/image-pull.sh
-    - tests/test_flows.py -v -u $RANDOM
+    - tests/test_flows.py -v -u $RANDOM --tcpdump
 
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ flake8:
   stage: build
   image: pipelinecomponents/flake8:f087c4c
   variables:
-      FLAKE8_FILES: "tests/capi.py"
+      FLAKE8_FILES: "tests/capi.py tests/opts.py"
   script:
     - flake8 --verbose $FLAKE8_FILES
 

--- a/tests/opts.py
+++ b/tests/opts.py
@@ -1,0 +1,37 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# Copyright (c) 2020 Arnout Vandecappelle (Essensium/Mind)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+
+class opts:
+    '''Static class that encodes the global options.'''
+    verbose = False
+    tcpdump = False
+    stop_on_failure = False
+
+
+def message(msg: str, color: int = 0):
+    '''Print a message, optionally in a color.'''
+    if color:
+        print('\x1b[1;{}m{}\x1b[0m'.format(color, msg))
+    else:
+        print(msg)
+
+
+def debug(msg: str):
+    '''Print a debug message if verbose is enabled.'''
+    if opts.verbose:
+        message(msg)
+
+
+def status(msg: str):
+    '''Print a purple status message.'''
+    message(msg, 35)
+
+
+def err(msg: str):
+    '''Print a red error message.'''
+    message(msg, 31)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -16,6 +16,7 @@ from typing import Dict
 import json
 
 from capi import tlv, UCCSocket
+from opts import debug, err, message, opts, status
 
 '''Regular expression to match a MAC address in a bytes string.'''
 RE_MAC = rb"(?P<mac>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2})"
@@ -62,50 +63,24 @@ class TestFlows:
         self.tcpdump_proc = None
         self.bridge_name = 'br-lan'
 
-
-    def message(self, message: str, color: int = 0):
-        '''Print a message, optionally in a color, preceded by the currently running test.'''
-        full_message = '{:20} {}'.format(self.running, message)
-        if color:
-            print('\x1b[1;{}m{}\x1b[0m'.format(color, full_message))
-        else:
-            print(full_message)
-
-    def debug(self, message: str):
-        '''Print a debug message if verbose is enabled.'''
-        if self.opts.verbose:
-            self.message(message)
-
-    def status(self, message: str):
-        '''Print a purple status message.'''
-        self.message(message, 35)
-
-    def err(self, message: str):
-        '''Print a red error message.'''
-        self.message(message, 31)
-
-    def ok(self):
-        '''Print a green OK message.'''
-        self.message("OK", 32)
-
-    def fail(self, message: str) -> bool:
+    def fail(self, msg: str) -> bool:
         '''Print a red error message, increment failure count and return False.'''
         self.check_error += 1
-        self.err('FAIL: {}'.format(message))
-        if self.opts.stop_on_failure:
+        err('FAIL: {}'.format(msg))
+        if opts.stop_on_failure:
             sys.exit(1)
         return False
 
     def start_test(self, test: str):
         '''Call this at the beginning of a test.'''
         self.running = test
-        self.status("starting")
+        status(test + " starting")
 
     def tcpdump_start(self):
         '''Start tcpdump if enabled by config.'''
-        if self.opts.tcpdump:
+        if opts.tcpdump:
             outputfile = os.path.join(self.rootdir, 'logs', 'test_{}.pcap'.format(self.running))
-            self.debug("Starting tcpdump, output file {}".format(outputfile))
+            debug("Starting tcpdump, output file {}".format(outputfile))
             inspect = json.loads(subprocess.check_output(('docker', 'network', 'inspect',
                                                           'prplMesh-net-{}'.format(self.opts.unique_id))))
             prplmesh_net = inspect[0]
@@ -122,18 +97,19 @@ class TestFlows:
             # poll() so we exit the loop if tcpdump terminates for any reason.
             while not self.tcpdump_proc.poll():
                 line = self.tcpdump_proc.stderr.readline()
-                self.debug(line.decode()[:-1]) # strip off newline
+                debug(line.decode()[:-1])  # strip off newline
                 if line.startswith(b"tcpdump: listening on " + bridge.encode()):
-                    self.tcpdump_proc.stderr.close() # Make sure it doesn't block due to stderr buffering
+                    # Make sure it doesn't block due to stderr buffering
+                    self.tcpdump_proc.stderr.close()
                     break
             else:
-                self.err("tcpdump terminated")
+                err("tcpdump terminated")
                 self.tcpdump_proc = None
 
     def tcpdump_kill(self):
         '''Stop tcpdump if it is running.'''
         if self.tcpdump_proc:
-            self.status("Terminating tcpdump")
+            status("Terminating tcpdump")
             self.tcpdump_proc.terminate()
             self.tcpdump_proc = None
 
@@ -143,12 +119,12 @@ class TestFlows:
 
     def beerocks_cli_command(self, command: str) -> bytes:
         '''Execute `command` beerocks_cli command on the controller and return its output.'''
-        self.debug("Send CLI command " + command)
+        debug("Send CLI command " + command)
         res = self.docker_command(self.gateway,
                                    os.path.join(self.installdir, "bin", "beerocks_cli"),
                                    "-c",
                                    command)
-        self.debug("  Response: " + res.decode('utf-8', errors='replace').strip())
+        debug("  Response: " + res.decode('utf-8', errors='replace').strip())
         return res
 
     def get_conn_map(self) -> Dict[str, MapDevice]:
@@ -203,25 +179,25 @@ class TestFlows:
         self.repeater2_ucc = self.open_CAPI_socket(self.repeater2)
 
         self.mac_gateway = self.gateway_ucc.dev_get_parameter('ALid')
-        self.debug('mac_gateway: {}'.format(self.mac_gateway))
+        debug('mac_gateway: {}'.format(self.mac_gateway))
         self.mac_repeater1 = self.repeater1_ucc.dev_get_parameter('ALid')
-        self.debug('mac_repeater1: {}'.format(self.mac_repeater1))
+        debug('mac_repeater1: {}'.format(self.mac_repeater1))
         self.mac_repeater2 = self.repeater2_ucc.dev_get_parameter('ALid')
-        self.debug('mac_repeater2: {}'.format(self.mac_repeater2))
+        debug('mac_repeater2: {}'.format(self.mac_repeater2))
 
         mac_repeater1_wlan0_output = self.docker_command(self.repeater1, "ip", "-o",  "link", "list", "dev", "wlan0")
         self.mac_repeater1_wlan0 = re.search(rb"link/ether " + RE_MAC, mac_repeater1_wlan0_output).group('mac').decode()
-        self.debug("Repeater1 wl0: {}".format(self.mac_repeater1_wlan0))
+        debug("Repeater1 wl0: {}".format(self.mac_repeater1_wlan0))
         mac_repeater1_wlan2_output = self.docker_command(self.repeater1, "ip", "-o",  "link", "list", "dev", "wlan2")
         self.mac_repeater1_wlan2 = re.search(rb"link/ether " + RE_MAC, mac_repeater1_wlan2_output).group('mac').decode()
-        self.debug("Repeater1 wl2: {}".format(self.mac_repeater1_wlan2))
+        debug("Repeater1 wl2: {}".format(self.mac_repeater1_wlan2))
 
         mac_repeater2_wlan0_output = self.docker_command(self.repeater2, "ip", "-o",  "link", "list", "dev", "wlan0")
         self.mac_repeater2_wlan0 = re.search(rb"link/ether " + RE_MAC, mac_repeater2_wlan0_output).group('mac').decode()
-        self.debug("Repeater2 wl0: {}".format(self.mac_repeater2_wlan0))
+        debug("Repeater2 wl0: {}".format(self.mac_repeater2_wlan0))
         mac_repeater2_wlan2_output = self.docker_command(self.repeater2, "ip", "-o",  "link", "list", "dev", "wlan2")
         self.mac_repeater2_wlan2 = re.search(rb"link/ether " + RE_MAC, mac_repeater2_wlan2_output).group('mac').decode()
-        self.debug("Repeater2 wl2: {}".format(self.mac_repeater2_wlan2))
+        debug("Repeater2 wl2: {}".format(self.mac_repeater2_wlan2))
 
     def _check_log_internal(self, device: str, program: str, regex: str) -> bool:
         '''Search for regex in logfile for program on device.'''
@@ -229,7 +205,7 @@ class TestFlows:
         with open(logfilename) as logfile:
             for line in logfile.readlines():
                 if re.search(regex, line):
-                    self.debug("Found '{}'\n\tin {}".format(regex, logfilename))
+                    debug("Found '{}'\n\tin {}".format(regex, logfilename))
                     return True
         return False
 
@@ -279,9 +255,9 @@ class TestFlows:
             finally:
                 self.tcpdump_kill()
             if self.check_error != 0:
-                self.err("failed")
+                err(test + " failed")
             else:
-                self.ok()
+                message(test + " OK", 32)
             total_errors += self.check_error
         return total_errors
 
@@ -373,21 +349,21 @@ class TestFlows:
                 self.fail('Wrong SSID: {vap.ssid} instead torn down'.format(vap = vap))
 
     def test_channel_selection(self):
-        self.debug("Send channel preference query")
+        debug("Send channel preference query")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8004)
         time.sleep(1)
-        self.debug("Confirming channel preference query has been received on agent")
+        debug("Confirming channel preference query has been received on agent")
         self.check_log(self.repeater1, "agent_wlan0", "CHANNEL_PREFERENCE_QUERY_MESSAGE")
         self.check_log(self.repeater1, "agent_wlan2", "CHANNEL_PREFERENCE_QUERY_MESSAGE")
 
-        self.debug("Send channel selection request")
+        debug("Send channel selection request")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8006)
         time.sleep(1)
-        self.debug("Confirming channel selection request has been received on agent")
+        debug("Confirming channel selection request has been received on agent")
         self.check_log(self.repeater1, "agent_wlan0", "CHANNEL_SELECTION_REQUEST_MESSAGE")
         self.check_log(self.repeater1, "agent_wlan2", "CHANNEL_SELECTION_REQUEST_MESSAGE")
 
-        #self.debug("Confirming 1905.1 Ack Message request was received on agent")
+        # debug("Confirming 1905.1 Ack Message request was received on agent")
         # TODO: When creating handler for the ACK message on the agent, replace lookup of this string
         # TODO: currently controller sends empty channel selection request, so no switch is performed
         # self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
@@ -397,10 +373,10 @@ class TestFlows:
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8001)
         time.sleep(1)
 
-        self.debug("Confirming ap capability query has been received on agent")
+        debug("Confirming ap capability query has been received on agent")
         self.check_log(self.repeater1, "agent", "AP_CAPABILITY_QUERY_MESSAGE")
 
-        self.debug("Confirming ap capability report has been received on controller")
+        debug("Confirming ap capability report has been received on controller")
         self.check_log(self.gateway, "controller", "AP_CAPABILITY_REPORT_MESSAGE")
 
     def test_link_metric_query(self):
@@ -408,16 +384,16 @@ class TestFlows:
                                        tlv(0x08,0x0002,"0x00 0x02"))
         time.sleep(1)
 
-        self.debug("Confirming link metric query has been received on agent")
+        debug("Confirming link metric query has been received on agent")
         self.check_log(self.repeater1, "agent", "Received LINK_METRIC_QUERY_MESSAGE")
 
-        self.debug("Confirming link metric response has been received on controller")
+        debug("Confirming link metric response has been received on controller")
         self.check_log(self.gateway, "controller", "Received LINK_METRIC_RESPONSE_MESSAGE")
         self.check_log(self.gateway, "controller", "Received TLV_TRANSMITTER_LINK_METRIC")
         self.check_log(self.gateway, "controller", "Received TLV_RECEIVER_LINK_METRIC")
 
     def test_combined_infra_metrics(self):
-        self.debug("Send AP Metrics query message to agent 1")
+        debug("Send AP Metrics query message to agent 1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x800B,
                                        tlv(0x93,0x0007,"0x01 {%s}" % (self.mac_repeater1_wlan0)))
         self.check_log(self.repeater1, "agent_wlan0", "Received AP_METRICS_QUERY_MESSAGE")
@@ -435,7 +411,7 @@ class TestFlows:
                 "0x14243444 0x15253545 0x16263646"))
         self.check_log(self.gateway, "controller", "Received AP_METRICS_RESPONSE_MESSAGE")
 
-        self.debug("Send AP Metrics query message to agent 2")
+        debug("Send AP Metrics query message to agent 2")
         self.gateway_ucc.dev_send_1905(self.mac_repeater2, 0x800B,
                                        tlv(0x93,0x0007,"0x01 {%s}" % self.mac_repeater2_wlan2))
         self.check_log(self.repeater2, "agent_wlan2", "Received AP_METRICS_QUERY_MESSAGE")
@@ -448,7 +424,7 @@ class TestFlows:
                          "0xa4243444 0xa5253545 0xa6263646"))
         self.check_log(self.gateway, "controller", "Received AP_METRICS_RESPONSE_MESSAGE")
 
-        self.debug("Send 1905 Link metric query to agent 1 (neighbor gateway)")
+        debug("Send 1905 Link metric query to agent 1 (neighbor gateway)")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0005,
                                        tlv(0x08,0x0008,"0x01 {%s} 0x02" % self.mac_gateway))
         self.check_log(self.repeater1, "agent", "Received LINK_METRIC_QUERY_MESSAGE")
@@ -457,7 +433,7 @@ class TestFlows:
         self.check_log(self.gateway, "controller", "Received TLV_RECEIVER_LINK_METRIC")
 
         # Trigger combined infra metrics
-        self.debug("Send Combined infrastructure metrics message to agent 1")
+        debug("Send Combined infrastructure metrics message to agent 1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8013)
         self.check_log(self.repeater1, "agent", "Received COMBINED_INFRASTRUCTURE_METRICS")
         self.check_log(self.repeater1, "agent", "Received TLV_TRANSMITTER_LINK_METRIC")
@@ -467,30 +443,30 @@ class TestFlows:
         sta_mac1 = '00:00:00:11:00:22'
         sta_mac2 = '00:00:00:11:00:33'
 
-        self.debug("Send client capability query for unconnected STA")
+        debug("Send client capability query for unconnected STA")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8009,
                                        tlv(0x90,0x000C,
                                            '{mac_repeater1_wlan0} {sta_mac1}'
                                             .format(sta_mac1 = sta_mac1,
                                                     mac_repeater1_wlan0 = self.mac_repeater1_wlan0)))
         time.sleep(1)
-        self.debug("Confirming client capability query has been received on agent")
+        debug("Confirming client capability query has been received on agent")
         # check that both radio agents received it, in the future we'll add a check to verify which
         # radio the query was intended for.
         self.check_log(self.repeater1, "agent", r"CLIENT_CAPABILITY_QUERY_MESSAGE")
 
-        self.debug("Confirming client capability report message has been received on controller")
+        debug("Confirming client capability report message has been received on controller")
         self.check_log(self.gateway, "controller", r"Received CLIENT_CAPABILITY_REPORT_MESSAGE")
         self.check_log(self.gateway, "controller",
                        r"Result Code= FAILURE, client MAC= {sta_mac1}, BSSID= {mac_repeater1_wlan0}"
                         .format(sta_mac1 = sta_mac1,
                                 mac_repeater1_wlan0 = self.mac_repeater1_wlan0))
 
-        self.debug("Connect dummy STA to wlan0")
+        debug("Connect dummy STA to wlan0")
         self.send_bwl_event(self.repeater1, "wlan0",
                             "EVENT AP-STA-CONNECTED {sta_mac2}".format(sta_mac2 = sta_mac2))
 
-        self.debug("Send client capability query for connected STA")
+        debug("Send client capability query for connected STA")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8009,
                                        tlv(0x90,0x000C,
                                            '{mac_repeater1_wlan0} {sta_mac2}'
@@ -498,7 +474,7 @@ class TestFlows:
                                                     mac_repeater1_wlan0 = self.mac_repeater1_wlan0)))
         time.sleep(1)
 
-        self.debug("Confirming client capability report message has been received on controller")
+        debug("Confirming client capability report message has been received on controller")
         self.check_log(self.gateway, "controller", r"Received CLIENT_CAPABILITY_REPORT_MESSAGE")
         self.check_log(self.gateway, "controller",
                        r"Result Code= SUCCESS, client MAC= {sta_mac2}, BSSID= {mac_repeater1_wlan0}"
@@ -508,83 +484,83 @@ class TestFlows:
     def test_client_association_dummy(self):
         sta_mac = "11:11:33:44:55:66"
 
-        self.debug("Connect dummy STA to wlan0")
+        debug("Connect dummy STA to wlan0")
         self.send_bwl_event(self.repeater1, "wlan0", "EVENT AP-STA-CONNECTED {}".format(sta_mac))
-        self.debug("Send client association control request to the chosen BSSID to steer the client (UNBLOCK) ")
+        debug("Send client association control request to the chosen BSSID (UNBLOCK)")
         self.beerocks_cli_command('client_allow {} {}'.format(sta_mac, self.mac_repeater1_wlan2))
         time.sleep(1)
 
-        self.debug("Confirming Client Association Control Request message was received (UNBLOCK)")
+        debug("Confirming Client Association Control Request message was received (UNBLOCK)")
         self.check_log(self.repeater1, "agent_wlan2",
                        r"Got client allow request for {}".format(sta_mac))
 
-        self.debug("Send client association control request to all other (BLOCK) ")
+        debug("Send client association control request to all other (BLOCK) ")
         self.beerocks_cli_command('client_disallow {} {}'.format(sta_mac, self.mac_repeater1_wlan0))
         time.sleep(1)
 
-        self.debug("Confirming Client Association Control Request message was received (BLOCK)")
+        debug("Confirming Client Association Control Request message was received (BLOCK)")
         self.check_log(self.repeater1, "agent_wlan0",
                        r"Got client disallow request for {}".format(sta_mac))
 
     def test_client_steering_mandate(self):
-        self.debug("Send topology request to agent 1")
+        debug("Send topology request to agent 1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0002)
         time.sleep(1)
-        self.debug("Confirming topology query was received")
+        debug("Confirming topology query was received")
         self.check_log(self.repeater1, "agent", "TOPOLOGY_QUERY_MESSAGE")
 
-        self.debug("Send topology request to agent 2")
+        debug("Send topology request to agent 2")
         self.gateway_ucc.dev_send_1905(self.mac_repeater2, 0x0002)
         time.sleep(1)
-        self.debug("Confirming topology query was received")
+        debug("Confirming topology query was received")
         self.check_log(self.repeater2, "agent", "TOPOLOGY_QUERY_MESSAGE")
 
-        self.debug("Send Client Steering Request message for Steering Mandate to CTT Agent1")
+        debug("Send Client Steering Request message for Steering Mandate to CTT Agent1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8014,
             tlv(0x9B, 0x001b, "{%s 0xe0 0x0000 0x1388 0x01 {0x000000110022} 0x01 {%s 0x73 0x24}}" %
                 (self.mac_repeater1_wlan0, self.mac_repeater2_wlan0)))
         time.sleep(1)
-        self.debug("Confirming Client Steering Request message was received - mandate")
+        debug("Confirming Client Steering Request message was received - mandate")
         self.check_log(self.repeater1, "agent_wlan0", "Got steer request")
 
-        self.debug("Confirming BTM Report message was received")
+        debug("Confirming BTM Report message was received")
         self.check_log(self.gateway, "controller", "CLIENT_STEERING_BTM_REPORT_MESSAGE")
 
-        self.debug("Checking BTM Report source bssid")
+        debug("Checking BTM Report source bssid")
         self.check_log(self.gateway, "controller", "BTM_REPORT from source bssid %s" % self.mac_repeater1_wlan0)
 
-        self.debug("Confirming ACK message was received")
+        debug("Confirming ACK message was received")
         self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
 
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8014,
             tlv(0x9B, 0x000C, "{%s 0x00 0x000A 0x0000 0x00}" % self.mac_repeater1_wlan0))
         time.sleep(1)
-        self.debug("Confirming Client Steering Request message was received - Opportunity")
+        debug("Confirming Client Steering Request message was received - Opportunity")
         self.check_log(self.repeater1, "agent_wlan0", "CLIENT_STEERING_REQUEST_MESSAGE")
 
-        self.debug("Confirming ACK message was received")
+        debug("Confirming ACK message was received")
         self.check_log(self.gateway, "controller", "ACK_MESSAGE")
 
-        self.debug("Confirming steering completed message was received")
+        debug("Confirming steering completed message was received")
         self.check_log(self.gateway, "controller", "STEERING_COMPLETED_MESSAGE")
 
-        self.debug("Confirming ACK message was received")
+        debug("Confirming ACK message was received")
         self.check_log(self.repeater1, "agent_wlan0", "ACK_MESSAGE")
 
     # Disabled because it sometimes fails (cfr. #711) and it has to be executed before any
     # autoconfig test
     def _test_optimal_path_dummy(self):
         # TODO make sure the same SSID is configured on each radio
-        self.debug("Connect dummy STA to wlan0")
+        debug("Connect dummy STA to wlan0")
         self.send_bwl_event(self.repeater1, "wlan0", "EVENT AP-STA-CONNECTED 11:22:33:44:55:66")
-        self.debug("Pre-prepare RRM Beacon Response for association handling task")
+        debug("Pre-prepare RRM Beacon Response for association handling task")
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-40 rsni=40 bssid=aa:bb:cc:00:00:10")
-        self.debug("Confirming 11k request is done by association handling task")
+        debug("Confirming 11k request is done by association handling task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:00:00:10 channel 1", 2)
 
-        self.debug("Update Stats")
+        debug("Update Stats")
         self.send_bwl_event(self.repeater1, "wlan0", "DATA STA-UPDATE-STATS 11:22:33:44:55:66 rssi=-38,-39,-40,-41 snr=38,39,40,41 uplink=1000 downlink=800")
-        self.debug("Pre-prepare RRM Beacon Responses for optimal path task")
+        debug("Pre-prepare RRM Beacon Responses for optimal path task")
         #Response for IRE1, BSSID of wlan0.0
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=aa:bb:cc:11:00:10")
         #Response for IRE1, BSSID of wlan2.0
@@ -597,28 +573,28 @@ class TestFlows:
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=00:11:22:33:00:10")
         #Response for GW, BSSID of wlan2.0
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-80 rsni=10 bssid=00:11:22:33:00:20")
-        self.debug("Confirming 11k request is done by optimal path task")
+        debug("Confirming 11k request is done by optimal path task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:11:00:20 channel 149", 20)
 
-        self.debug("Confirming 11k request is done by optimal path task")
+        debug("Confirming 11k request is done by optimal path task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:00:00:20 channel 149", 20)
 
-        self.debug("Confirming 11k request is done by optimal path task")
+        debug("Confirming 11k request is done by optimal path task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:66 on bssid aa:bb:cc:11:00:10 channel 1", 20)
 
-        self.debug("Confirming 11k request is done by optimal path task")
+        debug("Confirming 11k request is done by optimal path task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:66 on bssid 00:11:22:33:00:20 channel 149", 20)
 
-        self.debug("Confirming 11k request is done by optimal path task")
+        debug("Confirming 11k request is done by optimal path task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:66 on bssid 00:11:22:33:00:10 channel 1", 20)
 
-        self.debug("Confirming no steer is done")
+        debug("Confirming no steer is done")
         self.wait_for_log(self.gateway, "controller", r"could not find a better path for sta 11:22:33:44:55:66", 20)
 
         # Steer scenario
-        self.debug("Update Stats")
+        debug("Update Stats")
         self.send_bwl_event(self.repeater1, "wlan0", "DATA STA-UPDATE-STATS 11:22:33:44:55:66 rssi=-58,-59,-60,-61 snr=18,19,20,21 uplink=100 downlink=80")
-        self.debug("Pre-prepare RRM Beacon Responses for optimal path task")
+        debug("Pre-prepare RRM Beacon Responses for optimal path task")
         #Response for IRE1, BSSID of wlan0.0
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=aa:bb:cc:11:00:10")
         #Response for IRE1, BSSID of wlan2.0
@@ -631,122 +607,122 @@ class TestFlows:
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=1 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=00:11:22:33:00:10")
         #Response for GW, BSSID of wlan2.0
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:66 channel=149 dialog_token=0 measurement_rep_mode=0 op_class=0 duration=50 rcpi=-30 rsni=50 bssid=00:11:22:33:00:20")
-        self.debug("Confirming steering is requested by optimal path task")
+        debug("Confirming steering is requested by optimal path task")
         self.wait_for_log(self.gateway, "controller", r"optimal_path_task: steering", 20)
 
         # Error scenario, sta doesn't support 11k
-        self.debug("Connect dummy STA to wlan0")
+        debug("Connect dummy STA to wlan0")
         self.send_bwl_event(self.repeater1, "wlan0", "EVENT AP-STA-CONNECTED 11:22:33:44:55:77")
-        self.debug("Pre-prepare RRM Beacon Response with error for association handling task")
+        debug("Pre-prepare RRM Beacon Response with error for association handling task")
         self.send_bwl_event(self.repeater1, "wlan0", "DATA RRM-BEACON-REP-RECEIVED 11:22:33:44:55:77 channel=0 dialog_token=0 measurement_rep_mode=4 op_class=0 duration=0 rcpi=0 rsni=0 bssid=aa:bb:cc:00:00:10")
-        self.debug("Confirming 11k request is done by association handling task")
+        debug("Confirming 11k request is done by association handling task")
         self.wait_for_log(self.repeater1, "monitor_wlan0", r"Beacon 11k request to sta 11:22:33:44:55:77 on bssid aa:bb:cc:00:00:10 channel 1", 20)
 
-        self.debug("Confirming STA doesn't support beacon measurement")
+        debug("Confirming STA doesn't support beacon measurement")
         self.wait_for_log(self.gateway, "controller", r"setting sta 11:22:33:44:55:77 as beacon measurement unsupported", 20)
 
-        self.debug("Confirming optimal path falls back to RSSI measurements")
+        debug("Confirming optimal path falls back to RSSI measurements")
         self.wait_for_log(self.gateway, "controller", r"requesting rssi measurements for 11:22:33:44:55:77", 20)
 
     def test_client_steering_dummy(self):
         sta_mac = "11:22:33:44:55:66"
 
-        self.debug("Connect dummy STA to wlan0")
+        debug("Connect dummy STA to wlan0")
         self.send_bwl_event(self.repeater1, "wlan0", "EVENT AP-STA-CONNECTED {}".format(sta_mac))
-        self.debug("Send steer request ")
+        debug("Send steer request ")
         self.beerocks_cli_command("steer_client {} {}".format(sta_mac, self.mac_repeater1_wlan2))
         time.sleep(1)
 
-        self.debug("Confirming Client Association Control Request message was received (UNBLOCK)")
+        debug("Confirming Client Association Control Request message was received (UNBLOCK)")
         self.check_log(self.repeater1, "agent_wlan2", r"Got client allow request")
 
-        self.debug("Confirming Client Association Control Request message was received (BLOCK)")
+        debug("Confirming Client Association Control Request message was received (BLOCK)")
         self.check_log(self.repeater1, "agent_wlan0", r"Got client disallow request")
 
-        self.debug("Confirming Client Association Control Request message was received (BLOCK)")
+        debug("Confirming Client Association Control Request message was received (BLOCK)")
         self.check_log(self.repeater2, "agent_wlan0", r"Got client disallow request")
 
-        self.debug("Confirming Client Association Control Request message was received (BLOCK)")
+        debug("Confirming Client Association Control Request message was received (BLOCK)")
         self.check_log(self.repeater2, "agent_wlan2", r"Got client disallow request")
 
-        self.debug("Confirming Client Steering Request message was received - mandate")
+        debug("Confirming Client Steering Request message was received - mandate")
         self.check_log(self.repeater1, "agent_wlan0", r"Got steer request")
 
-        self.debug("Confirming BTM Report message was received")
+        debug("Confirming BTM Report message was received")
         self.check_log(self.gateway, "controller", r"CLIENT_STEERING_BTM_REPORT_MESSAGE")
 
-        self.debug("Confirming ACK message was received")
+        debug("Confirming ACK message was received")
         self.check_log(self.repeater1, "agent_wlan0", r"ACK_MESSAGE")
 
-        self.debug("Disconnect dummy STA from wlan0")
+        debug("Disconnect dummy STA from wlan0")
         self.send_bwl_event(self.repeater1, "wlan0", "EVENT AP-STA-DISCONNECTED {}".format(sta_mac))
         # Make sure that controller sees disconnect before connect by waiting a little
         time.sleep(1)
 
-        self.debug("Connect dummy STA to wlan2")
+        debug("Connect dummy STA to wlan2")
         self.send_bwl_event(self.repeater1, "wlan2", "EVENT AP-STA-CONNECTED {}".format(sta_mac))
-        self.debug("Confirm steering success by client connected")
+        debug("Confirm steering success by client connected")
         self.check_log(self.gateway, "controller", r"steering successful for sta {}".format(sta_mac))
         self.check_log(self.gateway, "controller", r"sta {} disconnected due to steering request".format(sta_mac))
 
     def test_client_steering_policy(self):
-        self.debug("Send client steering policy to agent 1")
+        debug("Send client steering policy to agent 1")
         mid = self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8003,
             tlv(0x89, 0x000C, "{0x00 0x00 0x01 {0x112233445566 0x01 0xFF 0x14}}"))
         time.sleep(1)
-        self.debug("Confirming client steering policy has been received on agent")
+        debug("Confirming client steering policy has been received on agent")
 
         self.check_log(self.repeater1, "agent_wlan0", r"MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE")
         time.sleep(1)
-        self.debug("Confirming client steering policy ack message has been received on the controller")
+        debug("Confirming client steering policy ack message has been received on the controller")
         self.check_log(self.gateway, "controller", r"ACK_MESSAGE, mid=0x{:04x}".format(mid))
 
     def test_client_association(self):
-        self.debug("Send topology request to agent 1")
+        debug("Send topology request to agent 1")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0002)
-        self.debug("Confirming topology query was received")
+        debug("Confirming topology query was received")
         self.check_log(self.repeater1, "agent", r"TOPOLOGY_QUERY_MESSAGE")
 
-        self.debug("Send client association control message")
+        debug("Send client association control message")
         self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8016,
             tlv(0x9D, 0x000F, "{%s 0x00 0x1E 0x01 {0x000000110022}}" % self.mac_repeater1_wlan0))
 
-        self.debug("Confirming client association control message has been received on agent")
+        debug("Confirming client association control message has been received on agent")
         # check that both radio agents received it,in the future we'll add a check to verify which
         # radio the query was intended for.
         self.check_log(self.repeater1, "agent_wlan0", r"CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE")
         self.check_log(self.repeater1, "agent_wlan2", r"CLIENT_ASSOCIATION_CONTROL_REQUEST_MESSAGE")
 
-        self.debug("Confirming ACK message was received on controller")
+        debug("Confirming ACK message was received on controller")
         self.check_log(self.gateway, "controller", r"ACK_MESSAGE")
 
     def test_higher_layer_data_payload_trigger(self):
         mac_gateway_hex = '0x' + self.mac_gateway.replace(':', '')
-        self.debug("mac_gateway_hex = " + mac_gateway_hex)
+        debug("mac_gateway_hex = " + mac_gateway_hex)
         payload = 199 * (mac_gateway_hex + " ") + mac_gateway_hex
 
-        self.debug("Send Higher Layer Data message")
+        debug("Send Higher Layer Data message")
         # MCUT sends Higher Layer Data message to CTT Agent1 by providing:
         # Higher layer protocol = "0x00"
         # Higher layer payload = 200 concatenated copies of the ALID of the MCUT (1200 octets)
         mid = self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x8018,
                                              tlv(0xA0, 0x04b1, "{0x00 %s}" % payload))
 
-        self.debug("Confirming higher layer data message was received in the agent" )
+        debug("Confirming higher layer data message was received in the agent")
 
         self.check_log(self.repeater1, "agent", r"HIGHER_LAYER_DATA_MESSAGE")
 
-        self.debug("Confirming matching protocol and payload length")
+        debug("Confirming matching protocol and payload length")
 
         self.check_log(self.repeater1, "agent", r"protocol: 0")
         self.check_log(self.repeater1, "agent", r"payload_length: 0x4b0")
 
-        self.debug("Confirming ACK message was received in the controller")
+        debug("Confirming ACK message was received in the controller")
         self.check_log(self.gateway, "controller", r"ACK_MESSAGE, mid=0x{:04x}".format(mid))
 
     def test_topology(self):
         mid = self.gateway_ucc.dev_send_1905(self.mac_repeater1, 0x0002)
-        self.debug("Confirming topology query was received")
+        debug("Confirming topology query was received")
         self.check_log(self.repeater1, "agent", r"TOPOLOGY_QUERY_MESSAGE")
 
 
@@ -776,6 +752,10 @@ if __name__ == '__main__':
     unknown_tests = [test for test in options.tests if test not in t.tests]
     if unknown_tests:
         parser.error("Unknown tests: {}".format(', '.join(unknown_tests)))
+
+    opts.verbose = options.verbose
+    opts.tcpdump = options.tcpdump
+    opts.stop_on_failure = options.stop_on_failure
 
     t.opts = options
     t.init()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -108,6 +108,7 @@ class TestFlows:
     def tcpdump_start(self):
         '''Start tcpdump if enabled by config.'''
         if opts.tcpdump:
+            os.makedirs(os.path.join(self.rootdir, 'logs'), exist_ok=True)
             outputfile = os.path.join(self.rootdir, 'logs', 'test_{}.pcap'.format(self.running))
             debug("Starting tcpdump, output file {}".format(outputfile))
             bridge = self.get_bridge_interface()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -243,10 +243,12 @@ class TestFlows:
         command = "echo \"{event}\" > /tmp/$USER/beerocks/{radio}/EVENT".format(**locals())
         self.docker_command(device, 'sh', '-c', command)
 
-    def run_tests(self):
+    def run_tests(self, tests):
         '''Run all tests as specified on the command line.'''
         total_errors = 0
-        for test in self.opts.tests:
+        if not tests:
+            tests = self.tests
+        for test in tests:
             self.start_test(test)
             self.tcpdump_start()
             self.check_error = 0
@@ -746,9 +748,6 @@ if __name__ == '__main__':
                         help="tests to run; if not specified, run all tests: " + ", ".join(t.tests))
     options = parser.parse_args()
 
-    if not options.tests:
-        options.tests = t.tests
-
     unknown_tests = [test for test in options.tests if test not in t.tests]
     if unknown_tests:
         parser.error("Unknown tests: {}".format(', '.join(unknown_tests)))
@@ -759,5 +758,5 @@ if __name__ == '__main__':
 
     t.opts = options
     t.init()
-    if t.run_tests():
+    if t.run_tests(options.tests):
         sys.exit(1)


### PR DESCRIPTION
Enable the tcpdump option of test_flows.py when running in CI.
This makes is easier to debug issues in CI, e.g. #1029.

This requires a fix taken from #1031 to make it possible to start tcpdump before test_gw_repeater.sh is called.
Cherrypicking just that single patch was a bit tricky, so I've taken along two other patches as well.