### PR TITLE
agent: monitor: handle both vendor-specific and ieee1905 messages

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -655,6 +655,15 @@ bool monitor_thread::update_ap_stats()
 
 bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
 {
+    if (cmdu_rx.getMessageType() == ieee1905_1::eMessageType::VENDOR_SPECIFIC_MESSAGE) {
+        return handle_cmdu_vs_message(sd, cmdu_rx);
+    }
+
+    return handle_cmdu_ieee1905_1_message(sd, cmdu_rx);
+}
+
+bool monitor_thread::handle_cmdu_vs_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
+{
     auto beerocks_header = message_com::parse_intel_vs_message(cmdu_rx);
     if (beerocks_header == nullptr) {
         LOG(ERROR) << "Not a vendor specific message";
@@ -1307,6 +1316,18 @@ bool monitor_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
     }
 
     return true;
+}
+
+bool monitor_thread::handle_cmdu_ieee1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    auto cmdu_message_type = cmdu_rx.getMessageType();
+
+    switch (cmdu_message_type) {
+    default:
+        LOG(ERROR) << "Unknown CMDU message type: " << std::hex << int(cmdu_message_type);
+    }
+
+    return false;
 }
 
 bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr)

--- a/agent/src/beerocks/monitor/monitor_thread.h
+++ b/agent/src/beerocks/monitor/monitor_thread.h
@@ -111,6 +111,9 @@ private:
 
     std::chrono::steady_clock::time_point m_sta_stats_polling_start_timestamp;
     bool m_sta_stats_polling_completed = true;
+
+    bool handle_cmdu_vs_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_cmdu_ieee1905_1_message(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 } // namespace son
 


### PR DESCRIPTION
Modify handle_cmdu() method to dispatch received CMDU messages to
either handle_cmdu_vs_message() or handle_cmdu_ieee1905_1_message(),
depending on if message is a vendor-specific message or not
respectively.

Signed-off-by: Mario Maz <mmazzapater@gmail.com>