### PR TITLE
bwl: update the get_radio_info to include additional flags

### DIFF
--- a/common/beerocks/bwl/include/bwl/nl80211_client.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client.h
@@ -141,6 +141,13 @@ public:
         bool radar_affected = false;
 
         /**
+         * This channel does not initiate radiation, meaning it is supported only when radar
+         * detection is supported as well.
+         * Set to true if attribute NL80211_FREQUENCY_ATTR_NO_IR is present
+         */
+        bool no_ir = false;
+
+        /**
          * @brief Gets the maximum supported bandwidth by the channel.
          *
          * @return Maximum supported bandwidth


### PR DESCRIPTION
Currently all channels that are not supported get filtered out.
The get_radio_info filters flags that indicate the channel cannot be
used as an AP. the flag NO_IR is filtered as part of this process, which
is incorrect seeing as radios with radar detection can use those
channels.

Lessen the filtering check in get_radio_info for channels.
Add a "no_ir" flag to the channel_info struct

Signed-off-by: itay elenzweig <itayx.elenzweig@intel.com>