### PR TITLE
hotfix: tlvf: don't use swapped length field in class_swap

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_apmanager.cpp
@@ -162,7 +162,7 @@ void cACTION_APMANAGER_JOINED_NOTIFICATION::class_swap()
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_params->struct_swap();
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_supported_channels_size; i++){
+    for (size_t i = 0; i < m_supported_channels_idx__; i++){
         m_supported_channels[i].struct_swap();
     }
 }
@@ -1285,7 +1285,7 @@ void cACTION_APMANAGER_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+    for (size_t i = 0; i < m_preferred_channels_idx__; i++){
         m_preferred_channels[i].struct_swap();
     }
 }
@@ -3202,7 +3202,7 @@ bool cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::add_wifi_credentials(std
 void cACTION_APMANAGER_WIFI_CREDENTIALS_UPDATE_REQUEST::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < (size_t)*m_wifi_credentials_size; i++){
+    for (size_t i = 0; i < m_wifi_credentials_idx__; i++){
         std::get<1>(wifi_credentials(i)).class_swap();
     }
 }
@@ -3502,7 +3502,7 @@ bool cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::alloc_preferred_channels(size_t
 void cACTION_APMANAGER_READ_ACS_REPORT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_APMANAGER), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+    for (size_t i = 0; i < m_preferred_channels_idx__; i++){
         m_preferred_channels[i].struct_swap();
     }
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_backhaul.cpp
@@ -579,7 +579,7 @@ void cACTION_BACKHAUL_ENABLE::class_swap()
     tlvf_swap(8*sizeof(beerocks::eWiFiBandwidth), reinterpret_cast<uint8_t*>(m_max_bandwidth));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_ht_capability));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_vht_capability));
-    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+    for (size_t i = 0; i < m_preferred_channels_idx__; i++){
         m_preferred_channels[i].struct_swap();
     }
 }
@@ -2087,7 +2087,7 @@ void cACTION_BACKHAUL_ASSOCIATED_STA_LINK_METRICS_RESPONSE::class_swap()
     tlvf_swap(8*sizeof(eActionOp_BACKHAUL), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_sta_mac->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_bssid_info_list_length; i++){
+    for (size_t i = 0; i < m_bssid_info_list_idx__; i++){
         m_bssid_info_list[i].struct_swap();
     }
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_bml.cpp
@@ -4549,7 +4549,7 @@ void cACTION_BML_SET_VAP_LIST_CREDENTIALS_REQUEST::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
-    for (size_t i = 0; i < (size_t)*m_vap_list_size; i++){
+    for (size_t i = 0; i < m_vap_list_idx__; i++){
         m_vap_list[i].struct_swap();
     }
 }
@@ -4746,7 +4746,7 @@ void cACTION_BML_GET_VAP_LIST_CREDENTIALS_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_result));
-    for (size_t i = 0; i < (size_t)*m_vap_list_size; i++){
+    for (size_t i = 0; i < m_vap_list_idx__; i++){
         m_vap_list[i].struct_swap();
     }
 }
@@ -6863,7 +6863,7 @@ bool cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::alloc_results(size_t count) 
 void cACTION_BML_CHANNEL_SCAN_GET_RESULTS_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_BML), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < (size_t)*m_results_size; i++){
+    for (size_t i = 0; i < m_results_idx__; i++){
         m_results[i].struct_swap();
     }
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_control.cpp
@@ -1925,7 +1925,7 @@ void cACTION_CONTROL_HOSTAP_ACS_NOTIFICATION::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
     m_cs_params->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_preferred_channels_size; i++){
+    for (size_t i = 0; i < m_preferred_channels_idx__; i++){
         m_preferred_channels[i].struct_swap();
     }
 }
