### PR TITLE
Support running test flows on WSL

### DIFF
--- a/tests/test_gw_repeater.sh
+++ b/tests/test_gw_repeater.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # Copyright (c) 2019 Tomer Eliyahu (Intel)
@@ -27,6 +27,37 @@ usage() {
     echo "      --repeater-only - start repeater only"
 }
 
+# This function checks if this script is executed in Microsoft's WSL
+# Docker for Windows currently is unable to forward traffic from the
+# host to the containers. Since we communicate with the UCC listeners
+# on the gateway and the repeaters, expose the UCC listening ports
+# from the containers to the host
+check_wsl() {
+    # Do nothing for non-WSL environments
+    if ! grep -q Microsoft /proc/version; then return; fi
+
+    status "Running in WSL"
+    
+    # Read GW & Repeater UCC ports
+    local GW_UCC_PORT
+    GW_UCC_PORT=$(grep ucc_listener_port \
+    "${rootdir}/build/install/config/beerocks_controller.conf" | \
+    awk -F'[= ]' '{ print $2 }')
+
+    local RP_UCC_PORT
+    RP_UCC_PORT=$(grep ucc_listener_port \
+    "${rootdir}/build/install/config/beerocks_agent.conf" | \
+    awk -F'[= ]' '{ print $2 }')
+
+    # In addition to exporting the UCC port on the host, we also
+    # need to make sure that the container's IP doesn't change.
+    # Docker fails to route traffic from the host to the containers
+    # if the IP is anything but what was allocated by the daemon
+    # when the container was created
+    GW_EXTRA_OPT="--expose ${GW_UCC_PORT} --publish 127.0.0.1::${GW_UCC_PORT} --ipaddr 0.0.0.0"
+    RP_EXTRA_OPT="--expose ${RP_UCC_PORT} --publish 127.0.0.1::${RP_UCC_PORT} --ipaddr 0.0.0.0"
+}
+
 main() {
     OPTS=`getopt -o 'hvd:fg:r:u:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater:,unique-id: -n 'parse-options' -- "$@"`
 
@@ -51,6 +82,8 @@ main() {
         esac
     done
 
+    check_wsl
+
     status "Starting GW+Repeater test"
 
     # default values for gateway and repeater[s] names
@@ -67,7 +100,8 @@ main() {
 
     [ "$START_GATEWAY" = "true" ] && {
         status "Start GW (Controller + local Agent)"
-        ${rootdir}/tools/docker/run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 -- "$@"
+        ${rootdir}/tools/docker/run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} ${GW_EXTRA_OPT} \
+        start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 -- "$@"
     }
 
     [ "$START_GATEWAY" = "true" -a "$START_REPEATER" = "true" ] && {
@@ -79,7 +113,8 @@ main() {
         index=0
         for repeater in $REPEATER_NAMES; do
             status "Start Repeater (Remote Agent): $repeater"
-            ${rootdir}/tools/docker/run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} start-agent -d -n ${repeater} -m aa:bb:cc:$index$index -- "$@"
+            ${rootdir}/tools/docker/run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} ${RP_EXTRA_OPT} \
+            start-agent -d -n ${repeater} -m aa:bb:cc:$index$index -- "$@"
             index=$((index+1))
         done
     }

--- a/tests/test_gw_repeater.sh
+++ b/tests/test_gw_repeater.sh
@@ -6,13 +6,14 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}"; pwd)"
+scriptdir=$(cd "${0%/*}" || exit 1; pwd)
 rootdir="${scriptdir%/*}"
 
-. ${rootdir}/tools/functions.sh
+# shellcheck source=../tools/functions.sh
+. "${rootdir}/tools/functions.sh"
 
 usage() {
-    echo "usage: $(basename $0) [-hv] [-d delay]"
+    echo "usage: $(basename "${0}") [-hv] [-d delay]"
     echo "  options:"
     echo "      -h|--help - show this help menu"
     echo "      -v|--verbose - verbosity on"
@@ -41,12 +42,12 @@ check_wsl() {
     # Read GW & Repeater UCC ports
     local GW_UCC_PORT
     GW_UCC_PORT=$(grep ucc_listener_port \
-    "${rootdir}/build/install/config/beerocks_controller.conf" | \
+    "${rootdir}"/build/install/config/beerocks_controller.conf | \
     awk -F'[= ]' '{ print $2 }')
 
     local RP_UCC_PORT
     RP_UCC_PORT=$(grep ucc_listener_port \
-    "${rootdir}/build/install/config/beerocks_agent.conf" | \
+    "${rootdir}"/build/install/config/beerocks_agent.conf | \
     awk -F'[= ]' '{ print $2 }')
 
     # In addition to exporting the UCC port on the host, we also
@@ -59,15 +60,15 @@ check_wsl() {
 }
 
 main() {
-    OPTS=`getopt -o 'hvd:fg:r:u:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater:,unique-id: -n 'parse-options' -- "$@"`
-
-    if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
+    if ! OPTS=$(getopt -o 'hvd:fg:r:u:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater:,unique-id: -n 'parse-options' -- "$@"); then
+        err "Failed parsing options." >&2 ; usage; exit 1 ; 
+    fi
 
     eval set -- "$OPTS"
 
     while true; do
         case "$1" in
-            -v | --verbose)       VERBOSE=true; VERBOSE_OPT="-v"; shift ;;
+            -v | --verbose)       VERBOSE_OPT="-v"; shift ;;
             -h | --help)          usage; exit 0; shift ;;
             -d | --delay)         DELAY="$2"; shift; shift ;;
             -f | --force)         FORCE_OPT="-f"; shift ;;
