### PR TITLE
deploy_ipk.sh: adding force reinstall in arguments

### DIFF
--- a/tools/deploy_ipk.sh
+++ b/tools/deploy_ipk.sh
@@ -40,7 +40,7 @@ pgrep opkg | xargs kill -SIGINT
 opkg remove --force-depends prplmesh prplmesh-dwpal prplmesh-nl80211
 # currently opkg remove does not remove everything from /opt/prplmesh:
 rm -rf /opt/prplmesh
-opkg install -V2 "$DEST_FOLDER/$IPK_FILENAME"
+opkg install -V2 --force-reinstall "$DEST_FOLDER/$IPK_FILENAME"
 EOF
 
     if [ "$CERTIFICATION_MODE" = true ] ; then


### PR DESCRIPTION
The opkg command in the deploy ipk script doesn't force the install of
the package. As a result, the installation fails when the package
version isn't newer than the current installed package. That might raise
a problem on debug version where the package version doesn't necessarily
aligned with the official versions.

Adding the --force-reinstall argument to opkg solves this issue.

Signed-off-by: Lior Amram <lior.amram@intel.com>