### PR TITLE
scripts: make owncloud_definitions.sh sourceable

### DIFF
--- a/ci/owncloud/owncloud_definitions.sh
+++ b/ci/owncloud/owncloud_definitions.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-scriptdir="$(cd "${0%/*}" || exit 1; pwd)"
-rootdir="${scriptdir%/*/*}"
-
 # shellcheck source=../../tools/functions.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../../tools/functions.sh"
 

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -8,6 +8,8 @@
 
 scriptdir=$(dirname "$(readlink -f "$0")")
 rootdir=$(realpath "$scriptdir/../..")
+# shellcheck disable=SC2034
+installdir="${rootdir:?}/build/install"
 
 # shellcheck source=tools/functions.sh
 . "${rootdir}/tools/functions.sh"

--- a/tools/functions.sh
+++ b/tools/functions.sh
@@ -6,9 +6,6 @@
 # See LICENSE file for more details.
 ###############################################################
 
-# shellcheck disable=SC2034
-installdir="${rootdir:?}/build/install"
-
 dbg() {
     if [ "$VERBOSE" = "true" ]; then echo "$(basename "$0"): $*"; fi
 }


### PR DESCRIPTION
When a shell script which may be sourced defines a global variable,
things can break easilly if the caller script defines a global variable
with the same name befoure the source directive.

Both functions.sh and owncloud_definitions.sh are sourcable scripts and
therefore this commit removes the global definitions since they are
anyway not needed:
1. functions.sh defines installdir which is only used by run.sh - so
move it there
2. owncloud_definitions.sh declares both scriptdir and rootdir which are
unused (we use BASH_SOURCE[0] to get the path to functions.sh). When
this script is sourced by run_easymesh_cert.sh, it breaks since the
rootdir path is overriden, so remove both.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>