### PR TITLE
boardfarm: Run test_initial_ap_config for dockerized device

### DIFF
--- a/tests/bft.sh
+++ b/tests/bft.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+scriptdir=$(dirname $(readlink -f $0))
+bf_dir=$(realpath "$scriptdir/../../boardfarm")
+bfp_dir=$scriptdir
+
+PYTHONPATH="$bfp_dir" python3 "$bf_dir/bft" "$@"

--- a/tests/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python3
+#
+# Work-In-Progress. Non-working code yet
+#
+
+from boardfarm.devices import debian
+
+import os
+import subprocess
+from pprint import pprint
+from environment import ALEntriryDocker
+
+# rootdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+
+
+class PrplMeshDocker(debian.DebianBox):
+    '''
+    Dockerized prplMesh device containing controller or agent
+    '''
+    model = ('prplmesh_docker')
+    name = "prplmesh_docker"
+    ptyproc = None
+
+    def __init__(self, *args, **kwargs):
+        name = kwargs.pop("name", "gateway")
+        net = kwargs.pop("net", "prplMesh-net")
+
+        if "controller" in kwargs:
+            controller_data = kwargs.pop("controller", {})
+            ucc_port = controller_data.get("ucc_port", 8002)
+            subprocess.check_call((os.path.join(rootdir, "tools", "docker", "run.sh"),
+                                   "--verbose", "--detach", "--force", 
+                                   "--expose {ucc_port} --publish 127.0.0.1::{ucc_port} --ipaddr 0.0.0.0".format(ucc_port=ucc_port),
+                                   "--name", name,
+                                   "--mac", "00:11:22:33",
+                                   "start-controller-agent")
+            self.controller = ALEntityDocker(name, is_controller=True)
+
+        if "agent" in kwargs:
+            agent_data = kwargs.pop("agent", {})
+            ucc_port = agent_data.get("ucc_port", 8005)
+            index = agent_data.get("index", 1)
+            subprocess.check_call((os.path.join(rootdir, "tools", "docker", "run.sh"),
+                                   "--verbose", "--detach", "--force", 
+                                   "--expose {ucc_port} --publish 127.0.0.1::{ucc_port} --ipaddr 0.0.0.0".format(ucc_port=ucc_port),
+                                   "--name", name,
+                                   "--mac", "aa:bb:cc:{idx}{idx}".format(idx=index),
+                                   "start-agent")
+            self.agent = ALEntityDocker(name)

--- a/tests/boardfarm_prplmesh/prplmesh_setup.json
+++ b/tests/boardfarm_prplmesh/prplmesh_setup.json
@@ -1,0 +1,79 @@
+{
+    "prplmesh_dummy": {
+        "name": "gateway",
+        "board_type": "prplmesh_docker",
+        "conn_cmd": "",
+        "controller": {
+            "type": "controller_dummy",
+            "ucc_port": 8002
+        },
+        "devices": [
+            {
+                "name": "repeater1",
+                "type": "prplmesh_docker",
+                "conn_cmd": "",
+                "agent": {
+                    "type": "agent_dummy",
+                    "ucc_port": 8005,
+                    "radios": [
+                        {
+                            "type": "radio_dummy",
+                            "iface": "wlan0"
+                        },
+                        {
+                            "type": "radio_dummy",
+                            "iface": "wlan2"
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "repeater2",
+                "type": "prplmesh_docker",
+                "conn_cmd": "",
+                "agent": {
+                    "type": "agent_dummy",
+                    "ucc_port": 8006,
+                    "radios": [
+                        {
+                            "type": "radio_dummy",
+                            "iface": "wlan0"
+                        },
+                        {
+                            "type": "radio_dummy",
+                            "iface": "wlan2"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "rax1": {
+        "board_type": "prplmesh_docker",
+        "conn_cmd": "cu -l /dev/ttyUSB0 -s 115200",
+        "controller": {
+            "type": "controller_dummy",
+            "ucc_port": 8002
+        },
+        "devices": [
+            {
+                "name": "agent",
+                "type": "RAX40",
+                "agents": {
+                    "type": "prplmesh_agent_hw",
+                    "ucc_port": 8002,
+                    "radios": [
+                        {
+                            "type": "prplmesh_radio_hw",
+                            "iface": "wlan0"
+                        },
+                        {
+                            "type": "prplmesh_radio_hw",
+                            "iface": "wlan2"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/tests/boardfarm_prplmesh/tests/fake.py
+++ b/tests/boardfarm_prplmesh/tests/fake.py
@@ -1,0 +1,8 @@
+from boardfarm.tests import rootfs_boot
+
+
+class Fake(rootfs_boot.RootFSBootTest):
+    '''lsmod shows loaded kernel modules.'''
+    def runTest(self):
+        print("Fake.runTest")
+

--- a/tests/boardfarm_prplmesh/testsuites.cfg
+++ b/tests/boardfarm_prplmesh/testsuites.cfg
@@ -1,0 +1,2 @@
+[prplmesh]
+Fake

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -44,7 +44,7 @@ generate_container_random_ip() {
 }
 
 gateway_netid_length() {
-    docker network inspect prplMesh-net-${UNIQUE_ID} --format "{{(index .IPAM.Config 0).Subnet}}" | sed -rn 's/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]{2})$/\1/p'
+    docker network inspect "$1" --format "{{(index .IPAM.Config 0).Subnet}}" | sed -rn 's/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]{2})$/\1/p'
 }
 
 main() {
@@ -80,7 +80,7 @@ main() {
         run ${scriptdir}/image-build.sh
     }
 
-    NETWORK=prplMesh-net-${UNIQUE_ID}
+    NETWORK=${NETWORK:-"prplMesh-net-${UNIQUE_ID}"}
     docker network inspect ${NETWORK} >/dev/null 2>&1 || {
         dbg "Network $NETWORK does not exist, creating..."
         run docker network create ${NETWORK} >/dev/null 2>&1
@@ -89,10 +89,10 @@ main() {
 
     [ -z "$IPADDR" -a -n "$NETWORK" ] && {
         dbg "Generate random IP for container $NAME for network $NETWORK"
-        IPADDR=$(generate_container_random_ip $NETWORK)
+        IPADDR=$(generate_container_random_ip ${NETWORK})
     }
 
-    IPADDR="${IPADDR}$(gateway_netid_length)"
+    IPADDR="${IPADDR}$(gateway_netid_length ${NETWORK})"
 
     dbg "VERBOSE=${VERBOSE}"
     dbg "DETACH=${DETACH}"


### PR DESCRIPTION
* Start PrplMeshDocker device
* Add draft of test setup config for dummy setup (controller + 2 agents)
  and for setup with single RAX40
* tools/docker/run.sh: fix use network name passed via cmdline args
  instead of hard-coded name