### PR TITLE
test_gw_repeater.sh: correctly use array for _EXTRA_OPT

### DIFF
--- a/tests/test_gw_repeater.sh
+++ b/tests/test_gw_repeater.sh
@@ -50,8 +50,8 @@ check_wsl() {
     "${rootdir}"/build/install/config/beerocks_agent.conf | \
     awk -F'[= ]' '{ print $2 }')
 
-    GW_EXTRA_OPT="--expose ${GW_UCC_PORT} --publish 127.0.0.1::${GW_UCC_PORT}"
-    RP_EXTRA_OPT="--expose ${RP_UCC_PORT} --publish 127.0.0.1::${RP_UCC_PORT}"
+    GW_EXTRA_OPT=(--expose "${GW_UCC_PORT}" --publish "127.0.0.1::${GW_UCC_PORT}")
+    RP_EXTRA_OPT=(--expose "${RP_UCC_PORT}" --publish "127.0.0.1::${RP_UCC_PORT}")
 }
 
 main() {


### PR DESCRIPTION
Commit c6d6aa05cadc1dae51b678f79d34ce0497b16aff fixed the shellcheck
errors SC2086 about double quoting around the GW_EXTRA_OPT and
RP_EXTRA_OPT variables by using the bash array syntax. However, the
place where those variables are set was not updated to actually create
an array.

Do so now.

This issue was observed by @RanRegev.
Since I don't use WSL myself, I wasn't able to test it.