### PR TITLE
boardfarm: expose 8002 port in spawned dockerized devices

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -43,7 +43,7 @@ class PrplMeshDocker(PrplMeshBase):
 
         docker_cmd = os.path.join(rootdir, "tools", "docker", "run.sh")
         docker_args = ["--verbose", "--detach", "--force", "--name", self.name,
-                       "--network", self.docker_network]
+                       "--network", self.docker_network, "--expose", "8002"]
 
         if self.role == "controller":
             # Spawn dockerized controller


### PR DESCRIPTION
### Description

During boardfarm tests, port 8002 is used to communicate with dockerized
devices. Currently, it's not exposed. So, test is failing as it's unable
to reach this port.

### Changes

Add `--expose 8002` to call of `run.sh` to allow boardfarm tests to reach this port.