### PR TITLE
DCS: Feature/limit dcs scans to one at a time

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1223,10 +1223,10 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             return false;
         }
 
-        bool result = mon_wlan_hal->channel_scan_trigger(int(dwell_time_ms), channel_pool_vector);
-        LOG_IF(!result, ERROR) << "channel_scan_trigger Failed";
+        response_out->success() =
+            mon_wlan_hal->channel_scan_trigger(int(dwell_time_ms), channel_pool_vector);
+        LOG_IF(!response_out->success(), ERROR) << "channel_scan_trigger Failed";
 
-        response_out->success() = (result) ? 1 : 0;
         message_com::send_cmdu(slave_socket, cmdu_tx);
         break;
     }

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -1760,7 +1760,7 @@ class cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE);
         }
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         void class_swap() override;
         bool finalize() override;
@@ -1847,7 +1847,7 @@ class cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE);
         }
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         void class_swap() override;
         bool finalize() override;
@@ -1932,7 +1932,7 @@ class cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE);
         }
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         void class_swap() override;
         bool finalize() override;
@@ -1980,7 +1980,7 @@ class cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE : public BaseClass
         }
         //0 - Success, Otherwise error according to beerocks_defines:eDcsScanErrCode
         uint8_t& result_status();
-        //0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+        //0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
         uint8_t& op_error_code();
         //0 - Not reached end of response, 1 - reached end of respons
         uint8_t& last();

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -372,7 +372,7 @@ cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_PARAMS_RESPONSE:
   _type: class
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode 
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
 
 cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_PARAMS_REQUEST:
   _type: class
@@ -391,7 +391,7 @@ cACTION_BML_CHANNEL_SCAN_SET_CONTINUOUS_ENABLE_RESPONSE:
   _type: class
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
 
 cACTION_BML_CHANNEL_SCAN_GET_CONTINUOUS_ENABLE_REQUEST:
   _type: class
@@ -409,7 +409,7 @@ cACTION_BML_CHANNEL_SCAN_START_SCAN_RESPONSE:
   _type: class
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
 
 cACTION_BML_CHANNEL_SCAN_GET_RESULTS_REQUEST:
   _type: class
@@ -425,7 +425,7 @@ cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE:
     _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsScanErrCode
   op_error_code:
     _type: uint8_t
-    _comment: 0 - Success, Otherwise error according to beerocks_defines:eDcsOpErrCode
+    _comment: 0 - Success, Otherwise error according to beerocks_defines:eChannelScanOpErrCode
   last:
     _type: uint8_t
     _comment: 0 - Not reached end of response, 1 - reached end of respons

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2393,6 +2393,16 @@ const std::list<sChannelScanResults> &db::get_channel_scan_results(const sMacAdd
     return (single_scan ? hostap->single_scan_results : hostap->continuous_scan_results);
 }
 
+bool db::try_lock_scan_permission(int task_id)
+{
+    return true;
+}
+
+bool db::unlock_scan_permission(int task_id)
+{
+    return true;
+}
+
 //
 // CLI
 //

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2417,6 +2417,22 @@ bool db::try_lock_scan_permission(int task_id)
 
 bool db::unlock_scan_permission(int task_id)
 {
+    if (task_id < 0) {
+        LOG(ERROR) << "invalid input, task_id(" << task_id << ") < 0";
+        return false;
+    }
+
+    if (-1 == m_scan_locked_by_task_id) {
+        return true;
+    }
+
+    if (task_id != m_scan_locked_by_task_id) {
+        LOG(ERROR) << "failed to unlock scan permission by task_id(" << task_id << "), scan is locked by other task_id(" << m_scan_locked_by_task_id << ")";
+        return false;
+    }
+
+    m_scan_locked_by_task_id = -1;
+
     return true;
 }
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2395,6 +2395,23 @@ const std::list<sChannelScanResults> &db::get_channel_scan_results(const sMacAdd
 
 bool db::try_lock_scan_permission(int task_id)
 {
+    if (task_id < 0) {
+        LOG(ERROR) << "invalid input, task_id(" << task_id << ") < 0";
+        return false;
+    }
+
+    if (-1 != m_scan_locked_by_task_id) {
+        return false;
+    }
+
+    if (task_id == m_scan_locked_by_task_id) {
+        LOG(DEBUG) << "scan permission already locked by task requesting to lock! task_id=" << task_id;
+        return true;
+    }
+
+    LOG(DEBUG) << "scan permission locked successfully for task_id=" << task_id;
+    m_scan_locked_by_task_id = task_id;
+    
     return true;
 }
 

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -564,6 +564,24 @@ public:
     const std::list<sChannelScanResults> &get_channel_scan_results(const sMacAddr &mac,
                                                                    bool single_scan);
 
+    /**
+     * @brief Lock permission for channel scan
+     * 
+     * @param task_id: id of task requesting to lock the scan permission
+     * @return true on success
+     * @return false on failure (if failed to lock or locked by other task)
+     */
+    bool try_lock_scan_permission(int task_id);
+
+    /**
+     * @brief Unlock permission for channel scan
+     * 
+     * @param task_id: id of task requesting to unlock the scan permission
+     * @return true on success
+     * @return false on failure (if failed to release or unlocked by other task)
+     */
+    bool unlock_scan_permission(int task_id);
+
     //
     // CLI
     //

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -926,6 +926,9 @@ private:
 
     master_thread *m_master_thread_ctx = nullptr;
     const std::string m_local_bridge_mac;
+
+    // task_id==-1 means lock is free
+    int m_scan_locked_by_task_id = -1;
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -250,6 +250,10 @@ void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
         m_is_single_scan_pending = true;
         break;
     }
