### PR TITLE
tests: capi: Fix timeout issue on prplMesh server [HotFix]

### DIFF
--- a/tests/capi.py
+++ b/tests/capi.py
@@ -90,7 +90,8 @@ class UCCSocket:
         self.timeout = timeout
 
     def __enter__(self):
-        self.conn = socket.create_connection((self.host, self.port), self.timeout)
+        self.conn = socket.create_connection((self.host, self.port))
+        self.conn.settimeout(self.timeout)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
### Description

Currently, each one of the tests in test_flows.py causing a timeout error (in prplMesh server only)
This PR is aiming to resolve this issue (maybe temporarily)

### Changes

After exploring online, I found out that others faced the same issue and the solution was to set the timeout value with the `settimeout` method.
For that reason, I did the same and that solved the issue.

Signed-off-by: Coral Malachi <coral.malachi@intel.com>