### PR TITLE
Dev/fix script paths

### DIFF
--- a/ci/cppcheck/cppcheck-new-issues.sh
+++ b/ci/cppcheck/cppcheck-new-issues.sh
@@ -1,24 +1,20 @@
 #!/bin/bash
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
-
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 # generate the list of current issues in the same format as the known issues:
-"$rootdir"/tools/docker/static-analysis/cppcheck.sh "$rootdir" "--template='{file}: {severity}: {message} [{id}]{code}'" > /dev/null 2>&1
+"$ROOT_DIR"/tools/docker/static-analysis/cppcheck.sh "$ROOT_DIR" "--template='{file}: {severity}: {message} [{id}]{code}'" > /dev/null 2>&1
 
-mapfile -t issues < <(grep -E ".+: .+: .+ \[.+\] .*$"  "$rootdir/cppcheck_results.txt")
+mapfile -t issues < <(grep -E ".+: .+: .+ \[.+\] .*$"  "$ROOT_DIR/cppcheck_results.txt")
 
 status=0
 for i in "${issues[@]}"
 do
-    if ! grep -q -F "$i" "$rootdir"/ci/cppcheck/cppcheck_existing_issues.txt ; then
+    if ! grep -q -F "$i" "$ROOT_DIR"/ci/cppcheck/cppcheck_existing_issues.txt ; then
         status=1
         err "New issue:"
-        grep -F -A2 "$i" "$rootdir/cppcheck_results.txt"
+        grep -F -A2 "$i" "$ROOT_DIR/cppcheck_results.txt"
     fi
 done
 

--- a/ci/owncloud/owncloud_definitions.sh
+++ b/ci/owncloud/owncloud_definitions.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 

--- a/ci/owncloud/upload_to_owncloud.sh
+++ b/ci/owncloud/upload_to_owncloud.sh
@@ -6,13 +6,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir=$(cd "${0%/*}" || exit 1; pwd)
-rootdir="${scriptdir%/*/*}"
-
-# shellcheck source=tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+# shellcheck source=../../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 # shellcheck source=ci/owncloud/owncloud_definitions.sh
-. "${rootdir}/ci/owncloud/owncloud_definitions.sh"
+. "${ROOT_DIR}/ci/owncloud/owncloud_definitions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hv] <user> <password> <remote-path> <local-path>"

--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -9,13 +9,10 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir=$(realpath "$scriptdir/../")
-
 # shellcheck source=../tools/functions.sh
-. "$rootdir/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../tools/functions.sh"
 # shellcheck source=ci/owncloud/owncloud_definitions.sh