@@ -2706,10 +2706,10 @@ bool cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
 void cACTION_CONTROL_HOSTAP_STATS_MEASUREMENT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_CONTROL), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < (size_t)*m_ap_stats_size; i++){
+    for (size_t i = 0; i < m_ap_stats_idx__; i++){
         m_ap_stats[i].struct_swap();
     }
-    for (size_t i = 0; i < (size_t)*m_sta_stats_size; i++){
+    for (size_t i = 0; i < m_sta_stats_idx__; i++){
         m_sta_stats[i].struct_swap();
     }
 }

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_monitor.cpp
@@ -1472,7 +1472,7 @@ void cACTION_MONITOR_CLIENT_ASSOCIATED_STA_LINK_METRIC_RESPONSE::class_swap()
     tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_sta_mac->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_bssid_info_list_length; i++){
+    for (size_t i = 0; i < m_bssid_info_list_idx__; i++){
         m_bssid_info_list[i].struct_swap();
     }
 }
@@ -1796,10 +1796,10 @@ bool cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::alloc_sta_stats(size_t c
 void cACTION_MONITOR_HOSTAP_STATS_MEASUREMENT_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_MONITOR), reinterpret_cast<uint8_t*>(m_action_op));
-    for (size_t i = 0; i < (size_t)*m_ap_stats_size; i++){
+    for (size_t i = 0; i < m_ap_stats_idx__; i++){
         m_ap_stats[i].struct_swap();
     }
-    for (size_t i = 0; i < (size_t)*m_sta_stats_size; i++){
+    for (size_t i = 0; i < m_sta_stats_idx__; i++){
         m_sta_stats[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceBridgingCapability.cpp
@@ -107,7 +107,7 @@ bool tlvDeviceBridgingCapability::add_bridging_tuples_list(std::shared_ptr<cMacL
 void tlvDeviceBridgingCapability::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_bridging_tuples_list_length; i++){
+    for (size_t i = 0; i < m_bridging_tuples_list_idx__; i++){
         std::get<1>(bridging_tuples_list(i)).class_swap();
     }
 }
@@ -254,7 +254,7 @@ bool cMacList::alloc_mac_list(size_t count) {
 
 void cMacList::class_swap()
 {
-    for (size_t i = 0; i < (size_t)*m_mac_list_length; i++){
+    for (size_t i = 0; i < m_mac_list_idx__; i++){
         m_mac_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvDeviceInformation.cpp
@@ -112,7 +112,7 @@ void tlvDeviceInformation::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_mac->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_local_interface_list_length; i++){
+    for (size_t i = 0; i < m_local_interface_list_idx__; i++){
         std::get<1>(local_interface_list(i)).class_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/ieee_1905_1/tlvPushButtonEventNotification.cpp
@@ -79,7 +79,7 @@ bool tlvPushButtonEventNotification::alloc_media_type_list(size_t count) {
 void tlvPushButtonEventNotification::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_media_type_list_length; i++){
+    for (size_t i = 0; i < m_media_type_list_idx__; i++){
         m_media_type_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/test/tlvVarList.cpp
@@ -437,10 +437,10 @@ void tlvTestVarList::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_var0));
-    for (size_t i = 0; i < (size_t)*m_simple_list_length; i++){
+    for (size_t i = 0; i < m_simple_list_idx__; i++){
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&m_simple_list[i]));
     }
-    for (size_t i = 0; i < (size_t)*m_complex_list_length; i++){
+    for (size_t i = 0; i < m_complex_list_idx__; i++){
         std::get<1>(complex_list(i)).class_swap();
     }
     if (m_var1_ptr) { m_var1_ptr->class_swap(); }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApMetricQuery.cpp
@@ -79,7 +79,7 @@ bool tlvApMetricQuery::alloc_bssid_list(size_t count) {
 void tlvApMetricQuery::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_bssid_list_length; i++){
+    for (size_t i = 0; i < m_bssid_list_idx__; i++){
         m_bssid_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApOperationalBSS.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApOperationalBSS.cpp
@@ -107,7 +107,7 @@ bool tlvApOperationalBSS::add_radio_list(std::shared_ptr<cRadioInfo> ptr) {
 void tlvApOperationalBSS::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_radio_list_length; i++){
+    for (size_t i = 0; i < m_radio_list_idx__; i++){
         std::get<1>(radio_list(i)).class_swap();
     }
 }
@@ -287,7 +287,7 @@ bool cRadioInfo::add_radio_bss_list(std::shared_ptr<cRadioBssInfo> ptr) {
 void cRadioInfo::class_swap()
 {
     m_radio_uid->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_radio_bss_list_length; i++){
+    for (size_t i = 0; i < m_radio_bss_list_idx__; i++){
         std::get<1>(radio_bss_list(i)).class_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvApRadioBasicCapabilities.cpp
@@ -116,7 +116,7 @@ void tlvApRadioBasicCapabilities::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_operating_classes_info_list_length; i++){
+    for (size_t i = 0; i < m_operating_classes_info_list_idx__; i++){
         std::get<1>(operating_classes_info_list(i)).class_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvAssociatedClients.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvAssociatedClients.cpp
@@ -107,7 +107,7 @@ bool tlvAssociatedClients::add_bss_list(std::shared_ptr<cBssInfo> ptr) {
 void tlvAssociatedClients::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_bss_list_length; i++){
+    for (size_t i = 0; i < m_bss_list_idx__; i++){
         std::get<1>(bss_list(i)).class_swap();
     }
 }
@@ -288,7 +288,7 @@ void cBssInfo::class_swap()
 {
     m_bssid->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_clients_associated_list_length));
-    for (size_t i = 0; i < (size_t)*m_clients_associated_list_length; i++){
+    for (size_t i = 0; i < m_clients_associated_list_idx__; i++){
         std::get<1>(clients_associated_list(i)).class_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvAssociatedStaLinkMetrics.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvAssociatedStaLinkMetrics.cpp
@@ -84,7 +84,7 @@ void tlvAssociatedStaLinkMetrics::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_sta_mac->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_bssid_info_list_length; i++){
+    for (size_t i = 0; i < m_bssid_info_list_idx__; i++){
         m_bssid_info_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvChannelPreference.cpp
@@ -112,7 +112,7 @@ void tlvChannelPreference::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_operating_classes_list_length; i++){
+    for (size_t i = 0; i < m_operating_classes_list_idx__; i++){
         std::get<1>(operating_classes_list(i)).class_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvClientAssociationControlRequest.cpp
@@ -94,7 +94,7 @@ void tlvClientAssociationControlRequest::class_swap()
     m_bssid_to_block_client->struct_swap();
     tlvf_swap(8*sizeof(eAssociationControl), reinterpret_cast<uint8_t*>(m_association_control));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_validity_period_sec));
-    for (size_t i = 0; i < (size_t)*m_sta_list_length; i++){
+    for (size_t i = 0; i < m_sta_list_idx__; i++){
         m_sta_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvMetricReportingPolicy.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvMetricReportingPolicy.cpp
@@ -83,7 +83,7 @@ bool tlvMetricReportingPolicy::alloc_metrics_reporting_conf_list(size_t count) {
 void tlvMetricReportingPolicy::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_metrics_reporting_conf_list_length; i++){
+    for (size_t i = 0; i < m_metrics_reporting_conf_list_idx__; i++){
         m_metrics_reporting_conf_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvOperatingChannelReport.cpp
@@ -89,7 +89,7 @@ void tlvOperatingChannelReport::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_operating_classes_list_length; i++){
+    for (size_t i = 0; i < m_operating_classes_list_idx__; i++){
         m_operating_classes_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvRadioOperationRestriction.cpp
@@ -112,7 +112,7 @@ void tlvRadioOperationRestriction::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
     m_radio_uid->struct_swap();
-    for (size_t i = 0; i < (size_t)*m_operating_classes_list_length; i++){
+    for (size_t i = 0; i < m_operating_classes_list_idx__; i++){
         std::get<1>(operating_classes_list(i)).class_swap();
     }
 }
@@ -271,7 +271,7 @@ bool cRestrictedOperatingClasses::alloc_channel_list(size_t count) {
 
 void cRestrictedOperatingClasses::class_swap()
 {
-    for (size_t i = 0; i < (size_t)*m_channel_list_length; i++){
+    for (size_t i = 0; i < m_channel_list_idx__; i++){
         m_channel_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringPolicy.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringPolicy.cpp
@@ -171,13 +171,13 @@ bool tlvSteeringPolicy::alloc_radio_ap_control_policy_list(size_t count) {
 void tlvSteeringPolicy::class_swap()
 {
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_length));
-    for (size_t i = 0; i < (size_t)*m_local_steering_disallowed_sta_list_length; i++){
+    for (size_t i = 0; i < m_local_steering_disallowed_sta_list_idx__; i++){
         m_local_steering_disallowed_sta_list[i].struct_swap();
     }
-    for (size_t i = 0; i < (size_t)*m_btm_steering_disallowed_sta_list_length; i++){
+    for (size_t i = 0; i < m_btm_steering_disallowed_sta_list_idx__; i++){
         m_btm_steering_disallowed_sta_list[i].struct_swap();
     }
-    for (size_t i = 0; i < (size_t)*m_radio_ap_control_policy_list_length; i++){
+    for (size_t i = 0; i < m_radio_ap_control_policy_list_idx__; i++){
         m_radio_ap_control_policy_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvSteeringRequest.cpp
@@ -144,10 +144,10 @@ void tlvSteeringRequest::class_swap()
     m_request_flags->struct_swap();
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_steering_opportunity_window_sec));
     tlvf_swap(16, reinterpret_cast<uint8_t*>(m_btm_disassociation_timer_ms));
-    for (size_t i = 0; i < (size_t)*m_sta_list_length; i++){
+    for (size_t i = 0; i < m_sta_list_idx__; i++){
         m_sta_list[i].struct_swap();
     }
-    for (size_t i = 0; i < (size_t)*m_target_bssid_list_length; i++){
+    for (size_t i = 0; i < m_target_bssid_list_idx__; i++){
         m_target_bssid_list[i].struct_swap();
     }
 }

--- a/framework/tlvf/tlvf.py
+++ b/framework/tlvf/tlvf.py
@@ -959,9 +959,10 @@ class TlvF:
                     t_name = ("&" if not param_type_info.swap_is_func else "") + ("std::get<1>(%s(i))" % param_name) + ("." if param_type_info.swap_is_func else "")
                 else:
                     t_name = ("&" if not param_type_info.swap_is_func else "") + ("m_%s[i]" % param_name) + ("." if param_type_info.swap_is_func else "")
-                if is_dynamic_len: t_length = ("m_" + param_name + "_idx__")
-                elif is_var_len: t_length = ("(size_t)*m_" + param_meta.length) 
-                else: t_length = str(param_meta.length)
+                if is_dynamic_len or is_var_len:
+                    t_length = ("m_" + param_name + "_idx__")
+                else:
+                    t_length = str(param_meta.length)
                 swap_func_lines.append( "for (size_t i = 0; i < %s; i++){" % (t_length) )
                 swap_func_lines.append( "%s%s%s%s;" % (self.getIndentation(1), param_type_info.swap_prefix, t_name, param_type_info.swap_suffix))
                 swap_func_lines.append( "}")


### PR DESCRIPTION
The class_swap() function for variable length fields generated something like this:

```
       tlvf_swap(16, reinterpret_cast<uint8_t*>(m_foo_length));
      for (size_t i = 0; i < *(m_foo_length); i++){
          std::get<1>(foo(i)).class_swap();
      }
```

In other words, for variable length fields where the length is 16-bit or 
longer, the swap function would iterate over the swapped length. For small
values of length this has no effect except for logging errors like:

```
      --> TLVF: Requested index is greater than the number of available entries
```

However, for larger lengths, it would have the effect of only swapping part
of the list.

Fix this by using the index instead of the length field directly. Since 
variable length fields are only allowed in classes, there is always an 
index field, so we can just as well use it.

This didn't use to be possible because originally the swapping was done 
before parsing. Now, however, swapping is done afterwards and swapping of
the length field is done separately. So also for variable length lists, we
can rely on an up-to-date index field when class_swap is called.