### PR TITLE
Bugfix/fix starvation due to max clients connected

### DIFF
--- a/agent/src/beerocks/monitor/monitor_db.h
+++ b/agent/src/beerocks/monitor/monitor_db.h
@@ -312,6 +312,8 @@ public:
         return sta_nodes.end();
     }
 
+    size_t get_sta_count() const { return sta_nodes.size(); }
+
     // Monitor parameters //
     void set_arp_burst_delay(int arp_burst_delay_) { arp_burst_delay = arp_burst_delay_; }
     uint8_t get_arp_burst_delay() { return arp_burst_delay; }

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -489,6 +489,11 @@ bool monitor_thread::update_sta_stats()
     auto poll_cnt  = mon_db.get_poll_cnt();
     auto poll_last = mon_db.is_last_poll();
 
+    if (m_sta_stats_polling_completed) {
+        m_sta_stats_polling_start_timestamp = std::chrono::steady_clock::now();
+        m_sta_stats_polling_completed       = false;
+    }
+
     for (auto it = mon_db.sta_begin(); it != mon_db.sta_end(); ++it) {
 
         auto sta_mac  = it->first;
@@ -501,6 +506,19 @@ bool monitor_thread::update_sta_stats()
 
         auto vap_node   = mon_db.vap_get_by_id(sta_node->get_vap_id());
         auto &sta_stats = sta_node->get_stats();
+
+        // Skip stations that were already updated in the current cycle
+        if (sta_stats.last_update_time > m_sta_stats_polling_start_timestamp) {
+            continue;
+        }
+
+        if (std::chrono::steady_clock::now() > awake_timeout()) {
+            // If we haven't finish to iterate on all stations, skip one time on the select timeout
+            // so the select will not be stuck on full select timeout and the thread will be able to
+            // finish this operation quickly.
+            skip_next_select_timeout();
+            return true;
+        }
 
         // Update the stats
         if (!mon_wlan_hal->update_stations_stats(vap_node->get_iface(), sta_mac,
@@ -576,6 +594,8 @@ bool monitor_thread::update_sta_stats()
         sta_stats.delta_ms         = float(time_span.count());
         sta_stats.last_update_time = now;
     }
+
+    m_sta_stats_polling_completed = true;
 
     return true;
 }

--- a/agent/src/beerocks/monitor/monitor_thread.h
+++ b/agent/src/beerocks/monitor/monitor_thread.h
@@ -108,6 +108,9 @@ private:
     std::shared_ptr<bwl::mon_wlan_hal> mon_wlan_hal;
     bool mon_hal_attached           = false;
     bwl::HALState last_attach_state = bwl::HALState::Uninitialized;
+
+    std::chrono::steady_clock::time_point m_sta_stats_polling_start_timestamp;
+    bool m_sta_stats_polling_completed = true;
 };
 } // namespace son
 

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -22,7 +22,7 @@ using namespace beerocks::net;
 ////////////////////////// Local Module Definitions //////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-#define SELECT_TIMEOUT_MSC 200
+#define SELECT_TIMEOUT_MSC 1000
 #define ACS_READ_SLEEP_USC 1000
 #define READ_ACS_ATTEMPT_MAX 5
 #define DISABLE_BACKHAUL_VAP_TIMEOUT_SEC 30
@@ -341,7 +341,9 @@ void ap_manager_thread::after_select(bool timeout)
             return;
         } else {
             LOG(INFO) << "waiting to attach to " << ap_wlan_hal->get_radio_info().iface_name;
-            UTILS_SLEEP_MSEC(200);
+            // Set the sleep to little less than the select timeout so we won't get awake timeout
+            // print to the log on the socket thread.
+            UTILS_SLEEP_MSEC(SELECT_TIMEOUT_MSC * 0.9);
         }
 
         // AP is attached

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2503,8 +2503,19 @@ bool slave_thread::handle_cmdu_monitor_message(Socket *sd,
             return false;
         }
 
