### PR TITLE
Update Basic Radio Capabilities

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -34,10 +34,10 @@ using namespace beerocks::net;
 //////////////////////////////////////////////////////////////////////////////
 
 static std::string
-get_radio_preferred_channels_string(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal)
+get_radio_channels_string(const std::vector<beerocks::message::sWifiChannel> &channels)
 {
     std::ostringstream os;
-    for (auto val : ap_wlan_hal->get_radio_info().preferred_channels) {
+    for (auto val : channels) {
         if (val.channel > 0) {
             os << " ch = " << int(val.channel) << " | dfs = " << int(val.tx_pow) << " | bw = "
                << int(beerocks::utils::convert_bandwidth_to_int(
@@ -1600,7 +1600,9 @@ void ap_manager_thread::handle_hostapd_attached()
     LOG(INFO) << " vht_supported = " << ap_wlan_hal->get_radio_info().vht_supported;
     LOG(INFO) << " vht_capability = " << std::hex << ap_wlan_hal->get_radio_info().vht_capability;
     LOG(INFO) << " preferred_channels = " << std::endl
-              << get_radio_preferred_channels_string(ap_wlan_hal);
+              << get_radio_channels_string(ap_wlan_hal->get_radio_info().preferred_channels);
+    LOG(INFO) << " supported_channels = " << std::endl
+              << get_radio_channels_string(ap_wlan_hal->get_radio_info().supported_channels);
 
     // Send CMDU
     message_com::send_cmdu(slave_socket, cmdu_tx);

--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1573,6 +1573,14 @@ void ap_manager_thread::handle_hostapd_attached()
                 beerocks::message::VHT_MCS_SET_SIZE, notification->params().vht_mcs_set);
 
     // Copy the channels supported by the AP
+    if (!notification->alloc_supported_channels(
+            ap_wlan_hal->get_radio_info().supported_channels.size())) {
+        LOG(ERROR) << "Failed to allocate supported_channels!";
+        return;
+    }
+    auto tuple_supported_channels = notification->supported_channels(0);
+    std::copy_n(ap_wlan_hal->get_radio_info().supported_channels.begin(),
+                notification->supported_channels_size(), &std::get<1>(tuple_supported_channels));
     std::copy_n(ap_wlan_hal->get_radio_info().preferred_channels.begin(),
                 beerocks::message::SUPPORTED_CHANNELS_LENGTH,
                 notification->params().preferred_channels);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1701,7 +1701,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
             return false;
         }
 
-        auto tuple_preferred_channels = request->preferred_channels_list(0);
+        auto tuple_preferred_channels = request->preferred_channels(0);
         if (!std::get<0>(tuple_preferred_channels)) {
             LOG(ERROR) << "access to supported channels list failed!";
             return false;
@@ -1709,8 +1709,7 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
 
         auto channels = &std::get<1>(tuple_preferred_channels);
 
-        std::copy_n(channels, beerocks::message::SUPPORTED_CHANNELS_LENGTH,
-                    soc->preferred_channels.begin());
+        std::copy_n(channels, request->preferred_channels_size(), soc->preferred_channels.begin());
 
         soc->radio_mac             = request->iface_mac();
         soc->freq_type             = request->frequency_band();

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1701,16 +1701,16 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
             return false;
         }
 
-        auto tuple_supported_channels = request->supported_channels_list(0);
-        if (!std::get<0>(tuple_supported_channels)) {
+        auto tuple_preferred_channels = request->preferred_channels_list(0);
+        if (!std::get<0>(tuple_preferred_channels)) {
             LOG(ERROR) << "access to supported channels list failed!";
             return false;
         }
 
-        auto channels = &std::get<1>(tuple_supported_channels);
+        auto channels = &std::get<1>(tuple_preferred_channels);
 
         std::copy_n(channels, beerocks::message::SUPPORTED_CHANNELS_LENGTH,
-                    soc->supported_channels.begin());
+                    soc->preferred_channels.begin());
 
         soc->radio_mac             = request->iface_mac();
         soc->freq_type             = request->frequency_band();
@@ -2141,9 +2141,9 @@ bool backhaul_manager::handle_ap_capability_query(ieee1905_1::CmduMessageRx &cmd
     for (const auto &slave : slaves_sockets) {
         // TODO skip slaves that are not operational
         auto radio_mac          = slave->radio_mac;
-        auto supported_channels = slave->supported_channels;
+        auto preferred_channels = slave->preferred_channels;
 
-        if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, radio_mac, supported_channels)) {
+        if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, radio_mac, preferred_channels)) {
             return false;
         }
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -289,7 +289,7 @@ private:
         bool he_supported = false;             /**< Is HE supported flag */
         beerocks_message::sVapsList vaps_list; /**< List of VAPs in radio. */
         std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
-            supported_channels; /**< Array of supported channels in radio. */
+            preferred_channels; /**< Array of supported channels in radio. */
         std::unordered_map<sMacAddr, associated_clients_t>
             associated_clients_map; /**< Associated clients grouped by BSSID. */
     };

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -201,6 +201,7 @@ private:
     beerocks_message::sNodeHostap hostap_params;
     beerocks_message::sApChannelSwitch hostap_cs_params;
     std::vector<wireless_utils::sChannelPreference> channel_preferences;
+    std::vector<beerocks::message::sWifiChannel> supported_channels;
 
     SocketClient *platform_manager_socket = nullptr;
     SocketClient *backhaul_manager_socket = nullptr;

--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -151,6 +151,7 @@ public:
                                                                beerocks::eWiFiBandwidth bw,
                                                                uint16_t vht_center_frequency);
     static const std::set<uint8_t> &operating_class_to_channel_set(uint8_t operating_class);
+    static const beerocks::eWiFiBandwidth &operating_class_to_bandwidth(uint8_t operating_class);
     static std::string wsc_to_bwl_authentication(WSC::eWscAuth authtype);
     static std::string wsc_to_bwl_encryption(WSC::eWscEncr enctype);
     static beerocks::eBssType wsc_to_bwl_bss_type(WSC::eWscVendorExtSubelementBssType bss_type);

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -782,6 +782,24 @@ const std::set<uint8_t> &wireless_utils::operating_class_to_channel_set(uint8_t 
     return it->second.channels;
 }
 
+/**
+ * @brief convert operating class to bandwidth based on Table 4-E in the ieee 802.11 specification
+ *
+ * @param operating_class operating class
+ * @return beerocks::eWiFiBandwidth enum of supported bandwidth for specific operating class.
+ */
+const beerocks::eWiFiBandwidth &
+wireless_utils::operating_class_to_bandwidth(uint8_t operating_class)
+{
+    static const beerocks::eWiFiBandwidth NA = beerocks::eWiFiBandwidth::BANDWIDTH_UNKNOWN;
+    auto it                                  = operating_classes_list.find(operating_class);
+    if (it == operating_classes_list.end()) {
+        LOG(ERROR) << "reserved operating class " << int(operating_class);
+        return NA;
+    }
+    return it->second.band;
+}
+
 std::string wireless_utils::wsc_to_bwl_authentication(WSC::eWscAuth authtype)
 {
     switch (authtype) {

--- a/common/beerocks/bwl/common/base_wlan_hal.cpp
+++ b/common/beerocks/bwl/common/base_wlan_hal.cpp
@@ -31,7 +31,7 @@ base_wlan_hal::base_wlan_hal(HALType type, std::string iface_name, IfaceType ifa
     }
 
     // Initialize complex containers of the radio_info structure
-    m_radio_info.supported_channels.resize(128 /* TODO: Get real value */);
+    m_radio_info.preferred_channels.resize(128 /* TODO: Get real value */);
 }
 
 base_wlan_hal::~base_wlan_hal()

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -282,10 +282,10 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
-            m_radio_info.supported_channels[idx].channel     = ch;
-            m_radio_info.supported_channels[idx].bandwidth   = 20;
-            m_radio_info.supported_channels[idx].bss_overlap = 10;
-            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            m_radio_info.preferred_channels[idx].channel     = ch;
+            m_radio_info.preferred_channels[idx].bandwidth   = 20;
+            m_radio_info.preferred_channels[idx].bss_overlap = 10;
+            m_radio_info.preferred_channels[idx].is_dfs      = 0;
             idx++;
         }
     } else {
@@ -293,28 +293,28 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
                 idx++;
             }
         }
         for (uint16_t ch = 100; ch <= 144; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 1;
                 idx++;
             }
         }
         for (uint16_t ch = 149; ch <= 165; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 0;
                 idx++;
             }
         }
