### PR TITLE
Feature/prplwrt single codebase

### DIFF
--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -94,7 +94,7 @@ RUN cp feeds.conf.default feeds.conf \
     fi ;\
     make defconfig \
     && cat .config \
-    && make -j$(nproc) V=sc \
+    && make -j$(nproc) \
     && make package/feeds/prpl/prplmesh/clean
     # note that the result from diffconfig.sh with a minimal
     # configuration has the 3 CONFIG_TARGET items we set here, but NOT

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -37,6 +37,8 @@ ARG PRPLMESH_VARIANT
 ARG PRPL_FEED
 # optional: intel feed to use.
 ARG INTEL_FEED
+# optional: iwlwav feed to use.
+ARG IWLWAV_FEED
 
 # Target to build for (CONFIG_TARGET_ will be prepended).
 # Example: TARGET_SYSTEM=mvebu
@@ -67,12 +69,18 @@ COPY --chown=openwrt:openwrt configs/base_${BASE_CONFIG}_config /home/openwrt/ba
 # We first install from the intel feed preferably, because
 # it replaces some packages from the "packages" feed.
 # If no intel feed is present, nothing will be done so it's still ok.
-RUN echo "src-git prpl ${PRPL_FEED}" >> feeds.conf.default \
+RUN cp feeds.conf.default feeds.conf \
+    && echo "src-git prpl $PRPL_FEED" >> feeds.conf \
     && if [ -n "$INTEL_FEED" ] ; then \
-        echo "src-git intel $INTEL_FEED" >> feeds.conf.default \
+        echo "src-git intel $INTEL_FEED" >> feeds.conf \
         && scripts/feeds update intel \
         && scripts/feeds install intel_mips \
         && scripts/feeds install -a -p intel ; \
+    fi ;\
+    if [ -n "$IWLWAV_FEED" ] ; then \
+        echo "src-git iwlwav $IWLWAV_FEED" >> feeds.conf \
+        && scripts/feeds update iwlwav \
+        && scripts/feeds install -a -p iwlwav ; \
     fi ;\
     scripts/feeds update -a \
     && scripts/feeds install -a \

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -90,7 +90,7 @@ RUN cp feeds.conf.default feeds.conf \
     && echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_${TARGET_PROFILE}=y" >> .config \
     && echo "CONFIG_PACKAGE_prplmesh${PRPLMESH_VARIANT}=y" >> .config \
     && if [ "$TARGET_PROFILE" = "DEVICE_NETGEAR_RAX40" ] ; then \
-        cat feeds/intel/rax40.profile >> .config ;\
+        grep -v -E 'CONFIG_SDK|CONFIG_MAKE_TOOLCHAIN' feeds/intel/rax40.profile >> .config ;\
     fi ;\
     make defconfig \
     && cat .config \

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -22,6 +22,9 @@ usage() {
     echo "   default: $PRPL_FEED"
     echo " - INTEL_FEED: only used for targets which needs the additional intel feed."
     echo "   default: empty"
+    echo " - IWLWAV_FEED: only used for targets which needs the additional iwlwav feed."
+    echo "   default: empty"
+
 }
 
 build_image() {
@@ -35,6 +38,7 @@ build_image() {
            --build-arg PRPL_FEED \
            --build-arg PRPLMESH_VARIANT \
            --build-arg INTEL_FEED \
+           --build-arg IWLWAV_FEED \
            --build-arg BASE_CONFIG \
            "$scriptdir/"
 }
@@ -108,8 +112,8 @@ main() {
             SUBTARGET=xrx500
             TARGET_PROFILE=DEVICE_NETGEAR_RAX40
             PRPLMESH_VARIANT="-dwpal"
-            PRPL_FEED="https://git.prpl.dev/prplmesh/iwlwav.git^98ba3cfaa63d36941c47e390a665f05c8b64a228"
             INTEL_FEED="https://git.prpl.dev/prplmesh/feed-intel.git^2ed4bb749bc2d9e67bc293a831f69a6c8a77ce49"
+            IWLWAV_FEED="https://git.prpl.dev/prplmesh/iwlwav.git^cf95c322f28cb1ae7016b6a5a613bc69c19c4f54"
             BASE_CONFIG=gcc8
             ;;
         *)
@@ -127,6 +131,7 @@ main() {
     dbg "BASE_CONFIG=$BASE_CONFIG"
     dbg "PRPL_FEED=$PRPL_FEED"
     dbg "INTEL_FEED=$INTEL_FEED"
+    dbg "IWLWAV_FEED=$IWLWAV_FEED"
     dbg "IMAGE_ONLY=$IMAGE_ONLY"
     dbg "TARGET_DEVICE=$TARGET_DEVICE"
     dbg "TAG=$TAG"
@@ -156,6 +161,7 @@ main() {
     export PRPL_FEED
     export PRPLMESH_VARIANT
     export INTEL_FEED
+    export IWLWAV_FEED
     export BASE_CONFIG
 
     if [ $IMAGE_ONLY = true ] ; then
@@ -171,8 +177,10 @@ main() {
 IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='30c0f8b1e23a59c3e15c4eb329d5689b55280529'
-PRPL_FEED='https://git.prpl.dev/prplmesh/iwlwav.git^6749d406d243465e06b4f518767b2d1b9372e3f5'
+PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^fcae5377c6e0d8c64073e47033f131a8e7d1b965'
 INTEL_FEED=""
+IWLWAV_FEED=""
+PRPLMESH_VARIANT="-nl80211"
 BASE_CONFIG=default
 
 main "$@"


### PR DESCRIPTION
Use the same prplMesh package definition for both variants (nl80211 and dwpal).

- Move the prplMesh package from [iwlwav](https://git.prpl.dev/prplmesh/iwlwav/) to [feed-prpl](https://git.prpl.dev/prplmesh/feed-prpl/).
- For the nl80211 variant:
  - Update the prplMesh package to use wlan1 instead of wlan2 for the second radio
  - Add hostapd-utils as a dependency (required by prplMesh at boot).
- Make the docker image build log smaller.
- Exclude the toolchain and SDK for the rax40.

The final step before this PR can be merged is to update the commit hashes once the 2 following MR have been merged:
https://git.prpl.dev/prplmesh/iwlwav/-/merge_requests/13/diffs
https://git.prpl.dev/prplmesh/feed-prpl/-/merge_requests/1/diffs?commit_id=531c27d86a912a12d649320418817db281534eb0


Fixes #763 