### PR TITLE
.gitlab-ci.yml: test-on-target: set a timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,9 +191,11 @@ run-tests:
   artifacts:
     paths:
       - logs
+    expire_in: 4 weeks
     when: always
   tags:
     - targets
+  timeout: 5m
 
 build-for-turris-omnia:
   extends: .build-for-openwrt


### PR DESCRIPTION
When deploying the ipk hangs for some reason, the job will continue to
run until the default timeout is reached (currently 4 hours).
An example of such a job is here:
https://gitlab.com/prpl-foundation/prplMesh/-/jobs/529636776

At the moment we only have one setup that can run those jobs one at a
time. As a result, a hanging job will first cause all the following
ones to be queued. Once the hanging one is finally expired or
canceled, it will take a lot of time for the runner to catch up with
all the queued jobs.

Since we expect prplMesh to be operational after less than a minute,
set the timeout to 5 minute to make it fail early in case it hung.

While we're at it, set the artifact to expire after 4 weeks, since we
don't need to keep them forever.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>