### PR TITLE
agent: backhaul_manager: get_media_type(): return true on success

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -3439,7 +3439,7 @@ bool backhaul_manager::get_media_type(const std::string &interface_name,
                     if ((std::get<0>(tuple) == radio_info.frequency_band) &&
                         (std::get<1>(tuple) == radio_info.max_bandwidth)) {
                         media_type = std::get<2>(tuple);
-
+                        result     = true;
                         break;
                     }
                 }


### PR DESCRIPTION
The get_media_type() function sets result to false by default. In the
IEEE_802_11, it wasn't set to true in the success case.

Set result to true before breaking out of the loop.

Fixes: #1097