### PR TITLE
Feature/ci certification tests manual jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
 stages:
   - build
   - test
+  - certification-dummy
+  - certification-netgear-rax40
   - upload
 
 .in-prplmesh-builder:
@@ -256,3 +258,8 @@ run-certification-tests:
   timeout: 36h
   rules:
     - if: '$TESTS_TO_RUN'
+
+include:
+  - local: '/ci/certification/generic.yml'
+  - local: '/ci/certification/dummy.yml'
+  - local: '/ci/certification/netgear-rax40.yml'

--- a/ci/certification/dummy.yml
+++ b/ci/certification/dummy.yml
@@ -1,0 +1,238 @@
+.certification:dummy:
+  stage: certification-dummy
+  extends: .certification-generic
+  variables:
+    DEVICE_UNDER_TEST: "prplmesh"
+  needs:
+    - job: build-in-docker
+
+MAP-5.3.1:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.3.1:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.1_ETH_FH24G:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.1_ETH_FH24G:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.1_ETH_FH5GL:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.1_ETH_FH5GL:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.1_ETH_FH5GH:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.1_ETH_FH5GH:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.2_ETH_FH24G:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.2_ETH_FH24G:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.2_ETH_FH5GL:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.2_ETH_FH5GL:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.2_ETH_FH5GH:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.2_ETH_FH5GH:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.3_ETH_FH24G:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.3_ETH_FH24G:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.3_ETH_FH5GL:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.3_ETH_FH5GL:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.4.3_ETH_FH5GH:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.4.3_ETH_FH5GH:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.5.1:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.5.1:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.6.1:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.6.1:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.6.2_ETH_FH24G:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.6.2_ETH_FH24G:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.6.2_ETH_FH5GL:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.6.2_ETH_FH5GL:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.6.2_ETH_FH5GH:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.6.2_ETH_FH5GH:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.7.1:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.7.1:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.8.1_ETH_FH24G:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.8.1_ETH_FH24G:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.8.2_ETH_FH24G:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.8.2_ETH_FH24G:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.8.2_ETH_FH5GL:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.8.2_ETH_FH5GL:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.8.2_ETH_FH5GH:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.8.2_ETH_FH5GH:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.8.3_ETH_FH5GL:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.8.3_ETH_FH5GL:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.10.1:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.10.1:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-5.10.2:dummy:
+  extends: .certification:dummy
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-5.10.2:dummy.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -1,0 +1,14 @@
+.certification-generic:
+  variables:
+    # DEVICE_UNDER_TEST need to be set when extending the job
+    GIT_CLONE_PATH: "/builds/prpl-foundation/prplMesh/"
+  script:
+      - echo $CI_COMMIT_DESCRIPTION
+      - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
+  artifacts:
+    paths:
+      - logs
+    when: always
+  tags:
+    - certs-tests
+  timeout: 30min

--- a/ci/certification/netgear-rax40.yml
+++ b/ci/certification/netgear-rax40.yml
@@ -1,0 +1,199 @@
+.certification:netgear-rax40:
+  stage: certification-netgear-rax40
+  extends: .certification-generic
+  variables:
+    DEVICE_UNDER_TEST: "netgear-rax40"
+  before_script:
+    - tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
+  needs:
+    - job: build-for-netgear-rax40
+
+MAP-4.2.1:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.2.1:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.2.3_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.2.3_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.4.2_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.4.2_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.5.2_ETH_FH5GL:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.5.1_ETH:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.6.1_ETH:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.6.1_ETH:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.6.2_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.6.2_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.7.3_ETH:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.7.3_ETH:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.7.4_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.7.4_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.7.5_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.7.5_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.7.6_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.7.6_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.7.7_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.7.7_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.7.9_ETH:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.7.9_ETH:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.8.1_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.8.1_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.8.2_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.8.2_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.8.3_ETH_FH5GL:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.8.2_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.8.5_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.8.5_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.10.3_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.10.3_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.10.4_ETH_FH24G:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.10.4_ETH_FH24G:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true
+
+MAP-4.11.1_ETH:netgear-rax40:
+  extends: .certification:netgear-rax40
+  rules:
+    # If the last commit description contains the test name and we're not on master, run it.
+    # Otherwise, make it a manual job
+    - if: '$CI_COMMIT_DESCRIPTION =~ /.*MAP-4.11.1_ETH:netgear-rax40.*/ && $CI_COMMIT_REF_NAME != "master"'
+      when: on_success
+    - when: manual
+      allow_failure: true


### PR DESCRIPTION
This is something I've quickly put together in the background to make it simpler for anyone to trigger certification tests.

With these changes:
- If the last commit of a pipeline contains the name of a test job (for example: `MAP-5.3.1:netgear-rax40`), the test is run automatically.
  If the test fails, the whole pipeline will be marked as failing.

  This will be very useful to trigger certification tests automatically before a pull request is merged. 
  If a developer is making changes that could affect a particular certification test(s), the test name(s) can just be mentioned in the commit description of the last commit, and the PR will be blocked until the certification test passes.

- It's no longer necessary to trigger a whole new pipeline just to run a certification test.
  Previously when multiple people were working at the same time, we had a lot of duplicate pipelines: one was created automatically by a push, and the other one was created only to run a test. This quickly slowed things down unnecessarily.

  From now on, every pipeline would have a list of tests that can be triggered from the web interface. In other words, even if the commits don't mention the test names, we could trigger a test for any branch at any time:
  ![image](https://user-images.githubusercontent.com/20061471/78797012-6b09c580-79b7-11ea-841d-4de686b5616d.png)
 (the image is truncated to save space)

  With this, if we wanted/needed to, we could also easily allow any project member with the "developer" role to trigger certification tests on the master branch (using [environments](https://docs.gitlab.com/ee/ci/yaml/#protecting-manual-jobs-premium)), which AFAIK was not possible before and has been requested by multiple other developers in the past.

- It makes it a whole lot easier to understand what is being run (fixes https://github.com/prplfoundation/prplMesh/issues/1007)

- When running multiple tests, we would no longer have to wait until they are all finished before we can get the artifacts (the logs).
  It also makes it easier to make use of Gitlab's auto-retry mechanism.
  fixes https://github.com/prplfoundation/prplMesh/issues/761.

Also fixes https://github.com/prplfoundation/prplMesh/issues/759.




Keeping it as a draft for now, because the number of total jobs for active pipelines on Gitlab.com are potentially limited for free plans, and it could be a blocking issue.