### PR TITLE
Readme.md: add troubleshooting for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,10 @@ System is operational if you see `FSM: CONNECTED --> OPERATIONAL` in the main ag
 
 There is a tool to display the connection map on a GUI in `tools/beerocks_analyzer`.
 Its [README file](tools/beerocks_analyzer/README.md) explains how to use it.
+
+### Troubleshooting
+
+If master branch does not work / does not pass tests on your computer make sure that:
+
+- you loaded ebtables kernel module: `sudo modprobe ebtables`
+- you updated your docker images with `tools/docker/image-pull.sh`


### PR DESCRIPTION
The master branch stopped passing tests on some team members computers.

The solution for this porblem is to use `ebtales` and update docker images.
These actions are neither automated nor reflected by the documentation,
so mentinioning them in the wiki can protect new team members
from being unable to run master branch.