-        response_out->ap_stats() = response_in->ap_stats();
-        auto sta_stats_size      = response_in->sta_stats_size();
+        auto ap_stats_size = response_in->ap_stats_size();
+        if (ap_stats_size > 0) {
+            if (!response_out->alloc_ap_stats(ap_stats_size)) {
+                LOG(ERROR) << "Failed buffer allocation to size=" << int(ap_stats_size);
+                break;
+            }
+            auto ap_stats_tuple_in  = response_in->ap_stats(0);
+            auto ap_stats_tuple_out = response_out->ap_stats(0);
+            std::copy_n(&std::get<1>(ap_stats_tuple_in), ap_stats_size,
+                        &std::get<1>(ap_stats_tuple_out));
+        }
+
+        auto sta_stats_size = response_in->sta_stats_size();
         if (sta_stats_size > 0) {
             if (!response_out->alloc_sta_stats(sta_stats_size)) {
                 LOG(ERROR) << "Failed buffer allocation to size=" << int(sta_stats_size);

--- a/common/beerocks/bcl/include/bcl/beerocks_socket_thread.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_socket_thread.h
@@ -55,6 +55,8 @@ protected:
     inline void clear_ready(Socket *s) { select.clearReady(s); }
     virtual bool read_ready(Socket *s) { return select.readReady(s); }
 
+    void skip_next_select_timeout();
+
     ieee1905_1::CmduMessageTx cmdu_tx;
     ieee1905_1::CmduMessageTx cert_cmdu_tx;
     const std::string unix_socket_path;
@@ -80,6 +82,9 @@ private:
 
     int server_max_connections;
     SocketSelect select;
+
+    uint32_t m_select_timeout_msec  = 0;
+    bool m_skip_next_select_timeout = false;
 };
 
 } // namespace beerocks

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -278,6 +278,7 @@ bool socket_thread::work()
         m_skip_next_select_timeout = false;
         set_select_timeout(m_select_timeout_msec);
     }
+    m_select_wake_up_time = std::chrono::steady_clock::now();
 
     after_select(bool(sel_ret == 0));
 

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -261,6 +261,15 @@ bool socket_thread::work()
 {
     before_select();
 
+    auto awake_time_msec = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::steady_clock::now() - m_select_wake_up_time)
+                               .count();
+
+    if (m_select_timeout_msec > 0 && awake_time_msec > m_select_timeout_msec) {
+        THREAD_LOG(WARNING) << "Thread awake time is exceptionally long: " << int(awake_time_msec)
+                            << " [ms]";
+    }
+
     int sel_ret = select.selectSocket();
     if (sel_ret < 0) {
         // Do not fail for the following "errors"

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -749,7 +749,9 @@ class cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
         static eActionOp_CONTROL get_action_op(){
             return (eActionOp_CONTROL)(ACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE);
         }
-        sApStatsParams& ap_stats();
+        uint8_t& ap_stats_size();
+        std::tuple<bool, sApStatsParams&> ap_stats(size_t idx);
+        bool alloc_ap_stats(size_t count = 1);
         uint8_t& sta_stats_size();
         std::tuple<bool, sStaStatsParams&> sta_stats(size_t idx);
         bool alloc_sta_stats(size_t count = 1);
@@ -760,11 +762,13 @@ class cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
+        uint8_t* m_ap_stats_size = nullptr;
         sApStatsParams* m_ap_stats = nullptr;
+        size_t m_ap_stats_idx__ = 0;
+        int m_lock_order_counter__ = 0;
         uint8_t* m_sta_stats_size = nullptr;
         sStaStatsParams* m_sta_stats = nullptr;
         size_t m_sta_stats_idx__ = 0;
-        int m_lock_order_counter__ = 0;
 };
 
 class cACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_monitor.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_monitor.h
@@ -477,7 +477,9 @@ class cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
         static eActionOp_MONITOR get_action_op(){
             return (eActionOp_MONITOR)(ACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE);
         }
-        sApStatsParams& ap_stats();
+        uint8_t& ap_stats_size();
+        std::tuple<bool, sApStatsParams&> ap_stats(size_t idx);
+        bool alloc_ap_stats(size_t count = 1);
         uint8_t& sta_stats_size();
         std::tuple<bool, sStaStatsParams&> sta_stats(size_t idx);
         bool alloc_sta_stats(size_t count = 1);
@@ -488,11 +490,13 @@ class cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_MONITOR* m_action_op = nullptr;
+        uint8_t* m_ap_stats_size = nullptr;
         sApStatsParams* m_ap_stats = nullptr;
+        size_t m_ap_stats_idx__ = 0;
+        int m_lock_order_counter__ = 0;
         uint8_t* m_sta_stats_size = nullptr;
         sStaStatsParams* m_sta_stats = nullptr;
         size_t m_sta_stats_idx__ = 0;
