### PR TITLE
agent: monitor: remove duplicate call to now()

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -624,7 +624,6 @@ bool monitor_thread::update_ap_stats()
         radio_stats.sta_count += vap_node->sta_get_count();
 
         // Update the measurement timestamp
-        auto now = std::chrono::steady_clock::now();
         auto time_span =
             std::chrono::duration_cast<std::chrono::milliseconds>(now - vap_stats.last_update_time);
         vap_stats.delta_ms         = float(time_span.count());

--- a/ci/cppcheck/cppcheck_existing_issues.txt
+++ b/ci/cppcheck/cppcheck_existing_issues.txt
@@ -218,7 +218,6 @@
 '/builds/prpl-foundation/prplMesh/controller/src/beerocks/cli/beerocks_cli_main.cpp: style: Variable 'cli_ptr' is assigned a value that is never used. [unreadVariable]    beerocks::cli *cli_ptr = &cli_soc;
 '/builds/prpl-foundation/prplMesh/controller/src/beerocks/cli/beerocks_cli_bml.cpp: performance: Function parameter 'ind' should be passed by const reference. [passedByValue]    const std::string &parent_bssid, const std::string ind, std::stringstream &ss)
 '/builds/prpl-foundation/prplMesh/controller/src/beerocks/cli/beerocks_cli_bml.cpp: performance: Function parameter 'beerocks_conf_path_' should be passed by const reference. [passedByValue]cli_bml::cli_bml(std::string beerocks_conf_path_)
-'/builds/prpl-foundation/prplMesh/agent/src/beerocks/monitor/monitor_thread.cpp: style: Local variable 'now' shadows outer variable [shadowVariable]        auto now = std::chrono::steady_clock::now();
 '/builds/prpl-foundation/prplMesh/agent/src/beerocks/monitor/monitor_thread.cpp: style: Local variable 'time_span' shadows outer variable [shadowVariable]        auto time_span =
 '/builds/prpl-foundation/prplMesh/controller/src/beerocks/cli/beerocks_cli.cpp: performance: Prefer prefix ++/-- operators for non-primitive types. [postfixOperator]         it++) {
 '/builds/prpl-foundation/prplMesh/agent/src/beerocks/monitor/monitor_thread.cpp: style: Variable 'iface' is assigned a value that is never used. [unreadVariable]        std::string iface = radio_node->get_iface();


### PR DESCRIPTION
There are two calls to std::chrono::steady_clock::now() in the same
method, one is out of a loop and the other inside the loop. Call to
the inner one can be removed as it is not necessary.

Also remove corresponding entry in cppcheck_existing_issues.txt because
local variable 'now' doees not shadow outer variable any more.