### PR TITLE
bwl: add get_survey_info method

### DIFF
--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
@@ -110,6 +110,24 @@ bool nl80211_client_dummy::get_sta_info(const std::string &interface_name,
     return true;
 }
 
+bool nl80211_client_dummy::get_survey_info(const std::string &interface_name,
+                                           std::vector<sSurveyInfo> &survey_info_list)
+{
+    for (size_t i = 0; i < 8; i++) {
+        sSurveyInfo survey_info;
+
+        survey_info.in_use        = (0 == i);
+        survey_info.frequency_mhz = 2412 + i * 5;
+        survey_info.noise_dbm     = i;
+        survey_info.time_on_ms    = i * 2000;
+        survey_info.time_busy_ms  = i * 1000;
+
+        survey_info_list.push_back(survey_info);
+    }
+
+    return true;
+}
+
 bool nl80211_client_dummy::set_tx_power_limit(const std::string &interface_name, uint32_t limit)
 {
     return true;

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.h
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.h
@@ -61,6 +61,16 @@ public:
                       sta_info &sta_info) override;
 
     /**
+     * @brief Gets dummy survey information.
+     *
+     * @see nl80211_client::get_survey_info
+     *
+     * This implementation returns fixed survey info for the first 8 2.4GHz channels.
+     */
+    bool get_survey_info(const std::string &interface_name,
+                         std::vector<sSurveyInfo> &survey_info_list) override;
+
+    /**
      * @brief Set the tx power limit
      *
      * Set tx power limit for a radio

--- a/common/beerocks/bwl/include/bwl/nl80211_client.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client.h
@@ -298,6 +298,60 @@ public:
     };
 
     /**
+     * @brief Survey information
+     *
+     * Information obtained with NL80211_CMD_GET_SURVEY command through a NL80211 socket.
+     * See NL80211_SURVEY_INFO* in <linux/nl80211.h> for a description of each field.
+     */
+    struct sSurveyInfo {
+        /**
+         * Center frequency of channel.
+         */
+        uint32_t frequency_mhz = 0;
+
+        /**
+         * Channel is currently being used.
+         */
+        bool in_use = false;
+
+        /**
+         * Noise level of channel (u8, dBm).
+         */
+        int8_t noise_dbm = 0;
+
+        /**
+         * Amount of time (in ms) that the radio was turned on (on channel or globally)
+         */
+        uint64_t time_on_ms = 0;
+
+        /**
+         * Amount of the time (in ms) the primary channel was sensed busy (either due to activity
+         * or energy detect).
+         */
+        uint64_t time_busy_ms = 0;
+
+        /**
+         * Amount of time (in ms) the extension channel was sensed busy.
+         */
+        uint64_t time_ext_busy_ms = 0;
+
+        /**
+         * Amount of time (in ms) the radio spent receiving data (on channel or globally)
+         */
+        uint64_t time_rx_ms = 0;
+
+        /**
+         * Amount of time (in ms) the radio spent transmitting data (on channel or globally).
+         */
+        uint64_t time_tx_ms = 0;
+
+        /**
+         * Time (in ms) the radio spent for scan (on this channel or globally).
+         */
+        uint64_t time_scan_ms = 0;
+    };
+
+    /**
      * @brief Class destructor.
      */
     virtual ~nl80211_client() = default;
@@ -342,6 +396,20 @@ public:
      */
     virtual bool get_sta_info(const std::string &interface_name, const sMacAddr &sta_mac_address,
                               sta_info &sta_info) = 0;
+
+    /**
+     * @brief Gets survey information.
+     *
+     * Survey information includes channel occupation and noise level.
+     *
+     * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
+     * @param[out] survey_info_list List of survey information structures, one for each channel,
+     * as returned by the NL80211_CMD_GET_SURVEY command.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_survey_info(const std::string &interface_name,
+                                 std::vector<sSurveyInfo> &survey_info_list) = 0;
 
     /**
      * @brief Set the tx power limit

--- a/common/beerocks/bwl/shared/nl80211_client_impl.h
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.h
@@ -83,6 +83,20 @@ public:
                               sta_info &sta_info) override;
 
     /**
+     * @brief Gets survey information.
+     *
+     * Survey information includes channel occupation and noise level.
+     *
+     * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
+     * @param[out] survey_info_list List of survey information structures, one for each channel,
+     * as returned by the NL80211_CMD_GET_SURVEY command.
+     *
+     * @return True on success and false otherwise.
+     */
+    bool get_survey_info(const std::string &interface_name,
+                         std::vector<sSurveyInfo> &survey_info_list) override;
+
+    /**
      * @brief Set the tx power limit
      *
      * Set tx power limit for a radio


### PR DESCRIPTION
Add a new method to nl80211_client to obtain survey information
(channel occupation and noise level).

This information will later be used to periodically compute channel
utilization and report AP metrics when the difference between computed
value and previous value crosses a configured threshold.