-. "$rootdir/ci/owncloud/owncloud_definitions.sh"
+. "$ROOT_DIR/ci/owncloud/owncloud_definitions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hboev] <test> [test]"
@@ -126,7 +123,7 @@ main() {
             REMOTE_PATH="certified/$TARGET_DEVICE"
         fi
         info "Uploading $LOG_FOLDER to $OWNCLOUD_PATH/$REMOTE_PATH"
-        "$scriptdir"/owncloud/upload_to_owncloud.sh --direct "$OWNCLOUD_PATH/$REMOTE_PATH" "$LOG_FOLDER" || {
+        "$ROOT_DIR"/ci/owncloud/upload_to_owncloud.sh --direct "$OWNCLOUD_PATH/$REMOTE_PATH" "$LOG_FOLDER" || {
             err "Failed to upload $LOG_FOLDER"
             exit 1
         }
@@ -137,8 +134,8 @@ main() {
 
 PRPLMESH_IPK=prplmesh.ipk
 PRPLMESH_BUILDINFO=prplmesh.buildinfo
-TOOLS_PATH="$rootdir/tools"
-EASYMESH_CERT_PATH=$(realpath "$rootdir/../easymesh_cert")
+TOOLS_PATH="$ROOT_DIR/tools"
+EASYMESH_CERT_PATH=$(realpath "$ROOT_DIR/../easymesh_cert")
 TARGET_DEVICE="netgear-rax40"
 TARGET_DEVICE_SSH="$TARGET_DEVICE-1"
 OWNCLOUD_PATH=Nightly/agent_certification

--- a/cppcheck.sh
+++ b/cppcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir="${scriptdir}"
+# shellcheck source=../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../tools/functions.sh"
 
-docker run --rm -it -w "$rootdir" -v "$rootdir:$rootdir"  prplfoundationinc/prplmesh-builder:alpine-3.11.3 "$rootdir"/tools/docker/static-analysis/cppcheck.sh -j"$(nproc)" .
+docker run --rm -it -w "$ROOT_DIR" -v "$ROOT_DIR:$ROOT_DIR"  prplfoundationinc/prplmesh-builder:alpine-3.11.3 "$ROOT_DIR"/tools/docker/static-analysis/cppcheck.sh -j"$(nproc)" .

--- a/docker-builder.sh
+++ b/docker-builder.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck source=tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/tools/functions.sh"
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-"${scriptdir}/tools/docker/build.sh" "$@"
+"${ROOT_DIR}/tools/docker/build.sh" "$@"

--- a/docker-builder.sh
+++ b/docker-builder.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 
 scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
 "${scriptdir}/tools/docker/build.sh" "$@"

--- a/docker-runner.sh
+++ b/docker-runner.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
 "${scriptdir}/tools/docker/run.sh" "$@"

--- a/docker-runner.sh
+++ b/docker-runner.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-"${scriptdir}/tools/docker/run.sh" "$@"
+# shellcheck source=tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/tools/functions.sh"
+
+"${ROOT_DIR}/tools/docker/run.sh" "$@"

--- a/tests/test_gw_repeater.sh
+++ b/tests/test_gw_repeater.sh
@@ -6,11 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir=$(cd "${0%/*}" || exit 1; pwd)
-rootdir="${scriptdir%/*}"
-
 # shellcheck source=../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "${0}") [-hv] [-d delay]"
@@ -42,12 +39,12 @@ check_wsl() {
     # Read GW & Repeater UCC ports
     local GW_UCC_PORT
     GW_UCC_PORT=$(grep ucc_listener_port \
-    "${rootdir}"/build/install/config/beerocks_controller.conf | \
+    "${ROOT_DIR}"/build/install/config/beerocks_controller.conf | \
     awk -F'[= ]' '{ print $2 }')
 
     local RP_UCC_PORT
     RP_UCC_PORT=$(grep ucc_listener_port \
-    "${rootdir}"/build/install/config/beerocks_agent.conf | \
+    "${ROOT_DIR}"/build/install/config/beerocks_agent.conf | \
     awk -F'[= ]' '{ print $2 }')
 
     GW_EXTRA_OPT="--expose ${GW_UCC_PORT} --publish 127.0.0.1::${GW_UCC_PORT}"
@@ -96,7 +93,7 @@ main() {
 
     [ "$START_GATEWAY" = "true" ] && {
         status "Start GW (Controller + local Agent)"
-        "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" ${VERBOSE_OPT} ${FORCE_OPT} "${GW_EXTRA_OPT[@]}" \
+        "${ROOT_DIR}"/tools/docker/run.sh -u "${UNIQUE_ID}" ${VERBOSE_OPT} ${FORCE_OPT} "${GW_EXTRA_OPT[@]}" \
             start-controller-agent -d -n "${GW_NAME}" -- "$@"
     }
 
@@ -108,7 +105,7 @@ main() {
     [ "$START_REPEATER" = "true" ] && {
         for repeater in $REPEATER_NAMES; do
             status "Start Repeater (Remote Agent): $repeater"
-            "${rootdir}"/tools/docker/run.sh -u "${UNIQUE_ID}" ${VERBOSE_OPT} ${FORCE_OPT} "${RP_EXTRA_OPT[@]}" \
+            "${ROOT_DIR}"/tools/docker/run.sh -u "${UNIQUE_ID}" ${VERBOSE_OPT} ${FORCE_OPT} "${RP_EXTRA_OPT[@]}" \
                 start-agent -d -n "${repeater}" -- "$@"
         done
     }
@@ -118,14 +115,14 @@ main() {
 
     error=0
     [ "$START_GATEWAY" = "true" ] && report "GW operational" \
-        "${rootdir}"/tools/docker/test.sh ${VERBOSE_OPT} -n "${GW_NAME}"
+        "${ROOT_DIR}"/tools/docker/test.sh ${VERBOSE_OPT} -n "${GW_NAME}"
 
 
     [ "$START_REPEATER" = "true" ] && {
         for repeater in $REPEATER_NAMES
         do
             report "Repeater $repeater operational" \
-            "${rootdir}"/tools/docker/test.sh ${VERBOSE_OPT} -n "${repeater}"
+            "${ROOT_DIR}"/tools/docker/test.sh ${VERBOSE_OPT} -n "${repeater}"
         done
     }
 

--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -6,24 +6,21 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 main() {
     docker image inspect prplmesh-builder >/dev/null 2>&1 || {
         echo "Image prplmesh-build does not exist, creating..."
-        run "${scriptdir}"/image-build.sh
+        run "${ROOT_DIR}"/tools/docker/image-build.sh
     }
 
     # Default docker arguments
     docker_args=(
-        --workdir "${rootdir}"
+        --workdir "${ROOT_DIR}"
         --user "${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)}"
         -e "USER=${SUDO_USER:-${USER}}"
-        -v "${rootdir}:${rootdir}"
+        -v "${ROOT_DIR}:${ROOT_DIR}"
         --entrypoint "./tools/maptools.py"
     )
 

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -1,10 +1,7 @@
-#!/bin/sh -e
+#!/bin/bash
 
-scriptdir="$(cd "${0%/*}"; pwd)"
-rootdir="${scriptdir%/*/*/*/*}"
-
-# shellcheck source=tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+# shellcheck source=../../../../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../../../../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "$0") -d <target_device> [-hfiortv]"
@@ -40,7 +37,7 @@ build_image() {
            --build-arg INTEL_FEED \
            --build-arg IWLWAV_FEED \
            --build-arg BASE_CONFIG \
-           "$scriptdir/"
+           "$ROOT_DIR/tools/docker/builder/openwrt"
 }
 
 build_prplmesh() {
@@ -55,8 +52,8 @@ build_prplmesh() {
            -e TARGET_PROFILE \
            -e OPENWRT_VERSION \
            -e PRPLMESH_VERSION \
-           -v "$scriptdir/scripts:/home/openwrt/openwrt/build_scripts/:ro" \
-           -v "${rootdir}:/home/openwrt/prplMesh_source:ro" \
+           -v "$ROOT_DIR/tools/docker/builder/openwrt/scripts:/home/openwrt/openwrt/build_scripts/:ro" \
+           -v "${ROOT_DIR}:/home/openwrt/prplMesh_source:ro" \
            "$image_tag" \
            ./build_scripts/build.sh
     mkdir -p "$build_dir"
@@ -170,7 +167,7 @@ main() {
     fi
 
     build_image
-    build_prplmesh "$rootdir/build/$TARGET_DEVICE"
+    build_prplmesh "$ROOT_DIR/build/$TARGET_DEVICE"
 
 }
 

--- a/tools/docker/builder/rdkb/toolchain/bitbake.sh
+++ b/tools/docker/builder/rdkb/toolchain/bitbake.sh
@@ -6,7 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" || exit; pwd)"
+# shellcheck source=../../../../../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../../../../../tools/functions.sh"
 
 err() {
     printf '\033[1;31m%s\033[0m\n' "$*"
@@ -27,7 +28,7 @@ usage() {
 }
 
 build_image() {
-    docker build --tag rdkb-builder "$scriptdir/"
+    docker build --tag rdkb-builder "$ROOT_DIR/tools/docker/builder/rdkb/toolchain"
 }
 
 main() {

--- a/tools/docker/builder/rdkb/toolchain/bitbake.sh
+++ b/tools/docker/builder/rdkb/toolchain/bitbake.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)

--- a/tools/docker/clang-format.sh
+++ b/tools/docker/clang-format.sh
@@ -6,11 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hvd] [-i ip] [-n name] [-N network]"
@@ -38,15 +35,15 @@ main() {
     docker image inspect prplmesh-runner"$TAG" >/dev/null 2>&1 || {
         [ -n "$TAG" ] && { err "image prplmesh-runner$TAG doesn't exist, aborting"; exit 1; }
         dbg "Image prplmesh-runner$TAG does not exist, creating..."
-        run "${scriptdir}"/image-build.sh
+        run "${ROOT_DIR}"/tools/docker/image-build.sh
     }
 
     dbg "VERBOSE=${VERBOSE}"
     dbg "IMAGE=prplmesh-runner$TAG"
 
     DOCKEROPTS="-e USER=${SUDO_USER:-${USER}}
-                -e SOURCES_DIR=${rootdir}
-                -v ${rootdir}:${rootdir}
+                -e SOURCES_DIR=${ROOT_DIR}
+                -v ${ROOT_DIR}:${ROOT_DIR}
                 --user=${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)}
                 --name prplMesh-clang-format"
 
@@ -55,7 +52,7 @@ main() {
     # TODO: replace DOCKEROPTS with a bash array (and require bash)
     # We disable SC2086 because of the DOCKEROPTS variable
     # shellcheck disable=SC2086
-    run docker container run --entrypoint "${rootdir}/clang-format.sh" ${DOCKEROPTS} prplmesh-builder"$TAG" "$@"
+    run docker container run --entrypoint "${ROOT_DIR}/clang-format.sh" ${DOCKEROPTS} prplmesh-builder"$TAG" "$@"
 }
 
 VERBOSE=false

--- a/tools/docker/clang-format.sh
+++ b/tools/docker/clang-format.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)

--- a/tools/docker/image-build.sh
+++ b/tools/docker/image-build.sh
@@ -6,11 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hvbt]"
@@ -45,20 +42,20 @@ main() {
 
     dbg "IMAGE=$IMAGE"
     dbg "TAG=$TAG"
-    dbg "rootdir=$rootdir"
+    dbg "ROOT_DIR=$ROOT_DIR"
 
     info "Base docker image $IMAGE"
     info "Generating builder docker image (prplmesh-builder$TAG)"
     run docker image build \
         --build-arg image="$IMAGE" \
         --tag "prplmesh-builder$TAG" \
-        "${scriptdir}/builder"
+        "${ROOT_DIR}/tools/docker/builder"
 
     info "Generating runner docker image (prplmesh-runner$TAG)"
     run docker image build \
         --build-arg image="$IMAGE" \
         --tag "prplmesh-runner$TAG" \
-        "${scriptdir}/runner"
+        "${ROOT_DIR}/tools/docker/runner"
 }
 
 VERBOSE=false

--- a/tools/docker/image-build.sh
+++ b/tools/docker/image-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)

--- a/tools/docker/image-pull.sh
+++ b/tools/docker/image-pull.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)

--- a/tools/docker/image-pull.sh
+++ b/tools/docker/image-pull.sh
@@ -6,11 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hvbt]"
@@ -53,7 +50,7 @@ main() {
     done
 
     dbg "TAG=$TAG"
-    dbg "rootdir=$rootdir"
+    dbg "ROOT_DIR=$ROOT_DIR"
 
     # The registry used in Gitlab has the base image name appended with : converted to -
     base_image="$(echo "$IMAGE" | tr : -)"

--- a/tools/docker/static-analysis/cppcheck.sh
+++ b/tools/docker/static-analysis/cppcheck.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir="${scriptdir%/*/*/*}"
+# shellcheck source=../../../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../../../tools/functions.sh"
 
 # shellcheck source=../../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "${ROOT_DIR}/tools/functions.sh"
 
-OUTPUT_FILE="$rootdir/cppcheck_results.txt"
+OUTPUT_FILE="$ROOT_DIR/cppcheck_results.txt"
 INCLUDES=()
-while IFS='' read -r line; do INCLUDES+=("-I$line"); done < <(find -L "$rootdir/common" "$rootdir/framework" -type d -name include)
+while IFS='' read -r line; do INCLUDES+=("-I$line"); done < <(find -L "$ROOT_DIR/common" "$ROOT_DIR/framework" -type d -name include)
 
 usage() {
     echo "usage: $(basename "$0") <source> [source]"

--- a/tools/docker/stop.sh
+++ b/tools/docker/stop.sh
@@ -11,7 +11,8 @@
 # test scripts.
 #
 
-scriptdir="$(cd "${0%/*}" && pwd)"
+# shellcheck source=../../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hkr]"
@@ -23,7 +24,7 @@ usage() {
 
 main() {
     local stop_cmd remove containers_file
-    containers_file="${scriptdir}/.test_containers"
+    containers_file="${ROOT_DIR}/tools/docker/.test_containers"
     stop_cmd=stop
     if ! OPTS=$(getopt -o 'hkr' --long help,kill,remove -n 'parse-options' -- "$@"); then
         err "Failed parsing options." >&2

--- a/tools/docker/test.sh
+++ b/tools/docker/test.sh
@@ -6,11 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
-. "${rootdir}/tools/functions.sh"
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hv] [-n name]"
@@ -39,7 +36,7 @@ main() {
         esac
     done
 
-    run docker container exec "${NAME}" "${rootdir}/build/install/scripts/prplmesh_utils.sh" status $OPT
+    run docker container exec "${NAME}" "${ROOT_DIR}/build/install/scripts/prplmesh_utils.sh" status $OPT
 }
 
 VERBOSE=false

--- a/tools/download_ipk.sh
+++ b/tools/download_ipk.sh
@@ -5,13 +5,12 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 ###############################################################
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir=$(realpath "$scriptdir/../")
 
-# shellcheck source=functions.sh
-. "$rootdir/tools/functions.sh"
+# shellcheck source=../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../tools/functions.sh"
+
 # shellcheck source=../ci/owncloud/owncloud_definitions.sh
-. "$rootdir/ci/owncloud/owncloud_definitions.sh"
+. "$ROOT_DIR/ci/owncloud/owncloud_definitions.sh"
 
 usage() {
     echo "usage: $(basename "$0") [-hv]"

--- a/tools/functions.sh
+++ b/tools/functions.sh
@@ -6,8 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-# shellcheck disable=SC2034
-installdir="${rootdir:?}/build/install"
+ROOT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")"/..)"
+export ROOT_DIR
 
 dbg() {
     if [ "$VERBOSE" = "true" ]; then echo "$(basename "$0"): $*"; fi

--- a/tools/functions.sh
+++ b/tools/functions.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)

--- a/tools/scripts/deploy.sh
+++ b/tools/scripts/deploy.sh
@@ -6,8 +6,8 @@
 # See LICENSE file for more details.
 ###############################################################
 
-scriptdir="$(cd "${0%/*}" && pwd)"
-rootdir="${scriptdir%/*/*}"
+# shellcheck source=../../tools/functions.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 
 dbg() {
     [ "$VERBOSE" = "true" ] && echo "$@"
@@ -97,7 +97,7 @@ main() {
 }
 
 VERBOSE=false
-BUILD_DIR=${rootdir}/build
+BUILD_DIR=${ROOT_DIR}/build
 DEPLOY=false
 KEEP_CONF=false
 TARGET=

--- a/tools/scripts/deploy.sh
+++ b/tools/scripts/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ###############################################################
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 # SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)


### PR DESCRIPTION
scriptdir and rootdir are defined globally in many of the prplmesh
scripts. Some scripts source other scripts, so these variables make the
scripts extremely fragile, since they may get overriden when sourcing
another script which defines them with the same name.

Update all utility scripts are bash, and use ${BASH_SOURCE[0] once
in the functions.sh script which is meant to be sourced, and export
ROOT_DIR only once so it can be safely used by all other scripts.
Since this is already done for tools/docker/run.sh with installdir,
remove this and update run.sh as the first script to use ROOT_DIR.
Followup commit will update the rest of the script to use ROOT_DIR
without defining global variables which may be overriden by other
sourced scripts.

Note that we use upper case for ROOT_DIR since shellcheck doesn't count
this as error/warning when using an upper case variable in a script if
it is not defined in the same script -
https://github.com/koalaman/shellcheck/wiki/SC2154#rationale.