### PR TITLE
gitignore: add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 .quilt_checked
 .source_dir
 ipkg-*/
+.vscode


### PR DESCRIPTION
added .vscode to .gitignore

Signed-off-by: Adam Dov <adamx.dov@intel.com>