### PR TITLE
Ignore

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -91,12 +91,17 @@ prplmesh_framework_init() {
     echo "prplmesh_framework_init - starting local_bus and ieee1905_transport processes..."
     @INSTALL_PATH@/bin/local_bus &
     @INSTALL_PATH@/bin/ieee1905_transport &
+
+    # This is required for solveing issue which causing meesges not geeting to their destination.
+    # For more information see: https://github.com/prplfoundation/prplMesh/pull/1029#issuecomment-608353274
+    ebtables -A FORWARD -d 01:80:c2:00:00:13 -j DROP
 }
 
 prplmesh_framework_deinit() {
     echo "prplmesh_framework_deinit - killing local_bus and ieee1905_transport processes..."
     killall_program local_bus
     killall_program ieee1905_transport
+    ebtables -D FORWARD -d 01:80:c2:00:00:13 -j DROP
 }
 
 prplmesh_controller_start() {

--- a/tools/docker/runner/Dockerfile
+++ b/tools/docker/runner/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
 	iproute2 \
 	psmisc \
 	clang-format \
+	ebtables \
 	netcat \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
When setting the relay indicator, it is observed that some message does not get to their
destination.
As it is mentioned on https://github.com/prplfoundation/prplMesh/pull/1029#issuecomment-608353274
The reason for that is a result of a combination of several issues:
1. Since we are using pcap to capture packets (#30, #1090), we receive outgoing packets as well
as incoming ones. For normal packets, this doesn't happen because they are sent on the bridge
and we don't sniff the bridge. For relayed multicast packets, however, we send it to each individual
interface. Thus, whenever a relayed multicast packet is sent, it is also received 3 times
(wlan0, wlan2, eth0).
2. Since we don't have an ebtable rule to disable bridge handling of ieee1905.1 packets, the br-lan
bridge will relay the packets even if the relayed multicast bit is not set. Thus, every relayed
multicast packet will be received twice on each interface.
3. Because of the combination of the above two, it is possible that the first time the transport
receives a packet, it came from one of the dummy interfaces (wlan0, wlan2) instead of the
interface it really came from (eth0). Therefore, it will be relayed back again to eth0 and
return to the sender.
3. We send to autoconfig search messages back-to-back, with a different MID.
4. The transport de-duplication only seems to keep track of the last received MID.
Thus, when the second autoconfig search has been received, and then a duplicate of the
first one is received, it will be considered as a new one so it will be relayed again.

The combination of all of the above leads to a rush of duplicate packets coming into
the transport, which overflows the pcap buffer and thus the autoconfig response message
is lost. The autoconfig response is unicast and is not retransmitted, so it really only arrives
once in the repeater, so it is easy to lose it between all the rest.

This commit adds ebtable rule that so the bridge itself doesn't do any relaying.
In order to use ebtable on docker, add it to the docker file.

Signed-off-by: Moran Shoeg <moranx.shoeg@intel.com>