### PR TITLE
Hotfix/certification deploy dummy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,12 +240,7 @@ run-certification-tests:
     # device to test with: prplmesh for dummy bwl, netgear-rax40 for dwpal on rax40
     DEVICE_UNDER_TEST: prplmesh
   script:
-      - |
-        if [ "$DEVICE_UNDER_TEST" != prplmesh ] ; then
-            echo "Deploying to $DEVICE_UNDER_TEST"
-            tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
-        fi
-      - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
+      - ci/run_easymesh_cert.sh --skip-download -o logs -s $DEVICE_UNDER_TEST -d $DEVICE_UNDER_TEST -e /easymesh_cert $TESTS_TO_RUN
   artifacts:
     paths:
       - logs

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -3,8 +3,7 @@
     # DEVICE_UNDER_TEST need to be set when extending the job
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplMesh/"
   script:
-      - echo $CI_COMMIT_DESCRIPTION
-      - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
+      - ci/run_easymesh_cert.sh --skip-download -o logs -s $DEVICE_UNDER_TEST -d $DEVICE_UNDER_TEST -e /easymesh_cert "${CI_JOB_NAME%%:*}"
   artifacts:
     paths:
       - logs

--- a/ci/certification/netgear-rax40.yml
+++ b/ci/certification/netgear-rax40.yml
@@ -3,8 +3,6 @@
   extends: .certification-generic
   variables:
     DEVICE_UNDER_TEST: "netgear-rax40"
-  before_script:
-    - tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
   needs:
     - job: build-for-netgear-rax40
 

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -32,6 +32,7 @@ usage() {
     echo "      --owncloud-upload - whether or not to upload results to owncloud. (default: false)"
     echo "      --owncloud-path - relative path in the owncloud server to upload results to. (default: $OWNCLOUD_PATH)"
     echo "      --skip-upgrade - skip prplmesh upgrade (default: false)"
+    echo "      --skip-download - skip prplmesh download (default: false)"
     echo "'test' can either be a test name, or the path to a file containing"
     echo " test names (newline-separated)."
     echo
@@ -75,24 +76,31 @@ upgrade_prplmesh() {
         echo "skip prplmesh upgrade for non prplmesh device $TARGET_DEVICE"
         return 1
     fi
-    info "download latest ipk"
-    "$TOOLS_PATH"/download_ipk.sh ${VERBOSE:+ -v} || {
-        err "Failed to download prplmesh.ipk, abort"
-        return 1
-    }
-    
+    local ipk_dir="$rootdir/build/$TARGET_DEVICE/"
+
+    if [ "$DOWNLOAD_PRPLMESH" = true ] ; then
+        info "download latest ipk in $ipk_dir"
+        mkdir -p "$ipk_dir"
+        "$TOOLS_PATH"/download_ipk.sh --path "$ipk_dir" ${VERBOSE:+ -v} || {
+            err "Failed to download prplmesh.ipk, abort"
+            return 1
+        }
+    fi
+
     info "prplmesh build info:"
-    cat "$PRPLMESH_BUILDINFO"
+    cat "$ipk_dir/$PRPLMESH_BUILDINFO"
 
     info "deploy latest ipk to $TARGET_DEVICE_SSH"
-    "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$PRPLMESH_IPK" || {
+    "$TOOLS_PATH"/deploy_ipk.sh "$TARGET_DEVICE_SSH" "$ipk_dir/$PRPLMESH_IPK" || {
         err "Failed to deploy prplmesh.ipk, abort"
         return 1
     }
+    mv "$ipk_dir/$PRPLMESH_IPK" "$LOG_FOLDER"
+    mv "$ipk_dir/$PRPLMESH_BUILDINFO" "$LOG_FOLDER"
 }
 
 main() {
-    if ! OPTS=$(getopt -o 'hvb:o:e:d:s:' --long help,verbose,log-folder:,easymesh-cert:,device:,ssh:,owncloud-upload,owncloud-path:,skip-upgrade -n 'parse-options' -- "$@"); then
+    if ! OPTS=$(getopt -o 'hvb:o:e:d:s:' --long help,verbose,log-folder:,easymesh-cert:,device:,ssh:,owncloud-upload,owncloud-path:,skip-upgrade,skip-download -n 'parse-options' -- "$@"); then
         err "Failed parsing options." >&2
         usage
         exit 1
@@ -111,6 +119,7 @@ main() {
             --owncloud-upload)      OWNCLOUD_UPLOAD=true; shift;;
             --owncloud-path)        OWNCLOUD_PATH="$2"; shift 2;;
             --skip-upgrade)         UPGRADE_PRPLMESH=false; shift;;
+            --skip-download)        DOWNLOAD_PRPLMESH=false; shift;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1;;
         esac
