### PR TITLE
DCS: Feature/limit dcs scans to one at a time

### DIFF
--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -195,16 +195,17 @@ void dynamic_channel_selection_task::work()
         }
 
         m_last_scan_error_code = beerocks::eChannelScanErrCode::CHANNEL_SCAN_SUCCESS;
-        database.set_channel_scan_results_status(m_radio_mac, m_last_scan_error_code,
-                                                 m_is_single_scan);
-
-        database.set_channel_scan_in_progress(m_radio_mac, false, m_is_single_scan);
-        m_is_single_scan = false;
-        fsm_move_state(eState::IDLE);
+        fsm_move_state(eState::FINISH);
         break;
     }
     case eState::ABORT_SCAN: {
         LOG(ERROR) << "aborting scan for mac=" << m_radio_mac << ", last_scan_timestamp is not set";
+
+        fsm_move_state(eState::FINISH);
+        break;
+    }
+    case eState::FINISH: {
+        LOG(TRACE) << "finish scan for mac=" << m_radio_mac;
 
         database.set_channel_scan_results_status(m_radio_mac, m_last_scan_error_code,
                                                  m_is_single_scan);

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -103,15 +103,16 @@ void dynamic_channel_selection_task::work()
         if (m_is_single_scan_pending) {
             m_is_single_scan         = true;
             m_is_single_scan_pending = false;
+            LOG(DEBUG) << "single scan is pending, trigger single scan";
             fsm_move_state(eState::TRIGGER_SCAN);
         } else if (database.get_channel_scan_is_enabled(m_radio_mac)) {
             auto now = std::chrono::steady_clock::now();
 
             if (now > m_next_scan_timestamp_interval) {
                 m_is_single_scan = false;
+                LOG(DEBUG) << "interval condition is met, trigger scan";
                 fsm_move_state(eState::TRIGGER_SCAN);
                 m_last_scan_try_timestamp = now;
-                LOG(DEBUG) << "interval condition is met, trigger scan";
             }
         }
         break;

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -52,6 +52,7 @@ public:
 #define FOREACH_DCS_STATE(STATE)                                                                   \
     STATE(INIT)                                                                                    \
     STATE(IDLE)                                                                                    \
+    STATE(PRE_SCAN)                                                                                \
     STATE(TRIGGER_SCAN)                                                                            \
     STATE(WAIT_FOR_SCAN_TRIGGERED)                                                                 \
     STATE(WAIT_FOR_RESULTS_READY)                                                                  \
@@ -72,6 +73,8 @@ private:
     void dcs_wait_for_event(eEvent cs_event);
     void fsm_move_state(eState new_state);
     bool fsm_in_state(eState state);
+    bool start_scan();
+    bool finish_scan();
 
     beerocks::eChannelScanErrCode dcs_request_scan_trigger();
     beerocks::eChannelScanErrCode dcs_request_scan_dump();
@@ -91,6 +94,8 @@ private:
 
     bool m_is_single_scan_pending = false;
     bool m_is_single_scan         = false;
+
+    static int m_scanning_task_id; // Currently scanning task id. -1 means no scan in progress.
 };
 } //namespace son
 #endif

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -57,7 +57,8 @@ public:
     STATE(WAIT_FOR_RESULTS_READY)                                                                  \
     STATE(WAIT_FOR_RESULTS_DUMP)                                                                   \
     STATE(SCAN_DONE)                                                                               \
-    STATE(ABORT_SCAN)
+    STATE(ABORT_SCAN)                                                                              \
+    STATE(FINISH)
 
     // State ENUM
     enum class eState { FOREACH_DCS_STATE(GENERATE_ENUM) };

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.h
@@ -27,7 +27,7 @@ class dynamic_channel_selection_task : public task, public std::enable_shared_fr
 public:
     dynamic_channel_selection_task(db &database, ieee1905_1::CmduMessageTx &cmdu_tx_,
                                    task_pool &tasks_, sMacAddr radio_mac_);
-    virtual ~dynamic_channel_selection_task() {}
+    virtual ~dynamic_channel_selection_task() { finish_scan(); }
 
     struct sScanEvent {
         sMacAddr radio_mac;


### PR DESCRIPTION
Added `FINISH` state and moved the scan-cleanups to the `FINISH` state.

Added to the DCS class functions and a static data member that adds the capability to limit to a single scan at a time.
Added PRE_SCAN state in which the limitation of single-scan-at-a-time is enforced. When single-scan or continuous-scan conditions are met, the state is changed to PRE_SCAN and only when the no-scan-in-progress condition is met, the state is changed to `TRIGGER_SCAN` which triggers the scan.

The limit to a single scan at a time is independent of the number of DCS tasks created.

The tasks release the ownership of the scan in the new `FINISH` state as part of the scan-cleanup.

In the case that the DCS task performs a retry of the scan, the task will require to take ownership once again - this is to prevent starvation of other tasks.

Fixes: #1094