### PR TITLE
Hotfix/ci/upload artifacts fix typo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,7 @@ upload-artifacts:
     - |
       if [ $CI_COMMIT_BRANCH = "master" ] ; then
           echo "Updating the 'latest' folder"
-          - ci/owncloud/upload_to_owncloud.sh -v "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" ./build
+          ci/owncloud/upload_to_owncloud.sh -v "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" ./build
           # Copying takes a lot of time, and we want the "latest" folder to be updated
           # "as fast as possible", so we make a copy and move it:
           ci/owncloud/owncloud_definitions.sh move "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" "artifacts/latest"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,13 +124,14 @@ upload-artifacts:
     - ln -s "$CI_OWNCLOUD_PASSWORD" ~/.netrc
     - sed --follow-symlinks -i 's/^/machine ftp.essensium.com login prplmesh-robot-ci password /' ~/.netrc
     - |
-      if [ $CI_COMMIT_BRANCH = "master" ] ; then
-          echo "Updating the 'latest' folder"
-          ci/owncloud/upload_to_owncloud.sh -v "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" ./build
-          # Copying takes a lot of time, and we want the "latest" folder to be updated
-          # "as fast as possible", so we make a copy and move it:
-          ci/owncloud/owncloud_definitions.sh move "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" "artifacts/latest"
-      fi
+      echo "Updating the 'latest' folder"
+      ci/owncloud/upload_to_owncloud.sh -v "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" ./build
+      # Copying takes a lot of time, and we want the "latest" folder to be updated
+      # "as fast as possible", so we make a copy and move it:
+      ci/owncloud/owncloud_definitions.sh move "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" "artifacts/latest"
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'
+      when: on_success
   needs:
     - build-in-docker
     - build-for-netgear-rax40


### PR DESCRIPTION
Fix a typo in the upload-artifacts job.

While we're at it, avoid creating an empty job for branches other than master.