### PR TITLE
.gitlab-ci.yml: use verbose mode when running cert tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,7 +254,7 @@ run-certification-tests:
             echo "Deploying to $DEVICE_UNDER_TEST"
             tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
         fi
-      - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
+      - /easymesh_cert/run_test_file.sh -v -o logs -d $DEVICE_UNDER_TEST $TESTS_TO_RUN
   artifacts:
     paths:
       - logs

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -3,8 +3,8 @@
     # DEVICE_UNDER_TEST need to be set when extending the job
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplMesh/"
   script:
-      - echo $CI_COMMIT_DESCRIPTION
-      - /easymesh_cert/run_test_file.sh -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
+    - echo $CI_COMMIT_DESCRIPTION
+    - /easymesh_cert/run_test_file.sh -v -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
   artifacts:
     paths:
       - logs


### PR DESCRIPTION
It is always useful to see the test's output in runtime, so add verbose
flag.

To make sure this looks OK - first run:
MAP-4.2.1:netgear-rax40

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>