### PR TITLE
tools: builder: openwrt: update to latest prplmesh

### DIFF
--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -177,7 +177,7 @@ main() {
 IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='30c0f8b1e23a59c3e15c4eb329d5689b55280529'
-PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^9fecb4b331593d15ccc250f6eabc831632481674'
+PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^53d1e11003ce318c043c42063bbd2f57d15aac81'
 INTEL_FEED=""
 IWLWAV_FEED=""
 PRPLMESH_VARIANT="-nl80211"


### PR DESCRIPTION
Update to latest prplmesh, and disable acceleration when prplmesh is
started to resolve
https://github.com/prplfoundation/prplMesh/issues/1220.

Relevant merge request in prplwrt -
https://git.prpl.dev/prplmesh/feed-prpl/-/merge_requests/3.

To make sure it fixes the issues with 4.2.3:
MAP-4.2.3_ETH_FH24G:netgear-rax40
MAP-4.2.3_ETH_FH5GL:netgear-rax40
MAP-4.2.3_ETH_FH5GH:netgear-rax40

Fixes #1220

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>