### PR TITLE
bwl: update basic radio capabilities

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1569,6 +1569,9 @@ void ap_manager_thread::handle_hostapd_attached()
                 beerocks::message::VHT_MCS_SET_SIZE, notification->params().vht_mcs_set);
 
     // Copy the channels supported by the AP
+    auto tuple_supported_channels = notification->supported_channels(0);
+    copy_radio_channels(ap_wlan_hal->get_radio_info().supported_channels,
+                        &std::get<1>(tuple_supported_channels));
     copy_radio_channels(ap_wlan_hal->get_radio_info().preferred_channels,
                         notification->params().preferred_channels);
 
@@ -1588,6 +1591,8 @@ void ap_manager_thread::handle_hostapd_attached()
     LOG(INFO) << " vht_capability = " << std::hex << ap_wlan_hal->get_radio_info().vht_capability;
     LOG(INFO) << " preferred_channels = " << std::endl
               << get_radio_channels_string(ap_wlan_hal->get_radio_info().preferred_channels);
+    LOG(INFO) << " supported_channels = " << std::endl
+              << get_radio_channels_string(ap_wlan_hal->get_radio_info().supported_channels);
 
     // Send CMDU
     message_com::send_cmdu(slave_socket, cmdu_tx);

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -39,7 +39,7 @@ static void copy_radio_supported_channels(std::shared_ptr<bwl::ap_wlan_hal> &ap_
     auto radio_channels = ap_wlan_hal->get_radio_info().supported_channels;
 
     // Copy the channels
-    for (uint i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH && i < radio_channels.size();
+    for (uint i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH && i < radio_channels.size();
          i++) {
 
         supported_channels[i].channel        = radio_channels[i].channel;

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1512,6 +1512,7 @@ void ap_manager_thread::handle_hostapd_attached()
 {
     LOG(DEBUG) << "handling enabled hostapd";
 
+    ap_wlan_hal->read_supported_channels();
     if (acs_enabled) {
         LOG(DEBUG) << "retrieving ACS report";
         int read_acs_attempt = 0;
@@ -1527,7 +1528,7 @@ void ap_manager_thread::handle_hostapd_attached()
             usleep(ACS_READ_SLEEP_USC);
         }
     } else {
-        ap_wlan_hal->read_supported_channels();
+        ap_wlan_hal->update_preference_channels_from_supported_channels();
     }
 
     auto notification =

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -33,30 +33,28 @@ using namespace beerocks::net;
 /////////////////////////// Local Module Functions ///////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-static void copy_radio_supported_channels(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal,
-                                          beerocks::message::sWifiChannel supported_channels[])
+static void copy_radio_channels(std::vector<bwl::WiFiChannel> radio_channels,
+                                beerocks::message::sWifiChannel dest_channels[])
 {
-    auto radio_channels = ap_wlan_hal->get_radio_info().supported_channels;
 
     // Copy the channels
     for (uint i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH && i < radio_channels.size();
          i++) {
 
-        supported_channels[i].channel        = radio_channels[i].channel;
-        supported_channels[i].noise          = radio_channels[i].noise;
-        supported_channels[i].tx_pow         = radio_channels[i].tx_pow;
-        supported_channels[i].bss_overlap    = radio_channels[i].bss_overlap;
-        supported_channels[i].is_dfs_channel = radio_channels[i].is_dfs;
-        supported_channels[i].channel_bandwidth =
+        dest_channels[i].channel        = radio_channels[i].channel;
+        dest_channels[i].noise          = radio_channels[i].noise;
+        dest_channels[i].tx_pow         = radio_channels[i].tx_pow;
+        dest_channels[i].bss_overlap    = radio_channels[i].bss_overlap;
+        dest_channels[i].is_dfs_channel = radio_channels[i].is_dfs;
+        dest_channels[i].channel_bandwidth =
             uint8_t(beerocks::utils::convert_bandwidth_to_enum(radio_channels[i].bandwidth));
     }
 }
 
-static std::string
-get_radio_supported_channels_string(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal)
+static std::string get_radio_channels_string(std::vector<bwl::WiFiChannel> radio_channels)
 {
     std::ostringstream os;
-    for (auto val : ap_wlan_hal->get_radio_info().supported_channels) {
+    for (auto val : radio_channels) {
         if (val.channel > 0) {
             os << " ch = " << int(val.channel) << " | dfs = " << int(val.tx_pow)
                << " | tx_pow = " << int(val.is_dfs) << " | noise = " << int(val.noise)
@@ -787,7 +785,8 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
             return false;
         }
         auto tuple_supported_channels = response->supported_channels_list(0);
-        copy_radio_supported_channels(ap_wlan_hal, &std::get<1>(tuple_supported_channels));
+        copy_radio_channels(ap_wlan_hal->get_radio_info().supported_channels,
+                            &std::get<1>(tuple_supported_channels));
 
         message_com::send_cmdu(slave_socket, cmdu_tx);
         break;
@@ -1112,7 +1111,8 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
                 return false;
             }
             auto tuple_supported_channels = notification->supported_channels_list(0);
-            copy_radio_supported_channels(ap_wlan_hal, &std::get<1>(tuple_supported_channels));
+            copy_radio_channels(ap_wlan_hal->get_radio_info().supported_channels,
+                                &std::get<1>(tuple_supported_channels));
             fill_cs_params(notification->cs_params());
             acs_completed_vap_update = true;
         } else {
@@ -1567,7 +1567,8 @@ void ap_manager_thread::handle_hostapd_attached()
                 beerocks::message::VHT_MCS_SET_SIZE, notification->params().vht_mcs_set);
 
     // Copy the channels supported by the AP
-    copy_radio_supported_channels(ap_wlan_hal, notification->params().supported_channels);
+    copy_radio_channels(ap_wlan_hal->get_radio_info().supported_channels,
+                        notification->params().supported_channels);
 
     LOG(INFO) << "send ACTION_APMANAGER_JOINED_NOTIFICATION";
     LOG(INFO) << " iface = " << ap_wlan_hal->get_iface_name();
@@ -1584,7 +1585,7 @@ void ap_manager_thread::handle_hostapd_attached()
     LOG(INFO) << " vht_supported = " << ap_wlan_hal->get_radio_info().vht_supported;
     LOG(INFO) << " vht_capability = " << std::hex << ap_wlan_hal->get_radio_info().vht_capability;
     LOG(INFO) << " supported_channels = " << std::endl
-              << get_radio_supported_channels_string(ap_wlan_hal);
+              << get_radio_channels_string(ap_wlan_hal->get_radio_info().supported_channels);
 
     // Send CMDU
     message_com::send_cmdu(slave_socket, cmdu_tx);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1784,7 +1784,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
 
         auto channels = &std::get<1>(tuple_supported_channels);
 
-        std::copy_n(channels, beerocks::message::SUPPORTED_CHANNELS_LENGTH,
+        std::copy_n(channels, beerocks::message::RADIO_CHANNELS_LENGTH,
                     soc->supported_channels.begin());
 
         soc->radio_mac             = request->iface_mac();

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1776,13 +1776,13 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
             return false;
         }
 
-        auto tuple_supported_channels = request->supported_channels_list(0);
-        if (!std::get<0>(tuple_supported_channels)) {
+        auto tuple_preferred_channels = request->preferred_channels_list(0);
+        if (!std::get<0>(tuple_preferred_channels)) {
             LOG(ERROR) << "access to supported channels list failed!";
             return false;
         }
 
-        auto channels = &std::get<1>(tuple_supported_channels);
+        auto channels = &std::get<1>(tuple_preferred_channels);
 
         std::copy_n(channels, beerocks::message::RADIO_CHANNELS_LENGTH,
                     soc->supported_channels.begin());

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -273,7 +273,7 @@ private:
             vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
         bool he_supported = false;             /**< Is HE supported flag */
         beerocks_message::sVapsList vaps_list; /**< List of VAPs in radio. */
-        std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+        std::array<beerocks::message::sWifiChannel, beerocks::message::RADIO_CHANNELS_LENGTH>
             supported_channels; /**< Array of supported channels in radio. */
         std::unordered_map<sMacAddr, associated_clients_t>
             associated_clients_map; /**< Associated clients grouped by BSSID. */

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1789,7 +1789,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         notification_out->cs_params()     = notification_in->cs_params();
         auto tuple_in_supported_channels  = notification_in->supported_channels_list(0);
         auto tuple_out_supported_channels = notification_out->supported_channels(0);
-        std::copy_n(&std::get<1>(tuple_in_supported_channels), message::SUPPORTED_CHANNELS_LENGTH,
+        std::copy_n(&std::get<1>(tuple_in_supported_channels), message::RADIO_CHANNELS_LENGTH,
                     &std::get<1>(tuple_out_supported_channels));
         send_cmdu_to_controller(cmdu_tx);
         send_operating_channel_report();
@@ -2239,7 +2239,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         }
 
         auto tuple_supported_channels = response->supported_channels_list(0);
-        std::copy_n(&std::get<1>(tuple_supported_channels), message::SUPPORTED_CHANNELS_LENGTH,
+        std::copy_n(&std::get<1>(tuple_supported_channels), message::RADIO_CHANNELS_LENGTH,
                     hostap_params.supported_channels);
 
         // build channel preference report
@@ -3258,7 +3258,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             break;
         }
 
-        std::copy_n(hostap_params.supported_channels, message::SUPPORTED_CHANNELS_LENGTH,
+        std::copy_n(hostap_params.supported_channels, message::RADIO_CHANNELS_LENGTH,
                     &std::get<1>(tuple_supported_channels));
 
         // Send the message
@@ -3383,7 +3383,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             return false;
         }
 
-        std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+        std::array<beerocks::message::sWifiChannel, beerocks::message::RADIO_CHANNELS_LENGTH>
             supported_channels;
         std::copy_n(std::begin(hostap_params.supported_channels), supported_channels.size(),
                     supported_channels.begin());
@@ -4500,7 +4500,7 @@ beerocks::message::sWifiChannel slave_thread::channel_selection_select_channel()
         if (preference.channels.empty()) {
             continue;
         }
-        for (uint8_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+        for (uint8_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
             const auto &channel  = hostap_params.supported_channels[i];
             auto operating_class = wireless_utils::get_operating_class_by_channel(channel);
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1626,6 +1626,9 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         }
         hostap_params    = notification->params();
         hostap_cs_params = notification->cs_params();
+        auto tuple_supported_channels = notification->supported_channels(0);
+        std::copy_n(&std::get<1>(tuple_supported_channels), message::RADIO_CHANNELS_LENGTH,
+                    supported_channels);
         if (slave_state == STATE_WAIT_FOR_AP_MANAGER_JOINED) {
             slave_state = STATE_AP_MANAGER_JOINED;
         } else {
@@ -3384,12 +3387,12 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         }
 
         std::array<beerocks::message::sWifiChannel, beerocks::message::RADIO_CHANNELS_LENGTH>
-            preferred_channels;
-        std::copy_n(std::begin(hostap_params.preferred_channels), preferred_channels.size(),
-                    preferred_channels.begin());
+            supported_channels;
+        std::copy_n(std::begin(hostap_params.supported_channels), supported_channels.size(),
+                    supported_channels.begin());
 
         if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, hostap_params.iface_mac,
-                                                         preferred_channels)) {
+                                                         supported_channels)) {
             LOG(ERROR) << "Failed adding AP Radio Basic Capabilities TLV";
             return false;
         }

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1787,10 +1787,10 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             return false;
         }
         notification_out->cs_params()     = notification_in->cs_params();
-        auto tuple_in_supported_channels  = notification_in->supported_channels_list(0);
-        auto tuple_out_supported_channels = notification_out->supported_channels(0);
-        std::copy_n(&std::get<1>(tuple_in_supported_channels), message::RADIO_CHANNELS_LENGTH,
-                    &std::get<1>(tuple_out_supported_channels));
+        auto tuple_in_preferred_channels  = notification_in->preferred_channels_list(0);
+        auto tuple_out_preferred_channels = notification_out->preferred_channels(0);
+        std::copy_n(&std::get<1>(tuple_in_preferred_channels), message::RADIO_CHANNELS_LENGTH,
+                    &std::get<1>(tuple_out_preferred_channels));
         send_cmdu_to_controller(cmdu_tx);
         send_operating_channel_report();
         break;
@@ -2238,9 +2238,9 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             return false;
         }
 
