### PR TITLE
gitlab-ci: add CI stage with check shell scripts with shellcheck linter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,14 @@ flake8-diff:
     - apk add --update --no-cache git
     - git diff -U0 origin/master | flake8 --verbose --diff
 
+shellcheck:
+  stage: build
+  image: koalaman/shellcheck-alpine:v0.7.1
+  before_script:
+    - apk add --update --no-cache git
+  script:
+      - git ls-files -z '*.sh' '*.sh.in'  | xargs -0 shellcheck -x -P tools:ci/owncloud
+
 clang-format:
   extends: .in-prplmesh-builder
   stage: build


### PR DESCRIPTION
Fix currently present issues detected by shellcheck in prplMesh shell scripts is not enough to keep scripts clean.

GitLab CI should check each commit.

CI will check all shell scripts under git source control.
Calculation diff and detection new issues will be not needed when all PRs with their fixes will be merged: #1123, #1132, #1133, #1204 