@@ -90,64 +91,63 @@ main() {
     REPEATER_NAMES=${REPEATER_NAMES-repeater-${UNIQUE_ID}}
     GW_NAME=${GW_NAME-gateway-${UNIQUE_ID}}
 
-    dbg REMOVE=$REMOVE
-    dbg GW_NAME=$GW_NAME
-    dbg REPEATER_NAMES=$REPEATER_NAMES
-    dbg START_GATEWAY=$START_GATEWAY
-    dbg START_REPEATER=$START_REPEATER
-    dbg DELAY=$DELAY
-    dbg UNIQUE_ID=$UNIQUE_ID
+    dbg REMOVE="${REMOVE}"
+    dbg GW_NAME="${GW_NAME}"
+    dbg REPEATER_NAMES="${REPEATER_NAMES}"
+    dbg START_GATEWAY="${START_GATEWAY}"
+    dbg START_REPEATER="${START_REPEATER}"
+    dbg DELAY="${DELAY}"
+    dbg UNIQUE_ID="${UNIQUE_ID}"
 
     [ "$START_GATEWAY" = "true" ] && {
         status "Start GW (Controller + local Agent)"
-        ${rootdir}/tools/docker/run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} ${GW_EXTRA_OPT} \
-        start-controller-agent -d -n ${GW_NAME} -m 00:11:22:33 -- "$@"
+        "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" "${VERBOSE_OPT}" "${FORCE_OPT}" "${GW_EXTRA_OPT}" \
+        start-controller-agent -d -n "${GW_NAME}" -m 00:11:22:33 -- "$@"
     }
 
-    [ "$START_GATEWAY" = "true" -a "$START_REPEATER" = "true" ] && {
+    [ "$START_GATEWAY" = "true" ] && [ "$START_REPEATER" = "true" ] && {
         status "Delay ${DELAY} seconds..."
-        sleep ${DELAY}
+        sleep "${DELAY}"
     }
 
     [ "$START_REPEATER" = "true" ] && {
         index=0
         for repeater in $REPEATER_NAMES; do
             status "Start Repeater (Remote Agent): $repeater"
-            ${rootdir}/tools/docker/run.sh -u ${UNIQUE_ID} ${VERBOSE_OPT} ${FORCE_OPT} ${RP_EXTRA_OPT} \
-            start-agent -d -n ${repeater} -m aa:bb:cc:$index$index -- "$@"
+            "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" "${VERBOSE_OPT}" "${FORCE_OPT}" "${RP_EXTRA_OPT}" \
+            start-agent -d -n "${repeater}" -m aa:bb:cc:"$index$index" -- "$@"
             index=$((index+1))
         done
     }
 
     status "Delay ${DELAY} seconds..."
-    sleep ${DELAY}
+    sleep "${DELAY}"
 
     error=0
     [ "$START_GATEWAY" = "true" ] && report "GW operational" \
-        ${rootdir}/tools/docker/test.sh ${VERBOSE_OPT} -n ${GW_NAME}
+        "${rootdir}"/tools/docker/test.sh "${VERBOSE_OPT}" -n "${GW_NAME}"
 
 
     [ "$START_REPEATER" = "true" ] && {
         for repeater in $REPEATER_NAMES
         do
             report "Repeater $repeater operational" \
-            ${rootdir}/tools/docker/test.sh ${VERBOSE_OPT} -n ${repeater}
+            "${rootdir}"/tools/docker/test.sh "${VERBOSE_OPT}" -n "${repeater}"
         done
     }
 
     [ "$REMOVE" = "true" ] && {
         status "Deleting containers ${GW_NAME} ${REPEATER_NAMES}"
-        docker rm -f ${GW_NAME} ${REPEATER_NAMES} >/dev/null 2>&1
+        docker rm -f "${GW_NAME}" "${REPEATER_NAMES}" >/dev/null 2>&1
     }
 
     return $error
 }
 
