### PR TITLE
tests: boardfarm_plugins: port initial_ap_config

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -6,8 +6,10 @@
 import os
 import time
 
-from environment import ALEntityDocker
+import boardfarm
+from environment import ALEntityDocker, _get_bridge_interface
 from .prplmesh_base import PrplMeshBase
+from sniffer import Sniffer
 
 rootdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..'))
 
@@ -58,6 +60,8 @@ class PrplMeshDocker(PrplMeshBase):
             time.sleep(self.delay)
             self.agent_entity = ALEntityDocker(self.name, is_controller=False)
 
+        self.wired_sniffer = Sniffer(_get_bridge_interface(self.docker_network),
+                                     True, boardfarm.config.output_dir)
         self.check_status()
 
     def __del__(self):

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -4,6 +4,17 @@
         "board_type": "prplmesh_docker",
         "role": "controller",
         "conn_cmd": "",
-        "devices": []
+        "devices": [
+            {
+                "name": "repeater1",
+                "type": "prplmesh_docker",
+                "conn_cmd": ""
+            },
+            {
+                "name": "repeater2",
+                "type": "prplmesh_docker",
+                "conn_cmd": ""
+            }
+        ]
     }
 }

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -4,13 +4,31 @@
 # See LICENSE file for more details.
 
 from boardfarm.tests import bft_base_test
+from utils import Utils
 
 
 class InitialApConfig(bft_base_test.BftBaseTest):
-    """PrplMesh sample test case, no actual testing, it just passes."""
+    """Check initial configuration on device."""
 
     def runTest(self):
-        """Main test logic must be implemented here."""
+        for dev in self.dev:
+            if dev.agent_entity:
+                dev.wired_sniffer.start(self.__class__.__name__)
+
+                Utils.check_log(dev.agent_entity.radios[0],
+                                r"WSC Global authentication success")
+                Utils.check_log(dev.agent_entity.radios[1],
+                                r"WSC Global authentication success")
+                Utils.check_log(dev.agent_entity.radios[0],
+                                r"KWA \(Key Wrap Auth\) success")
+                Utils.check_log(dev.agent_entity.radios[1],
+                                r"KWA \(Key Wrap Auth\) success")
+                Utils.check_log(dev.agent_entity.radios[0],
+                                r".* Controller configuration \(WSC M2 Encrypted Settings\)")
+                Utils.check_log(dev.agent_entity.radios[1],
+                                r".* Controller configuration \(WSC M2 Encrypted Settings\)")
+
+                dev.wired_sniffer.stop()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -265,9 +265,8 @@ class VirtualAPDocker(VirtualAP):
         self.radio.send_bwl_event("EVENT AP-STA-DISCONNECTED {}".format(sta.mac))
 
 
-def _get_bridge_interface(unique_id):
+def _get_bridge_interface(docker_network):
     '''Use docker network inspect to get the docker bridge interface.'''
-    docker_network = 'prplMesh-net-{}'.format(unique_id)
     docker_network_inspect_cmd = ('docker', 'network', 'inspect', docker_network)
     inspect_result = subprocess.run(docker_network_inspect_cmd, stdout=subprocess.PIPE)
     if inspect_result.returncode != 0:
@@ -296,8 +295,8 @@ def _get_bridge_interface(unique_id):
 
 def launch_environment_docker(unique_id: str, skip_init: bool = False):
     global wired_sniffer
-    wired_sniffer = sniffer.Sniffer(_get_bridge_interface(unique_id),
-                                    opts.tcpdump, opts.tcpdump_dir)
+    iface = _get_bridge_interface('prplMesh-net-{}'.format(unique_id))
+    wired_sniffer = sniffer.Sniffer(iface, opts.tcpdump, opts.tcpdump_dir)
 
     gateway = 'gateway-' + unique_id
     repeater1 = 'repeater1-' + unique_id

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -13,7 +13,7 @@ import subprocess
 import time
 
 from capi import UCCSocket
-from opts import debug, err
+from opts import opts, debug, err
 import sniffer
 
 
@@ -296,7 +296,8 @@ def _get_bridge_interface(unique_id):
 
 def launch_environment_docker(unique_id: str, skip_init: bool = False):
     global wired_sniffer
-    wired_sniffer = sniffer.Sniffer(_get_bridge_interface(unique_id))
+    wired_sniffer = sniffer.Sniffer(_get_bridge_interface(unique_id),
+                                    opts.tcpdump, opts.tcpdump_dir)
 
     gateway = 'gateway-' + unique_id
     repeater1 = 'repeater1-' + unique_id

--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -8,21 +8,23 @@
 import os
 import subprocess
 
-from opts import debug, err, opts, status
+from opts import debug, err, status
 
 
 class Sniffer:
     '''Captures packets on an interface.'''
-    def __init__(self, interface: str):
+    def __init__(self, interface: str, use_tcpdump: bool, tcpdump_log_dir: str):
         self.interface = interface
+        self.use_tcpdump = use_tcpdump
+        self.tcpdump_log_dir = tcpdump_log_dir
         self.tcpdump_proc = None
 
     def start(self, outputfile_basename):
         '''Start tcpdump if enabled by config.'''
-        if opts.tcpdump:
+        if self.use_tcpdump:
             debug("Starting tcpdump, output file {}.pcap".format(outputfile_basename))
-            os.makedirs(os.path.join(opts.tcpdump_dir, 'logs'), exist_ok=True)
-            outputfile = os.path.join(opts.tcpdump_dir, outputfile_basename) + ".pcap"
+            os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
+            outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
             command = ["tcpdump", "-i", self.interface, "-w", outputfile]
             self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
             # tcpdump takes a while to start up. Wait for the appropriate output before continuing.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+from typing import Union
+
+import environment as env
+
+
+class Utils(object):
+    """Collection of common functions used by tests."""
+
+    @staticmethod
+    def check_log(entity_or_radio: Union[env.ALEntity, env.Radio], regex: str,
+                  start_line: int = 0, timeout: float = 0.3) -> bool:
+        result, line, match = entity_or_radio.wait_for_log(regex, start_line, timeout)
+        if not result:
+            raise Exception
+        return result, line, match


### PR DESCRIPTION
Ported test_initial_ap_config from tests/test_flow.py for dockerized
boardfarm device and created prplMesh testsuite.

During porting:
* environment.py contents were used "as is", there's
  no strong necessity to modify it;
* boardfarm logs contains only output of commands issued by
  its devices, i.e. all actual test logs still generated in:
  <prplMesh-repo-root>/logs/*
  (for that reason, RadioDocker.wait_for_log still works)
* boardfarm logs can be found in directory "results" created
  in same dir bft was started from;

Signed-off-by: Oleksii Ponomarenko <o.ponomarenko@inango-systems.com>