@@ -128,8 +137,6 @@ main() {
 
     [ "$UPGRADE_PRPLMESH" = "true" ] && {
         upgrade_prplmesh
-        mv "$PRPLMESH_IPK" "$LOG_FOLDER"
-        mv "$PRPLMESH_BUILDINFO" "$LOG_FOLDER"
     }
     
     info "Start running tests"
@@ -159,5 +166,6 @@ TARGET_DEVICE="netgear-rax40"
 TARGET_DEVICE_SSH="$TARGET_DEVICE-1"
 OWNCLOUD_PATH=Nightly/agent_certification
 UPGRADE_PRPLMESH=true
+DOWNLOAD_PRPLMESH=true
 
 main "$@"

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -141,6 +141,7 @@ main() {
     
     info "Start running tests"
     "$EASYMESH_CERT_PATH"/run_test_file.sh -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" ${VERBOSE:+ -v}
+    test_results="$?"
 
     if [ -n "$OWNCLOUD_UPLOAD" ]; then
         if is_prplmesh_device "$TARGET_DEVICE"; then
@@ -156,6 +157,7 @@ main() {
         success "URL: $(browse_url certification "$OWNCLOUD_PATH/$REMOTE_PATH/$(basename "$LOG_FOLDER")")"
     fi
     info "done"
+    return "$test_results"
 }
 
 PRPLMESH_IPK=prplmesh.ipk

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -9,13 +9,16 @@
 # See LICENSE file for more details.
 ###############################################################
 
+
 scriptdir="$(cd "${0%/*}" && pwd)"
+
+# shellcheck source=./owncloud/owncloud_definitions.sh
+. "$scriptdir/owncloud/owncloud_definitions.sh"
+
 rootdir=$(realpath "$scriptdir/../")
 
 # shellcheck source=../tools/functions.sh
 . "$rootdir/tools/functions.sh"
-# shellcheck source=ci/owncloud/owncloud_definitions.sh
-. "$rootdir/ci/owncloud/owncloud_definitions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hboev] <test> [test]"

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -54,7 +54,20 @@ is_prplmesh_device() {
     return 1
 }
 
+deploy_dummy_prplmesh() {
+    info "Deploy prplmesh locally to /opt/prplMesh"
+    rm -rf /opt/prplMesh
+    mkdir -p /opt/
+    if ! mv "$rootdir/build/install" /opt/prplMesh ; then
+        err "Failed to deploy prplMesh locally, aborting"
+        exit 1
+    fi
+}
+
 upgrade_prplmesh() {
+    if [ "$TARGET_DEVICE" = prplmesh ] ; then
+        deploy_dummy_prplmesh && return 0 || return 1
+    fi
     if ! is_prplmesh_device "$TARGET_DEVICE"; then
         echo "skip prplmesh upgrade for non prplmesh device $TARGET_DEVICE"
         return 1

--- a/tools/download_ipk.sh
+++ b/tools/download_ipk.sh
@@ -72,8 +72,8 @@ main() {
 
     if [ "$REMOTE" = "owncloud" ]; then
         info "Download from owncloud"
-        download_artifact latest/build/"$DEVICE"/prplmesh.ipk
-        download_artifact latest/build/"$DEVICE"/prplmesh.buildinfo
+        download_artifact latest/build/"$DEVICE"/prplmesh.ipk "$DOWNLOAD_PATH"/prplmesh.ipk
+        download_artifact latest/build/"$DEVICE"/prplmesh.buildinfo "$DOWNLOAD_PATH"/prplmesh.buildinfo
     elif [ "$REMOTE" = "gitlab" ]; then
         GITLAB_BASE_URL="https://gitlab.com/prpl-foundation/prplmesh/-/jobs/artifacts/"
         # URL for downloading the prplmesh.ipk according to


### PR DESCRIPTION
We have an issue in the certification testbed where the dummy prplMesh is not always stopped.

This PR deploys the dummy build to /opt/prplMesh, so that it's always accessible on subsequent runs, to fix the issue.

It also uses `ci/run_easymesh_cert.sh` in Gitlab CI, so that both the nightly tests on the intel testbed and the tests in CI use the same script.

It requires the following change in the easymesh_cert repository: https://git.prpl.dev/prplmesh/wfa-certification/easymesh_cert/-/merge_requests/12