### PR TITLE
docker: build.sh: add userns keep-id option to be able to run fully unprivileged

### DIFF
--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -17,6 +17,7 @@ main() {
     docker_args=(
         --workdir "${rootdir}"
         --user "${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)}"
+        --userns keep-id
         -e "USER=${SUDO_USER:-${USER}}"
         -v "${rootdir}:${rootdir}"
         --entrypoint "./tools/maptools.py"


### PR DESCRIPTION
The builder docker image could be run completely unprivileged. However, we
do require write access to the build directory which is mounted into the
container. When running unprivileged, the user in the container is not
really the same user as the user outside the container, even if they have
the same ID, because it uses a user namespace. To avoid this, use the
keep-id userns option. This makes sure that for the running user, it really
is the same user inside the container as well.