@@ -323,7 +323,7 @@ bool ap_wlan_hal_dummy::read_acs_report()
     return true;
 }
 
-bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
+bool ap_wlan_hal_dummy::read_preferred_channels() { return true; }
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -282,10 +282,11 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
-            m_radio_info.preferred_channels[idx].channel     = ch;
-            m_radio_info.preferred_channels[idx].bandwidth   = 20;
-            m_radio_info.preferred_channels[idx].bss_overlap = 10;
-            m_radio_info.preferred_channels[idx].is_dfs      = 0;
+            m_radio_info.preferred_channels[idx].channel = ch;
+            m_radio_info.preferred_channels[idx].channel_bandwidth =
+                beerocks::utils::convert_bandwidth_to_enum(20);
+            m_radio_info.preferred_channels[idx].bss_overlap    = 10;
+            m_radio_info.preferred_channels[idx].is_dfs_channel = 0;
             idx++;
         }
     } else {
@@ -293,28 +294,31 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.preferred_channels[idx].channel     = ch;
-                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.preferred_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                m_radio_info.preferred_channels[idx].channel = ch;
+                m_radio_info.preferred_channels[idx].channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                m_radio_info.preferred_channels[idx].bss_overlap    = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs_channel = (ch > 48) ? 1 : 0;
                 idx++;
             }
         }
         for (uint16_t ch = 100; ch <= 144; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.preferred_channels[idx].channel     = ch;
-                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.preferred_channels[idx].is_dfs      = 1;
+                m_radio_info.preferred_channels[idx].channel = ch;
+                m_radio_info.preferred_channels[idx].channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                m_radio_info.preferred_channels[idx].bss_overlap    = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs_channel = 1;
                 idx++;
             }
         }
         for (uint16_t ch = 149; ch <= 165; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.preferred_channels[idx].channel     = ch;
-                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.preferred_channels[idx].is_dfs      = 0;
+                m_radio_info.preferred_channels[idx].channel = ch;
+                m_radio_info.preferred_channels[idx].channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                m_radio_info.preferred_channels[idx].bss_overlap    = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs_channel = 0;
                 idx++;
             }
         }

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
@@ -67,7 +67,7 @@ public:
     virtual bool restricted_channels_set(char *channel_list) override;
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
-    virtual bool read_supported_channels() override;
+    virtual bool read_preferred_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -297,8 +297,49 @@ bool base_wlan_hal_dummy::refresh_radio_info()
     if (get_iface_name() == "wlan2") {
         m_radio_info.is_5ghz        = true;
         m_radio_info.frequency_band = beerocks::eFreqType::FREQ_5G;
+        for (uint16_t ch = 36; ch <= 64; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                beerocks::message::sWifiChannel supported_channel;
+                supported_channel.channel = ch;
+                supported_channel.channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                supported_channel.bss_overlap    = 10 + step * 10;
+                supported_channel.is_dfs_channel = (ch > 48) ? 1 : 0;
+                m_radio_info.supported_channels.push_back(supported_channel);
+            }
+        }
+        for (uint16_t ch = 100; ch <= 144; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                beerocks::message::sWifiChannel supported_channel;
+                supported_channel.channel = ch;
+                supported_channel.channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                supported_channel.bss_overlap    = 10 + step * 10;
+                supported_channel.is_dfs_channel = 1;
+                m_radio_info.supported_channels.push_back(supported_channel);
+            }
+        }
+        for (uint16_t ch = 149; ch <= 165; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                beerocks::message::sWifiChannel supported_channel;
+                supported_channel.channel = ch;
+                supported_channel.channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                supported_channel.bss_overlap    = 10 + step * 10;
+                supported_channel.is_dfs_channel = 0;
+                m_radio_info.supported_channels.push_back(supported_channel);
+            }
+        }
     } else {
         m_radio_info.frequency_band = beerocks::eFreqType::FREQ_24G;
+        for (uint16_t ch = 1; ch <= 11; ch++) {
+            beerocks::message::sWifiChannel supported_channel;
+            supported_channel.channel           = ch;
+            supported_channel.channel_bandwidth = beerocks::utils::convert_bandwidth_to_enum(20);
+            supported_channel.bss_overlap       = 10;
+            supported_channel.is_dfs_channel    = 0;
+            m_radio_info.supported_channels.push_back(supported_channel);
+        }
     }
 
     std::string radio_mac;

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1459,13 +1459,13 @@ bool ap_wlan_hal_dwpal::read_acs_report()
     m_radio_info.is_5ghz = false;
 
     // Resize the supported channels vector
-    if (MAX_SUPPORTED_20M_CHANNELS >= m_radio_info.supported_channels.size()) {
+    if (MAX_SUPPORTED_20M_CHANNELS >= m_radio_info.preferred_channels.size()) {
         LOG(DEBUG) << "Increasing supported channels vector to: " << MAX_SUPPORTED_20M_CHANNELS;
-        m_radio_info.supported_channels.resize(MAX_SUPPORTED_20M_CHANNELS);
+        m_radio_info.preferred_channels.resize(MAX_SUPPORTED_20M_CHANNELS);
     }
 
     // Clear the supported channels vector
-    for (auto &chan : m_radio_info.supported_channels) {
+    for (auto &chan : m_radio_info.preferred_channels) {
         memset(&chan, 0, sizeof(chan));
     }
 
@@ -1503,16 +1503,16 @@ bool ap_wlan_hal_dwpal::read_acs_report()
                    << " DFS=" << acs_report[i].DFS << " bss=" << acs_report[i].bss;
 
         if (acs_report[i].BW == 20) {
-            m_radio_info.supported_channels[channel_idx].bandwidth = acs_report[i].BW;
-            m_radio_info.supported_channels[channel_idx].channel   = acs_report[i].Ch;
+            m_radio_info.preferred_channels[channel_idx].bandwidth = acs_report[i].BW;
+            m_radio_info.preferred_channels[channel_idx].channel   = acs_report[i].Ch;
             // Check if channel is 5GHz
             if (son::wireless_utils::which_freq(
-                    m_radio_info.supported_channels[channel_idx].channel) ==
+                    m_radio_info.preferred_channels[channel_idx].channel) ==
                 beerocks::eFreqType::FREQ_5G) {
                 m_radio_info.is_5ghz = true;
             }
-            m_radio_info.supported_channels[channel_idx].bss_overlap = acs_report[i].bss;
-            m_radio_info.supported_channels[channel_idx].is_dfs      = acs_report[i].DFS;
+            m_radio_info.preferred_channels[channel_idx].bss_overlap = acs_report[i].bss;
+            m_radio_info.preferred_channels[channel_idx].is_dfs      = acs_report[i].DFS;
 
             channel_idx++;
             if (channel_idx == MAX_SUPPORTED_20M_CHANNELS) {
@@ -1525,7 +1525,7 @@ bool ap_wlan_hal_dwpal::read_acs_report()
     return true;
 }
 
-bool ap_wlan_hal_dwpal::read_supported_channels()
+bool ap_wlan_hal_dwpal::read_preferred_channels()
 {
     auto ifname = get_radio_info().iface_name;
     LOG(TRACE) << "for interface: " << ifname;
@@ -1536,7 +1536,7 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
         LOG(TRACE) << "Failed to get channels info from nl80211";
         return false;
     }
-    std::vector<bwl::WiFiChannel> supported_channels;
+    std::vector<bwl::WiFiChannel> preferred_channels;
     for (auto const &band : radio_info.bands) {
         for (auto const &pair : band.supported_channels) {
             auto &channel_info = pair.second;
@@ -1546,16 +1546,16 @@ bool ap_wlan_hal_dwpal::read_supported_channels()
                 channel.bandwidth = beerocks::utils::convert_bandwidth_to_int(bw);
                 channel.tx_pow    = channel_info.tx_power;
                 channel.is_dfs    = channel_info.is_dfs;
-                supported_channels.push_back(channel);
+                preferred_channels.push_back(channel);
             }
         }
     }
 
     // Clear the supported channels vector
-    m_radio_info.supported_channels.clear();
+    m_radio_info.preferred_channels.clear();
     // Resize the supported channels vector
-    m_radio_info.supported_channels.insert(m_radio_info.supported_channels.begin(),
-                                           supported_channels.begin(), supported_channels.end());
+    m_radio_info.preferred_channels.insert(m_radio_info.preferred_channels.begin(),
+                                           preferred_channels.begin(), preferred_channels.end());
     return true;
 }
 

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
@@ -67,7 +67,7 @@ public:
     virtual bool restricted_channels_set(char *channel_list) override;
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
-    virtual bool read_supported_channels() override;
+    virtual bool read_preferred_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -726,7 +726,7 @@ bool base_wlan_hal_dwpal::refresh_radio_info()
     char *reply = nullptr;
 
     /**
-     * Obtain frequency band and maximum supported bandwidth using NL80211.
+     * Obtain frequency band, maximum supported bandwidth and supported channels using NL80211.
      * As this information does not change, this is required the first time this method is called
      * only.
      */