+    case eEvent::SCAN_TRIGGER_FAILED: {
+        TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED received";
+        break;
+    }
     case eEvent::SCAN_TRIGGERED: {
         TASK_LOG(DEBUG) << "SCAN_TRIGGERED received";
         if (fsm_in_state(eState::WAIT_FOR_SCAN_TRIGGERED)) {

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -108,15 +108,16 @@ void dynamic_channel_selection_task::work()
         if (m_is_single_scan_pending) {
             m_is_single_scan         = true;
             m_is_single_scan_pending = false;
+            LOG(DEBUG) << "single scan is pending, trigger single scan";
             fsm_move_state(eState::TRIGGER_SCAN);
         } else if (database.get_channel_scan_is_enabled(m_radio_mac)) {
             auto now = std::chrono::steady_clock::now();
 
             if (now > m_next_scan_timestamp_interval) {
+                LOG(DEBUG) << "interval condition is met, trigger scan";
                 m_is_single_scan = false;
                 fsm_move_state(eState::TRIGGER_SCAN);
                 m_last_scan_try_timestamp = now;
-                LOG(DEBUG) << "interval condition is met, trigger scan";
             }
         }
         break;

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -252,6 +252,15 @@ void dynamic_channel_selection_task::handle_event(int event_type, void *obj)
     }
     case eEvent::SCAN_TRIGGER_FAILED: {
         TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED received";
+        if (fsm_in_state(eState::WAIT_FOR_SCAN_TRIGGERED)) {
+            auto scan_trigger_failed_event = reinterpret_cast<sScanEvent *>(obj);
+            event_handled                  = true;
+            TASK_LOG(DEBUG) << "SCAN_TRIGGER_FAILED handled on:"
+                            << scan_trigger_failed_event->radio_mac.oct;
+            m_last_scan_error_code = beerocks::eChannelScanErrCode::CHANNEL_SCAN_INTERNAL_FAILURE;
+            clear_pending_events();
+            fsm_move_state(eState::ABORT_SCAN);
+        }
         break;
     }
     case eEvent::SCAN_TRIGGERED: {

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -100,6 +100,11 @@ void dynamic_channel_selection_task::work()
         break;
     }
     case eState::IDLE: {
+        // get permission to scan
+        if (!database.try_lock_scan_permission(id)) {
+            break;
+        }
+        
         if (m_is_single_scan_pending) {
             m_is_single_scan         = true;
             m_is_single_scan_pending = false;
@@ -186,6 +191,9 @@ void dynamic_channel_selection_task::work()
     case eState::SCAN_DONE: {
         LOG(TRACE) << "SCAN_DONE";
 
+        auto unlock = database.unlock_scan_permission(id);
+        LOG_IF(!unlock,FATAL) << "failed to unlock scan permission for task_id=" << id << "on radio=" << m_radio_mac;
+
         //update next continuous scan time
         if (!m_is_single_scan) {
             auto interval =
@@ -204,6 +212,9 @@ void dynamic_channel_selection_task::work()
     }
     case eState::ABORT_SCAN: {
         LOG(ERROR) << "aborting scan for mac=" << m_radio_mac << ", last_scan_timestamp is not set";
+
+        auto unlock = database.unlock_scan_permission(id);
+        LOG_IF(!unlock,FATAL) << "failed to unlock scan permission for task_id=" << id << "on radio=" << m_radio_mac;
 
         database.set_channel_scan_results_status(m_radio_mac, m_last_scan_error_code,
                                                  m_is_single_scan);

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -39,6 +39,7 @@ public:
 #define FOREACH_DCS_EVENT(EVENT)                                                                   \
     EVENT(INVALID_EVENT)                                                                           \
     EVENT(TRIGGER_SINGLE_SCAN)                                                                     \
+    EVENT(SCAN_TRIGGER_FAILED)                                                                     \
     EVENT(SCAN_TRIGGERED)                                                                          \
     EVENT(SCAN_RESULTS_READY)                                                                      \
     EVENT(SCAN_RESULTS_DUMP)                                                                       \


### PR DESCRIPTION
Added DB APIs to try-lock/unlock scan-permission.
The above-mentioned APIs are used by the DCS task instances to check if the task can trigger a scan or another task is already scanning.
This is to limit to a single scan at a time - independent of the number of DCS tasks created.

The tasks release the ownership if a scan is complete (including getting all of the dump-results from the BWL) or if a scan failed/aborted for any reason.

In the case that the DCS task performs a retry of the scan, the task will require to take ownership once again - this is to prevent starvation of other tasks.