### PR TITLE
Feature/channel pool validation

### DIFF
--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -513,6 +513,17 @@ public:
                                bool single_scan);
 
     /**
+     * @brief Validate the channel scan pool
+     * 
+     * @param mac:          MAC address of radio
+     * @param channel_pool: Channel pool of channel scan
+     * @return true if pool is valid
+     * @return false if pool is invalid
+     */
+    bool is_channel_scan_pool_supported(const sMacAddr &mac,
+                                        const std::unordered_set<uint8_t> &channel_pool);
+
+    /**
      * @brief Get the channel scan pool object
      * 
      * @param mac:         MAC address of radio


### PR DESCRIPTION
Currently the DCS's set_channel_scan_pool uses a static list of supported channels for verifications to see if the channels provided in the channel pool are supported.

The DB has a list known as hostap_supported_channels, this is filled with channels provided by the basic radio capabilities

The DCS's set_channel_scan_pool need to validate it's channel pool against this supported channels list