@@ -745,6 +745,18 @@ bool base_wlan_hal_dwpal::refresh_radio_info()
                 m_radio_info.vht_capability = band_info.vht_capability;
                 m_radio_info.vht_mcs_set.assign(band_info.vht_mcs_set,
                                                 sizeof(band_info.vht_mcs_set));
+
+                for (auto const &pair : band_info.supported_channels) {
+                    auto &channel_info = pair.second;
+                    for (auto bw : channel_info.supported_bandwidths) {
+                        beerocks::message::sWifiChannel channel;
+                        channel.channel           = channel_info.number;
+                        channel.channel_bandwidth = bw;
+                        channel.tx_pow            = channel_info.tx_power;
+                        channel.is_dfs_channel    = channel_info.is_dfs;
+                        m_radio_info.supported_channels.push_back(channel);
+                    }
+                }
             }
         }
     }

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
@@ -279,10 +279,11 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
-            m_radio_info.preferred_channels[idx].channel     = ch;
-            m_radio_info.preferred_channels[idx].bandwidth   = 20;
-            m_radio_info.preferred_channels[idx].bss_overlap = 10;
-            m_radio_info.preferred_channels[idx].is_dfs      = 0;
+            m_radio_info.preferred_channels[idx].channel = ch;
+            m_radio_info.preferred_channels[idx].channel_bandwidth =
+                beerocks::utils::convert_bandwidth_to_enum(20);
+            m_radio_info.preferred_channels[idx].bss_overlap    = 10;
+            m_radio_info.preferred_channels[idx].is_dfs_channel = 0;
             idx++;
         }
     } else {
@@ -290,28 +291,31 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.preferred_channels[idx].channel     = ch;
-                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.preferred_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                m_radio_info.preferred_channels[idx].channel = ch;
+                m_radio_info.preferred_channels[idx].channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                m_radio_info.preferred_channels[idx].bss_overlap    = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs_channel = (ch > 48) ? 1 : 0;
                 idx++;
             }
         }
         for (uint16_t ch = 100; ch <= 144; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.preferred_channels[idx].channel     = ch;
-                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.preferred_channels[idx].is_dfs      = 1;
+                m_radio_info.preferred_channels[idx].channel = ch;
+                m_radio_info.preferred_channels[idx].channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                m_radio_info.preferred_channels[idx].bss_overlap    = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs_channel = 1;
                 idx++;
             }
         }
         for (uint16_t ch = 149; ch <= 165; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.preferred_channels[idx].channel     = ch;
-                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.preferred_channels[idx].is_dfs      = 0;
+                m_radio_info.preferred_channels[idx].channel = ch;
+                m_radio_info.preferred_channels[idx].channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                m_radio_info.preferred_channels[idx].bss_overlap    = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs_channel = 0;
                 idx++;
             }
         }

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.cpp
@@ -279,10 +279,10 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 1;
         // 2.4G simulated report
         for (uint16_t ch = 1; ch <= 11; ch++) {
-            m_radio_info.supported_channels[idx].channel     = ch;
-            m_radio_info.supported_channels[idx].bandwidth   = 20;
-            m_radio_info.supported_channels[idx].bss_overlap = 10;
-            m_radio_info.supported_channels[idx].is_dfs      = 0;
+            m_radio_info.preferred_channels[idx].channel     = ch;
+            m_radio_info.preferred_channels[idx].bandwidth   = 20;
+            m_radio_info.preferred_channels[idx].bss_overlap = 10;
+            m_radio_info.preferred_channels[idx].is_dfs      = 0;
             idx++;
         }
     } else {
@@ -290,28 +290,28 @@ bool ap_wlan_hal_dummy::read_acs_report()
         m_radio_info.channel = 149;
         for (uint16_t ch = 36; ch <= 64; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = (ch > 48) ? 1 : 0;
                 idx++;
             }
         }
         for (uint16_t ch = 100; ch <= 144; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 1;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 1;
                 idx++;
             }
         }
         for (uint16_t ch = 149; ch <= 165; ch += 4) {
             for (uint16_t step = 0; step < 3; step++) {
-                m_radio_info.supported_channels[idx].channel     = ch;
-                m_radio_info.supported_channels[idx].bandwidth   = 20 + step * 20;
-                m_radio_info.supported_channels[idx].bss_overlap = 10 + step * 10;
-                m_radio_info.supported_channels[idx].is_dfs      = 0;
+                m_radio_info.preferred_channels[idx].channel     = ch;
+                m_radio_info.preferred_channels[idx].bandwidth   = 20 + step * 20;
+                m_radio_info.preferred_channels[idx].bss_overlap = 10 + step * 10;
+                m_radio_info.preferred_channels[idx].is_dfs      = 0;
                 idx++;
             }
         }
@@ -320,7 +320,7 @@ bool ap_wlan_hal_dummy::read_acs_report()
     return true;
 }
 
