### PR TITLE
DCS: Feature/add scan trigger response error handling in dcs task

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1223,10 +1223,10 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             return false;
         }
 
-        bool result = mon_wlan_hal->channel_scan_trigger(int(dwell_time_ms), channel_pool_vector);
-        LOG_IF(!result, ERROR) << "channel_scan_trigger Failed";
+        response_out->success() =
+            mon_wlan_hal->channel_scan_trigger(int(dwell_time_ms), channel_pool_vector);
+        LOG_IF(!response_out->success(), ERROR) << "channel_scan_trigger Failed";
 
-        response_out->success() = (result) ? 1 : 0;
         message_com::send_cmdu(slave_socket, cmdu_tx);
         break;
     }

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -1760,7 +1760,7 @@ class cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE);
         }
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         void class_swap() override;
         bool finalize() override;
@@ -1847,7 +1847,7 @@ class cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE);
         }
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         void class_swap() override;
         bool finalize() override;
@@ -1932,7 +1932,7 @@ class cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE);
         }
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         void class_swap() override;
         bool finalize() override;
@@ -1980,7 +1980,7 @@ class cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE : public BaseClass
         }
         //0 - Success, Otherwise error according to beerocks_defines:eDcsScanErrCode
         uint8_t& result_status();
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         //0 - Not reached end of response, 1 - reached end of respons
         uint8_t& last();

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -372,7 +372,7 @@ cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE:
   _type: class
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode 
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
 
 cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST:
   _type: class
@@ -391,7 +391,7 @@ cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE:
   _type: class
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
 
 cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST:
   _type: class
@@ -409,7 +409,7 @@ cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE:
   _type: class
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
 
 cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST:
   _type: class
@@ -425,7 +425,7 @@ cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE:
     _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsScanErrCode
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
   last:
     _type: uint8_t
     _comment: 0 - Not reached end of response, 1 - reached end of respons

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -3558,18 +3558,18 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             LOG(ERROR) << "addClass cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE failed";
             return false;
         }
-        //get the mac from hostap_mac
         auto radio_mac = network_utils::mac_from_string(hostap_mac);
 
         if (!response->success()) {
-            LOG(ERROR) << "failed to trigger scan on radio(" << radio_mac
+            LOG(ERROR) << "Failed to trigger scan on radio (" << radio_mac
                        << "): sending notification to DCS task";
 
             dynamic_channel_selection_task::sScanEvent new_event;
             new_event.radio_mac = radio_mac;
             auto taskId         = database.get_dynamic_channel_selection_task_id(radio_mac);
             if (taskId == -1) {
-                LOG(ERROR) << "no task for the requested mac (" << radio_mac << ") could be found!";
+                LOG(ERROR) << "No DCS task for the requested mac (" << radio_mac
+                           << ") is currently running!";
                 break;
             }
 
@@ -3601,7 +3601,8 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         new_event.radio_mac = radio_mac;
         auto taskID         = database.get_dynamic_channel_selection_task_id(radio_mac);
         if (taskID == -1) {
-            LOG(ERROR) << "no task for the requested mac (" << radio_mac << ") could be found!";
+            LOG(ERROR) << "No DCS task for the requested mac (" << radio_mac
+                       << ") is currently running!";
         } else {
             tasks.push_event(taskID, (int)dynamic_channel_selection_task::eEvent::SCAN_TRIGGERED,
                              (void *)&new_event);

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -269,6 +269,15 @@ void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
     }
     case eEvent::SCAN_TRIGGER_FAILED: {
         TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED received";
+        if (fsm_in_state(eState::WAIT_FOR_SCAN_TRIGGERED)) {
+            auto scan_trigger_failed_event = reinterpret_cast<sScanEvent *>(obj);
+            event_handled                  = true;
+            TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED handled on:"
+                            << scan_trigger_failed_event->radio_mac.oct;
+            m_last_scan_error_code = beerocks::eChannelScanErrCode::CHANNEL_SCAN_INTERNAL_FAILURE;
+            clear_pending_events();
+            fsm_move_state(eState::ABORT_SCAN);
+        }
         break;
     }
     case eEvent::SCAN_TRIGGERED: {

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -267,6 +267,10 @@ void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
         m_is_single_scan_pending = true;
         break;
     }
+    case eEvent::SCAN_TRIGGER_FAILED: {
+        TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED received";
+        break;
+    }
     case eEvent::SCAN_TRIGGERED: {
         TASK_LOG(DEBUG) << "SCAN_TRIGGERED received";
         if (fsm_in_state(eState::WAIT_FOR_SCAN_TRIGGERED)) {

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -272,8 +272,8 @@ void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
         if (fsm_in_state(eState::WAIT_FOR_SCAN_TRIGGERED)) {
             auto scan_trigger_failed_event = reinterpret_cast<sScanEvent *>(obj);
             event_handled                  = true;
-            TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED handled on:"
-                            << scan_trigger_failed_event->radio_mac.oct;
+            TASK_LOG(WARNING) << "failed to trigger a scan on:"
+                              << scan_trigger_failed_event->radio_mac.oct << ", aborting scan";
             m_last_scan_error_code = beerocks::eChannelScanErrCode::CHANNEL_SCAN_INTERNAL_FAILURE;
             clear_pending_events();
             fsm_move_state(eState::ABORT_SCAN);

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -39,6 +39,7 @@ public:
 #define FOREACH_DCS_EVENT(EVENT)                                                                   \
     EVENT(INVALID_EVENT)                                                                           \
     EVENT(TRIGGER_SINGLE_SCAN)                                                                     \
+    EVENT(SCAN_TRIGGER_FAILED)                                                                     \
     EVENT(SCAN_TRIGGERED)                                                                          \
     EVENT(SCAN_RESULTS_READY)                                                                      \
     EVENT(SCAN_RESULTS_DUMP)                                                                       \


### PR DESCRIPTION
Add scan-trigger-response with failure handling for the DCS task.

In the case where scan-trigger operation failed, the DCS task would only fail due to timeout on the scan-triggered event, even though the failure was already received by the son_master in the ACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_RESPONSE CMDU.

Added SCAN_TRIGGER_FAILED event to DCS task and in the case of failure to trigger a scan, the son_manager will push that event to the task. The DCS task will abort the scan and set the last_scan_error_code to CHANNEL_SCAN_INTERNAL_FAILURE.

Fixes #1135 

Signed-off-by: Adam Dov adamx.dov@intel.com