### PR TITLE
Bugfix/fix arp response is not received

### DIFF
--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -1010,7 +1010,7 @@ bool network_utils::arp_send(const std::string &iface, const std::string &dst_ip
     // with broadcast IP, so all clients will receive it and answer, but since the request is
     // being sent to a specific mac address, then only the requested client will answer.
     uint32_t dst_ip_uint;
-    if (dst_ip.empty()) {
+    if (dst_ip.empty() || dst_ip == ZERO_IP_STRING) {
         dst_ip_uint = 0xFFFFFFFF; // "255.255.255.255" equivalent
     } else {
         dst_ip_uint = network_utils::uint_ipv4_from_string(dst_ip);

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -83,7 +83,6 @@ void association_handling_task::work()
          */
 
         std::string new_hostap_mac;
-        std::string ipv4;
 
         new_hostap_mac = database.get_node_parent(sta_mac);
         if (new_hostap_mac != original_parent_mac ||
@@ -105,8 +104,8 @@ void association_handling_task::work()
             return;
         }
 
-        request->params().mac     = network_utils::mac_from_string(sta_mac);
-        request->params().ipv4    = network_utils::ipv4_from_string(ipv4);
+        request->params().mac  = network_utils::mac_from_string(sta_mac);
+        request->params().ipv4 = network_utils::ipv4_from_string(database.get_node_ipv4(sta_mac));
         request->params().channel = database.get_node_channel(sta_mac);
         request->params().vap_id  = database.get_node_vap_id(sta_mac);
         request->params().is_ire  = false;


### PR DESCRIPTION
It is observed that sometimes mon_rssi_want to send arp request, but it doesn't have the
ipv4 of the client. If we don't have the station ipv4, the arp request will not get a response, and sending it to wildcard IP doesn't work apparently.

This PR adds the following:
Fix bug in the updating of the station IP on the Agent.
Fix ipv4 that was unset on start monitoring message.