### PR TITLE
Hotfix/rax40 include kernel modules

### DIFF
--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -96,7 +96,6 @@ RUN cp feeds.conf.default feeds.conf \
     : "force regeneration by removing it"; \
     rm -rf tmp \
     && make defconfig \
-    && cat .config \
     && make -j$(nproc) \
     && make package/feeds/prpl/prplmesh/clean
     # note that the result from diffconfig.sh with a minimal

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -92,7 +92,10 @@ RUN cp feeds.conf.default feeds.conf \
     && if [ "$TARGET_PROFILE" = "DEVICE_NETGEAR_RAX40" ] ; then \
         grep -v -E 'CONFIG_SDK|CONFIG_MAKE_TOOLCHAIN' feeds/intel/rax40.profile >> .config ;\
     fi ;\
-    make defconfig \
+    : "Installing intel feed doesn't correctly regenerate kernel .package-info"; \
+    : "force regeneration by removing it"; \
+    rm -rf tmp \
+    && make defconfig \
     && cat .config \
     && make -j$(nproc) \
     && make package/feeds/prpl/prplmesh/clean

--- a/tools/docker/builder/openwrt/scripts/build.sh
+++ b/tools/docker/builder/openwrt/scripts/build.sh
@@ -16,3 +16,4 @@ PRPLMESH_VERSION=${PRPLMESH_VERSION}
 EOT
 find bin -name 'prplmesh*.ipk' -exec cp -v {} "artifacts/prplmesh.ipk" \;
 find bin/targets/"$TARGET_SYSTEM"/"$SUBTARGET"/ -type f -maxdepth 1 -exec cp -v {} "artifacts/" \;
+cp .config artifacts/openwrt.config


### PR DESCRIPTION
- Fix for https://github.com/prplfoundation/prplMesh/issues/1222 (remove the `tmp` folder before generating the full defconfig
- Save the full .config file in the artifacts