### PR TITLE
common: bwl: return error on consecutive nl-msg-get failures

### DIFF
--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -110,6 +110,8 @@ private:
 
     char m_wpa_ctrl_buffer[HOSTAPD_TO_DWPAL_MSG_LENGTH];
     size_t m_wpa_ctrl_buffer_size = HOSTAPD_TO_DWPAL_MSG_LENGTH;
+
+    int dwpal_nl_consecutive_msg_get_failures = 0;
 };
 
 } // namespace dwpal


### PR DESCRIPTION
Added failure on attempt counter for dwpal_driver_nl_msg_get operation
to prevent unnecessary monitor thread restarts in case of a one-time
buffer glitch in dwpal-nl-parser.

The above-mentioned scenario can happen when 2 sockets are using
dwpal_driver_nl_msg_get simultaneously and receiving an event at the
same time.
If max-retries is reached, the process_nl_events() fails and the
monitor_thread_stop will be performed.

Fixes #1001 

Signed-off-by: Adam Dov <adamx.dov@intel.com>