### PR TITLE
DCS: Feature/limit dcs scans to one at a time

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2416,7 +2416,29 @@ bool db::try_lock_scan_permission(int task_id)
     return true;
 }
 
-bool db::unlock_scan_permission(int task_id) { return true; }
+bool db::unlock_scan_permission(int task_id)
+{
+    if (task_id < 0) {
+        LOG(ERROR) << "invalid input, task_id(" << task_id << ") < 0";
+        return false;
+    }
+
+    if (-1 == m_scan_locked_by_task_id) {
+        LOG(DEBUG) << "scan permission already unlocked! task_id=" << task_id;
+        return true;
+    }
+
+    if (task_id != m_scan_locked_by_task_id) {
+        LOG(ERROR) << "failed to unlock scan permission by task_id(" << task_id
+                   << "), scan is locked by other task_id(" << m_scan_locked_by_task_id << ")";
+        return false;
+    }
+
+    m_scan_locked_by_task_id = -1;
+    LOG(DEBUG) << "scan permission unlocked successfully for task_id=" << task_id;
+
+    return true;
+}
 
 //
 // CLI

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2393,6 +2393,10 @@ const std::list<sChannelScanResults> &db::get_channel_scan_results(const sMacAdd
     return (single_scan ? hostap->single_scan_results : hostap->continuous_scan_results);
 }
 
+bool db::try_lock_scan_permission(int task_id) { return true; }
+
+bool db::unlock_scan_permission(int task_id) { return true; }
+
 //
 // CLI
 //

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2393,7 +2393,28 @@ const std::list<sChannelScanResults> &db::get_channel_scan_results(const sMacAdd
     return (single_scan ? hostap->single_scan_results : hostap->continuous_scan_results);
 }
 
-bool db::try_lock_scan_permission(int task_id) { return true; }
+bool db::try_lock_scan_permission(int task_id)
+{
+    if (task_id < 0) {
+        LOG(ERROR) << "invalid input, task_id(" << task_id << ") < 0";
+        return false;
+    }
+
+    if (task_id == m_scan_locked_by_task_id) {
+        LOG(DEBUG) << "scan permission already locked by task requesting to lock! task_id="
+                   << task_id;
+        return true;
+    }
+
+    if (-1 != m_scan_locked_by_task_id) {
+        return false;
+    }
+
+    LOG(DEBUG) << "scan permission locked successfully for task_id=" << task_id;
+    m_scan_locked_by_task_id = task_id;
+
+    return true;
+}
 
 bool db::unlock_scan_permission(int task_id) { return true; }
 

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -564,6 +564,24 @@ public:
     const std::list<sChannelScanResults> &get_channel_scan_results(const sMacAddr &mac,
                                                                    bool single_scan);
 
+    /**
+     * @brief Lock permission for channel scan
+     * 
+     * @param task_id: id of task requesting to lock the scan permission
+     * @return true on success
+     * @return false on failure (if failed to lock or locked by other task)
+     */
+    bool try_lock_scan_permission(int task_id);
+
+    /**
+     * @brief Unlock permission for channel scan
+     * 
+     * @param task_id: id of task requesting to unlock the scan permission
+     * @return true on success
+     * @return false on failure (if failed to release or unlocked by other task)
+     */
+    bool unlock_scan_permission(int task_id);
+
     //
     // CLI
     //

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -926,6 +926,9 @@ private:
 
     master_thread *m_master_thread_ctx = nullptr;
     const std::string m_local_bridge_mac;
+
+    // task_id==-1 means lock is free
+    int m_scan_locked_by_task_id = -1;
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -103,15 +103,16 @@ void dynamic_channel_selection_task::work()
         if (m_is_single_scan_pending) {
             m_is_single_scan         = true;
             m_is_single_scan_pending = false;
+            LOG(DEBUG) << "single scan is pending, trigger single scan";
             fsm_move_state(eState::TRIGGER_SCAN);
         } else if (database.get_channel_scan_is_enabled(m_radio_mac)) {
             auto now = std::chrono::steady_clock::now();
 
             if (now > m_next_scan_timestamp_interval) {
+                LOG(DEBUG) << "interval condition is met, trigger scan";
                 m_is_single_scan = false;
                 fsm_move_state(eState::TRIGGER_SCAN);
                 m_last_scan_try_timestamp = now;
-                LOG(DEBUG) << "interval condition is met, trigger scan";
             }
         }
         break;


### PR DESCRIPTION
Added DB APIs to try-lock/unlock scan-permission.
The above-mentioned APIs are used by the DCS task instances to check if the task can trigger a scan or another task is already scanning.
This is to limit to a single scan at a time - independent of the number of DCS tasks created.

The tasks release the ownership if a scan is complete (including getting all of the dump-results from the BWL) or if a scan failed/aborted for any reason.

In the case that the DCS task performs a retry of the scan, the task will require to take ownership once again - this is to prevent starvation of other tasks.

Fixes: #1094 