-bool ap_wlan_hal_dummy::read_supported_channels() { return true; }
+bool ap_wlan_hal_dummy::read_preferred_channels() { return true; }
 
 bool ap_wlan_hal_dummy::set_tx_power_limit(int tx_pow_limit)
 {

--- a/common/beerocks/bwl/econet/ap_wlan_hal_econet.h
+++ b/common/beerocks/bwl/econet/ap_wlan_hal_econet.h
@@ -67,7 +67,7 @@ public:
     virtual bool restricted_channels_set(char *channel_list) override;
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
-    virtual bool read_supported_channels() override;
+    virtual bool read_preferred_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/econet/base_wlan_hal_econet.cpp
+++ b/common/beerocks/bwl/econet/base_wlan_hal_econet.cpp
@@ -294,6 +294,48 @@ bool base_wlan_hal_dummy::refresh_radio_info()
 {
     if (get_iface_name() == "wlan2") {
         m_radio_info.is_5ghz = true;
+        for (uint16_t ch = 36; ch <= 64; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                beerocks::message::sWifiChannel supported_channel;
+                supported_channel.channel = ch;
+                supported_channel.channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                supported_channel.bss_overlap    = 10 + step * 10;
+                supported_channel.is_dfs_channel = (ch > 48) ? 1 : 0;
+                m_radio_info.supported_channels.push_back(supported_channel);
+            }
+        }
+        for (uint16_t ch = 100; ch <= 144; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                beerocks::message::sWifiChannel supported_channel;
+                supported_channel.channel = ch;
+                supported_channel.channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                supported_channel.bss_overlap    = 10 + step * 10;
+                supported_channel.is_dfs_channel = 1;
+                m_radio_info.supported_channels.push_back(supported_channel);
+            }
+        }
+        for (uint16_t ch = 149; ch <= 165; ch += 4) {
+            for (uint16_t step = 0; step < 3; step++) {
+                beerocks::message::sWifiChannel supported_channel;
+                supported_channel.channel = ch;
+                supported_channel.channel_bandwidth =
+                    beerocks::utils::convert_bandwidth_to_enum(20 + step * 20);
+                supported_channel.bss_overlap    = 10 + step * 10;
+                supported_channel.is_dfs_channel = 0;
+                m_radio_info.supported_channels.push_back(supported_channel);
+            }
+        }
+    } else {
+        for (uint16_t ch = 1; ch <= 11; ch++) {
+            beerocks::message::sWifiChannel supported_channel;
+            supported_channel.channel           = ch;
+            supported_channel.channel_bandwidth = beerocks::utils::convert_bandwidth_to_enum(20);
+            supported_channel.bss_overlap       = 10;
+            supported_channel.is_dfs_channel    = 0;
+            m_radio_info.supported_channels.push_back(supported_channel);
+        }
     }
     std::string radio_mac;
     beerocks::net::network_utils::linux_iface_get_mac(m_radio_info.iface_name, radio_mac);

--- a/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/ap_wlan_hal.h
@@ -317,7 +317,7 @@ public:
      *
      * @return true on success or false on error.
      */
-    virtual bool read_supported_channels() = 0;
+    virtual bool read_preferred_channels() = 0;
 
     /*!
      * Set Transmit Power Limit 

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -101,7 +101,7 @@ struct RadioInfo {
     std::basic_string<uint8_t>
         vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
     ChanSwReason last_csa_sw_reason = ChanSwReason::Unknown;
-    std::vector<WiFiChannel> supported_channels;
+    std::vector<WiFiChannel> preferred_channels;
     std::unordered_map<int, VAPElement> available_vaps; // key = vap_id
 };
 

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -45,16 +45,6 @@ enum class AntMode { Invalid = 0, ANT_1X1, ANT_2X2, ANT_3X3, ANT_4X4 };
 
 enum class WiFiChanBW { Invalid = 0, BW_20 = 20, BW_40 = 40, BW_80 = 80 };
 
-struct WiFiChannel {
-    int channel;
-    int bandwidth;
-    int noise;
-    int tx_pow;
-    int bss_overlap;
-    bool is_dfs;
-    bool radar_affected;
-};
-
 struct VAPElement {
     std::string ssid;
     std::string mac;
@@ -101,7 +91,7 @@ struct RadioInfo {
     std::basic_string<uint8_t>
         vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
     ChanSwReason last_csa_sw_reason = ChanSwReason::Unknown;
-    std::vector<WiFiChannel> preferred_channels;
+    std::vector<beerocks::message::sWifiChannel> preferred_channels;
     std::unordered_map<int, VAPElement> available_vaps; // key = vap_id
 };
 

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -92,6 +92,7 @@ struct RadioInfo {
         vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
     ChanSwReason last_csa_sw_reason = ChanSwReason::Unknown;
     std::vector<beerocks::message::sWifiChannel> preferred_channels;
+    std::vector<beerocks::message::sWifiChannel> supported_channels;
     std::unordered_map<int, VAPElement> available_vaps; // key = vap_id
 };
 

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -454,17 +454,16 @@ bool ap_wlan_hal_nl80211::read_preferred_channels()
         LOG(TRACE) << "Failed to get channels info from nl80211";
         return false;
     }
-    std::vector<bwl::WiFiChannel> preferred_channels;
+    std::vector<beerocks::message::sWifiChannel> preferred_channels;
     for (auto const &band : radio_info.bands) {
         for (auto const &pair : band.supported_channels) {
             auto &channel_info = pair.second;
             for (auto bw : channel_info.supported_bandwidths) {
-                bwl::WiFiChannel channel;
-                channel.channel   = channel_info.number;
-                channel.bandwidth = beerocks::utils::convert_bandwidth_to_int(bw);
-                channel.tx_pow    = channel_info.tx_power;
-                channel.is_dfs    = channel_info.is_dfs;
-                preferred_channels.push_back(channel);
+                beerocks::message::sWifiChannel channel;
+                channel.channel           = channel_info.number;
+                channel.channel_bandwidth = bw;
+                channel.tx_pow            = channel_info.tx_power;
+                channel.is_dfs_channel    = channel_info.is_dfs;
             }
         }
     }

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -439,11 +439,11 @@ bool ap_wlan_hal_nl80211::read_acs_report()
 {
     LOG(TRACE) << __func__ << " for interface: " << get_radio_info().iface_name;
 
-    return read_supported_channels();
+    return read_preferred_channels();
 }
 
 // based on print_channels_handler() iw/phy.c
-bool ap_wlan_hal_nl80211::read_supported_channels()
+bool ap_wlan_hal_nl80211::read_preferred_channels()
 {
     auto ifname = get_radio_info().iface_name;
     LOG(TRACE) << "for interface: " << ifname;
@@ -454,7 +454,7 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
         LOG(TRACE) << "Failed to get channels info from nl80211";
         return false;
     }
-    std::vector<bwl::WiFiChannel> supported_channels;
+    std::vector<bwl::WiFiChannel> preferred_channels;
     for (auto const &band : radio_info.bands) {
         for (auto const &pair : band.supported_channels) {
             auto &channel_info = pair.second;
@@ -464,16 +464,16 @@ bool ap_wlan_hal_nl80211::read_supported_channels()
                 channel.bandwidth = beerocks::utils::convert_bandwidth_to_int(bw);
                 channel.tx_pow    = channel_info.tx_power;
                 channel.is_dfs    = channel_info.is_dfs;
-                supported_channels.push_back(channel);
+                preferred_channels.push_back(channel);
             }
         }
     }
 
     // Clear the supported channels vector
-    m_radio_info.supported_channels.clear();
+    m_radio_info.preferred_channels.clear();
     // Resize the supported channels vector
-    m_radio_info.supported_channels.insert(m_radio_info.supported_channels.begin(),
-                                           supported_channels.begin(), supported_channels.end());
+    m_radio_info.preferred_channels.insert(m_radio_info.preferred_channels.begin(),
+                                           preferred_channels.begin(), preferred_channels.end());
     return true;
 }
 

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
@@ -66,7 +66,7 @@ public:
     virtual bool restricted_channels_set(char *channel_list) override;
     virtual bool restricted_channels_get(char *channel_list) override;
     virtual bool read_acs_report() override;
-    virtual bool read_supported_channels() override;
+    virtual bool read_preferred_channels() override;
     virtual bool set_tx_power_limit(int tx_pow_limit) override;
     virtual std::string get_radio_driver_version() override;
     virtual bool set_vap_enable(const std::string &iface_name, const bool enable) override;

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -634,7 +634,7 @@ bool base_wlan_hal_nl80211::refresh_radio_info()
     parsed_obj_map_t reply;
 
     /**
-     * Obtain frequency band and maximum supported bandwidth using NL80211.
+     * Obtain frequency band, maximum supported bandwidth and supported channels using NL80211.
      * As this information does not change, this is required the first time this method is called
      * only.
      */