-        int m_lock_order_counter__ = 0;
 };
 
 class cACTION_MONITOR_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -1482,8 +1482,48 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::~cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE() {
 }
-sApStatsParams& cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::ap_stats() {
-    return (sApStatsParams&)(*m_ap_stats);
+uint8_t& cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::ap_stats_size() {
+    return (uint8_t&)(*m_ap_stats_size);
+}
+
+std::tuple<bool, sApStatsParams&> cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::ap_stats(size_t idx) {
+    bool ret_success = ( (m_ap_stats_idx__ > 0) && (m_ap_stats_idx__ > idx) );
+    size_t ret_idx = ret_success ? idx : 0;
+    if (!ret_success) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+    }
+    return std::forward_as_tuple(ret_success, m_ap_stats[ret_idx]);
+}
+
+bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_ap_stats(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list ap_stats, abort!";
+        return false;
+    }
+    size_t len = sizeof(sApStatsParams) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_ap_stats[*m_ap_stats_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_sta_stats_size = (uint8_t *)((uint8_t *)(m_sta_stats_size) + len);
+    m_sta_stats = (sStaStatsParams *)((uint8_t *)(m_sta_stats) + len);
+    m_ap_stats_idx__ += count;
+    *m_ap_stats_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { 
+        for (size_t i = m_ap_stats_idx__ - count; i < m_ap_stats_idx__; i++) { m_ap_stats[i].struct_init(); }
+    }
+    return true;
 }
 
 uint8_t& cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::sta_stats_size() {
@@ -1500,7 +1540,7 @@ std::tuple<bool, sStaStatsParams&> cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESP
 }
 
 bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t count) {
-    if (m_lock_order_counter__ > 0) {;
+    if (m_lock_order_counter__ > 1) {;
         TLVF_LOG(ERROR) << "Out of order allocation for variable length list sta_stats, abort!";
         return false;
     }
@@ -1509,7 +1549,7 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
         TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
         return false;
     }
-    m_lock_order_counter__ = 0;
+    m_lock_order_counter__ = 1;
     uint8_t *src = (uint8_t *)&m_sta_stats[*m_sta_stats_size];
     uint8_t *dst = src + len;
     if (!m_parse__) {
@@ -1531,7 +1571,9 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
 void cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
-    m_ap_stats->struct_swap();
+    for (size_t i = 0; i < (size_t)*m_ap_stats_size; i++){
+        m_ap_stats[i].struct_swap();
+    }
     for (size_t i = 0; i < (size_t)*m_sta_stats_size; i++){
         m_sta_stats[i].struct_swap();
     }
@@ -1567,7 +1609,7 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::finalize()
 size_t cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(sApStatsParams); // ap_stats
+    class_size += sizeof(uint8_t); // ap_stats_size
     class_size += sizeof(uint8_t); // sta_stats_size
     return class_size;
 }
@@ -1578,12 +1620,19 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_ap_stats = (sApStatsParams*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sApStatsParams))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApStatsParams) << ") Failed!";
+    m_ap_stats_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_ap_stats_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    if (!m_parse__) { m_ap_stats->struct_init(); }
+    m_ap_stats = (sApStatsParams*)m_buff_ptr__;
+    uint8_t ap_stats_size = *m_ap_stats_size;
+    m_ap_stats_idx__ = ap_stats_size;
+    if (!buffPtrIncrementSafe(sizeof(sApStatsParams) * (ap_stats_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sApStatsParams) * (ap_stats_size) << ") Failed!";
+        return false;
+    }
     m_sta_stats_size = (uint8_t*)m_buff_ptr__;
     if (!m_parse__) *m_sta_stats_size = 0;
     if (!buffPtrIncrementSafe(sizeof(uint8_t))) {

--- a/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
+++ b/common/beerocks/tlvf/src/include/beerocks/tlvf/beerocks_message.h
@@ -23,8 +23,6 @@
     (MSG *)(TX_B + SIZE_VAR);                                                                      \
     SIZE_VAR += sizeof(MSG);
 
-#define MTU_SIZE (size_t)1500
-
 namespace beerocks {
 
 class message_com {

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
@@ -181,7 +181,12 @@ cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_REQUEST:
 
 cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE:
   _type: class
-  ap_stats: sApStatsParams
+  ap_stats_size:
+    _type: uint8_t
+    _length_var: True
+  ap_stats: 
+    _type: sApStatsParams
+    _length: [ ap_stats_size ]
   sta_stats_size:
     _type: uint8_t
     _length_var: True

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_monitor.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_monitor.yaml
@@ -105,7 +105,12 @@ cACTION_MONITOR_HOSTAP_STATUS_CHANGED_NOTIFICATION:
 
 cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE:
   _type: class
-  ap_stats: sApStatsParams 
+  ap_stats_size:
+    _type: uint8_t
+    _length_var: True
+  ap_stats: 
+    _type: sApStatsParams
+    _length: [ ap_stats_size ]
   sta_stats_size:
     _type: uint8_t
     _length_var: True

--- a/controller/src/beerocks/cli/beerocks_cli_main.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_main.cpp
@@ -267,10 +267,8 @@ static void cli_interactive(std::string path, std::string tmp_path, std::string 
               << BEEROCKS_BUILD_DATE << std::endl;
     std::cout << "Enter 'help' for help, 'exit' to exit" << std::endl;
 
-    beerocks::cli_socket cli_soc(tmp_path, ip);
     beerocks::cli_bml cli_bml(path);
-    beerocks::cli *cli_ptr = &cli_soc;
-    int is_onboarding      = -1;
+    int is_onboarding = -1;
 
     if (!cli_bml.connect()) {
         std::cout << "cli_bml: Can't connect to BML, exit..." << std::endl;
@@ -279,6 +277,8 @@ static void cli_interactive(std::string path, std::string tmp_path, std::string 
         is_onboarding = cli_bml.get_onboarding_status();
     }
 
+    beerocks::cli_socket cli_soc(tmp_path, ip);
+    beerocks::cli *cli_ptr = &cli_soc;
     if (is_onboarding == 0) {
         if (!cli_soc.connect()) {
             std::cout << "cli_socket: Can't connect to master." << std::endl;

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -3147,7 +3147,17 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             database.set_node_stats_info(client_mac, &sta_stats);
         }
 
-        database.set_hostap_stats_info(hostap_mac, &response->ap_stats());
+        if (response->ap_stats_size() == 0) {
+            break;
+        }
+
+        auto ap_stats_tuple = response->ap_stats(response->ap_stats_size() - 1);
+        if (!std::get<0>(ap_stats_tuple)) {
+            LOG(ERROR) << "Couldn't access ap element";
+            return false;
+        }
+        auto &ap_stats = std::get<1>(ap_stats_tuple);
+        database.set_hostap_stats_info(hostap_mac, &ap_stats);
         break;
     }
     case beerocks_message::ACTION_CONTROL_HOSTAP_LOAD_MEASUREMENT_NOTIFICATION: {

--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -51,7 +51,6 @@ public:
     bool is_finalized() const { return msg.is_finalized(); };
     bool is_swapped() const { return msg.is_swapped(); };
 
-    static const size_t kMaxCmduLength      = 1500;
     static const uint16_t kCmduHeaderLength = 8;
     static const uint16_t kTlvHeaderLength  = 3;
 

--- a/framework/tlvf/src/include/tlvf/CmduMessageTx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageTx.h
@@ -12,6 +12,8 @@
 #include <tlvf/CmduMessage.h>
 #include <tlvf/ieee_1905_1/tlvVendorSpecific.h>
 
+#define MTU_SIZE (size_t)1500
+
 namespace ieee1905_1 {
 
 class CmduMessageTx : public CmduMessage {
@@ -27,6 +29,7 @@ public:
     template <class T> std::shared_ptr<T> addClass() { return msg.addClass<T>(); }
     void reset() { msg.reset(false); }
     bool finalize();
+    size_t elements_in_message(size_t size);
 };
 
 }; // namespace ieee1905_1


### PR DESCRIPTION
Fix to #1105 

Change the save the select wakeup time on socket thread and charged set_select_timeout, to be able to stop a thread work in order to let it do other stuff such as message handling so it wouldn't be blocked for a long time and change temporarily the select timeout so the thread could finish its work quickly and not wait for a whole select timeout cycle.

Change also the way we send HOSTAP_STATS_MEASUREMENT_RESPONSE message since it causes to a buffer overflow and could not be sent on the bus since it is one big message that is bigger than MTU size restriction.
