### PR TITLE
check rdkb wlan task state before handling steering socket remove event

### DIFF
--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
@@ -377,16 +377,18 @@ void rdkb_wlan_task::handle_event(int event_type, void *obj)
     case STEERING_REMOVE_SOCKET: {
         if (obj) {
             auto event_obj = (listener_general_register_unregister_event *)obj;
-            TASK_LOG(DEBUG) << "STEERING_REMOVE_SOCKET event was received";
+            if (is_bml_rdkb_wlan_listener_socket(event_obj->sd)) {
+                TASK_LOG(DEBUG) << "STEERING_REMOVE_SOCKET event was received";
 
-            if (!set_bml_rdkb_wlan_events_update_enable(event_obj->sd, false)) {
-                TASK_LOG(ERROR) << "fail in set_bml_rdkb_wlan_events_update_enable";
-            }
+                if (!set_bml_rdkb_wlan_events_update_enable(event_obj->sd, false)) {
+                    TASK_LOG(ERROR) << "fail in set_bml_rdkb_wlan_events_update_enable";
+                }
 
-            remove_bml_rdkb_wlan_socket(event_obj->sd);
+                remove_bml_rdkb_wlan_socket(event_obj->sd);
 
-            if (!is_bml_rdkb_wlan_listener_exist()) {
-                state = IDLE;
+                if (!is_bml_rdkb_wlan_listener_exist()) {
+                    state = IDLE;
+                }
             }
         }
         break;
@@ -844,6 +846,19 @@ bool rdkb_wlan_task::is_bml_rdkb_wlan_listener_exist()
         listener_exist = (*it).events_updates;
         if (listener_exist) {
             return true;
+        }
+    }
+    return false;
+}
+
+bool rdkb_wlan_task::is_bml_rdkb_wlan_listener_socket(Socket *sd)
+{
+    if (sd) {
+        for (auto it = bml_rdkb_wlan_listeners_sockets.begin();
+             it < bml_rdkb_wlan_listeners_sockets.end(); it++) {
+            if (sd == (*it).sd) {
+                return true;
+            }
         }
     }
     return false;

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.h
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.h
@@ -119,6 +119,7 @@ private:
     std::vector<sBmlRdkbWlanListener> bml_rdkb_wlan_listeners_sockets;
 
     bool is_bml_rdkb_wlan_listener_exist();
+    bool is_bml_rdkb_wlan_listener_socket(Socket *sd);
     Socket *get_bml_rdkb_wlan_socket_at(uint32_t idx);
     bool get_bml_rdkb_wlan_events_update_enable(Socket *sd);
     bool set_bml_rdkb_wlan_events_update_enable(Socket *sd, bool update_enable);


### PR DESCRIPTION
Currently if any controller socket is disconnected an additional
STEERING_REMOVE_SOCKET event is sent to rdkb wlan task.
In case there are no actual steering listeners to remove this event
results in a failure and prints several error messages.
This happens each time any 3rd party API is triggered via BML and
fills the controller log file with unnecessary error messages.

Solution is to check if steering listener socket even exists before
trying to remove it.