@@ -653,6 +653,18 @@ bool base_wlan_hal_nl80211::refresh_radio_info()
                 m_radio_info.vht_capability = band_info.vht_capability;
                 m_radio_info.vht_mcs_set.assign(band_info.vht_mcs_set,
                                                 sizeof(band_info.vht_mcs_set));
+
+                for (auto const &pair : band_info.supported_channels) {
+                    auto &channel_info = pair.second;
+                    for (auto bw : channel_info.supported_bandwidths) {
+                        beerocks::message::sWifiChannel channel;
+                        channel.channel           = channel_info.number;
+                        channel.channel_bandwidth = bw;
+                        channel.tx_pow            = channel_info.tx_power;
+                        channel.is_dfs_channel    = channel_info.is_dfs;
+                        m_radio_info.supported_channels.push_back(channel);
+                    }
+                }
             }
         }
     }
@@ -740,7 +752,7 @@ bool base_wlan_hal_nl80211::refresh_radio_info()
     }
 
     return true;
-}
+} // namespace nl80211
 
 bool base_wlan_hal_nl80211::refresh_vaps_info(int id)
 {

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -383,7 +383,7 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION);
         }
         sApChannelSwitch& cs_params();
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -392,8 +392,8 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
-        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
-        size_t m_supported_channels_list_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
+        size_t m_preferred_channels_list_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 
@@ -984,7 +984,7 @@ class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE);
         }
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -992,8 +992,8 @@ class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
-        size_t m_supported_channels_list_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
+        size_t m_preferred_channels_list_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -63,6 +63,9 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
         }
         sNodeHostap& params();
         sApChannelSwitch& cs_params();
+        uint8_t& supported_channels_size();
+        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels(size_t idx);
+        bool alloc_supported_channels(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -72,6 +75,10 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
         eActionOp_APMANAGER* m_action_op = nullptr;
         sNodeHostap* m_params = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
+        uint8_t* m_supported_channels_size = nullptr;
+        beerocks::message::sWifiChannel* m_supported_channels = nullptr;
+        size_t m_supported_channels_idx__ = 0;
+        int m_lock_order_counter__ = 0;
 };
 
 class cACTION_APMANAGER_ENABLE_APS_REQUEST : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -383,7 +383,9 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION);
         }
         sApChannelSwitch& cs_params();
-        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
+        uint8_t& preferred_channels_size();
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
+        bool alloc_preferred_channels(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -392,8 +394,9 @@ class cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION : public BaseClass
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
-        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
-        size_t m_preferred_channels_list_idx__ = 0;
+        uint8_t* m_preferred_channels_size = nullptr;
+        beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
+        size_t m_preferred_channels_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 
@@ -984,7 +987,9 @@ class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
         static eActionOp_APMANAGER get_action_op(){
             return (eActionOp_APMANAGER)(ACTION_APMANAGER_READ_ACS_REPORT_RESPONSE);
         }
-        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
+        uint8_t& preferred_channels_size();
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
+        bool alloc_preferred_channels(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -992,8 +997,9 @@ class cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_APMANAGER* m_action_op = nullptr;
-        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
-        size_t m_preferred_channels_list_idx__ = 0;
+        uint8_t* m_preferred_channels_size = nullptr;
+        beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
+        size_t m_preferred_channels_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -152,7 +152,9 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint32_t& vht_capability();
         uint8_t* vht_mcs_set(size_t idx = 0);
         bool set_vht_mcs_set(const void* buffer, size_t size);
-        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
+        uint8_t& preferred_channels_size();
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
+        bool alloc_preferred_channels(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -186,8 +188,9 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint32_t* m_vht_capability = nullptr;
         uint8_t* m_vht_mcs_set = nullptr;
         size_t m_vht_mcs_set_idx__ = 0;
-        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
-        size_t m_preferred_channels_list_idx__ = 0;
+        uint8_t* m_preferred_channels_size = nullptr;
+        beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
+        size_t m_preferred_channels_idx__ = 0;
 };
 
 class cACTION_BACKHAUL_CONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_backhaul.h
@@ -152,7 +152,7 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint32_t& vht_capability();
         uint8_t* vht_mcs_set(size_t idx = 0);
         bool set_vht_mcs_set(const void* buffer, size_t size);
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels_list(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels_list(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -186,8 +186,8 @@ class cACTION_BACKHAUL_ENABLE : public BaseClass
         uint32_t* m_vht_capability = nullptr;
         uint8_t* m_vht_mcs_set = nullptr;
         size_t m_vht_mcs_set_idx__ = 0;
-        beerocks::message::sWifiChannel* m_supported_channels_list = nullptr;
-        size_t m_supported_channels_list_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels_list = nullptr;
+        size_t m_preferred_channels_list_idx__ = 0;
 };
 
 class cACTION_BACKHAUL_CONNECTED_NOTIFICATION : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -361,7 +361,7 @@ typedef struct sNodeHostap {
     uint32_t vht_capability;
     uint8_t vht_mcs_set[beerocks::message::VHT_MCS_SET_SIZE];
     char driver_version[beerocks::message::WIFI_DRIVER_VER_LENGTH];
-    beerocks::message::sWifiChannel supported_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
+    beerocks::message::sWifiChannel preferred_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
     void struct_swap(){
         iface_mac.struct_swap();
         tlvf_swap(8*sizeof(beerocks::eFreqType), reinterpret_cast<uint8_t*>(&frequency_band));
@@ -369,13 +369,13 @@ typedef struct sNodeHostap {
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&ht_capability));
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&vht_capability));
         for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-            (supported_channels[i]).struct_swap();
+            (preferred_channels[i]).struct_swap();
         }
     }
     void struct_init(){
         iface_mac.struct_init();
             for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
-                (supported_channels[i]).struct_init();
+                (preferred_channels[i]).struct_init();
             }
     }
 } __attribute__((packed)) sNodeHostap;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -538,7 +538,7 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
             return (eActionOp_CONTROL)(ACTION_CONTROL_HOSTAP_ACS_NOTIFICATION);
         }
         sApChannelSwitch& cs_params();
-        std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels(size_t idx);
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -547,8 +547,8 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
-        beerocks::message::sWifiChannel* m_supported_channels = nullptr;
-        size_t m_supported_channels_idx__ = 0;
+        beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
+        size_t m_preferred_channels_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };
 

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_control.h
@@ -538,7 +538,9 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
             return (eActionOp_CONTROL)(ACTION_CONTROL_HOSTAP_ACS_NOTIFICATION);
         }
         sApChannelSwitch& cs_params();
+        uint8_t& preferred_channels_size();
         std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
+        bool alloc_preferred_channels(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -547,6 +549,7 @@ class cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION : public BaseClass
         bool init();
         eActionOp_CONTROL* m_action_op = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
+        uint8_t* m_preferred_channels_size = nullptr;
         beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
         size_t m_preferred_channels_idx__ = 0;
         int m_lock_order_counter__ = 0;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1180,13 +1180,13 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cs_params() {
     return (sApChannelSwitch&)(*m_cs_params);
 }
 
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::supported_channels_list(size_t idx) {
-    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::preferred_channels_list(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
 }
 
 void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
@@ -1194,7 +1194,7 @@ void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_supported_channels_list[i].struct_swap();
+        m_preferred_channels_list[i].struct_swap();
     }
 }
 
