### PR TITLE
tests: initial_ap_config.py: remove utils.py class

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -3,30 +3,29 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 
-from boardfarm.tests import bft_base_test
-from utils import Utils
+from .prplmesh_base_test import PrplMeshBaseTest
 
 
-class InitialApConfig(bft_base_test.BftBaseTest):
+class InitialApConfig(PrplMeshBaseTest):
     """Check initial configuration on device."""
 
     def runTest(self):
         for dev in self.dev:
             if dev.agent_entity:
-                dev.wired_sniffer.start(self.__class__.__name__)
+                dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
 
-                Utils.check_log(dev.agent_entity.radios[0],
-                                r"WSC Global authentication success")
-                Utils.check_log(dev.agent_entity.radios[1],
-                                r"WSC Global authentication success")
-                Utils.check_log(dev.agent_entity.radios[0],
-                                r"KWA \(Key Wrap Auth\) success")
-                Utils.check_log(dev.agent_entity.radios[1],
-                                r"KWA \(Key Wrap Auth\) success")
-                Utils.check_log(dev.agent_entity.radios[0],
-                                r".* Controller configuration \(WSC M2 Encrypted Settings\)")
-                Utils.check_log(dev.agent_entity.radios[1],
-                                r".* Controller configuration \(WSC M2 Encrypted Settings\)")
+                self.check_log(dev.agent_entity.radios[0],
+                               r"WSC Global authentication success")
+                self.check_log(dev.agent_entity.radios[1],
+                               r"WSC Global authentication success")
+                self.check_log(dev.agent_entity.radios[0],
+                               r"KWA \(Key Wrap Auth\) success")
+                self.check_log(dev.agent_entity.radios[1],
+                               r"KWA \(Key Wrap Auth\) success")
+                self.check_log(dev.agent_entity.radios[0],
+                               r".* Controller configuration \(WSC M2 Encrypted Settings\)")
+                self.check_log(dev.agent_entity.radios[1],
+                               r".* Controller configuration \(WSC M2 Encrypted Settings\)")
 
                 dev.wired_sniffer.stop()
 

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
@@ -5,14 +5,17 @@
 
 from typing import Union
 
+from boardfarm.tests import bft_base_test
 import environment as env
 
 
-class Utils(object):
-    """Collection of common functions used by tests."""
+class PrplMeshBaseTest(bft_base_test.BftBaseTest):
+    """PrplMesh base test case, no actual testing.
 
-    @staticmethod
-    def check_log(entity_or_radio: Union[env.ALEntity, env.Radio], regex: str,
+    Contains common methods used by other(derived) prplmesh test cases.
+    """
+
+    def check_log(self, entity_or_radio: Union[env.ALEntity, env.Radio], regex: str,
                   start_line: int = 0, timeout: float = 0.3) -> bool:
         result, line, match = entity_or_radio.wait_for_log(regex, start_line, timeout)
         if not result:


### PR DESCRIPTION
### Description 

This PR is reaction to discussion of #1136 which was closed too early.

To avoid unnecessary refactoring, we have to be as close as possible to
original `test_flows.py`. Thus,  suggestion to introduce base class for the prplMesh test and derive all other tests from it was raised.

### Changes

- Remove separate `utils.py` and embed its content in
`prplmesh_base_test.py`. 
- Renames in `InitialApConfig` test due to move
of code to `PrplMeshBaseTest` class.