### PR TITLE
Remove flake8-diff from CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,13 +59,6 @@ flake8:
     - git ls-files -z -- '*.py' ':(exclude)tools/maptools.py' ':(exclude)framework/tlvf/tlvf.py' |
       xargs -0 -t flake8 --verbose
 
-flake8-diff:
-  stage: build
-  image: pipelinecomponents/flake8:f087c4c
-  script:
-    - apk add --update --no-cache git
-    - git diff -U0 origin/master | flake8 --verbose --diff
-
 shellcheck:
   stage: build
   image: koalaman/shellcheck-alpine:v0.7.1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,11 +54,10 @@ cppcheck-diff:
 flake8:
   stage: build
   image: pipelinecomponents/flake8:f087c4c
-  variables:
-    FLAKE8_FILES: "tests/*.py tools/beerocks_analyzer/conf/conf1.py tools/beerocks_analyzer/*.py tools/commands/*.py"
   script:
     - apk add --update --no-cache git
-    - git ls-files -z -- $FLAKE8_FILES | xargs -0 -t flake8 --verbose
+    - git ls-files -z -- '*.py' ':(exclude)tools/maptools.py' ':(exclude)framework/tlvf/tlvf.py' |
+      xargs -0 -t flake8 --verbose
 
 flake8-diff:
   stage: build


### PR DESCRIPTION
flake8-diff is causing trouble when editing tlvf.py (cfr. https://gitlab.com/prpl-foundation/prplMesh/-/jobs/542918185).
Rather than trying to fix the issue, remove the job entirely.
Instead, run flake8 on everything except the two files that are not OK.