@@ -1229,7 +1229,7 @@ size_t cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
     return class_size;
 }
 
@@ -1245,14 +1245,14 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_preferred_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;
@@ -3303,20 +3303,20 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::~cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE() {
 }
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::supported_channels_list(size_t idx) {
-    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::preferred_channels_list(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
 }
 
 void cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_supported_channels_list[i].struct_swap();
+        m_preferred_channels_list[i].struct_swap();
     }
 }
 
@@ -3350,7 +3350,7 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::finalize()
 size_t cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
     return class_size;
 }
 
@@ -3360,14 +3360,14 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_preferred_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -1180,21 +1180,54 @@ sApChannelSwitch& cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::cs_params() {
     return (sApChannelSwitch&)(*m_cs_params);
 }
 
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::preferred_channels_list(size_t idx) {
-    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
+uint8_t& cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::preferred_channels_size() {
+    return (uint8_t&)(*m_preferred_channels_size);
+}
+
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::preferred_channels(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_idx__ > 0) && (m_preferred_channels_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels[ret_idx]);
+}
+
+bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::alloc_preferred_channels(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list preferred_channels, abort!";
+        return false;
+    }
+    size_t len = sizeof(beerocks::message::sWifiChannel) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_preferred_channels[*m_preferred_channels_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_preferred_channels_idx__ += count;
+    *m_preferred_channels_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { 
+        for (size_t i = m_preferred_channels_idx__ - count; i < m_preferred_channels_idx__; i++) { m_preferred_channels[i].struct_init(); }
+    }
+    return true;
 }
 
 void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_preferred_channels_list[i].struct_swap();
+    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+        m_preferred_channels[i].struct_swap();
     }
 }
 
@@ -1229,7 +1262,7 @@ size_t cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
+    class_size += sizeof(uint8_t); // preferred_channels_size
     return class_size;
 }
 
@@ -1245,14 +1278,18 @@ bool cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    m_preferred_channels_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_preferred_channels_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    m_preferred_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
-    if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
+    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    uint8_t preferred_channels_size = *m_preferred_channels_size;
+    m_preferred_channels_idx__ = preferred_channels_size;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size) << ") Failed!";
+        return false;
     }
     if (m_parse__) { class_swap(); }
     return true;
@@ -3303,20 +3340,53 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::~cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE() {
 }
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::preferred_channels_list(size_t idx) {
-    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
+uint8_t& cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::preferred_channels_size() {
+    return (uint8_t&)(*m_preferred_channels_size);
+}
+
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::preferred_channels(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_idx__ > 0) && (m_preferred_channels_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels[ret_idx]);
+}
+
+bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::alloc_preferred_channels(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list preferred_channels, abort!";
+        return false;
+    }
+    size_t len = sizeof(beerocks::message::sWifiChannel) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_preferred_channels[*m_preferred_channels_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_preferred_channels_idx__ += count;
+    *m_preferred_channels_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { 
+        for (size_t i = m_preferred_channels_idx__ - count; i < m_preferred_channels_idx__; i++) { m_preferred_channels[i].struct_init(); }
+    }
+    return true;
 }
 
 void cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_preferred_channels_list[i].struct_swap();
+    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+        m_preferred_channels[i].struct_swap();
     }
 }
 
@@ -3350,7 +3420,7 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::finalize()
 size_t cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
+    class_size += sizeof(uint8_t); // preferred_channels_size
     return class_size;
 }
 
@@ -3360,14 +3430,18 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    m_preferred_channels_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_preferred_channels_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    m_preferred_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
-    if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
+    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    uint8_t preferred_channels_size = *m_preferred_channels_size;
+    m_preferred_channels_idx__ = preferred_channels_size;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size) << ") Failed!";
+        return false;
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -527,13 +527,46 @@ bool cACTION_BACKHAUL_ENABLE::set_vht_mcs_set(const void* buffer, size_t size) {
     std::copy_n(reinterpret_cast<const uint8_t *>(buffer), size, m_vht_mcs_set);
     return true;
 }
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::preferred_channels_list(size_t idx) {
-    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
+uint8_t& cACTION_BACKHAUL_ENABLE::preferred_channels_size() {
+    return (uint8_t&)(*m_preferred_channels_size);
+}
+
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::preferred_channels(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_idx__ > 0) && (m_preferred_channels_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels[ret_idx]);
+}
+
+bool cACTION_BACKHAUL_ENABLE::alloc_preferred_channels(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list preferred_channels, abort!";
+        return false;
+    }
+    size_t len = sizeof(beerocks::message::sWifiChannel) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_preferred_channels[*m_preferred_channels_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_preferred_channels_idx__ += count;
+    *m_preferred_channels_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { 
+        for (size_t i = m_preferred_channels_idx__ - count; i < m_preferred_channels_idx__; i++) { m_preferred_channels[i].struct_init(); }
+    }
+    return true;
 }
 
 void cACTION_BACKHAUL_ENABLE::class_swap()
@@ -546,8 +579,8 @@ void cACTION_BACKHAUL_ENABLE::class_swap()
     tlvf_swap(8*sizeof(beerocks::eWiFiBandwidth), reinterpret_cast<uint8_t*>(m_max_bandwidth));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ht_capability));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_vht_capability));
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_preferred_channels_list[i].struct_swap();
+    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+        m_preferred_channels[i].struct_swap();
     }
 }
 
@@ -600,7 +633,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
     class_size += sizeof(uint8_t); // vht_supported
     class_size += sizeof(uint32_t); // vht_capability
     class_size += beerocks::message::VHT_MCS_SET_SIZE * sizeof(uint8_t); // vht_mcs_set
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
+    class_size += sizeof(uint8_t); // preferred_channels_size
     return class_size;
 }
 
@@ -713,14 +746,18 @@ bool cACTION_BACKHAUL_ENABLE::init()
         return false;
     }
     m_vht_mcs_set_idx__  = beerocks::message::VHT_MCS_SET_SIZE;
-    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    m_preferred_channels_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_preferred_channels_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    m_preferred_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
-    if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
+    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    uint8_t preferred_channels_size = *m_preferred_channels_size;
+    m_preferred_channels_idx__ = preferred_channels_size;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size) << ") Failed!";
+        return false;
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -527,13 +527,13 @@ bool cACTION_BACKHAUL_ENABLE::set_vht_mcs_set(const void* buffer, size_t size) {
     std::copy_n(reinterpret_cast<const uint8_t *>(buffer), size, m_vht_mcs_set);
     return true;
 }
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::supported_channels_list(size_t idx) {
-    bool ret_success = ( (m_supported_channels_list_idx__ > 0) && (m_supported_channels_list_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_BACKHAUL_ENABLE::preferred_channels_list(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_list_idx__ > 0) && (m_preferred_channels_list_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels_list[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels_list[ret_idx]);
 }
 
 void cACTION_BACKHAUL_ENABLE::class_swap()
@@ -547,7 +547,7 @@ void cACTION_BACKHAUL_ENABLE::class_swap()
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ht_capability));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_vht_capability));
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_supported_channels_list[i].struct_swap();
+        m_preferred_channels_list[i].struct_swap();
     }
 }
 
@@ -600,7 +600,7 @@ size_t cACTION_BACKHAUL_ENABLE::get_initial_size()
     class_size += sizeof(uint8_t); // vht_supported
     class_size += sizeof(uint32_t); // vht_capability
     class_size += beerocks::message::VHT_MCS_SET_SIZE * sizeof(uint8_t); // vht_mcs_set
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels_list
+    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels_list
     return class_size;
 }
 
