### PR TITLE
Feature/ci certification use run tests py

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,7 +276,7 @@ run-certification-tests:
             echo "Deploying to $DEVICE_UNDER_TEST"
             tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
         fi
-      - /easymesh_cert/run_test_file.sh -v -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
+      - sudo /easymesh_cert/run_test_file.py -v -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
   artifacts:
     paths:
       - logs

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -3,8 +3,8 @@
     # DEVICE_UNDER_TEST need to be set when extending the job
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplMesh/"
   script:
-    - echo $CI_COMMIT_DESCRIPTION
-    - /easymesh_cert/run_test_file.sh -v -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
+      - echo $CI_COMMIT_DESCRIPTION
+      - sudo /easymesh_cert/run_test_file.py -v -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
   artifacts:
     paths:
       - logs

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Simple wrapper script to easymesh_cert/run_test_file.sh
+# Simple wrapper script to easymesh_cert/run_test_file.py
 # which also updates to the latest prplmesh IPK, run the tests and
 # uploads the results
 ###############################################################
@@ -117,7 +117,7 @@ main() {
     }
     
     info "Start running tests"
-    "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" ${VERBOSE:+ -v}
+    sudo "$EASYMESH_CERT_PATH"/run_test_file.py -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" ${VERBOSE:+ -v}
 
     if [ -n "$OWNCLOUD_UPLOAD" ]; then
         if is_prplmesh_device "$TARGET_DEVICE"; then


### PR DESCRIPTION
Use run_test_file.py instead of run_test_file.sh.

Note:
Uploading to the google sheet is not enabled yet, because it requires https://git.prpl.dev/prplmesh/wfa-certification/easymesh_cert/-/issues/4 to be done first