-        auto tuple_supported_channels = response->supported_channels_list(0);
-        std::copy_n(&std::get<1>(tuple_supported_channels), message::RADIO_CHANNELS_LENGTH,
-                    hostap_params.supported_channels);
+        auto tuple_preferred_channels = response->preferred_channels_list(0);
+        std::copy_n(&std::get<1>(tuple_preferred_channels), message::RADIO_CHANNELS_LENGTH,
+                    hostap_params.preferred_channels);
 
         // build channel preference report
         auto cmdu_tx_header = cmdu_tx.create(
@@ -2252,7 +2252,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
         }
 
         auto preferences =
-            wireless_utils::get_channel_preferences(hostap_params.supported_channels);
+            wireless_utils::get_channel_preferences(hostap_params.preferred_channels);
 
         auto channel_preference_tlv = cmdu_tx.addClass<wfa_map::tlvChannelPreference>();
         if (!channel_preference_tlv) {
@@ -3252,14 +3252,14 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         std::copy_n(hostap_params.vht_mcs_set, beerocks::message::VHT_MCS_SET_SIZE,
                     bh_enable->vht_mcs_set());
 
-        auto tuple_supported_channels = bh_enable->supported_channels_list(0);
-        if (!std::get<0>(tuple_supported_channels)) {
+        auto tuple_preferred_channels = bh_enable->preferred_channels_list(0);
+        if (!std::get<0>(tuple_preferred_channels)) {
             LOG(ERROR) << "getting supported channels has failed!";
             break;
         }
 
-        std::copy_n(hostap_params.supported_channels, message::RADIO_CHANNELS_LENGTH,
-                    &std::get<1>(tuple_supported_channels));
+        std::copy_n(hostap_params.preferred_channels, message::RADIO_CHANNELS_LENGTH,
+                    &std::get<1>(tuple_preferred_channels));
 
         // Send the message
         LOG(DEBUG) << "send ACTION_BACKHAUL_ENABLE for mac " << bh_enable->iface_mac();
@@ -3384,12 +3384,12 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         }
 
         std::array<beerocks::message::sWifiChannel, beerocks::message::RADIO_CHANNELS_LENGTH>
-            supported_channels;
-        std::copy_n(std::begin(hostap_params.supported_channels), supported_channels.size(),
-                    supported_channels.begin());
+            preferred_channels;
+        std::copy_n(std::begin(hostap_params.preferred_channels), preferred_channels.size(),
+                    preferred_channels.begin());
 
         if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, hostap_params.iface_mac,
-                                                         supported_channels)) {
+                                                         preferred_channels)) {
             LOG(ERROR) << "Failed adding AP Radio Basic Capabilities TLV";
             return false;
         }
