### PR TITLE
Feature/ci upload artifacts to owncloud 2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,8 @@
+stages:
+  - build
+  - test
+  - upload
+
 .in-prplmesh-builder:
   image:
     name: prplfoundationinc/prplmesh-builder:ubuntu-18.04
@@ -82,6 +87,21 @@ build-in-docker-static:
   extends: build-in-docker
   variables:
     EXTRA_CMAKE_FLAGS: "-DBUILD_SHARED_LIBS=OFF"
+
+upload-artifacts:
+  stage: upload
+  extends: .in-prplmesh-builder
+  script:
+    - ln -s "$CI_OWNCLOUD_PASSWORD" ~/.netrc
+    - sed -i 's/^/machine ftp.essensium.com login prplmesh-robot-ci password /' ~/.netrc
+    - ci/upload_to_owncloud.sh -v --overwrite-remote-path "artifacts/$CI_JOB_ID" artifacts/latest ./build
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+  dependencies:
+    - build-in-docker
+    - build-for-netgear-rax40
+    - build-for-glinet-b1300
+    - build-for-turris-omnia
 
 .run-test-in-docker:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,8 +95,6 @@ upload-artifacts:
     - ln -s "$CI_OWNCLOUD_PASSWORD" ~/.netrc
     - sed -i 's/^/machine ftp.essensium.com login prplmesh-robot-ci password /' ~/.netrc
     - ci/upload_to_owncloud.sh -v --overwrite-remote-path "artifacts/$CI_JOB_ID" artifacts/latest ./build
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
   dependencies:
     - build-in-docker
     - build-for-netgear-rax40

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Alternatively, [tools/maptools.py](tools/README.md) can be used to build and ins
 
 Note - to build and run with Docker, see provided [building with docker](tools/docker/README.md)
 
+Builds for the master branch are also available through the following link: https://ftp.essensium.com/owncloud/index.php/s/6ob8ka1zYORDOVA .
+
 ## Running Instructions
 
 Once built, prplMesh controller, agent and framework can be started using `prplmesh_utils.sh`:

--- a/ci/upload_to_owncloud.sh
+++ b/ci/upload_to_owncloud.sh
@@ -50,6 +50,7 @@ main() {
     remote_path="$1"; shift
     [ -n "$1" ] || { usage; err "Missing local-path"; exit 1; }
     local_path="$1"; shift
+    OWNCLOUD_BROWSE_URL="https://ftp.essensium.com/owncloud/index.php/apps/files/?dir=$remote_path/$(basename "$local_path")"
 
     info "upload $local_path to $OWNCLOUD_BROWSE_URL/$remote_path/$(basename "$local_path") (using user $user)"
     if ! find "$local_path" -type d -exec \


### PR DESCRIPTION
When a pipeline succeeds on the master branch, upload the artifacts to owncloud: https://ftp.essensium.com/owncloud/index.php/apps/files/?dir=/artifacts&fileid=735563.

To make sure there is always a "latest" folder available with all the artifacts, they are not directly uploaded to the latest folder. They are first uploaded to a temporary folder, then on success the folder replaces the "latest" one.