### PR TITLE
tests: boardfarm_plugins: add boardfarm tests template

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@ This file lists all contributors.
 - Mario Maz
 - MaxLinear
 - Moran Shoeg
+- Oleksii Ponomarenko
 - Ostap Slyusar
 - Pavel Levitsky
 - Ram Marzin

--- a/tests/boardfarm_plugins/README.md
+++ b/tests/boardfarm_plugins/README.md
@@ -1,0 +1,182 @@
+<!--
+SPDX-License-Identifier: BSD-2-Clause-Patent
+Copyright (c) 2020 the prplMesh contributors
+This code is subject to the terms of the BSD+Patent license.
+See LICENSE file for more details.
+-->
+
+### Prerequisites
+
+To obtain prplMesh and boardfarm sources a Google repo tool is used.
+Refer to its [README](https://gerrit.googlesource.com/git-repo/+/refs/heads/master/README.md) for detailed info.
+
+### Boardfarm installation
+
+1. To obtain sources using previously mentioned repo tool run:
+```
+repo init -u https://github.com/prplfoundation/prplMesh-manifest.git
+repo sync
+repo forall -p -c 'git checkout $REPO_RREV' # (optional)
+```
+
+2. Install prplMesh to your host using instruction provided by its [README](https://github.com/prplfoundation/prplMesh/blob/master/README.md). 
+
+3. Install additional python packages:
+```
+cd boardfarm
+pip3 install -r requirements.txt
+```
+
+4. Install boardfarm to your host(optional):
+```
+python3 setup.py install --user
+```
+If you consider not to install boardfarm to your host and use binary provided in sources, then you may encounter additional warnings in boardfarm log caused by files not included in instalation package.
+
+### Boardfarm plugin dir structure:
+```
+boardfarm_*     <--- "boardfarm_" prefix is mandatory for boardfarm plugin name
+    |
+    +- __init__.py
+    +- boardfarm_config.json
+    +- devices
+    |   |
+    |   +- __init__.py
+    |   +- sample_device_0.py
+    |   +- sample_device_1.py
+    +- tests
+    |   |
+    |   +- __init__.py
+    |   +- sample_test_0.py
+    |   +- sample_test_1.py
+    |   +- ...
+    +- testsuites.cfg
+```
+
+### Custom device description
+If the tested device is abcent in `boardfarm/boardfarm/devices` dir we can specify new one by creating `custom_config.json` file sort of:
+```json
+{
+    "prplmesh_dummy": {
+        "name": "prplMesh-controller",
+        "board_type": "prplmesh_docker",
+        "role": "controller",
+        "delay": 7,
+        "conn_cmd": "",
+        "connection_type": "local_cmd",
+        "devices": [
+            {
+                "name": "repeater1",
+                "type": "prplMesh_dut",
+                "role": "agent",
+                "delay": 7,
+                "conn_cmd": "",
+                "radios": [
+                    {
+                        "type": "radio_dummy",
+                        "iface": "wlan0"
+                    },
+                    {
+                        "type": "radio_dummy",
+                        "iface": "wlan2"
+                    }
+                ]
+            },
+            {
+                "name": "repeater2",
+                "type": "prplMesh_dut",
+                "role": "agent",
+                "delay": 7,
+                "conn_cmd": "",
+                "radios": [
+                    {
+                        "type": "radio_dummy",
+                        "iface": "wlan0"
+                    },
+                    {
+                        "type": "radio_dummy",
+                        "iface": "wlan2"
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+```
+Mandatory fields for parent device are:
+* `name` is any unique name at all
+* `board_type` is a name of existing device class
+* `devices` is a list of devices that will be added, must be present even it's empty(i.e. `"devices": []`).
+Mandatory fields for child devices(those are listed in **devices** section of parent one):
+* `name` is any unique name at all
+* `type` is a name of existing device class
+
+When running boardfarm we can specify that custom config with in following manner:
+```
+-c /path/to/custom_config.json
+```
+
+### Devices
+There are several devices already existing in `<boardfarm-repo-root>/boardfarm/devices`, but if we created `custom_config.json` which uses previously unknown device, then we must implement its class in plugin dir `boardfarm_*/devices/<device-name>.py`.
+As template for the device we can use `<boardfarm-repo-root>/devices/base.py`.
+
+### Test suites
+Custom test suite should be present in root of boardfarm plugin dir and its name must match `testsuites*.cfg`.
+Suite names are specified in brackets [], test names must match test classes names defined in the files at the "boardfarm_*/tests/" directory.
+Sample contents:
+```
+[suite-name]
+TestCaseName0
+
+[another-suite-name]
+TestCaseName0
+TestCaseName1
+TestCaseName2
+```
+
+### Test file contents:
+Each test must be presented as class, for test file template please refer to:
+`boardfarm/tests/bft_base_test.py`
+Below you can see mandatory class members:
+```
+class SampleTest(BftBaseTest):
+    def runTest(self):
+        '''Main test logic must be implemented here.'''
+        print('{}: Running...'.format(self.__class__.__name__))
+
+    def skipTest(self):
+        '''Method invoked if DUT doesn't respond.
+
+        If the DUT's consoles don't respond, generally the device is considered as 'dead'.
+        Here we can provide info about possible reasons and suggestions.
+        '''
+        print('{}: Skipping...'.format(self.__class__.__name__))
+
+    def recover(self):
+        '''Method invoked if test fails with an unexpected exception type.
+
+        According to boardfarm sources, it is considered as deprecated,
+        but it is suggested to leave it as a stub to prevent possible faults.
+        '''
+        print('{}: Recovering...'.format(self.__class__.__name__)
+
+    @classmethod
+    def teardown_class(cls):
+        '''Teardown method, optional for boardfarm tests.'''
+        print('{}: Teardown...'.format(cls.__class__.__name__))
+```
+For operational example please refer to **boardfarm_prplmesh** plugin.
+
+### Boardfarm usage
+
+To run boardfarm sample you can use following command:
+```
+PYTHONPATH=/path/to/module/dir bft -c /path/to/boardfarm_config.json --testsuite <test-suite-name> -n <device-name>
+```
+or invoke provided script:
+```
+/bin/bash run_bf.sh
+```
+It will lauch *boardfarm_prplmesh* plugin.
+By default, all test logs will be stored in **results** dir.

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/__init__.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/__init__.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_base.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_base.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+import pexpect
+
+from boardfarm.devices import linux
+
+
+class PrplMeshBase(linux.LinuxDevice):
+    """PrplMesh abstract device."""
+
+    def _run_shell_cmd(self, cmd: str = "", args: list = None, timeout: int = 30):
+        """Wrapper that executes command with specified args on host machine and logs output."""
+
+        res = pexpect.run(cmd, args=args, timeout=timeout, encoding="utf-8")
+        entry = " ".join((cmd, " ".join(args)))
+        self.log_calls += entry
+        self.log += "$ " + entry + "\r\n" + res
+
+    def check_status(self):
+        """Method required by boardfarm.
+
+        It is used by boardfarm to indicate that spawned device instance is ready for test
+        and also after test - to insure that device still operational.
+        """
+        pass
+
+    def close(self):
+        """Method required by boardfarm.
+
+        Purpose is to close connection to device's consoles.
+        """
+        pass
+
+    def isalive(self):
+        """Method required by boardfarm.
+
+        States that device is operational and its consoles are accessible.
+        """
+        pass
+
+    def touch(self):
+        """Method required by boardfarm.
+
+        Purpose is to keep consoles active, so they don't disconnect for long running activities.
+        """
+        pass

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+import os
+import time
+
+from environment import ALEntityDocker
+from .prplmesh_base import PrplMeshBase
+
+rootdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..'))
+
+
+class PrplMeshDocker(PrplMeshBase):
+    """Dockerized prplMesh device."""
+
+    model = ("prplmesh_docker")
+    agent_entity = None
+    controller_entity = None
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+        config = kwargs.get("config", kwargs)
+
+        # List of device's consoles test can interact with
+        self.consoles = [self]
+
+        # Getting unic ID to distinguish devices and network they belong to
+        self.unique_id = os.getenv("SUDO_USER", os.getenv("USER", ""))
+
+        self.name = "-".join((config.get("name", "prplmesh_docker"), self.unique_id))
+        self.role = config.get("role", "agent")
+        self.cleanup_cmd = config.get("cleanup_cmd", None)
+        self.conn_cmd = config.get("conn_cmd", None)
+        self.delay = config.get("delay", 7)
+        self.docker_network = config.get("docker_network",
+                                         "prplMesh-net-{}".format(self.unique_id))
+
+        docker_cmd = os.path.join(rootdir, "tools", "docker", "run.sh")
+        docker_args = ["--verbose", "--detach", "--force", "--name", self.name,
+                       "--network", self.docker_network]
+
+        if self.role == "controller":
+            # Spawn dockerized controller
+            docker_args.append("start-controller-agent")
+            self._run_shell_cmd(docker_cmd, docker_args)
+
+            time.sleep(self.delay)
+            self.controller_entity = ALEntityDocker(self.name, is_controller=True)
+        else:
+            # Spawn dockerized agent
+            docker_args.append("start-agent")
+            self._run_shell_cmd(docker_cmd, docker_args)
+
+            time.sleep(self.delay)
+            self.agent_entity = ALEntityDocker(self.name, is_controller=False)
+
+        self.check_status()
+
+    def __del__(self):
+        if self.cleanup_cmd:
+            self._run_shell_cmd(self.cleanup_cmd)
+
+    def check_status(self):
+        """Method required by boardfarm.
+
+        It is used by boardfarm to indicate that spawned device instance is ready for test
+        and also after test - to insure that device still operational.
+        """
+        self._run_shell_cmd(os.path.join(rootdir, "tools", "docker", "test.sh"),
+                            ["-v", "-n", self.name])
+
+    def isalive(self):
+        """Method required by boardfarm.
+
+        States that device is operational and its consoles are accessible.
+        """
+        return True

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -1,0 +1,9 @@
+{
+    "prplmesh_docker": {
+        "name": "dockerized_device",
+        "board_type": "prplmesh_docker",
+        "role": "controller",
+        "conn_cmd": "",
+        "devices": []
+    }
+}

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/__init__.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+from boardfarm.tests import bft_base_test
+
+
+class InitialApConfig(bft_base_test.BftBaseTest):
+    """PrplMesh sample test case, no actual testing, it just passes."""
+
+    def runTest(self):
+        """Main test logic must be implemented here."""
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown method, optional for boardfarm tests."""

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+[test_flows]
+InitialApConfig

--- a/tests/run_bf.sh
+++ b/tests/run_bf.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+scriptdir=$(dirname "$(readlink -f "${0}")")
+bf_plugins_dir=${scriptdir}/boardfarm_plugins
+bf_dir=$(realpath "${scriptdir}/../../boardfarm")
+
+if [ -n "${PYTHONPATH}" ]; then
+   PYTHONPATH="${bf_dir}:${bf_plugins_dir}:${scriptdir}:${PYTHONPATH}"
+else
+   PYTHONPATH="${bf_dir}:${bf_plugins_dir}:${scriptdir}"
+fi
+export PYTHONPATH
+
+exec python3 "${bf_dir}"/bft -c "${bf_plugins_dir}"/boardfarm_prplmesh/prplmesh_config.json -n prplmesh_docker -x test_flows


### PR DESCRIPTION
Added boardfarm plugin's usage description in README.md.
According to plugin's behavior, it was created example of plugin,
which contains suggested file hierarchy, common necessary files,
with stub test to demonstrate its workflow.

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>