### PR TITLE
build.sh: set valid value of docker run option --userns

### DIFF
--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -17,7 +17,6 @@ main() {
     docker_args=(
         --workdir "${rootdir}"
         --user "${SUDO_UID:-$(id -u)}:${SUDO_GID:-$(id -g)}"
-        --userns keep-id
         -e "USER=${SUDO_USER:-${USER}}"
         -v "${rootdir}:${rootdir}"
         --entrypoint "./tools/maptools.py"


### PR DESCRIPTION
Latest available Docker version  (19.03.8) on Ubuntu 18.04 from official
Docker APT repo does not support value "keep-id" for docker run option "--userns"

Set "--userns" option value to format acceptable by docker client:
    "keep-id" -> "host:USER_ID"
