### PR TITLE
Gitlab CI: fix typo in FLAKE8_FILES

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ flake8:
   stage: build
   image: pipelinecomponents/flake8:f087c4c
   variables:
-    FLAKE8_FILES: "tests/*.py tools/beerocks_analyzer/conf/conf1.py tools/beerocks_analyzer/*.py tools/commends/*.py"
+    FLAKE8_FILES: "tests/*.py tools/beerocks_analyzer/conf/conf1.py tools/beerocks_analyzer/*.py tools/commands/*.py"
   script:
     - apk add --update --no-cache git
     - git ls-files -z -- $FLAKE8_FILES | xargs -0 -t flake8 --verbose

--- a/tools/commands/config.py
+++ b/tools/commands/config.py
@@ -151,7 +151,7 @@ class mapcfg(object):
         if self.args.board_id:
             try:
                 board = chdlabv2(self.args.board_id, self.args.user)
-            except ImportError as e:
+            except ImportError:
                 board = chdlabv3(self.args.board_id, self.args.setup_id, self.args.user)
             except RuntimeError as e:
                 logger.error("board jira failure (%s)" % e)


### PR DESCRIPTION
Fix typo in path tools/commands/ so that
files in this folder can be checked in CI

Signed-off-by: Vitalii Komisarenko <vitalii.komisarenko@gmail.com>