### PR TITLE
ci: owncloud_definitions.sh: add rootdir

### DIFF
--- a/ci/owncloud/owncloud_definitions.sh
+++ b/ci/owncloud/owncloud_definitions.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
+rootdir="${scriptdir%/*/*}"
+
 # shellcheck source=../../tools/functions.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 


### PR DESCRIPTION
Since commit "633a4032d50141ded8cde64a79c6f4f848feda0d", $rootdir must
be defined to be able to source tools/functions.sh.

Since it was not, every upload to owncloud on the master branch was
failing with:
ci/owncloud/../../tools/functions.sh: line 10: rootdir: parameter null or not set

owncloud_definitions.sh doesn't make any use of rootdir, we only
define it because we need the functions from functions.sh

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>