### PR TITLE
tools: deploy_ipk.sh: restart network before deploy

### DIFF
--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -25,6 +25,14 @@ deploy() {
     IPK_FILENAME="$(basename "$2")"
     DEST_FOLDER=/tmp/prplmesh_ipks
 
+    echo "Stopping prplmesh and restarting netifd on remote"
+    eval ssh "$SSH_OPTIONS" "$TARGET" <<EOF
+# during prplmesh run, it might change hostapd conf files, which may
+# result with a currpot configuration. To avoid this, stop prplmesh
+# and restart netifd so it will re-create the conf files.
+/etc/init.d/prplmesh stop
+/etc/init.d/network restart
+EOF
     echo "Removing previous ipks"
     eval ssh "$SSH_OPTIONS" "$TARGET" \""rm -rf \"$DEST_FOLDER\" ; mkdir -p \"$DEST_FOLDER\"\""
     echo "Copying $IPK to $TARGET:$DEST_FOLDER/$IPK_FILENAME"


### PR DESCRIPTION
The hostapd configuration files are created during initialization by the
netifd in /var/run/hostapd-phyX.conf, before prplMesh is
started.
During autoconfig, prplmesh overrides these files, and runs RECONF on
the hostapd ctrl interface for changes to take effect.

Since the target device is used to test pull requests, it may be that
these files get corrupted after a faulty PR has run. The PR might fail,
but the contents of the files will remain and will cause the next run to
also fail, thus failing a potentially valid PR, or even worse, a full
nightly certification run.

In order to prevent this from happening, restart netifd when deploying
prplmesh.