### PR TITLE
update iterator after erase

### DIFF
--- a/agent/src/beerocks/monitor/monitor_db.cpp
+++ b/agent/src/beerocks/monitor/monitor_db.cpp
@@ -334,7 +334,7 @@ void monitor_db::sta_erase(const std::string sta_mac)
     if (it != sta_nodes.end()) {
         auto vap_id = it->second->get_vap_id();
         delete it->second;
-        sta_nodes.erase(it);
+        it            = sta_nodes.erase(it);
         auto vap_node = vap_get_by_id(vap_id);
         if (vap_node) {
             vap_node->sta_count_dec();

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -1407,7 +1407,7 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
                 std::copy_n(hal_data->bssid.oct, sizeof(response->params().bssid.oct),
                             response->params().bssid.oct);
 
-                pending_11k_events.erase(it);
+                it = pending_11k_events.erase(it);
                 LOG(INFO) << "Sending beacon measurement reponse on BSSID: "
                           << response->params().bssid << " to task_id: " << id;
 

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1147,7 +1147,7 @@ bool ap_manager_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t ev
             [&](pending_disable_vap_t vap) { return (vap.vap_id == msg->params.vap_id); });
 
         if (it != pending_disable_vaps.end()) {
-            pending_disable_vaps.erase(it);
+            it = pending_disable_vaps.erase(it);
             if (enable_backhaul_vap(ap_wlan_hal, backhaul_vaps_list, connected_ires, true)) {
                 // update master about the updated vap list
                 // Note: this could be removed if bwl vap list will contain disabled backhaul vaps
@@ -1732,7 +1732,7 @@ void ap_manager_thread::remove_client_from_disallowed_list(const sMacAddr &mac,
 
     if (it != m_disallowed_clients.end()) {
         // remove client from the disallow list
-        m_disallowed_clients.erase(it);
+        it = m_disallowed_clients.erase(it);
     }
 }
 

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1744,7 +1744,7 @@ void ap_manager_thread::allow_expired_clients()
             LOG(DEBUG) << "CLIENT_ALLOW: mac = " << it->mac << ", bssid = " << it->bssid;
             ap_wlan_hal->sta_allow(network_utils::mac_to_string(it->mac),
                                    network_utils::mac_to_string(it->bssid));
-            m_disallowed_clients.erase(it);
+            it = m_disallowed_clients.erase(it);
         } else {
             it++;
         }

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -2053,7 +2053,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
         auto &associated_clients = soc->associated_clients_map[msg->bssid()];
         auto it                  = associated_clients.find(msg->client_mac());
         if (it != associated_clients.end()) {
-            associated_clients.erase(it);
+            it = associated_clients.erase(it);
         }
         break;
     }

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -449,7 +449,7 @@ static void hostapd_config_set_value(std::vector<std::string> &hostapd_config,
                                });
     // Delete the key-value if found
     if (it_str != hostapd_config.end()) {
-        hostapd_config.erase(it_str);
+        it_str = hostapd_config.erase(it_str);
     }
     // If the new value is provided add the key back with that new value
     if (value.length() != 0) {

--- a/controller/src/beerocks/cli/beerocks_cli_proxy.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_proxy.cpp
@@ -72,7 +72,7 @@ bool cli_proxy::socket_disconnected(Socket *sd)
                 remove_socket(soc->master);
                 delete soc->master;
             }
