### PR TITLE
tools: docker: README.md: add docker logs to the cheatsheet

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -132,4 +132,6 @@ Delete all images - `docker rmi $(docker images -q)`
 
 Delete all containers - `docker rm $(docker ps -a -q)`
 
+Fetch the logs of a specific container - `docker logs CONTAINER`
+
 Proxy - The recommended way to work with docker behind a proxy is by [configuring the docker client to pass proxy information to containers automatically](https://docs.docker.com/network/proxy/).


### PR DESCRIPTION
Docker logs is very useful to check what happened when something goes
wrong.

For example, it allows to check if the ebtables rules was applied
correctly or not. When it wasn't, "docker logs gateway-$USER"
gives (among other things):

modprobe: ERROR: ../libkmod/libkmod.c:586 kmod_search_moddep() could not open moddep file '/lib/modules/4.19.0-6-amd64/modules.dep.bin'
modprobe: FATAL: Module ebtables not found in directory /lib/modules/4.19.0-6-amd64
The kernel doesn't support the ebtables 'filter' table.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>