@@ -4501,7 +4501,7 @@ beerocks::message::sWifiChannel slave_thread::channel_selection_select_channel()
             continue;
         }
         for (uint8_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
-            const auto &channel  = hostap_params.supported_channels[i];
+            const auto &channel  = hostap_params.preferred_channels[i];
             auto operating_class = wireless_utils::get_operating_class_by_channel(channel);
 
             // Skip DFS channels

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -200,6 +200,7 @@ private:
     sSlaveBackhaulParams backhaul_params;
     beerocks_message::sNodeHostap hostap_params;
     beerocks_message::sApChannelSwitch hostap_cs_params;
+    std::vector<beerocks::message::sWifiChannel> supported_channels;
     std::vector<wireless_utils::sChannelPreference> channel_preferences;
 
     SocketClient *platform_manager_socket = nullptr;

--- a/agent/src/beerocks/slave/tlvf_utils.cpp
+++ b/agent/src/beerocks/slave/tlvf_utils.cpp
@@ -17,7 +17,7 @@ using namespace beerocks;
 
 bool tlvf_utils::add_ap_radio_basic_capabilities(
     ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &ruid,
-    const std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
+    const std::array<beerocks::message::sWifiChannel, beerocks::message::RADIO_CHANNELS_LENGTH>
         &supported_channels)
 {
     std::vector<uint8_t> operating_classes;

--- a/agent/src/beerocks/slave/tlvf_utils.h
+++ b/agent/src/beerocks/slave/tlvf_utils.h
@@ -29,7 +29,7 @@ public:
     static bool add_ap_radio_basic_capabilities(
         ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &ruid,
         const std::array<beerocks::message::sWifiChannel,
-                         beerocks::message::SUPPORTED_CHANNELS_LENGTH> &supported_channels);
+                         beerocks::message::RADIO_CHANNELS_LENGTH> &supported_channels);
 };
 
 } // namespace beerocks

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -43,7 +43,7 @@ enum eStructsConsts {
     VERSION_LENGTH                = 16,
     NODE_NAME_LENGTH              = 32,
     IFACE_NAME_LENGTH             = 32 + 4, //need extra 1 byte for null termination + alignment
-    SUPPORTED_CHANNELS_LENGTH     = 64,     //support upto # channels, every channel item is 32-bit
+    RADIO_CHANNELS_LENGTH         = 128,    //support upto # channels, every channel item is 32-bit
     HOSTAP_ERR_MSG_LENGTH         = 64,
     WIFI_DRIVER_VER_LENGTH        = 32 + 4,
     WIFI_SSID_MAX_LENGTH          = 32 + 1 + 3, //need extra 1 byte for null termination + alignment

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -638,7 +638,7 @@ wireless_utils::get_channel_preferences(const beerocks::message::sWifiChannel su
 
     for (auto oper_class : operating_classes_list) {
         std::vector<beerocks::message::sWifiChannel> radar_affected_channels;
-        for (uint8_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+        for (uint8_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
             if (has_operating_class_channel(oper_class.second, supported_channels[i]) &&
                 supported_channels[i].radar_affected) {
                 radar_affected_channels.push_back(supported_channels[i]);
@@ -667,7 +667,7 @@ std::vector<uint8_t> wireless_utils::get_supported_operating_classes(
     std::vector<uint8_t> operating_classes;
     //TODO handle regulatory domain operating classes
     for (auto oper_class : operating_classes_list) {
-        for (uint8_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+        for (uint8_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
             if (has_operating_class_channel(oper_class.second, supported_channels[i])) {
                 operating_classes.push_back(oper_class.first);
                 break;
@@ -691,7 +691,7 @@ uint8_t wireless_utils::get_operating_class_max_tx_power(
     uint8_t max_tx_power = 0;
     auto oper_class      = operating_classes_list.at(operating_class);
 
-    for (uint8_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+    for (uint8_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
         if (has_operating_class_channel(oper_class, supported_channels[i])) {
             max_tx_power = std::max(max_tx_power, supported_channels[i].tx_pow);
         }
@@ -750,7 +750,7 @@ std::vector<uint8_t> wireless_utils::get_operating_class_non_oper_channels(
 
     for (auto op_class_channel : oper_class.channels) {
         uint8_t found = 0;
-        for (uint8_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+        for (uint8_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
             if (op_class_channel == supported_channels[i].channel &&
                 oper_class.band == supported_channels[i].channel_bandwidth) {
                 found = 1;

--- a/common/beerocks/bwl/common/base_wlan_hal.cpp
+++ b/common/beerocks/bwl/common/base_wlan_hal.cpp
@@ -31,7 +31,7 @@ base_wlan_hal::base_wlan_hal(HALType type, std::string iface_name, IfaceType ifa
     }
 
     // Initialize complex containers of the radio_info structure
-    m_radio_info.supported_channels.resize(128 /* TODO: Get real value */);
+    m_radio_info.preferred_channels.fill({});
 }
 
 base_wlan_hal::~base_wlan_hal()

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -282,10 +282,10 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
-            m_radio_info.supported_channels[idx].channel     = ch;
-            m_radio_info.supported_channels[idx].bandwidth   = 20;
-            m_radio_info.supported_channels[idx].bss_overlap = 10;
-            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            m_radio_info.preferred_channels[idx].channel     = ch;
+            m_radio_info.preferred_channels[idx].bandwidth   = 20;
+            m_radio_info.preferred_channels[idx].bss_overlap = 10;
+            m_radio_info.preferred_channels[idx].is_dfs      = 0;
             idx++;
         }
     } else {
@@ -293,28 +293,28 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
                 idx++;
             }
         }
         for (uint16_t ch = 100; ch <= 144; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 1;
                 idx++;
             }
         }
         for (uint16_t ch = 149; ch <= 165; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 0;
                 idx++;
             }
         }

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -371,6 +371,12 @@ bool ap_wlan_hal_dummy::read_supported_channels()
     return true;
 }
 
+bool ap_wlan_hal_dummy::update_preference_channels_from_supported_channels()
+{
+    m_radio_info.preferred_channels = m_radio_info.supported_channels;
+    return true;
+}
+
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {
     LOG(TRACE) << " setting power limit: " << tx_pow_limit << " dBm";

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -323,7 +323,53 @@ bool ap_wlan_hal_dummy::read_acs_report()
     return true;
 }
 
-bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
+bool ap_wlan_hal_dummy::read_supported_channels()
+{
+    uint8_t idx = 0;
+    if (m_radio_info.is_5ghz == false) {
+        m_radio_info.channel = 1;
+        // 2.4G simulated report
+        for (uint16_t ch = 1; ch <= 11; ch++) {
+            m_radio_info.supported_channels[idx].channel     = ch;
+            m_radio_info.supported_channels[idx].bandwidth   = 20;
+            m_radio_info.supported_channels[idx].bss_overlap = 10;
+            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            idx++;
+        }
+    } else {
+        // 5G simulated report
+        m_radio_info.channel = 149;
+        for (uint16_t ch = 36; ch <= 64; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                idx++;
+            }
+        }
+        for (uint16_t ch = 100; ch <= 144; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                idx++;
+            }
+        }
+        for (uint16_t ch = 149; ch <= 165; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                idx++;
+            }
+        }
+    }
+
+    return true;
+}
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
@@ -68,6 +68,7 @@ public:
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
     virtual bool read_supported_channels() override;
+    virtual bool update_preference_channels_from_supported_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1551,8 +1551,8 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
         }
     }
 
-    m_radio_info.preferred_channels.insert(m_radio_info.preferred_channels.begin(),
-                                           supported_channels.begin(), supported_channels.end());
+    m_radio_info.supported_channels.insert(m_radio_info.supported_channels.begin(),
+                                           preferred_channels.begin(), preferred_channels.end());
     return true;
 }
 

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1459,13 +1459,13 @@ bool ap_wlan_hal_dwpal::read_acs_report()
     m_radio_info.is_5ghz = false;
 
     // Resize the supported channels vector
-    if (MAX_SUPPORTED_20M_CHANNELS >= m_radio_info.supported_channels.size()) {
+    if (MAX_SUPPORTED_20M_CHANNELS >= m_radio_info.preferred_channels.size()) {
         LOG(DEBUG) << "Increasing supported channels vector to: " << MAX_SUPPORTED_20M_CHANNELS;
-        m_radio_info.supported_channels.resize(MAX_SUPPORTED_20M_CHANNELS);
+        m_radio_info.preferred_channels.resize(MAX_SUPPORTED_20M_CHANNELS);
     }
 
     // Clear the supported channels vector
-    for (auto &chan : m_radio_info.supported_channels) {
+    for (auto &chan : m_radio_info.preferred_channels) {
         memset(&chan, 0, sizeof(chan));
     }
 
@@ -1503,16 +1503,16 @@ bool ap_wlan_hal_dwpal::read_acs_report()
                    << " DFS=" << acs_report[i].DFS << " bss=" << acs_report[i].bss;
 
         if (acs_report[i].BW == 20) {
-            m_radio_info.supported_channels[channel_idx].bandwidth = acs_report[i].BW;
-            m_radio_info.supported_channels[channel_idx].channel   = acs_report[i].Ch;
+            m_radio_info.preferred_channels[channel_idx].bandwidth = acs_report[i].BW;
+            m_radio_info.preferred_channels[channel_idx].channel   = acs_report[i].Ch;
             // Check if channel is 5GHz
             if (son::wireless_utils::which_freq(
-                    m_radio_info.supported_channels[channel_idx].channel) ==
+                    m_radio_info.preferred_channels[channel_idx].channel) ==
                 beerocks::eFreqType::FREQ_5G) {
                 m_radio_info.is_5ghz = true;
             }
-            m_radio_info.supported_channels[channel_idx].bss_overlap = acs_report[i].bss;
-            m_radio_info.supported_channels[channel_idx].is_dfs      = acs_report[i].DFS;
+            m_radio_info.preferred_channels[channel_idx].bss_overlap = acs_report[i].bss;
+            m_radio_info.preferred_channels[channel_idx].is_dfs      = acs_report[i].DFS;
 
             channel_idx++;
             if (channel_idx == MAX_SUPPORTED_20M_CHANNELS) {
@@ -1551,10 +1551,7 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
         }
     }
 
-    // Clear the supported channels vector
-    m_radio_info.supported_channels.clear();
-    // Resize the supported channels vector
-    m_radio_info.supported_channels.insert(m_radio_info.supported_channels.begin(),
+    m_radio_info.preferred_channels.insert(m_radio_info.preferred_channels.begin(),
                                            supported_channels.begin(), supported_channels.end());
     return true;
 }

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1556,6 +1556,12 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
     return true;
 }
 
+bool ap_wlan_hal_dwpal::update_preference_channels_from_supported_channels()
+{
+    m_radio_info.preferred_channels = m_radio_info.supported_channels;
+    return true;
+}
+
 bool ap_wlan_hal_dwpal::set_tx_power_limit(int tx_pow_limit)
 {
     return m_nl80211_client->set_tx_power_limit(m_radio_info.iface_name, tx_pow_limit);

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
@@ -68,6 +68,7 @@ public:
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
     virtual bool read_supported_channels() override;
+    virtual bool update_preference_channels_from_supported_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
@@ -368,6 +368,12 @@ bool ap_wlan_hal_dummy::read_supported_channels()
     return true;
 }
 
+bool ap_wlan_hal_dummy::update_preference_channels_from_supported_channels()
+{
+    m_radio_info.preferred_channels = m_radio_info.supported_channels;
+    return true;
+}
+
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {
     LOG(TRACE) << __func__ << " power limit: " << tx_pow_limit;

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
@@ -279,10 +279,10 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
-            m_radio_info.supported_channels[idx].channel     = ch;
-            m_radio_info.supported_channels[idx].bandwidth   = 20;
-            m_radio_info.supported_channels[idx].bss_overlap = 10;
-            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            m_radio_info.preferred_channels[idx].channel     = ch;
+            m_radio_info.preferred_channels[idx].bandwidth   = 20;
+            m_radio_info.preferred_channels[idx].bss_overlap = 10;
+            m_radio_info.preferred_channels[idx].is_dfs      = 0;
             idx++;
         }
     } else {
@@ -290,28 +290,28 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
                 idx++;
             }
         }
         for (uint16_t ch = 100; ch <= 144; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 1;
                 idx++;
             }
         }
         for (uint16_t ch = 149; ch <= 165; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 0;
                 idx++;
             }
         }

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
@@ -320,7 +320,53 @@ bool ap_wlan_hal_dummy::read_acs_report()
     return true;
 }
 
-bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
+bool ap_wlan_hal_dummy::read_supported_channels()
+{
+    uint8_t idx = 0;
+    if (m_radio_info.is_5ghz == false) {
+        m_radio_info.channel = 1;
+        // 2.4G simulated report
+        for (uint16_t ch = 1; ch <= 11; ch++) {
+            m_radio_info.supported_channels[idx].channel     = ch;
+            m_radio_info.supported_channels[idx].bandwidth   = 20;
+            m_radio_info.supported_channels[idx].bss_overlap = 10;
+            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            idx++;
+        }
+    } else {
+        // 5G simulated report
+        m_radio_info.channel = 149;
+        for (uint16_t ch = 36; ch <= 64; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                idx++;
+            }
+        }
+        for (uint16_t ch = 100; ch <= 144; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                idx++;
+            }
+        }
+        for (uint16_t ch = 149; ch <= 165; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                m_radio_info.supported_channels[idx].channel     = ch;
+                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                idx++;
+            }
+        }
+    }
+
+    return true;
+}
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.h
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.h
@@ -68,6 +68,7 @@ public:
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
     virtual bool read_supported_channels() override;