@@ -713,14 +713,14 @@ bool cACTION_BACKHAUL_ENABLE::init()
         return false;
     }
     m_vht_mcs_set_idx__  = beerocks::message::VHT_MCS_SET_SIZE;
-    m_supported_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels_list = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_preferred_channels_list_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels_list->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels_list->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -1879,13 +1879,13 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cs_params() {
     return (sApChannelSwitch&)(*m_cs_params);
 }
 
-std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::supported_channels(size_t idx) {
-    bool ret_success = ( (m_supported_channels_idx__ > 0) && (m_supported_channels_idx__ > idx) );
+std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::preferred_channels(size_t idx) {
+    bool ret_success = ( (m_preferred_channels_idx__ > 0) && (m_preferred_channels_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
     if (!ret_success) {
         TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
     }
-    return std::forward_as_tuple(ret_success, m_supported_channels[ret_idx]);
+    return std::forward_as_tuple(ret_success, m_preferred_channels[ret_idx]);
 }
 
 void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
@@ -1893,7 +1893,7 @@ void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
     tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
     for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-        m_supported_channels[i].struct_swap();
+        m_preferred_channels[i].struct_swap();
     }
 }
 
@@ -1928,7 +1928,7 @@ size_t cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // supported_channels
+    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels
     return class_size;
 }
 
@@ -1944,14 +1944,14 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    m_supported_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
     if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
         return false;
     }
-    m_supported_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
+    m_preferred_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_supported_channels->struct_init(); }
+        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels->struct_init(); }
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -1879,6 +1879,10 @@ sApChannelSwitch& cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::cs_params() {
     return (sApChannelSwitch&)(*m_cs_params);
 }
 
+uint8_t& cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::preferred_channels_size() {
+    return (uint8_t&)(*m_preferred_channels_size);
+}
+
 std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::preferred_channels(size_t idx) {
     bool ret_success = ( (m_preferred_channels_idx__ > 0) && (m_preferred_channels_idx__ > idx) );
     size_t ret_idx = ret_success ? idx : 0;
@@ -1888,11 +1892,40 @@ std::tuple<bool, beerocks::message::sWifiChannel&> cACTION_CONTROL_HOSTAP_ACS_NO
     return std::forward_as_tuple(ret_success, m_preferred_channels[ret_idx]);
 }
 
+bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::alloc_preferred_channels(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list preferred_channels, abort!";
+        return false;
+    }
+    size_t len = sizeof(beerocks::message::sWifiChannel) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_preferred_channels[*m_preferred_channels_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_preferred_channels_idx__ += count;
+    *m_preferred_channels_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    if (!m_parse__) { 
+        for (size_t i = m_preferred_channels_idx__ - count; i < m_preferred_channels_idx__; i++) { m_preferred_channels[i].struct_init(); }
+    }
+    return true;
+}
+
 void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
+    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
         m_preferred_channels[i].struct_swap();
     }
 }
@@ -1928,7 +1961,7 @@ size_t cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::get_initial_size()
 {
     size_t class_size = 0;
     class_size += sizeof(sApChannelSwitch); // cs_params
-    class_size += beerocks::message::SUPPORTED_CHANNELS_LENGTH * sizeof(beerocks::message::sWifiChannel); // preferred_channels
+    class_size += sizeof(uint8_t); // preferred_channels_size
     return class_size;
 }
 
@@ -1944,14 +1977,18 @@ bool cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::init()
         return false;
     }
     if (!m_parse__) { m_cs_params->struct_init(); }
-    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (beerocks::message::SUPPORTED_CHANNELS_LENGTH) << ") Failed!";
+    m_preferred_channels_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_preferred_channels_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
         return false;
     }
-    m_preferred_channels_idx__  = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
-    if (!m_parse__) {
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) { m_preferred_channels->struct_init(); }
+    m_preferred_channels = (beerocks::message::sWifiChannel*)m_buff_ptr__;
+    uint8_t preferred_channels_size = *m_preferred_channels_size;
+    m_preferred_channels_idx__ = preferred_channels_size;
+    if (!buffPtrIncrementSafe(sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(beerocks::message::sWifiChannel) * (preferred_channels_size) << ") Failed!";
+        return false;
     }
     if (m_parse__) { class_swap(); }
     return true;

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -89,9 +89,12 @@ cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION:
 cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION:
   _type: class
   cs_params: sApChannelSwitch
-  preferred_channels_list:
+  preferred_channels_size:
+    _type: uint8_t
+    _length_var: True
+  preferred_channels:
     _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ preferred_channels_size ]
 
 cACTION_APMANAGER_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION:
   _type: class
@@ -215,7 +218,10 @@ cACTION_APMANAGER_READ_ACS_REPORT_REQUEST:
 
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE:
   _type: class
-  preferred_channels_list:
+  preferred_channels_size:
+    _type: uint8_t
+    _length_var: True
+  preferred_channels:
     _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ preferred_channels_size ]
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -27,6 +27,12 @@ cACTION_APMANAGER_JOINED_NOTIFICATION:
   _type: class
   params: sNodeHostap
   cs_params: sApChannelSwitch
+  supported_channels_size:
+    _type: uint8_t
+    _length_var: True
+  supported_channels:
+    _type: beerocks::message::sWifiChannel
+    _length: [ supported_channels_size ]
 
 cACTION_APMANAGER_ENABLE_APS_REQUEST:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -89,7 +89,7 @@ cACTION_APMANAGER_HOSTAP_ACS_ERROR_NOTIFICATION:
 cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION:
   _type: class
   cs_params: sApChannelSwitch
-  supported_channels_list:
+  preferred_channels_list:
     _type: beerocks::message::sWifiChannel
     _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
 
@@ -215,7 +215,7 @@ cACTION_APMANAGER_READ_ACS_REPORT_REQUEST:
 
 cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE:
   _type: class
-  supported_channels_list:
+  preferred_channels_list:
     _type: beerocks::message::sWifiChannel
     _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -66,7 +66,7 @@ cACTION_BACKHAUL_ENABLE:
   vht_mcs_set:
     _type: uint8_t
     _length: [ "beerocks::message::VHT_MCS_SET_SIZE" ]
-  supported_channels_list:
+  preferred_channels_list:
     _type: beerocks::message::sWifiChannel 
     _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_backhaul.yaml
@@ -66,9 +66,12 @@ cACTION_BACKHAUL_ENABLE:
   vht_mcs_set:
     _type: uint8_t
     _length: [ "beerocks::message::VHT_MCS_SET_SIZE" ]
-  preferred_channels_list:
-    _type: beerocks::message::sWifiChannel 
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+  preferred_channels_size:
+    _type: uint8_t
+    _length_var: True
+  preferred_channels:
+    _type: beerocks::message::sWifiChannel
+    _length: [ preferred_channels_size ]
 
 cACTION_BACKHAUL_CONNECTED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -274,7 +274,7 @@ sNodeHostap:
   driver_version:
     _type: char  
     _length: [ "beerocks::message::WIFI_DRIVER_VER_LENGTH" ]
-  supported_channels:
+  preferred_channels:
     _type: beerocks::message::sWifiChannel 
     _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]          
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
@@ -140,9 +140,12 @@ cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION:
 cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION:
   _type: class
   cs_params: sApChannelSwitch 
+  preferred_channels_size:
+    _type: uint8_t
+    _length_var: True
   preferred_channels:
     _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
+    _length: [ preferred_channels_size ]
 
 cACTION_CONTROL_HOSTAP_DFS_CAC_COMPLETED_NOTIFICATION:
   _type: class

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_control.yaml
@@ -140,7 +140,7 @@ cACTION_CONTROL_HOSTAP_ACS_ERROR_NOTIFICATION:
 cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION:
   _type: class
   cs_params: sApChannelSwitch 
