### PR TITLE
controller: bml: Revive bml_set_wifi_credentials (part 2/2)

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -1124,7 +1124,26 @@ class cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_WIFI_CREDENTIALS_SET_REQUEST);
         }
-        sWifiCredentials& params();
+        sMacAddr& al_mac();
+        uint16_t& authentication_type();
+        uint16_t& encryption_type();
+        uint8_t& bss_type();
+        uint8_t& ssid_size();
+        std::string ssid_str();
+        char* ssid(size_t length = 0);
+        bool set_ssid(const std::string& str);
+        bool set_ssid(const char buffer[], size_t size);
+        bool alloc_ssid(size_t count = 1);
+        uint8_t& network_key_size();
+        std::string network_key_str();
+        char* network_key(size_t length = 0);
+        bool set_network_key(const std::string& str);
+        bool set_network_key(const char buffer[], size_t size);
+        bool alloc_network_key(size_t count = 1);
+        uint8_t& operating_classes_size();
+        uint8_t* operating_classes(size_t idx = 0);
+        bool set_operating_classes(const void* buffer, size_t size);
+        bool alloc_operating_classes(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
         static size_t get_initial_size();
@@ -1132,7 +1151,20 @@ class cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST : public BaseClass
     private:
         bool init();
         eActionOp_BML* m_action_op = nullptr;
-        sWifiCredentials* m_params = nullptr;
+        sMacAddr* m_al_mac = nullptr;
+        uint16_t* m_authentication_type = nullptr;
+        uint16_t* m_encryption_type = nullptr;
+        uint8_t* m_bss_type = nullptr;
+        uint8_t* m_ssid_size = nullptr;
+        char* m_ssid = nullptr;
+        size_t m_ssid_idx__ = 0;
+        int m_lock_order_counter__ = 0;
+        uint8_t* m_network_key_size = nullptr;
+        char* m_network_key = nullptr;
+        size_t m_network_key_idx__ = 0;
+        uint8_t* m_operating_classes_size = nullptr;
+        uint8_t* m_operating_classes = nullptr;
+        size_t m_operating_classes_idx__ = 0;
 };
 
 class cACTION_BML_WIFI_CREDENTIALS_SET_RESPONSE : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -3584,14 +3584,189 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::~cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST() {
 }