+    virtual bool update_preference_channels_from_supported_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
@@ -311,12 +311,20 @@ public:
     virtual bool read_acs_report() = 0;
 
     /*!
-     * Read the supported channls from the hardware
+     * Read the supported channels from the hardware
      * On successful completion the information can be retrieved 
      *
      * @return true on success or false on error.
      */
     virtual bool read_supported_channels() = 0;
+
+     /*!
+     * Copy the supported channels  to the preferred channels 
+     * On successful completion the preferred channels  can be retrieved 
+     *
+     * @return true on success or false on error.
+     */
+    virtual bool update_preference_channels_from_supported_channels() = 0;
 
     /*!
      * Set Transmit Power Limit 

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -101,7 +101,7 @@ struct RadioInfo {
     std::basic_string<uint8_t>
         vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
     ChanSwReason last_csa_sw_reason = ChanSwReason::Unknown;
-    std::vector<WiFiChannel> supported_channels;
+    std::array<WiFiChannel, beerocks::message::RADIO_CHANNELS_LENGTH> preferred_channels;
     std::unordered_map<int, VAPElement> available_vaps; // key = vap_id
 };
 

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -102,6 +102,7 @@ struct RadioInfo {
         vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
     ChanSwReason last_csa_sw_reason = ChanSwReason::Unknown;
     std::array<WiFiChannel, beerocks::message::RADIO_CHANNELS_LENGTH> preferred_channels;
+    std::array<WiFiChannel, beerocks::message::RADIO_CHANNELS_LENGTH> supported_channels;
     std::unordered_map<int, VAPElement> available_vaps; // key = vap_id
 };
 

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -264,7 +264,7 @@ typedef struct {
 
 #define SSID_MAX_SIZE beerocks::message::WIFI_SSID_MAX_LENGTH
 #define MAC_ADDR_SIZE 18
-#define MAX_SUPPORTED_20M_CHANNELS beerocks::message::SUPPORTED_CHANNELS_LENGTH
+#define MAX_SUPPORTED_20M_CHANNELS beerocks::message::RADIO_CHANNELS_LENGTH
 #define MAX_SUPPORTED_CHANNELS                                                                     \
     (MAX_SUPPORTED_20M_CHANNELS * 4) //max 64 channels, each with BW 20/40/80/160
 } // namespace bwl

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -469,10 +469,7 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
         }
     }
 
-    // Clear the supported channels vector
-    m_radio_info.supported_channels.clear();
-    // Resize the supported channels vector
-    m_radio_info.supported_channels.insert(m_radio_info.supported_channels.begin(),
+    m_radio_info.preferred_channels.insert(m_radio_info.preferred_channels.begin(),
                                            supported_channels.begin(), supported_channels.end());
     return true;
 }

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -469,7 +469,7 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
         }
     }
 
-    m_radio_info.preferred_channels.insert(m_radio_info.preferred_channels.begin(),
+    m_radio_info.supported_channels.insert(m_radio_info.supported_channels.begin(),
                                            supported_channels.begin(), supported_channels.end());
     return true;
 }

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -474,6 +474,12 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
     return true;
 }
 
+bool ap_wlan_hal_nl80211::update_preference_channels_from_supported_channels()
+{
+    m_radio_info.preferred_channels = m_radio_info.supported_channels;
+    return true;
+}
+
 bool ap_wlan_hal_nl80211::set_tx_power_limit(int tx_pow_limit)
 {
     return m_nl80211_client->set_tx_power_limit(m_radio_info.iface_name, tx_pow_limit);

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
@@ -67,6 +67,7 @@ public:
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
     virtual bool read_supported_channels() override;
+    virtual bool update_preference_channels_from_supported_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -383,7 +383,7 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION);
         }
         sApChannelSwitch& cs_params();
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -392,8 +392,8 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
-        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
-        size_t m_supported_channels_list_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
+        size_t m_preferred_channels_list_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 
@@ -971,7 +971,7 @@ class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE);
         }
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -979,8 +979,8 @@ class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
-        size_t m_supported_channels_list_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
+        size_t m_preferred_channels_list_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -61,6 +61,7 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_JOINED_NOTIFICATION);
         }
+        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels(size_t idx);
         sNodeHostap& params();
         sApChannelSwitch& cs_params();
         void class_swap() override;
@@ -70,6 +71,9 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
+        beerocks::message::sWifiChannel* m_supported_channels = nullptr;
+        size_t m_supported_channels_idx__ = 0;
+        int m_lock_order_counter__ = 0;
         sNodeHostap* m_params = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
 };

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -152,7 +152,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint32_t& vht_capability();
         uint8_t* vht_mcs_set(size_t idx = 0);
         bool set_vht_mcs_set(const void* buffer, size_t size);
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -186,8 +186,8 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint32_t* m_vht_capability = nullptr;
         uint8_t* m_vht_mcs_set = nullptr;
         size_t m_vht_mcs_set_idx__ = 0;
-        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
-        size_t m_supported_channels_list_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
+        size_t m_preferred_channels_list_idx__ = 0;
 };
 
 class cACTION_BACKHAUL_CONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -378,7 +378,7 @@ typedef struct sNodeHostap {
     uint32_t vht_capability;
     uint8_t vht_mcs_set[beerocks::message::VHT_MCS_SET_SIZE];
     char driver_version[beerocks::message::WIFI_DRIVER_VER_LENGTH];
-    beerocks::message::sWifiChannel supported_channels[beerocks::message::RADIO_CHANNELS_LENGTH];
+    beerocks::message::sWifiChannel preferred_channels[beerocks::message::RADIO_CHANNELS_LENGTH];
     void struct_swap(){
         iface_mac.struct_swap();
         tlvf_swap(8*sizeof(beerocks::eFreqType), reinterpret_cast<uint8_t*>(&frequency_band));
@@ -386,13 +386,13 @@ typedef struct sNodeHostap {
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&ht_capability));
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&vht_capability));
         for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
-            (supported_channels[i]).struct_swap();
+            (preferred_channels[i]).struct_swap();
         }
     }
     void struct_init(){
         iface_mac.struct_init();
             for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
-                (supported_channels[i]).struct_init();
+                (preferred_channels[i]).struct_init();
             }
     }
 } __attribute__((packed)) sNodeHostap;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -378,20 +378,20 @@ typedef struct sNodeHostap {
     uint32_t vht_capability;
     uint8_t vht_mcs_set[beerocks::message::VHT_MCS_SET_SIZE];
     char driver_version[beerocks::message::WIFI_DRIVER_VER_LENGTH];
-    beerocks::message::sWifiChannel supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+    beerocks::message::sWifiChannel supported_channels[beerocks::message::RADIO_CHANNELS_LENGTH];
     void struct_swap(){
         iface_mac.struct_swap();
         tlvf_swap(8*sizeof(beerocks::eFreqType), reinterpret_cast<uint8_t*>(&frequency_band));
         tlvf_swap(8*sizeof(beerocks::eWiFiBandwidth), reinterpret_cast<uint8_t*>(&max_bandwidth));
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&ht_capability));
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&vht_capability));
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
             (supported_channels[i]).struct_swap();
         }
     }
     void struct_init(){
         iface_mac.struct_init();
-            for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
+            for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) {
                 (supported_channels[i]).struct_init();
             }
     }
@@ -1219,7 +1219,7 @@ typedef struct sTriggerChannelScanParams {
     //size of provided channel_pool
     uint8_t channel_pool_size;
     //pool of channels to be scaned
-    uint8_t channel_pool[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+    uint8_t channel_pool[beerocks::message::RADIO_CHANNELS_LENGTH];
     void struct_swap(){
         radio_mac.struct_swap();
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&dwell_time_ms));
@@ -1238,7 +1238,7 @@ typedef struct sChannelScanRequestParams {
     int32_t interval_time_sec;
     //an invalid (-1) value indicates this value is not requested
     int8_t channel_pool_size;
-    uint8_t channel_pool[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+    uint8_t channel_pool[beerocks::message::RADIO_CHANNELS_LENGTH];
     void struct_swap(){
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&dwell_time_ms));
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&interval_time_sec));

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -538,7 +538,7 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
             return (eActionOp_CONTROL)(ACTION_CONTROL_HOSTAP_ACS_NOTIFICATION);
         }
         sApChannelSwitch& cs_params();
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -547,8 +547,8 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
-        beerocks::message::sWifiChannel* m_supported_channels = nullptr;
-        size_t m_supported_channels_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
+        size_t m_preferred_channels_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1193,7 +1193,7 @@ void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+    for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
         m_supported_channels_list[i].struct_swap();
     }
 }
@@ -1229,7 +1229,7 @@ size_t cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
     return class_size;
 }
 
@@ -1246,13 +1246,13 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_supported_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;
@@ -3237,7 +3237,7 @@ std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_RE
 void cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+    for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
         m_supported_channels_list[i].struct_swap();
     }
 }
@@ -3272,7 +3272,7 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::finalize()
 size_t cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
     return class_size;
 }
 
@@ -3283,13 +3283,13 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::init()
         return false;
     }
     m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_supported_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1180,13 +1180,13 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cs_params() {
     return (sApChannelSwitch&)(*m_cs_params);
 }
 
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::supported_channels_list(size_t idx) {
-    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::preferred_channels_list(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
 }
 
 void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
@@ -1194,7 +1194,7 @@ void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
     for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
-        m_supported_channels_list[i].struct_swap();
+        m_preferred_channels_list[i].struct_swap();
     }
 }
 
@@ -1229,7 +1229,7 @@ size_t cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
     return class_size;
 }
 
@@ -1245,14 +1245,14 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
+    m_preferred_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;
@@ -3225,20 +3225,20 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::~cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE() {
 }
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::supported_channels_list(size_t idx) {
-    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::preferred_channels_list(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
 }
 
 void cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
-        m_supported_channels_list[i].struct_swap();
+        m_preferred_channels_list[i].struct_swap();
     }
 }
 
@@ -3272,7 +3272,7 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::finalize()
 size_t cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
     return class_size;
 }
 
@@ -3282,14 +3282,14 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
+    m_preferred_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -527,13 +527,13 @@ bool cACTION_BACKHAUL_ENABLE::set_vht_mcs_set(const void* buffer, size_t size) {
     std::copy_n(reinterpret_cast<const uint8_t *>(buffer), size, m_vht_mcs_set);
     return true;
 }
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::supported_channels_list(size_t idx) {
-    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::preferred_channels_list(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
 }
 
 void cACTION_BACKHAUL_ENABLE::class_swap()
@@ -547,7 +547,7 @@ void cACTION_BACKHAUL_ENABLE::class_swap()
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ht_capability));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_vht_capability));
     for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
-        m_supported_channels_list[i].struct_swap();
+        m_preferred_channels_list[i].struct_swap();
     }
 }
 
@@ -600,7 +600,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
     class_size += sizeof(uint8_t); // vht_supported
     class_size += sizeof(uint32_t); // vht_capability
     class_size += beerocks::message::VHT_MCS_SET_SIZE * sizeof(uint8_t); // vht_mcs_set
-    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
     return class_size;
 }
 
@@ -713,14 +713,14 @@ bool cACTION_BACKHAUL_ENABLE::init()
         return false;
     }
     m_vht_mcs_set_idx__  = beerocks::message::VHT_MCS_SET_SIZE;
-    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
+    m_preferred_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -546,7 +546,7 @@ void cACTION_BACKHAUL_ENABLE::class_swap()
     tlvf_swap(8*sizeof(beerocks::eWiFiBandwidth), reinterpret_cast<uint8_t*>(m_max_bandwidth));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ht_capability));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_vht_capability));
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+    for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
         m_supported_channels_list[i].struct_swap();
     }
 }
@@ -600,7 +600,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
     class_size += sizeof(uint8_t); // vht_supported
     class_size += sizeof(uint32_t); // vht_capability
     class_size += beerocks::message::VHT_MCS_SET_SIZE * sizeof(uint8_t); // vht_mcs_set
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
     return class_size;
 }
 
@@ -714,13 +714,13 @@ bool cACTION_BACKHAUL_ENABLE::init()
     }
     m_vht_mcs_set_idx__  = beerocks::message::VHT_MCS_SET_SIZE;
     m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_supported_channels_list_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -1879,13 +1879,13 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cs_params() {
     return (sApChannelSwitch&)(*m_cs_params);
 }
 
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::supported_channels(size_t idx) {
-    bool ret_success = ( (m_supported_channels_idx__ > 0) && (m_supported_channels_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::preferred_channels(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_idx__ > 0) && (m_preferred_channels_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels[ret_idx]);
 }
 
 void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
@@ -1893,7 +1893,7 @@ void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
     tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
     for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
-        m_supported_channels[i].struct_swap();
+        m_preferred_channels[i].struct_swap();
     }
 }
 
@@ -1928,7 +1928,7 @@ size_t cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels
     return class_size;
 }
 
@@ -1944,14 +1944,14 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    m_supported_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
+    m_preferred_channels_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_preferred_channels->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -1892,7 +1892,7 @@ void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+    for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++){
         m_supported_channels[i].struct_swap();
     }
 }
@@ -1928,7 +1928,7 @@ size_t cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels
+    class_size += beerocks::message::RADIO_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels
     return class_size;
 }
 
@@ -1945,13 +1945,13 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
     m_supported_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::RADIO_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_supported_channels_idx__  = beerocks::message::RADIO_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::RADIO_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -89,7 +89,7 @@ cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION:
 cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION:
   _type: class
   cs_params: sApChannelSwitch
-  supported_channels_list:
+  preferred_channels_list:
     _type: beerocks::message::sWifiChannel
     _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 
@@ -209,7 +209,7 @@ cACTION_APMANAGER_READ_ACS_REPORT_REQUEST:
 
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE:
   _type: class
-  supported_channels_list:
+  preferred_channels_list:
     _type: beerocks::message::sWifiChannel
     _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -25,6 +25,9 @@ cACTION_APMANAGER_4ADDR_STA_JOINED:
  
 cACTION_APMANAGER_JOINED_NOTIFICATION:
   _type: class
+  supported_channels:
+    _type: beerocks::message::sWifiChannel 
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
   params: sNodeHostap
   cs_params: sApChannelSwitch
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -91,7 +91,7 @@ cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION:
   cs_params: sApChannelSwitch
   supported_channels_list:
     _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 
 cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION:
   _type: class
@@ -211,5 +211,5 @@ cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE:
   _type: class
   supported_channels_list:
     _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -68,7 +68,7 @@ cACTION_BACKHAUL_ENABLE:
     _length: [ "beerocks::message::VHT_MCS_SET_SIZE" ]
   supported_channels_list:
     _type: beerocks::message::sWifiChannel 
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 
 cACTION_BACKHAUL_CONNECTED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -66,7 +66,7 @@ cACTION_BACKHAUL_ENABLE:
   vht_mcs_set:
     _type: uint8_t
     _length: [ "beerocks::message::VHT_MCS_SET_SIZE" ]
-  supported_channels_list:
+  preferred_channels_list:
     _type: beerocks::message::sWifiChannel 
     _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -282,7 +282,7 @@ sNodeHostap:
     _length: [ "beerocks::message::WIFI_DRIVER_VER_LENGTH" ]
   supported_channels:
     _type: beerocks::message::sWifiChannel 
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]          
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]          
 
 sVapsList:
   _type: struct
@@ -847,7 +847,7 @@ sTriggerChannelScanParams:
     _comment: size of provided channel_pool
  channel_pool:
     _type: uint8_t
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
     _comment: pool of channels to be scaned
 
 sChannelScanRequestParams:
@@ -866,7 +866,7 @@ sChannelScanRequestParams:
     _comment: an invalid (-1) value indicates this value is not requested
  channel_pool:
     _type: uint8_t 
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 
 eChannelScanResultMode:
   _type: enum

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -280,7 +280,7 @@ sNodeHostap:
   driver_version:
     _type: char  
     _length: [ "beerocks::message::WIFI_DRIVER_VER_LENGTH" ]
-  supported_channels:
+  preferred_channels:
     _type: beerocks::message::sWifiChannel 
     _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]          
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
@@ -142,7 +142,7 @@ cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION:
   cs_params: sApChannelSwitch 
   supported_channels:
     _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 
 cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
@@ -140,7 +140,7 @@ cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION:
 cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION:
   _type: class
   cs_params: sApChannelSwitch 
-  supported_channels:
+  preferred_channels:
     _type: beerocks::message::sWifiChannel
     _length: [ "beerocks::message::RADIO_CHANNELS_LENGTH" ]
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2243,8 +2243,8 @@ bool master_thread::autoconfig_wsc_parse_radio_caps(
         LOG(WARNING) << "operating class info list larger then maximum supported channels";
         operating_classes_list_length = beerocks::message::RADIO_CHANNELS_LENGTH;
     }
+    std::stringstream ss;
     for (int oc_idx = 0; oc_idx < operating_classes_list_length; oc_idx++) {
-        std::stringstream ss;
         auto operating_class_tuple = radio_caps->operating_classes_info_list(oc_idx);
         if (!std::get<0>(operating_class_tuple)) {
             LOG(ERROR) << "getting operating class entry has failed!";
@@ -2272,11 +2272,11 @@ bool master_thread::autoconfig_wsc_parse_radio_caps(
             non_operable_channels.push_back(*channel);
         }
         ss << " }" << std::endl;
-        //        LOG(DEBUG) << ss.str();
         // store operating class in the DB for this hostap
         database.add_hostap_supported_operating_class(
             radio_mac, operating_class, maximum_transmit_power_dbm, non_operable_channels);
     }
+    LOG(DEBUG) << "Radio basic capabilities:" << std::endl << ss.str();
 
     return true;
 }

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2102,7 +2102,7 @@ bool master_thread::handle_intel_slave_join(
     database.set_node_manufacturer(radio_mac, "Intel");
 
     database.set_hostap_supported_channels(radio_mac, notification->hostap().supported_channels,
-                                           message::SUPPORTED_CHANNELS_LENGTH);
+                                           message::RADIO_CHANNELS_LENGTH);
 
     if (database.get_node_5ghz_support(radio_mac)) {
         if (notification->low_pass_filter_on()) {
@@ -2239,9 +2239,9 @@ bool master_thread::autoconfig_wsc_parse_radio_caps(
 {
     // read all operating class list
     auto operating_classes_list_length = radio_caps->operating_classes_info_list_length();
-    if (operating_classes_list_length > beerocks::message::SUPPORTED_CHANNELS_LENGTH) {
+    if (operating_classes_list_length > beerocks::message::RADIO_CHANNELS_LENGTH) {
         LOG(WARNING) << "operating class info list larger then maximum supported channels";
-        operating_classes_list_length = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+        operating_classes_list_length = beerocks::message::RADIO_CHANNELS_LENGTH;
     }
     for (int oc_idx = 0; oc_idx < operating_classes_list_length; oc_idx++) {
         std::stringstream ss;
@@ -2560,7 +2560,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         new_event->hostap_mac         = network_utils::mac_from_string(hostap_mac);
         new_event->cs_params          = notification->cs_params();
         auto tuple_supported_channels = notification->supported_channels(0);
-        std::copy_n(&std::get<1>(tuple_supported_channels), message::SUPPORTED_CHANNELS_LENGTH,
+        std::copy_n(&std::get<1>(tuple_supported_channels), message::RADIO_CHANNELS_LENGTH,
                     new_event->supported_channels);
         tasks.push_event(database.get_channel_selection_task_id(),
                          (int)channel_selection_task::eEvent::ACS_RESPONSE_EVENT,

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2101,7 +2101,7 @@ bool master_thread::handle_intel_slave_join(
     database.set_node_ipv4(radio_mac, bridge_ipv4);
     database.set_node_manufacturer(radio_mac, "Intel");
 
-    database.set_hostap_supported_channels(radio_mac, notification->hostap().supported_channels,
+    database.set_hostap_supported_channels(radio_mac, notification->hostap().preferred_channels,
                                            message::RADIO_CHANNELS_LENGTH);
 
     if (database.get_node_5ghz_support(radio_mac)) {
@@ -2183,9 +2183,9 @@ bool master_thread::handle_intel_slave_join(
                    << " cs_new_event = " << intptr_t(cs_new_event);
         cs_new_event->hostap_mac = network_utils::mac_from_string(radio_mac);
         cs_new_event->cs_params  = notification->cs_params();
-        for (auto supported_channel : notification->hostap().supported_channels) {
-            if (supported_channel.channel > 0) {
-                LOG(DEBUG) << "supported_channel = " << int(supported_channel.channel);
+        for (auto preferred_channel : notification->hostap().preferred_channels) {
+            if (preferred_channel.channel > 0) {
+                LOG(DEBUG) << "preferred_channel = " << int(preferred_channel.channel);
             }
         }
 
@@ -2559,8 +2559,8 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             CHANNEL_SELECTION_ALLOCATE_EVENT(channel_selection_task::sAcsResponse_event);
         new_event->hostap_mac         = network_utils::mac_from_string(hostap_mac);
         new_event->cs_params          = notification->cs_params();
-        auto tuple_supported_channels = notification->supported_channels(0);
-        std::copy_n(&std::get<1>(tuple_supported_channels), message::RADIO_CHANNELS_LENGTH,
+        auto tuple_preferred_channels = notification->preferred_channels(0);
+        std::copy_n(&std::get<1>(tuple_preferred_channels), message::RADIO_CHANNELS_LENGTH,
                     new_event->supported_channels);
         tasks.push_event(database.get_channel_selection_task_id(),
                          (int)channel_selection_task::eEvent::ACS_RESPONSE_EVENT,

--- a/controller/src/beerocks/master/tasks/channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.cpp
@@ -695,7 +695,7 @@ void channel_selection_task::work()
         break;
     }
     case eState::ON_ACS_RESPONSE: {
-        //database.set_hostap_supported_channels(hostap_mac, acs_response_event->supported_channels, message::SUPPORTED_CHANNELS_LENGTH);
+        //database.set_hostap_supported_channels(hostap_mac, acs_response_event->supported_channels, message::RADIO_CHANNELS_LENGTH);
 
         cs_wait_for_event(eEvent::CSA_EVENT);
         set_events_timeout(CSA_NOTIFICATION_RESPONSE_WAIT_TIME);

--- a/controller/src/beerocks/master/tasks/channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.h
@@ -60,7 +60,7 @@ public:
         beerocks_message::sApChannelSwitch cs_params;
 
         beerocks::message::sWifiChannel
-            supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+            supported_channels[beerocks::message::RADIO_CHANNELS_LENGTH];
     } sAcsResponse_event;
 
     typedef struct {
@@ -71,7 +71,7 @@ public:
         uint8_t channel;
         beerocks_message::sApChannelSwitch cs_params;
         beerocks::message::sWifiChannel
-            supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+            supported_channels[beerocks::message::RADIO_CHANNELS_LENGTH];
         beerocks::net::sScanResult
             backhaul_scan_measurement_list[beerocks::message::BACKHAUL_SCAN_MEASUREMENT_MAX_LENGTH];
     } sSlaveJoined_event;

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -73,7 +73,7 @@ beerocks::eChannelScanErrCode dynamic_channel_selection_task::dcs_request_scan_t
         return beerocks::eChannelScanErrCode::CHANNEL_SCAN_INVALID_PARAMS;
     }
 
-    if (curr_channel_pool.size() > beerocks::message::SUPPORTED_CHANNELS_LENGTH) {
+    if (curr_channel_pool.size() > beerocks::message::RADIO_CHANNELS_LENGTH) {
         LOG(ERROR) << "channel_pool is too big";
         return beerocks::eChannelScanErrCode::CHANNEL_SCAN_POOL_TOO_BIG;
     }


### PR DESCRIPTION
The supported_channels are needed to created the Radio Basic Capabilities TLV
To do so they need to be sent to the son_slave_thread, where they will be stored locally
Then the son_slave_thread needs to sent the stored hardware_supported_channels to the son_master_thread as part of the Radio Basic Capabilities TLV