### PR TITLE
Feature/Packet capture using tshark processing of tcpdump capture

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,7 +165,7 @@ run-tests:
   stage: test
   image: $CI_REGISTRY_IMAGE/tests-runner:18.09.7-dind
   script:
-    - tests/test_flows.py -v -u $RANDOM --tcpdump
+    - tests/test_flows.py -v -u $RANDOM
 
   artifacts:
     paths:

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -61,7 +61,7 @@ class PrplMeshDocker(PrplMeshBase):
             self.agent_entity = ALEntityDocker(self.name, is_controller=False)
 
         self.wired_sniffer = Sniffer(_get_bridge_interface(self.docker_network),
-                                     True, boardfarm.config.output_dir)
+                                     boardfarm.config.output_dir)
         self.check_status()
 
     def __del__(self):

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -297,7 +297,7 @@ def _get_bridge_interface(docker_network):
 def launch_environment_docker(unique_id: str, skip_init: bool = False):
     global wired_sniffer
     iface = _get_bridge_interface('prplMesh-net-{}'.format(unique_id))
-    wired_sniffer = sniffer.Sniffer(iface, opts.tcpdump, opts.tcpdump_dir)
+    wired_sniffer = sniffer.Sniffer(iface, True, opts.tcpdump_dir)
 
     gateway = 'gateway-' + unique_id
     repeater1 = 'repeater1-' + unique_id

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -297,7 +297,7 @@ def _get_bridge_interface(docker_network):
 def launch_environment_docker(unique_id: str, skip_init: bool = False):
     global wired_sniffer
     iface = _get_bridge_interface('prplMesh-net-{}'.format(unique_id))
-    wired_sniffer = sniffer.Sniffer(iface, True, opts.tcpdump_dir)
+    wired_sniffer = sniffer.Sniffer(iface, opts.tcpdump_dir)
 
     gateway = 'gateway-' + unique_id
     repeater1 = 'repeater1-' + unique_id

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -138,6 +138,17 @@ def beerocks_cli_command(command: str) -> bytes:
     return res
 
 
+def checkpoint() -> None:
+    '''Checkpoint the current state.
+
+    Any subsequent calls to functions that query cumulative state (e.g. log files, packet captures)
+    will not match any of the state that was accumulated up till now, but only afterwards.
+
+    TODO: Implement for log functions.
+    '''
+    wired_sniffer.checkpoint()
+
+
 # Concrete implementation with docker
 
 rootdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/tests/opts.py
+++ b/tests/opts.py
@@ -9,7 +9,6 @@
 class opts:
     '''Static class that encodes the global options.'''
     verbose = False
-    tcpdump = False
     tcpdump_dir = ''
     stop_on_failure = False
 

--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -13,32 +13,30 @@ from opts import debug, err, status
 
 class Sniffer:
     '''Captures packets on an interface.'''
-    def __init__(self, interface: str, use_tcpdump: bool, tcpdump_log_dir: str):
+    def __init__(self, interface: str, tcpdump_log_dir: str):
         self.interface = interface
-        self.use_tcpdump = use_tcpdump
         self.tcpdump_log_dir = tcpdump_log_dir
         self.tcpdump_proc = None
 
     def start(self, outputfile_basename):
-        '''Start tcpdump if enabled by config.'''
-        if self.use_tcpdump:
-            debug("Starting tcpdump, output file {}.pcap".format(outputfile_basename))
-            os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
-            outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
-            command = ["tcpdump", "-i", self.interface, "-w", outputfile]
-            self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
-            # tcpdump takes a while to start up. Wait for the appropriate output before continuing.
-            # poll() so we exit the loop if tcpdump terminates for any reason.
-            while not self.tcpdump_proc.poll():
-                line = self.tcpdump_proc.stderr.readline()
-                debug(line.decode()[:-1])  # strip off newline
-                if line.startswith(b"tcpdump: listening on " + self.interface.encode()):
-                    # Make sure it doesn't block due to stderr buffering
-                    self.tcpdump_proc.stderr.close()
-                    break
-            else:
-                err("tcpdump terminated")
-                self.tcpdump_proc = None
+        '''Start tcpdump to outputfile.'''
+        debug("Starting tcpdump, output file {}.pcap".format(outputfile_basename))
+        os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
+        outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
+        command = ["tcpdump", "-i", self.interface, "-w", outputfile]
+        self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
+        # tcpdump takes a while to start up. Wait for the appropriate output before continuing.
+        # poll() so we exit the loop if tcpdump terminates for any reason.
+        while not self.tcpdump_proc.poll():
+            line = self.tcpdump_proc.stderr.readline()
+            debug(line.decode()[:-1])  # strip off newline
+            if line.startswith(b"tcpdump: listening on " + self.interface.encode()):
+                # Make sure it doesn't block due to stderr buffering
+                self.tcpdump_proc.stderr.close()
+                break
+        else:
+            err("tcpdump terminated")
+            self.tcpdump_proc = None
 
     def stop(self):
         '''Stop tcpdump if it is running.'''

--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -23,7 +23,7 @@ class Sniffer:
         debug("Starting tcpdump, output file {}.pcap".format(outputfile_basename))
         os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
         outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