-sWifiCredentials& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::params() {
-    return (sWifiCredentials&)(*m_params);
+sMacAddr& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::al_mac() {
+    return (sMacAddr&)(*m_al_mac);
+}
+
+uint16_t& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::authentication_type() {
+    return (uint16_t&)(*m_authentication_type);
+}
+
+uint16_t& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::encryption_type() {
+    return (uint16_t&)(*m_encryption_type);
+}
+
+uint8_t& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::bss_type() {
+    return (uint8_t&)(*m_bss_type);
+}
+
+uint8_t& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::ssid_size() {
+    return (uint8_t&)(*m_ssid_size);
+}
+
+std::string cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::ssid_str() {
+    char *ssid_ = ssid();
+    if (!ssid_) { return std::string(); }
+    return std::string(ssid_, m_ssid_idx__);
+}
+
+char* cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::ssid(size_t length) {
+    if( (m_ssid_idx__ == 0) || (m_ssid_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "ssid length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_ssid);
+}
+
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::set_ssid(const std::string& str) { return set_ssid(str.c_str(), str.size()); }
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::set_ssid(const char str[], size_t size) {
+    if (str == nullptr) {
+        TLVF_LOG(WARNING) << "set_ssid received a null pointer.";
+        return false;
+    }
+    if (!alloc_ssid(size)) { return false; }
+    std::copy(str, str + size, m_ssid);
+    return true;
+}
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::alloc_ssid(size_t count) {
+    if (m_lock_order_counter__ > 0) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list ssid, abort!";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 0;
+    uint8_t *src = (uint8_t *)&m_ssid[*m_ssid_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_network_key_size = (uint8_t *)((uint8_t *)(m_network_key_size) + len);
+    m_network_key = (char *)((uint8_t *)(m_network_key) + len);
+    m_operating_classes_size = (uint8_t *)((uint8_t *)(m_operating_classes_size) + len);
+    m_operating_classes = (uint8_t *)((uint8_t *)(m_operating_classes) + len);
+    m_ssid_idx__ += count;
+    *m_ssid_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    return true;
+}
+
+uint8_t& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::network_key_size() {
+    return (uint8_t&)(*m_network_key_size);
+}
+
+std::string cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::network_key_str() {
+    char *network_key_ = network_key();
+    if (!network_key_) { return std::string(); }
+    return std::string(network_key_, m_network_key_idx__);
+}
+
+char* cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::network_key(size_t length) {
+    if( (m_network_key_idx__ == 0) || (m_network_key_idx__ < length) ) {
+        TLVF_LOG(ERROR) << "network_key length is smaller than requested length";
+        return nullptr;
+    }
+    return ((char*)m_network_key);
+}
+
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::set_network_key(const std::string& str) { return set_network_key(str.c_str(), str.size()); }
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::set_network_key(const char str[], size_t size) {
+    if (str == nullptr) {
+        TLVF_LOG(WARNING) << "set_network_key received a null pointer.";
+        return false;
+    }
+    if (!alloc_network_key(size)) { return false; }
+    std::copy(str, str + size, m_network_key);
+    return true;
+}
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::alloc_network_key(size_t count) {
+    if (m_lock_order_counter__ > 1) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list network_key, abort!";
+        return false;
+    }
+    size_t len = sizeof(char) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 1;
+    uint8_t *src = (uint8_t *)&m_network_key[*m_network_key_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_operating_classes_size = (uint8_t *)((uint8_t *)(m_operating_classes_size) + len);
+    m_operating_classes = (uint8_t *)((uint8_t *)(m_operating_classes) + len);
+    m_network_key_idx__ += count;
+    *m_network_key_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    return true;
+}
+
+uint8_t& cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::operating_classes_size() {
+    return (uint8_t&)(*m_operating_classes_size);
+}
+
+uint8_t* cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::operating_classes(size_t idx) {
+    if ( (m_operating_classes_idx__ == 0) || (m_operating_classes_idx__ <= idx) ) {
+        TLVF_LOG(ERROR) << "Requested index is greater than the number of available entries";
+        return nullptr;
+    }
+    return &(m_operating_classes[idx]);
+}
+
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::set_operating_classes(const void* buffer, size_t size) {
+    if (buffer == nullptr) {
+        TLVF_LOG(WARNING) << "set_operating_classes received a null pointer.";
+        return false;
+    }
+    if (!alloc_operating_classes(size)) { return false; }
+    std::copy_n(reinterpret_cast<const uint8_t *>(buffer), size, m_operating_classes);
+    return true;
+}
+bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::alloc_operating_classes(size_t count) {
+    if (m_lock_order_counter__ > 2) {;
+        TLVF_LOG(ERROR) << "Out of order allocation for variable length list operating_classes, abort!";
+        return false;
+    }
+    size_t len = sizeof(uint8_t) * count;
+    if(getBuffRemainingBytes() < len )  {
+        TLVF_LOG(ERROR) << "Not enough available space on buffer - can't allocate";
+        return false;
+    }
+    m_lock_order_counter__ = 2;
+    uint8_t *src = (uint8_t *)&m_operating_classes[*m_operating_classes_size];
+    uint8_t *dst = src + len;
+    if (!m_parse__) {
+        size_t move_length = getBuffRemainingBytes(src) - len;
+        std::copy_n(src, move_length, dst);
+    }
+    m_operating_classes_idx__ += count;
+    *m_operating_classes_size += count;
+    if (!buffPtrIncrementSafe(len)) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << len << ") Failed!";
+        return false;
+    }
+    return true;
 }
 
 void cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
-    m_params->struct_swap();
+    m_al_mac->struct_swap();
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_authentication_type));
+    tlvf_swap(16, reinterpret_cast<uint8_t*>(m_encryption_type));
 }
 
 bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::finalize()
@@ -3624,7 +3799,13 @@ bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::finalize()
 size_t cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(sWifiCredentials); // params
+    class_size += sizeof(sMacAddr); // al_mac
+    class_size += sizeof(uint16_t); // authentication_type
+    class_size += sizeof(uint16_t); // encryption_type
+    class_size += sizeof(uint8_t); // bss_type
+    class_size += sizeof(uint8_t); // ssid_size
+    class_size += sizeof(uint8_t); // network_key_size
+    class_size += sizeof(uint8_t); // operating_classes_size
     return class_size;
 }
 
