### PR TITLE
scripts: tools/docker/run.sh: fix usage docker network name passed via cmdline arg

### DIFF
--- a/tests/test_gw_repeater.sh
+++ b/tests/test_gw_repeater.sh
@@ -101,8 +101,8 @@ main() {
 
     [ "$START_GATEWAY" = "true" ] && {
         status "Start GW (Controller + local Agent)"
-        "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" "${VERBOSE_OPT}" "${FORCE_OPT}" "${GW_EXTRA_OPT}" \
-        start-controller-agent -d -n "${GW_NAME}" -m 00:11:22:33 -- "$@"
+        "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" ${VERBOSE_OPT} ${FORCE_OPT} ${GW_EXTRA_OPT} \
+            start-controller-agent -d -n "${GW_NAME}" -m 00:11:22:33 -- "$@"
     }
 
     [ "$START_GATEWAY" = "true" ] && [ "$START_REPEATER" = "true" ] && {
@@ -114,8 +114,8 @@ main() {
         index=0
         for repeater in $REPEATER_NAMES; do
             status "Start Repeater (Remote Agent): $repeater"
-            "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" "${VERBOSE_OPT}" "${FORCE_OPT}" "${RP_EXTRA_OPT}" \
-            start-agent -d -n "${repeater}" -m aa:bb:cc:"$index$index" -- "$@"
+            "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" ${VERBOSE_OPT} ${FORCE_OPT} ${RP_EXTRA_OPT} \
+                start-agent -d -n "${repeater}" -m aa:bb:cc:"$index$index" -- "$@"
             index=$((index+1))
         done
     }

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -44,7 +44,7 @@ generate_container_random_ip() {
 }
 
 gateway_netid_length() {
-    docker network inspect prplMesh-net-${UNIQUE_ID} --format "{{(index .IPAM.Config 0).Subnet}}" | sed -rn 's/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]{2})$/\1/p'
+    docker network inspect "$1" --format "{{(index .IPAM.Config 0).Subnet}}" | sed -rn 's/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]{2})$/\1/p'
 }
 
 main() {
@@ -80,19 +80,19 @@ main() {
         run ${scriptdir}/image-build.sh
     }
 
-    NETWORK=prplMesh-net-${UNIQUE_ID}
+    NETWORK=${NETWORK:-prplMesh-net-${UNIQUE_ID}}
     docker network inspect ${NETWORK} >/dev/null 2>&1 || {
-        dbg "Network $NETWORK does not exist, creating..."
+        dbg "Network ${NETWORK} does not exist, creating..."
         run docker network create ${NETWORK} >/dev/null 2>&1
-        echo "network $NETWORK" >> "${scriptdir}/.test_containers"
+        echo "network ${NETWORK}" >> "${scriptdir}/.test_containers"
     }
 
     [ -z "$IPADDR" -a -n "$NETWORK" ] && {
         dbg "Generate random IP for container $NAME for network $NETWORK"
-        IPADDR=$(generate_container_random_ip $NETWORK)
+        IPADDR=$(generate_container_random_ip ${NETWORK})
     }
 
-    IPADDR="${IPADDR}$(gateway_netid_length)"
+    IPADDR="${IPADDR}$(gateway_netid_length ${NETWORK})"
 
     dbg "VERBOSE=${VERBOSE}"
     dbg "DETACH=${DETACH}"
@@ -122,7 +122,7 @@ main() {
     else
         DOCKEROPTS="$DOCKEROPTS -d"
     fi
-    if [ -n "$(docker ps -a -f name="${NAME}" | grep -w "${NAME}")" ]; then
+    if docker ps -a --format '{{ .Names }}' --filter name="${NAME}" | grep -q -x "${NAME}"; then
         info "Container ${NAME} is already running"
         if [ "$FORCE" = "true" ]; then
             run docker container rm -f "$NAME"


### PR DESCRIPTION
Script "tools/docker/run.sh" assumes that gateway/repeater container
will be attached to Docker network named "prplMesh-net-${UNIQUE_ID}" and
ignore network name passed via cmdline argument.

For real boards usage purposes it's need to be able pass custom Docker
network name to provide connectivity of gateway container with choosen
board.

Fix assignement network name with value from args if the last is exist.
Fix checking the presense of created container. Current solution does
not correctly match, for example, "test" name if
"test-and-the-rest-name" is already present.

Signed-off-by: Ivan Efimov <i.efimov@inango-systems.com>