-        command = ["tcpdump", "-i", self.interface, "-w", outputfile]
+        command = ["tcpdump", "-i", self.interface, '-U', '-w', outputfile]
         self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
         # tcpdump takes a while to start up. Wait for the appropriate output before continuing.
         # poll() so we exit the loop if tcpdump terminates for any reason.

--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -6,8 +6,8 @@
 ###############################################################
 
 import os
+import json
 import subprocess
-
 from opts import debug, err, status
 
 
@@ -17,13 +17,14 @@ class Sniffer:
         self.interface = interface
         self.tcpdump_log_dir = tcpdump_log_dir
         self.tcpdump_proc = None
+        self.current_outputfile = None
 
     def start(self, outputfile_basename):
         '''Start tcpdump to outputfile.'''
         debug("Starting tcpdump, output file {}.pcap".format(outputfile_basename))
         os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
-        outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
-        command = ["tcpdump", "-i", self.interface, '-U', '-w', outputfile]
+        self.current_outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
+        command = ["tcpdump", "-i", self.interface, '-U', '-w', self.current_outputfile]
         self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
         # tcpdump takes a while to start up. Wait for the appropriate output before continuing.
         # poll() so we exit the loop if tcpdump terminates for any reason.
@@ -37,6 +38,26 @@ class Sniffer:
         else:
             err("tcpdump terminated")
             self.tcpdump_proc = None
+            self.current_outputfile = None
+
+    def get_packet_capture(self):
+        '''Get a list of packets from the last started tcpdump.'''
+        if not self.current_outputfile:
+            err("get_packet_capture but no capture file")
+            return []
+        tshark_command = ['tshark', '-r', self.current_outputfile, '-T', 'json']
+        tshark_result = subprocess.run(tshark_command, stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE)
+        if tshark_result.returncode != 0:
+            err(tshark_result.stderr)
+            err("tshark failed: {}".format(tshark_result.returncode))
+            return []
+        try:
+            capture = json.loads(tshark_result.stdout)
+            return capture
+        except json.JSONDecodeError as error:
+            err("capture JSON decoding failed: %s".format(error))
+            return []
 
     def stop(self):
         '''Stop tcpdump if it is running.'''
@@ -44,3 +65,4 @@ class Sniffer:
             status("Terminating tcpdump")
             self.tcpdump_proc.terminate()
             self.tcpdump_proc = None
+            self.current_outputfile = None

--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -107,7 +107,8 @@ class Sniffer:
         os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
         self.current_outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
         self.checkpoint_frame_number = 0
-        command = ["tcpdump", "-i", self.interface, '-U', '-w', self.current_outputfile]
+        command = ["tcpdump", "-i", self.interface, '-U', '-w', self.current_outputfile,
+                   "ether proto 0x88CC or ether proto 0x893A"]
         self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
         # tcpdump takes a while to start up. Wait for the appropriate output before continuing.
         # poll() so we exit the loop if tcpdump terminates for any reason.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -760,8 +760,6 @@ if __name__ == '__main__':
     t = TestFlows()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--tcpdump", "-t", action='store_true', default=False,
-                        help="capture the packets during each test")
     parser.add_argument("--verbose", "-v", action='store_true', default=False,
                         help="report each action")
     parser.add_argument("--stop-on-failure", "-s", action='store_true', default=False,
@@ -781,7 +779,6 @@ if __name__ == '__main__':
         parser.error("Unknown tests: {}".format(', '.join(unknown_tests)))
 
     opts.verbose = options.verbose
-    opts.tcpdump = options.tcpdump
 
     opts.tcpdump_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..', 'logs'))
     opts.stop_on_failure = options.stop_on_failure

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -36,6 +36,8 @@ The docker runner image can be used to run prplMesh inside containers using `run
 The runner docker allows running multiple containers, for example one with a controller+agent, the other with an agent only:
 The 2 containers are connected using a docker network (bridge), so can
 communicate + sniffed by running `wireshark` / `tcpdump` on the bridge from the host to see 1905 packets.
+This is what is done by the test scripts in the tests/ directory.
+Therefore they require tcpdump and tshark to be installed in order to work.
 
 ## Docker all
 

--- a/tools/docker/tests-runner/Dockerfile
+++ b/tools/docker/tests-runner/Dockerfile
@@ -1,11 +1,13 @@
-FROM docker:18.09.7-dind
+# docker:18.09.7-dind on Thu  7 May 07:38:06 2020
+FROM docker.io/library/docker@sha256:a490c83561c1cef49b6fe12aba2c31f908391ec3efe4eb173225809c981e50c3
 
 RUN apk add --update --no-cache \
     bash \
     python3 \
     grep \
     coreutils \
-    tcpdump
+    tcpdump \
+    tshark
 
 COPY entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
As a third attempt, this change allows easy, **fast** and simple analysis of CMDU messages passing through the container's bridge interface.

The general idea is that each running test is monitored by tcpdump, then saves the packet data into a pcap file, which is later quickly scanned by tshark.

In addition, a helper method extends the dictionary with direct, casted entries of more important values from the tree - for easier access and handling.