-            master_sockets.erase(it);
+            it = master_sockets.erase(it);
             return false;
         }
     }

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -137,7 +137,7 @@ bool db::remove_node(const sMacAddr &mac)
             // map may include 2 keys to same node - if so remove other key-node pair from map
             // if removed by mac
             if (network_utils::mac_to_string(mac) == node_mac) {
-                nodes[i].erase(it);
+                it = nodes[i].erase(it);
                 // if ruid_key exists for this node
                 if (!ruid_key.empty()) {
                     nodes[i].erase(ruid_key);
@@ -2409,7 +2409,7 @@ void db::remove_cli_socket(Socket *sd)
     if (sd) {
         for (auto it = cli_debug_sockets.begin(); it < cli_debug_sockets.end(); it++) {
             if (sd == (*it)) {
-                cli_debug_sockets.erase(it);
+                it = cli_debug_sockets.erase(it);
                 return;
             }
         }
@@ -2464,7 +2464,7 @@ void db::remove_bml_socket(Socket *sd)
     if (sd) {
         for (auto it = bml_listeners_sockets.begin(); it < bml_listeners_sockets.end(); it++) {
             if (sd == (*it).sd) {
-                bml_listeners_sockets.erase(it);
+                it = bml_listeners_sockets.erase(it);
                 return;
             }
         }

--- a/controller/src/beerocks/master/tasks/channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/channel_selection_task.cpp
@@ -835,7 +835,7 @@ void channel_selection_task::work()
 
         if (it_cac != std::end(hostaps_cac_pending)) {
             database.set_hostap_cac_completed(it_cac->first, true);
-            hostaps_cac_pending.erase(it_cac);
+            it_cac = hostaps_cac_pending.erase(it_cac);
             TASK_LOG(DEBUG) << "hostap_mac - " << hostap_mac
                             << " cac completed - found in pending cac - erasing, update DB";
 
@@ -1200,7 +1200,7 @@ bool channel_selection_task::cac_pending_hostap_check()
             TASK_LOG(INFO) << "cac_complete_delta = " << int(cac_complete_delta)
                            << " > ( CAC_COMPLETED_WAIT_TIME = 11 min )";
             dfs_cac_pending_hostap->timeout_expired = true;
-            hostaps_cac_pending.erase(it_cac_pending);
+            it_cac_pending                          = hostaps_cac_pending.erase(it_cac_pending);
             return true;
         } else {
             //inject again the event to check for cac completed.

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task.cpp
@@ -920,7 +920,7 @@ void rdkb_wlan_task::remove_bml_rdkb_wlan_socket(Socket *sd)
         for (auto it = bml_rdkb_wlan_listeners_sockets.begin();
              it < bml_rdkb_wlan_listeners_sockets.end(); it++) {
             if (sd == (*it).sd) {
-                bml_rdkb_wlan_listeners_sockets.erase(it);
+                it = bml_rdkb_wlan_listeners_sockets.erase(it);
                 return;
             }
         }
@@ -1135,7 +1135,7 @@ std::pair<bool, Socket *> rdkb_wlan_task::check_for_pending_events(int event)
         pending_events.clear();
         return res;
     } else if (std::distance(ret.first, ret.second) > 1) {
-        pending_events.erase(it);
+        it  = pending_events.erase(it);
         res = std::make_pair(true, nullptr);
         return res;
     }

--- a/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task_db.cpp
+++ b/controller/src/beerocks/master/tasks/rdkb/rdkb_wlan_task_db.cpp
@@ -109,7 +109,7 @@ bool rdkb_wlan_task_db::clear_steering_group_config(int index)
         LOG(ERROR) << "can't find steering group index=" << index;
         return false;
     } else {
-        steering_group_list.erase(it);
+        it = steering_group_list.erase(it);
         return true;
     }
 }

--- a/controller/src/beerocks/master/tasks/task.cpp
+++ b/controller/src/beerocks/master/tasks/task.cpp
@@ -49,7 +49,7 @@ void task::event_received(int event_type, void *obj)
     if (it == pending_events.end()) {
         TASK_LOG(DEBUG) << "received non-pending event " << event_type;
     } else {
-        pending_events.erase(it);
+        it = pending_events.erase(it);
     }
 
     handle_event(event_type, obj);

--- a/framework/common/nng/socket.cpp
+++ b/framework/common/nng/socket.cpp
@@ -273,7 +273,7 @@ void SubSocket::EraseSubscription(const std::string &topic)
 {
     auto it = FindSubscription(topic);
     if (it != topics_.end())
-        topics_.erase(it);
+        it = topics_.erase(it);
 }
 
 std::ostream &SubSocket::Print(std::ostream &s) const

--- a/framework/common/zmq/poller.cpp
+++ b/framework/common/zmq/poller.cpp
@@ -115,7 +115,7 @@ int Poller::Remove(const Socket &socket)
     errno   = 0;
     auto it = items_->Find(&socket);
     if (it != items_->items_.end()) {
-        items_->items_.erase(it);
+        it = items_->items_.erase(it);
         return 0;
     } else {
         errno = ENONET;
@@ -131,7 +131,7 @@ int Poller::Remove(int fd)
     errno   = 0;
     auto it = items_->Find(fd);
     if (it != items_->items_.end()) {
-        items_->items_.erase(it);
+        it = items_->items_.erase(it);
         return 0;
     } else {
         errno = ENONET;

--- a/framework/common/zmq/socket.cpp
+++ b/framework/common/zmq/socket.cpp
@@ -352,7 +352,7 @@ void SubSocket::EraseSubscription(const std::string &topic)
 {
     auto it = FindSubscription(topic);
     if (it != topics_.end())
-        topics_.erase(it);
+        it = topics_.erase(it);
 }
 
 } // namespace mapf

--- a/framework/platform/bpl/uci/arp/monitor/arp_monitor.cpp
+++ b/framework/platform/bpl/uci/arp/monitor/arp_monitor.cpp
@@ -488,7 +488,7 @@ int arp_monitor::process_arp(BPL_ARP_MON_ENTRY &sArpMonData)
         // Found our node
         if (!std::memcmp(&node->mac, pArpHeader->sender_mac, ETH_ALEN)) {
             iTaskID = node->iTaskID;
-            m_lstProbe.erase(iter);
+            iter    = m_lstProbe.erase(iter);
             break;
         }
 


### PR DESCRIPTION
When an element is erased, any iterator pointing to it is invalidated. 
Thus, `foo.erase(it)` invalidates `it` and `it` should no longer be used.
Fortunately, erase() returns a new iterator that points to the next
element. Therefore, update `it` with the returned value.

In most places, this is not needed, since the iterator is no longer used 
after the erase. However, it never hurts to update the iterator, and it 
avoids problems when the code is changed afterwards. Also, it's easier to
not forget to update the iterator if the same pattern is used everywhere.