@@ -3634,12 +3815,66 @@ bool cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_params = (sWifiCredentials*)m_buff_ptr__;
-    if (!buffPtrIncrementSafe(sizeof(sWifiCredentials))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWifiCredentials) << ") Failed!";
+    m_al_mac = (sMacAddr*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(sMacAddr))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sMacAddr) << ") Failed!";
         return false;
     }
-    if (!m_parse__) { m_params->struct_init(); }
+    if (!m_parse__) { m_al_mac->struct_init(); }
+    m_authentication_type = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_encryption_type = (uint16_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint16_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint16_t) << ") Failed!";
+        return false;
+    }
+    m_bss_type = (uint8_t*)m_buff_ptr__;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    m_ssid_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_ssid_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    m_ssid = (char*)m_buff_ptr__;
+    uint8_t ssid_size = *m_ssid_size;
+    m_ssid_idx__ = ssid_size;
+    if (!buffPtrIncrementSafe(sizeof(char) * (ssid_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (ssid_size) << ") Failed!";
+        return false;
+    }
+    m_network_key_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_network_key_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    m_network_key = (char*)m_buff_ptr__;
+    uint8_t network_key_size = *m_network_key_size;
+    m_network_key_idx__ = network_key_size;
+    if (!buffPtrIncrementSafe(sizeof(char) * (network_key_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (network_key_size) << ") Failed!";
+        return false;
+    }
+    m_operating_classes_size = (uint8_t*)m_buff_ptr__;
+    if (!m_parse__) *m_operating_classes_size = 0;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    m_operating_classes = (uint8_t*)m_buff_ptr__;
+    uint8_t operating_classes_size = *m_operating_classes_size;
+    m_operating_classes_idx__ = operating_classes_size;
+    if (!buffPtrIncrementSafe(sizeof(uint8_t) * (operating_classes_size))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) * (operating_classes_size) << ") Failed!";
+        return false;
+    }
     if (m_parse__) { class_swap(); }
     return true;
 }

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -217,7 +217,28 @@ cACTION_BML_CHANGE_MODULE_LOGGING_LEVEL_RESPONSE:
 
 cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST:
   _type: class
-  params: sWifiCredentials
+  al_mac: sMacAddr
+  authentication_type: uint16_t #  eWscAuth
+  encryption_type: uint16_t #  eWscEncr
+  bss_type: uint8_t  #  eWscVendorExtSubelementBssType
+  ssid_size:
+    _type: uint8_t
+    _length_var: True
+  ssid:
+    _type: char
+    _length: [ ssid_size ]
+  network_key_size:
+    _type: uint8_t
+    _length_var: True
+  network_key:
+    _type: char
+    _length: [ network_key_size ]
+  operating_classes_size:
+    _type: uint8_t
+    _length_var: True
+  operating_classes:
+    _type: uint8_t
+    _length: [ operating_classes_size ]
 
 cACTION_BML_WIFI_CREDENTIALS_SET_RESPONSE:
   _type: class

--- a/controller/src/beerocks/bml/bml.h
+++ b/controller/src/beerocks/bml/bml.h
@@ -136,20 +136,19 @@ int bml_stat_register_cb(BML_CTX ctx, BML_STATS_UPDATE_CB cb);
 int bml_event_register_cb(BML_CTX ctx, BML_EVENT_CB cb);
 
 /**
- * Updates the Wi-Fi credentials (for WPA2-Personal policy) for the 
- * beerocks network.
+ * Adds the Wi-Fi credentials tor the beerocks network.
  *
  * @param [in] ctx BML Context.
- * @param [in] ssid[BML_NODE_SSID_LEN] The SSID for the network. ssid array length must be equal to BML_NODE_SSID_LEN
- * @param [in] pass[BML_NODE_PASS_LEN] The WPA2 passphrase for the network. pass array length must be equal to BML_NODE_PASS_LEN
- * @param [in] sec Wi-Fi security/encryption (BML_WLAN_SEC_*).
- * @param [in] vap_id ID of the requested VAP (0 for main VAP).
- * @param [in] force Force update even if not all registered IREs are online.
+ * @param [in] al_mac The agent mac adress.
+ * @param [in] ssid[BML_NODE_SSID_LEN] The SSID for the network. SSID array length must be equal to BML_NODE_SSID_LEN.
+ * @param [in] network_key[BML_NODE_PASS_LEN] The WPA2 passphrase for the network. Pass array length must be equal to BML_NODE_PASS_LEN.
+ * @param [in] bands Can be 24g, 5g, 24g-5g.
+ * @param [in] bss_type BSS, can be fronthaul, backhaul, fronthaul-backhaul.
  *
  * @return BML_RET_OK on success.
  */
-int bml_set_wifi_credentials(BML_CTX ctx, const char *ssid, const char *pass, int sec, int vap_id,
-                             int force);
+int bml_set_wifi_credentials(BML_CTX ctx, const char *al_mac, const char *ssid,
+                             const char *network_key, const char *bands, const char *bss_type);
 /**
  * Removes the Wi-Fi credentials for the client with AL-MAC
  *

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -13,7 +13,6 @@
 
 #include <bcl/beerocks_message_structs.h>
 #include <bcl/beerocks_utils.h>
-#include <bcl/network/network_utils.h>
 #include <easylogging++.h>
 
 #include <beerocks/tlvf/beerocks_message_bml.h>
@@ -773,17 +772,26 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             }
         } break;
         case beerocks_message::ACTION_BML_WIFI_CREDENTIALS_SET_RESPONSE: {
-            auto response =
-                beerocks_header
-                    ->addClass<beerocks_message::cACTION_BML_WIFI_CREDENTIALS_SET_RESPONSE>();
+            if (m_prmWiFiCredentialsSet) {
+                auto response =
+                    beerocks_header
+                        ->addClass<beerocks_message::cACTION_BML_WIFI_CREDENTIALS_SET_RESPONSE>();
 
-            // Signal any waiting threads
-            if (m_prmWiFiCredentialsUpdate) {
-                m_prmWiFiCredentialsUpdate->set_value(response->error_code() == 0);
-                m_prmWiFiCredentialsUpdate = nullptr;
+                if (!response) {
+                    LOG(ERROR) << "addClass cACTION_BML_WIFI_CREDENTIALS_SET_RESPONSE failed";
+                    return BML_RET_OP_FAILED;
+                }
+
+                auto error_code = response->error_code();
+                if (!error_code) {
+                    LOG(WARNING) << "Adding WiFi credentals to the database failed, check "
+                                    "controller log for detailes";
+                }
+                m_prmWiFiCredentialsSet->set_value(response->error_code() == 0);
+                m_prmWiFiCredentialsSet = nullptr;
             } else {
                 LOG(WARNING)
-                    << "Received CREDENTIALS_UPDATE_RESPONSE response, but no one is waiting...";
+                    << "Received CREDENTIALS_SET_RESPONSE response, but no one is waiting...";
             }
         } break;
         case beerocks_message::ACTION_BML_WIFI_CREDENTIALS_CLEAR_RESPONSE: {
@@ -1981,150 +1989,96 @@ int bml_internal::register_event_cb(BML_EVENT_CB pCB)
     return (BML_RET_OK);
 }
 
-int bml_internal::set_wifi_credentials(const std::string ssid, const std::string pass, int sec,
-                                       int vap_id, int force)
+int bml_internal::set_wifi_credentials(const sMacAddr &al_mac,
+                                       const son::wireless_utils::sBssInfoConf &wifi_credentials)
 {
     // If the socket is not valid, attempt to re-establish the connection
     if (m_sockPlatform == nullptr && !connect_to_platform()) {
         return (-BML_RET_CONNECT_FAIL);
     }
 
-    // Validate SSID length
-    // Workaround for SSID containing consecutive spaces or start/ end with spaces
-    if (ssid[0] == ' ' || ssid[ssid.length() - 1] == ' ') {
-        LOG(ERROR) << "Invalid SSID. SSID cannot start or end with space";
-        return (-BML_RET_INVALID_ARGS);
-    }
-    if (ssid.find("  ") != std::string::npos) {
-        LOG(ERROR) << "Invalid SSID. SSID cannot contain consecutive spaces";
-        return (-BML_RET_INVALID_ARGS);
-    }
-
-    // Max length should be 31 chars, need last byte for null char to avoid overflow
-    if (ssid.length() == 0 || ssid.length() >= message::WIFI_SSID_MAX_LENGTH) {
-        LOG(ERROR) << "Invalid SSID (Len = " << int(ssid.length()) << "): " << ssid;
-        return (-BML_RET_INVALID_ARGS);
-    }
-
-    // Validate Pass length
-    // Max length should be 63 chars, need last byte for null char to avoid overflow
-    if (pass.length() == 0 || pass.length() >= message::WIFI_PASS_MAX_LENGTH) {
-        LOG(ERROR) << "Invalid PASS (Len = " << int(pass.length()) << "): " << pass;
-        return (-BML_RET_INVALID_ARGS);
-    }
-
-    // Workaround for password containing consecutive spaces or start/ end with spaces
-    if (pass[0] == ' ' || pass[pass.length() - 1] == ' ') {
-        LOG(ERROR) << "Invalid PASS. Password cannot start or end with space";
-        return (-BML_RET_INVALID_ARGS);
-    }
-    if (pass.find("  ") != std::string::npos) {
-        LOG(ERROR) << "Invalid PASS. Password cannot contain consecutive spaces";
-        return (-BML_RET_INVALID_ARGS);
+    if (!is_local_master()) {
+        LOG(ERROR) << "Command supported only on local master!";
+        return (-BML_RET_OP_NOT_SUPPORTED);
     }
 
     // Initialize the promise for receiving the response
-    beerocks::promise<bool> prmWiFiCredentialsUpdate;
-    m_prmWiFiCredentialsUpdate = &prmWiFiCredentialsUpdate;
-    int iOpTimeout             = 60000; // Default timeout
-
-    // Send to master for credential update
-    LOG(TRACE) << "BML:: Config update prepareing message to send to master";
-
-    // Increase the operation timeout to 3 minutes (for global update)
-    iOpTimeout = 180000;
-
-    // Command supported only on local master
-    if (!is_local_master()) {
-        LOG(ERROR) << "Command supported only on local master!";
-        // Clear the promise holder
-        m_prmWiFiCredentialsUpdate = nullptr;
-        return (-BML_RET_OP_NOT_SUPPORTED);
-    }
+    beerocks::promise<bool> prmWiFiCredentialsSet;
+    m_prmWiFiCredentialsSet = &prmWiFiCredentialsSet;
+    int iOpTimeout          = 60000; // Default timeout
 
     // If the socket is not valid, attempt to re-establish the connection
     if (m_sockMaster == nullptr) {
         int iRet = connect_to_master();
         if (iRet != BML_RET_OK) {
             // Clear the promise holder
-            m_prmWiFiCredentialsUpdate = nullptr;
+            m_prmWiFiCredentialsSet = nullptr;
             return iRet;
         }
     }
 
-    auto config =
+    auto set_request =
         message_com::create_vs_message<beerocks_message::cACTION_BML_WIFI_CREDENTIALS_SET_REQUEST>(
             cmdu_tx);
 
-    if (config == nullptr) {
+    if (set_request == nullptr) {
         LOG(ERROR) << "Failed building ACTION_BML_WIFI_CREDENTIALS_SET_REQUEST message!";
         // Clear the promise holder
-        m_prmWiFiCredentialsUpdate = nullptr;
+        m_prmWiFiCredentialsSet = nullptr;
         return (-BML_RET_OP_FAILED);
     }
 
-    mapf::utils::copy_string(config->params().ssid, ssid.c_str(), message::WIFI_SSID_MAX_LENGTH);
-    mapf::utils::copy_string(config->params().pass, pass.c_str(), message::WIFI_PASS_MAX_LENGTH);
+    set_request->al_mac()              = al_mac;
+    set_request->authentication_type() = uint16_t(wifi_credentials.authentication_type);
+    set_request->encryption_type()     = uint16_t(wifi_credentials.encryption_type);
+    set_request->bss_type()            = uint8_t(wifi_credentials.bss_type);
 
-    switch (sec) {
-    case BML_WLAN_SEC_NONE:
-        config->params().sec = beerocks_message::eWiFiSec_None;
-        break;
-
-    case BML_WLAN_SEC_WEP64:
-        config->params().sec = beerocks_message::eWiFiSec_WEP64;
-        break;
-
-    case BML_WLAN_SEC_WEP128:
-        config->params().sec = beerocks_message::eWiFiSec_WEP128;
-        break;
-
-    case BML_WLAN_SEC_WPA_PSK:
-        config->params().sec = beerocks_message::eWiFiSec_WPA_PSK;
-        break;
-
-    case BML_WLAN_SEC_WPA2_PSK:
-        config->params().sec = beerocks_message::eWiFiSec_WPA2_PSK;
-        break;
-
-    case BML_WLAN_SEC_WPA_WPA2_PSK:
-        config->params().sec = beerocks_message::eWiFiSec_WPA_WPA2_PSK;
-        break;
-
-    default: {
-        LOG(WARNING) << "Unsupported Wi-Fi security: " << sec;
-        // Clear the promise holder
-        m_prmWiFiCredentialsUpdate = nullptr;
-        return (false);
+    auto ssid_size = wifi_credentials.ssid.size();
+    if (!set_request->alloc_ssid(ssid_size)) {
+        LOG(ERROR) << "Failed TLV buffer allocation to size = " << ssid_size;
+        return (-BML_RET_OP_FAILED);
     }
-    }
+    auto ssid = set_request->ssid();
+    std::copy_n(wifi_credentials.ssid.begin(), ssid_size, ssid);
 
-    // Set the rest of the message values
-    config->params().vap_id = uint8_t(vap_id);
-    config->params().force  = (force) ? 1 : 0;
+    auto network_key_size = wifi_credentials.network_key.size();
+    if (!set_request->alloc_network_key(network_key_size)) {
+        LOG(ERROR) << "Failed TLV buffer allocation to size = " << network_key_size;
+        return (-BML_RET_OP_FAILED);
+    }
+    auto network_key = set_request->network_key();
+    std::copy_n(wifi_credentials.network_key.c_str(), network_key_size, network_key);
+
+    auto operating_class_size = wifi_credentials.operating_class.size();
+    if (!set_request->alloc_operating_classes(operating_class_size)) {
+        LOG(ERROR) << "Failed TLV buffer allocation to size = " << operating_class_size;
+        return (-BML_RET_OP_FAILED);
+    }
+    auto operating_class = set_request->operating_classes();
+    std::copy_n(wifi_credentials.operating_class.begin(), operating_class_size, operating_class);
 
     // Build and send the message
-    LOG(TRACE) << "Sending config update message to master";
+    LOG(TRACE) << "Sending set wifi credentials message to master";
 
     if (!message_com::send_cmdu(m_sockMaster, cmdu_tx)) {
-        LOG(ERROR) << "Failed sending configuration update message!";
+        LOG(ERROR) << "Failed sending set wifi credentials message!";
         // Clear the promise holder
-        m_prmWiFiCredentialsUpdate = nullptr;
+        m_prmWiFiCredentialsSet = nullptr;
         return (-BML_RET_OP_FAILED);
     }
 
     int iRet = BML_RET_OK;
 
-    if (!prmWiFiCredentialsUpdate.wait_for(iOpTimeout)) {
-        LOG(WARNING) << "Timeout while waiting for configuration update response...";
+    if (!prmWiFiCredentialsSet.wait_for(iOpTimeout)) {
+        LOG(WARNING) << "Timeout while waiting for set wifi credentials response...";
         iRet = -BML_RET_TIMEOUT;
     }
 
     // Clear the promise holder
-    m_prmWiFiCredentialsUpdate = nullptr;
+    m_prmWiFiCredentialsSet = nullptr;
 
     if (iRet != BML_RET_OK) {
-        LOG(ERROR) << "Configuration update failed!";
+        LOG(ERROR) << "Set wifi credentials failed!";
         return (-BML_RET_OP_FAILED);
     }
 

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -12,6 +12,8 @@
 #include <bcl/beerocks_config_file.h>
 #include <bcl/beerocks_promise.h>
 #include <bcl/beerocks_socket_thread.h>
+#include <bcl/network/network_utils.h>
+#include <bcl/son/son_wireless_utils.h>
 
 #include <beerocks/tlvf/beerocks_message_common.h>
 
@@ -51,9 +53,17 @@ public:
     // Register a callback for events
     int register_event_cb(BML_EVENT_CB pCB);
 
-    // Set the wireless lan SSID and password
-    int set_wifi_credentials(const std::string ssid, const std::string pass, int sec, int vap_id,
-                             int force);
+    /**
+    * @brief Add the Wi-Fi credentials for the beerocks network.
+    * 
+    * @param [in] al_mac The agent mac adress
+    * @param [in] wifi_credentials Structure with credentials (ssid, network_key, etc)
+    * 
+    * @return BML_RET_OK on success.
+    */
+    int set_wifi_credentials(const sMacAddr &al_mac,
+                             const son::wireless_utils::sBssInfoConf &wifi_credentials);
+
     /**
     * @brief Clear wifi credentials for specific AL-MAC
     *
@@ -300,6 +310,7 @@ private:
     beerocks::promise<bool> *m_prmGetVapListCreds       = nullptr;
     beerocks::promise<bool> *m_prmSetVapListCreds       = nullptr;
     beerocks::promise<bool> *m_prmOnboard               = nullptr;
+    beerocks::promise<bool> *m_prmWiFiCredentialsSet    = nullptr;
     beerocks::promise<bool> *m_prmWiFiCredentialsUpdate = nullptr;
     beerocks::promise<bool> *m_prmWiFiCredentialsClear  = nullptr;
     beerocks::promise<bool> *m_prmWiFiCredentialsGet    = nullptr;

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -384,14 +384,16 @@ void cli_bml::setFunctionsMapAndArray()
                        static_cast<pFunction>(&cli_bml::events_register_cb_caller), 0, 1,
                        STRING_ARG);
     insertCommandToMap(
-        "bml_set_wifi_credentials", "<new_ssid> <new_pass> [<security>] [<vap_id>] [<force>]",
-        "Sets new ssid and password for the given VAP."
-        " Security values: 0=No Wi-Fi Security, 1=WEP-64 Encryption, 2=WEP-128 Encryption, "
-        "3=WPA-Personal, 4=WPA2-Personal, 5=WPA-WPA2-Personal Encryption. Default value 4."
-        " Vap default vaule 0."
-        " [<1(True) or 0(False)>] for force. Default value 1",
+        "bml_set_wifi_credentials",
+        "<al_mac> <ssid> [<network_key>] [<operating_class>] [<bss_type>]",
+        "Sets WiFi credentials to the given AL-MAC "
+        "al_mac - agent mac address "
+        "ssid - service set identifier "
+        "network_key - password. If empty, configure open network. Default - empty. "
+        "bands - can be 24g, 5g or 24g-5g. Default - 24g-5g. "
+        "bss_type - can be fronthaul, backhaul, fronthaul-backhaul. Default fronthaul.",
         static_cast<pFunction>(&cli_bml::set_wifi_credentials_caller), 2, 5, STRING_ARG, STRING_ARG,
-        INT_ARG, INT_ARG, INT_ARG);
+        STRING_ARG, STRING_ARG, STRING_ARG);
     insertCommandToMap(
         "bml_clear_wifi_credentials", "<al_mac>", "Removes wifi credentials for specific AL-MAC.",
         static_cast<pFunction>(&cli_bml::clear_wifi_credentials_caller), 1, 1, STRING_ARG);
@@ -926,13 +928,13 @@ int cli_bml::set_wifi_credentials_caller(int numOfArgs)
     if (numOfArgs == 2)
         return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1]);
     else if (numOfArgs == 3)
-        return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1], args.intArgs[2]);
+        return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1], args.stringArgs[2]);
     else if (numOfArgs == 4)
-        return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1], args.intArgs[2],
-                                    args.intArgs[3]);
+        return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1], args.stringArgs[2],
+                                    args.stringArgs[3]);
     else if (numOfArgs == 5)
-        return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1], args.intArgs[2],
-                                    args.intArgs[3], args.intArgs[4]);
+        return set_wifi_credentials(args.stringArgs[0], args.stringArgs[1], args.stringArgs[2],
+                                    args.stringArgs[3], args.stringArgs[4]);
     else
         return -1;
 }
@@ -1373,11 +1375,13 @@ int cli_bml::events_register_cb(const std::string &optional)
     return 0;
 }
 
-int cli_bml::set_wifi_credentials(const std::string &ssid, const std::string &pass, int sec,
-                                  int vap_id, int force)
+int cli_bml::set_wifi_credentials(const std::string &al_mac, const std::string &ssid,
+                                  const std::string &network_key, const std::string &bands,
+                                  const std::string &bss_type)
 {
 
-    int ret = bml_set_wifi_credentials(ctx, ssid.c_str(), pass.c_str(), sec, vap_id, force);
+    int ret = bml_set_wifi_credentials(ctx, al_mac.c_str(), ssid.c_str(), network_key.c_str(),
+                                       bands.c_str(), bss_type.c_str());
 
     printBmlReturnVals("bml_set_wifi_credentials", ret);
     return 0;

--- a/controller/src/beerocks/cli/beerocks_cli_bml.h
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.h
@@ -156,8 +156,10 @@ private:
     int connection_map();
     int stat_register_cb(const std::string &optional = std::string());
     int events_register_cb(const std::string &optional = std::string());
-    int set_wifi_credentials(const std::string &ssid, const std::string &pass, int sec = 4,
-                             int vap_id = 0, int force = 1);
+    int set_wifi_credentials(const std::string &al_mac, const std::string &ssid,
+                             const std::string &network_key = "",
+                             const std::string &bands       = "24g-5g",
+                             const std::string &bss_type    = "fronthaul");
     int clear_wifi_credentials(const std::string &al_mac);
     int update_wifi_credentials(const std::string &al_mac);
     int get_wifi_credentials(int vap_id = 0);

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -171,24 +171,22 @@ class TestFlows:
         # Same test as the previous one but using CLI instead of dev_send_1905
 
         env.beerocks_cli_command('bml_clear_wifi_credentials {}'.format(env.agents[0].mac))
-        # TODO replace with bml_set_wifi_credentials
-        env.controller.cmd_reply(
-            "DEV_SET_CONFIG,bss_info1,"
-            "{} 8x Multi-AP-24G-3 0x0020 0x0008 maprocks1 0 1".format(env.agents[0].mac))
+        env.beerocks_cli_command('bml_set_wifi_credentials {} {} {} {} {}'.format(env.agents[0].mac,
+                                 "Multi-AP-24G-3-cli", "maprocks1", "24g", "fronthaul"))
         env.beerocks_cli_command('bml_update_wifi_credentials {}'.format(env.agents[0].mac))
 
         # Wait a bit for the renew to complete
         time.sleep(3)
 
         self.check_log(env.agents[0].radios[0],
-                       r"Received credentials for ssid: Multi-AP-24G-3 .* bss_type: 2")
+                       r"Received credentials for ssid: Multi-AP-24G-3-cli .* bss_type: 2")
         self.check_log(env.agents[0].radios[1], r".* tear down radio")
         conn_map = connmap.get_conn_map()
         repeater1 = conn_map[env.agents[0].mac]
         repeater1_wlan0 = repeater1.radios[env.agents[0].radios[0].mac]
         for vap in repeater1_wlan0.vaps.values():
-            if vap.ssid not in (b'Multi-AP-24G-3', b'N/A'):
-                self.fail('Wrong SSID: {vap.ssid} instead of Multi-AP-24G-3'.format(vap=vap))
+            if vap.ssid not in (b'Multi-AP-24G-3-cli', b'N/A'):
+                self.fail('Wrong SSID: {vap.ssid} instead of Multi-AP-24G-3-cli'.format(vap=vap))
         repeater1_wlan2 = repeater1.radios[env.agents[0].radios[1].mac]
         for vap in repeater1_wlan2.vaps.values():
             if vap.ssid != b'N/A':


### PR DESCRIPTION
According to the set_credentials UML diagram need to do refactoring for `set_wifi_credentials` API and update command for `beerocks_cli`.
Replace `cmd_reply` in `test_ap_config_bss_tear_down_cli` on the call `bml_set_wifi_credentials` via beerocks_cli.