-  supported_channels:
+  preferred_channels:
     _type: beerocks::message::sWifiChannel
     _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1248,8 +1248,9 @@ std::string db::get_hostap_supported_channels_string(const std::string &radio_ma
     for (const auto &val : supported_channels) {
         if (val.channel > 0) {
             os << " ch = " << int(val.channel) << " | dfs = " << int(val.is_dfs_channel)
-               << " | tx_pow = " << int(val.tx_pow) << " | noise = " << int(val.noise)
-               << " [dbm] | bss_overlap = " << int(val.bss_overlap) << std::endl;
+               << " | bw = " << int(val.channel_bandwidth) << " | tx_pow = " << int(val.tx_pow)
+               << " | noise = " << int(val.noise) << " [dbm]"
+               << " | bss_overlap = " << int(val.bss_overlap) << std::endl;
         }
     }
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1275,19 +1275,20 @@ bool db::add_hostap_supported_operating_class(const std::string &radio_mac, uint
 {
     auto supported_channels = get_hostap_supported_channels(radio_mac);
     auto channel_set        = wireless_utils::operating_class_to_channel_set(operating_class);
-
+    auto class_bw           = wireless_utils::operating_class_to_bandwidth(operating_class);
     // Update current channels
     for (auto c : channel_set) {
         auto channel = std::find_if(
             supported_channels.begin(), supported_channels.end(),
             [&c](const beerocks::message::sWifiChannel &ch) { return ch.channel == c; });
         if (channel != supported_channels.end()) {
-            channel->tx_pow = tx_power;
-            //TODO fill other channel parameters
+            channel->tx_pow            = tx_power;
+            channel->channel_bandwidth = class_bw;
         } else {
             beerocks::message::sWifiChannel ch;
-            ch.channel = c;
-            ch.tx_pow  = tx_power;
+            ch.channel           = c;
+            ch.tx_pow            = tx_power;
+            ch.channel_bandwidth = class_bw;
             supported_channels.push_back(ch);
         }
     }

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2248,8 +2248,8 @@ bool master_thread::autoconfig_wsc_parse_radio_caps(
         LOG(WARNING) << "operating class info list larger then maximum supported channels";
         operating_classes_list_length = beerocks::message::SUPPORTED_CHANNELS_LENGTH;
     }
+    std::stringstream ss;
     for (int oc_idx = 0; oc_idx < operating_classes_list_length; oc_idx++) {
-        std::stringstream ss;
         auto operating_class_tuple = radio_caps->operating_classes_info_list(oc_idx);
         if (!std::get<0>(operating_class_tuple)) {
             LOG(ERROR) << "getting operating class entry has failed!";
@@ -2277,11 +2277,14 @@ bool master_thread::autoconfig_wsc_parse_radio_caps(
             non_operable_channels.push_back(*channel);
         }
         ss << " }" << std::endl;
-        //        LOG(DEBUG) << ss.str();
         // store operating class in the DB for this hostap
         database.add_hostap_supported_operating_class(
             radio_mac, operating_class, maximum_transmit_power_dbm, non_operable_channels);
     }
+    LOG(DEBUG) << "Radio basic capabilities:" << std::endl
+               << ss.str() << std::endl
+               << "Supported Channels:" << std::endl
+               << database.get_hostap_supported_channels_string(radio_mac);
 
     return true;
 }

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2109,7 +2109,7 @@ bool master_thread::handle_intel_slave_join(
     database.set_node_ipv4(radio_mac, bridge_ipv4);
     database.set_node_manufacturer(radio_mac, "Intel");
 
-    database.set_hostap_supported_channels(radio_mac, notification->hostap().supported_channels,
+    database.set_hostap_supported_channels(radio_mac, notification->hostap().preferred_channels,
                                            message::SUPPORTED_CHANNELS_LENGTH);
 
     if (database.get_node_5ghz_support(radio_mac)) {
@@ -2191,9 +2191,9 @@ bool master_thread::handle_intel_slave_join(
                    << " cs_new_event = " << intptr_t(cs_new_event);
         cs_new_event->hostap_mac = network_utils::mac_from_string(radio_mac);
         cs_new_event->cs_params  = notification->cs_params();
-        for (auto supported_channel : notification->hostap().supported_channels) {
-            if (supported_channel.channel > 0) {
-                LOG(DEBUG) << "supported_channel = " << int(supported_channel.channel);
+        for (auto preferred_channel : notification->hostap().preferred_channels) {
+            if (preferred_channel.channel > 0) {
+                LOG(DEBUG) << "preferred_channel = " << int(preferred_channel.channel);
             }
         }
 
@@ -2567,8 +2567,8 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
             CHANNEL_SELECTION_ALLOCATE_EVENT(channel_selection_task::sAcsResponse_event);
         new_event->hostap_mac         = network_utils::mac_from_string(hostap_mac);
         new_event->cs_params          = notification->cs_params();
-        auto tuple_supported_channels = notification->supported_channels(0);
-        std::copy_n(&std::get<1>(tuple_supported_channels), message::SUPPORTED_CHANNELS_LENGTH,
+        auto tuple_preferred_channels = notification->preferred_channels(0);
+        std::copy_n(&std::get<1>(tuple_preferred_channels), message::SUPPORTED_CHANNELS_LENGTH,
                     new_event->supported_channels);
         tasks.push_event(database.get_channel_selection_task_id(),
                          (int)channel_selection_task::eEvent::ACS_RESPONSE_EVENT,

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2568,7 +2568,7 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
         new_event->hostap_mac         = network_utils::mac_from_string(hostap_mac);
         new_event->cs_params          = notification->cs_params();
         auto tuple_preferred_channels = notification->preferred_channels(0);
-        std::copy_n(&std::get<1>(tuple_preferred_channels), message::SUPPORTED_CHANNELS_LENGTH,
+        std::copy_n(&std::get<1>(tuple_preferred_channels), notification->preferred_channels_size(),
                     new_event->supported_channels);
         tasks.push_event(database.get_channel_selection_task_id(),
                          (int)channel_selection_task::eEvent::ACS_RESPONSE_EVENT,

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2109,9 +2109,6 @@ bool master_thread::handle_intel_slave_join(
     database.set_node_ipv4(radio_mac, bridge_ipv4);
     database.set_node_manufacturer(radio_mac, "Intel");
 
-    database.set_hostap_supported_channels(radio_mac, notification->hostap().preferred_channels,
-                                           message::SUPPORTED_CHANNELS_LENGTH);
-
     if (database.get_node_5ghz_support(radio_mac)) {
         if (notification->low_pass_filter_on()) {
             database.set_hostap_band_capability(radio_mac, beerocks::LOW_SUBBAND_ONLY);


### PR DESCRIPTION
Currently the terminology for the ACS Report uses `supported_channels`, this is incorrect as the `supported_channels` should be used for setting the AP Basic Radio Capabilities.
This causes the ACS Report to also be used for setting the AP Basic Radio Capabilities, when the NL80211's supported channels should be used instead.

To fix this the current `supported_channels` need to be replaced with a more appropriate name for the ACS Report.
And the "real" `supported_channels` need to be retrieved from the NL80211 client, so they can be used in the `son_slave` for the AP Basic Radio Capabilities.

This PR suggests the following steps:
- Rename all uses of `supported_channels` to `preferred_channels` throughout the tree
- Add a new `supported_channels` to the BWL's RadioInfo, and during refresh_radio_info fill it with the NL80211's supported channels.
- Send the new `supported_channels` as part of the AP_JOINED notification
- Use the new `supported_channels` in the `radio_basic_caps`