### PR TITLE
agent: backhaul_manager: use reference to map entry to persist changes

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1562,12 +1562,15 @@ void ap_manager_thread::handle_hostapd_attached()
     copy_radio_supported_channels(ap_wlan_hal, notification->params().supported_channels);
 
     LOG(INFO) << "send ACTION_APMANAGER_JOINED_NOTIFICATION";
+    LOG(INFO) << " iface = " << ap_wlan_hal->get_iface_name();
     LOG(INFO) << " mac = " << ap_wlan_hal->get_radio_mac();
     LOG(INFO) << " ant_num = " << ap_wlan_hal->get_radio_info().ant_num;
     LOG(INFO) << " tx_power = " << ap_wlan_hal->get_radio_info().tx_power;
     LOG(INFO) << " current channel = " << ap_wlan_hal->get_radio_info().channel;
     LOG(INFO) << " vht_center_frequency = " << ap_wlan_hal->get_radio_info().vht_center_freq;
     LOG(INFO) << " current bw = " << ap_wlan_hal->get_radio_info().bandwidth;
+    LOG(INFO) << " frequency_band = " << ap_wlan_hal->get_radio_info().frequency_band;
+    LOG(INFO) << " max_bandwidth = " << ap_wlan_hal->get_radio_info().max_bandwidth;
     LOG(INFO) << " supported_channels = " << std::endl
               << get_radio_supported_channels_string(ap_wlan_hal);
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1755,7 +1755,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<SSlaveSocke
             return false;
         }
 
-        auto radio_info = m_radio_info_map[request->iface_mac()];
+        auto &radio_info = m_radio_info_map[request->iface_mac()];
 
         radio_info.interface_name = request->ap_iface();
         radio_info.frequency_band = request->frequency_band();


### PR DESCRIPTION
When a ACTION_BACKHAUL_ENABLE message is received, the map entry in `m_radio_info_map` corresponding to the interface needs to be updated.
    
Map entry must be obtained by reference, not by value, or otherwise a copy of the entry is used and changes made to it are lost.

Fixes: #1097