### PR TITLE
tests: capi.py: UCCSocket use longer timeout

### DIFF
--- a/tests/capi.py
+++ b/tests/capi.py
@@ -72,7 +72,7 @@ class UCCSocket:
     CAPI commands from it.
     """
 
-    def __init__(self, host: str, port: int, timeout: int = 10):
+    def __init__(self, host: str, port: int, timeout: int = 30):
         """Constructor for UCCSocket
 
         Parameters


### PR DESCRIPTION
On prplmesh-s1 (Intel) server, UCC connection now time outs when trying
to reach the controller/agents over CAPI.
One possible reason is that for some reason it now takes longer for the
controller / agents UCC listener to come up.
Fix it by increasing the default timeout in the UCCSocket class.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>