### PR TITLE
tools: openwrt: update feed-prpl hash

### DIFF
--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -177,7 +177,7 @@ main() {
 IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='30c0f8b1e23a59c3e15c4eb329d5689b55280529'
-PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^fcae5377c6e0d8c64073e47033f131a8e7d1b965'
+PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^9fecb4b331593d15ccc250f6eabc831632481674'
 INTEL_FEED=""
 IWLWAV_FEED=""
 PRPLMESH_VARIANT="-nl80211"


### PR DESCRIPTION
On normal operation, prplmesh is reconfiguring the hostapd as part of
autoconfiguration where it gets the VAPs configuration from the
controller in the WSC M2 message.
When prplmesh is stopped, the wireless configuration should be
reconfigured based on the UCI settings, which is missing now in the
prplmesh init script.

Update feed-prpl hash to include the following merge request which
runs /etc/init.d/network restart to restart the wireless LAN when prplmesh is
stopped - https://git.prpl.dev/prplmesh/feed-prpl/-/merge_requests/2.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>