-VERBOSE=false
 REMOVE=false
 START_GATEWAY=true
 START_REPEATER=true
 UNIQUE_ID=${SUDO_USER:-${USER}}
 DELAY=5
 
-main $@
+main "$@"

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -22,6 +22,7 @@ usage() {
     echo "      -m|--mac - base MAC address for interfaces in the container"
     echo "      -n|--name - container name (for later easy attach)"
     echo "      -p|--port - port to expose on the container"
+    echo "      -P|--publish - publish all exposed ports to the host"
     echo "      -I|--image - docker network to which to attach the container"
     echo "      -N|--network - docker network to which to attach the container"
     echo "      -u|--unique-id - unique id to add as suffix to container and network names"
@@ -47,7 +48,7 @@ gateway_netid_length() {
 }
 
 main() {
-    OPTS=`getopt -o 'hvdfi:m:n:N:o:t:p:u:' --long verbose,help,detach,force,ipaddr:,mac:,name:,network:,entrypoint:,tag:,port:,options:,unique-id: -n 'parse-options' -- "$@"`
+    OPTS=`getopt -o 'hvdfi:m:n:N:o:t:e:p:u:' --long verbose,help,detach,force,ipaddr:,mac:,name:,network:,entrypoint:,tag:,expose:,publish:,options:,unique-id: -n 'parse-options' -- "$@"`
 
     if [ $? != 0 ] ; then err "Failed parsing options." >&2 ; usage; exit 1 ; fi
 
@@ -64,7 +65,8 @@ main() {
             -n | --name)        NAME="$2"; shift; shift ;;
             -u | --unique-id)   UNIQUE_ID="$2"; shift; shift ;;
             -t | --tag)         TAG=":$2"; shift; shift ;;
-            -p | --port)        PORT=":$2"; shift; shift ;;
+            -e | --expose)      PORT="${PORT} --expose $2"; shift; shift ;;
+            -p | --publish)     PUBLISH="${PUBLISH} -p ${2}"; shift; shift ;;
             -N | --network)     NETWORK="$2"; shift; shift ;;
             --entrypoint)       ENTRYPOINT="$2"; shift; shift ;;
             -- ) shift; break ;;
@@ -99,6 +101,7 @@ main() {
     dbg "IPADDR=${IPADDR}"
     dbg "BASE_MAC=${BASE_MAC}"
     dbg "PORT=${PORT}"
+    dbg "PUBLISH=${PUBLISH}"
     dbg "NAME=${NAME}"
     dbg "FORCE=${FORCE}"
     dbg "UNIQUE_ID=${UNIQUE_ID}"
@@ -107,7 +110,7 @@ main() {
                 -e INSTALL_DIR=${installdir}
                 --privileged
                 --network ${NETWORK}
-                --expose ${PORT}
+                ${PORT} ${PUBLISH}
                 -v ${installdir}:${installdir}
                 -v ${rootdir}:${rootdir}
                 -v ${rootdir}/logs/${NAME}:/tmp/${SUDO_USER:-${USER}}/beerocks/logs
@@ -140,7 +143,7 @@ UNIQUE_ID=${SUDO_USER:-${USER}}
 IPADDR=
 NAME=prplMesh
 ENTRYPOINT=
-PORT=5000
+PORT="--expose 5000"
 BASE_MAC=44:55:66:77
 
 main $@

--- a/tools/docker/runner/entrypoint.sh
+++ b/tools/docker/runner/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # Copyright (c) 2019 Tomer Eliyahu (Intel)
@@ -13,6 +13,12 @@ run() {
 
 bridge_ip="$1"; shift
 base_mac="$1"; shift
+
+# If the requested bridge ip is 0.0.0.0, use the ip address that
+# was allocated by the daemon to this container (from eth0)
+if [[ ${bridge_ip} == 0.0.0.0* ]]; then
+    bridge_ip="$(ip addr show dev eth0 | grep inet | awk '{print $2}')"
+fi
 
 run ip link add          br-lan   address "${base_mac}:00:00" type bridge
 run ip link add          wlan0    address "${base_mac}:00:10" type dummy

--- a/tools/docker/tests-runner/Dockerfile
+++ b/tools/docker/tests-runner/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker:18.09.7-dind
 
 RUN apk add --update --no-cache \
+    bash \
     python3 \
     grep \
     coreutils \


### PR DESCRIPTION
The purpose of this PR is to add support for running the test flows on WSL.
Docker for Windows is currently unable to forward traffic from the host to Linux based containers.
To workaround this limitation, when running on WSL, we expose the UCC ports to the host machine.
Once the ports are exposed, the `test_flows.py` script opens the CAPI sockets to the localhost and is able to communicate with the listeners in the containers.