### PR TITLE
tests: openwrt: save hostapd configuration files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,8 +190,7 @@ run-tests:
     - tests/openwrt/test_status.sh $TARGET_DEVICE_NAME
   artifacts:
     paths:
-      - ${TARGET_DEVICE_NAME}_logs.tar.gz
-      - ${TARGET_DEVICE_NAME}_diags.log
+      - logs
     when: always
   tags:
     - targets


### PR DESCRIPTION
We recently had issues with hostapd configuration files not being
updated when prplMesh was reinstalled.

To help debug the issue, we need to save them as artifacts.

While we're at it, we also take the opportunity to make other small
improvements.

tests/openwrt/test_status.sh:

- group all the logs under "logs".

- don't tar the prplMesh logs. While it makes sense to compress them to
  save space and bandwidth, it makes it harder to have a quick look
  when a job is failing.

- add the hostapd configuration files.

- split the connection map and kernel messages in separate files.

.gitlab-ci.yml:

- since all the logs are grouped under /logs, we don't have to specify
  the name of every file anymore.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>