### PR TITLE
Hotfix/exit codes

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -356,7 +356,7 @@ main() {
     # Give write permissions (linux only)
     # shellcheck disable=SC2050
     if [ "@TARGET_PLATFORM@" = "linux" ]; then
-        chmod -R +o+w "/tmp/${SUDO_USER:-${USER}}"
+        chmod -R +o+w "/tmp/${SUDO_USER:-${USER}}" || true
     fi
 }
 


### PR DESCRIPTION
Fix exit codes in prplmesh_utils.sh:
- ~~when running "status", exit immediately with the correct exit code.~~
- when running any other command, don't take the last call to chmod into account (allow it to fail in case the `/tmp/$USER` folder doesn't exist for example).