### PR TITLE
agent: backhaul_manager: get_media_type(): return true on success

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -3444,6 +3444,12 @@ bool backhaul_manager::get_media_type(const std::string &interface_name,
                     }
                 }
 
+                /**
+                 * Media type has been successfully computed for given interface.
+                 * Notice however that returned media type can be UNKNONWN_MEDIA if frequency
+                 * band and max bandwidth were not found in table_6_12_media_type.
+                 */
+                result = true;
                 break;
             }
         }


### PR DESCRIPTION
The get_media_type() function sets result to false by default. In the  
IEEE_802_11, it wasn't set to true in the success case.
Set result to true before breaking out of the loop.

Fixes: #1097