### PR TITLE
bwl: dwpal: fix missing channel bandwidth

### DIFF
--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
@@ -394,7 +394,7 @@ static bool translate_nl_data_to_bwl_results(sChannelScanResults &results,
     }
 
     //get information elements from information-elements-buffer or from beacon
-    if (bss[NL80211_BSS_BEACON_IES]) {
+    if (bss[NL80211_BSS_BEACON_IES] || bss[NL80211_BSS_INFORMATION_ELEMENTS]) {
         enum nl80211_bss ies_index = (bss[NL80211_BSS_INFORMATION_ELEMENTS])
                                          ? NL80211_BSS_INFORMATION_ELEMENTS
                                          : NL80211_BSS_BEACON_IES;


### PR DESCRIPTION
As part of the DCS's channel scan, the channel bandwidth for each
neighboring AP is retrieved from the NL message.
The value is stored as part of the Information Elements or IES
in the vht & ht fields.

During scan dump, add check to both Information Elements and IES.