### PR TITLE
Deploy the prplwrt firmwares in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,6 +223,7 @@ run-tests:
     # kill prplmesh on each target to make sure they don't interfere with the test
     - for i in $ALL_TARGETS ; do ssh "$i" 'pgrep -f beerocks | xargs kill -9 2>/dev/null' || true ; done
   script:
+    - tools/deploy_firmware.py --device "$TARGET_DEVICE" --target-name "$TARGET_DEVICE_NAME" --image "$OPENWRT_IMAGE"
     - tools/deploy_ipk.sh $TARGET_DEVICE_NAME "build/$TARGET_DEVICE/"prplmesh.ipk
     - tests/openwrt/test_status.sh $TARGET_DEVICE_NAME
   artifacts:
@@ -232,7 +233,7 @@ run-tests:
     when: always
   tags:
     - targets
-  timeout: 5m
+  timeout: 20m
 
 build-for-turris-omnia:
   extends: .build-for-openwrt
@@ -254,6 +255,7 @@ test-on-turris-omnia:
   variables:
     TARGET_DEVICE: turris-omnia
     TARGET_DEVICE_NAME: turris-omnia-1
+    OPENWRT_IMAGE: openwrt-mvebu-cortexa9-cznic_turris-omnia-sysupgrade.img.gz
   needs: ["build-for-turris-omnia"]
 
 test-on-glinet-b1300:
@@ -261,6 +263,7 @@ test-on-glinet-b1300:
   variables:
     TARGET_DEVICE: glinet-b1300
     TARGET_DEVICE_NAME: glinet-b1300-1
+    OPENWRT_IMAGE: openwrt-ipq40xx-generic-glinet_gl-b1300-squashfs-sysupgrade.bin
   needs: ["build-for-glinet-b1300"]
 
 test-on-netgear-rax40:
@@ -268,6 +271,7 @@ test-on-netgear-rax40:
   variables:
     TARGET_DEVICE: netgear-rax40
     TARGET_DEVICE_NAME: netgear-rax40-1
+    OPENWRT_IMAGE: NETGEAR_RAX40-squashfs-fullimage.img
   needs: ["build-for-netgear-rax40"]
 
 run-certification-tests:
@@ -279,7 +283,8 @@ run-certification-tests:
     DEVICE_UNDER_TEST: prplmesh
   script:
     - |
-      if [ "$DEVICE_UNDER_TEST" != prplmesh ] ; then
+      if [ "$DEVICE_UNDER_TEST" = netgear-rax40 ] ; then
+          tools/deploy_firmware.py --device netgear-rax40 --target-name "$DEVICE_UNDER_TEST" --image NETGEAR_RAX40-squashfs-fullimage.img
           echo "Deploying to $DEVICE_UNDER_TEST"
           tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
       fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+variables:
+  PYTHONUNBUFFERED: "1"
+
 stages:
   - containers
   - build

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -11,4 +11,4 @@
     when: always
   tags:
     - certs-tests
-  timeout: 30min
+  timeout: 45min

--- a/ci/certification/netgear-rax40.yml
+++ b/ci/certification/netgear-rax40.yml
@@ -4,6 +4,7 @@
   variables:
     DEVICE_UNDER_TEST: "netgear-rax40"
   before_script:
+    - tools/deploy_firmware.py --device netgear-rax40 --target-name "$DEVICE_UNDER_TEST" --image NETGEAR_RAX40-squashfs-fullimage.img
     - tools/deploy_ipk.sh --certification-mode $DEVICE_UNDER_TEST build/$DEVICE_UNDER_TEST/prplmesh.ipk
   needs:
     - job: build-for-netgear-rax40

--- a/tools/deploy_firmware.py
+++ b/tools/deploy_firmware.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+
+import time
+import sys
+import os
+import subprocess
+import difflib
+import argparse
+import shutil
+from typing import List
+
+import pexpect
+import pexpect.fdpexpect
+import pexpect.pxssh
+import serial
+
+
+class PrplwrtDevice:
+    """Represents a prplWrt device.
+
+    Offers methods to check if a device needs to be upgraded and to do the actual upgrade.
+
+    It needs to have access to the artifacts of a build job to determine when an upgrade
+    is needed (see `artifacts_dir`).
+    """
+
+    serial_prompt = "_pexpect_prompt_ "
+    """For serial connections we will set this prompt to make it easier to "expect" it."""
+
+    baudrate = 115200
+    """The baudrate of the serial connection to the device."""
+
+    def __init__(self, device: str, name: str, image: str, username: str = "root"):
+        """
+
+        Parameters
+        -----------
+        device: str
+            The name of the platform (example: netgear-rax40).
+        name: str
+            The name of the device (it should ne reachable through ssh without a password).
+        image: str
+            The name of the image that can be used to upgrade the device.
+        username: str, optional
+            The username to use when connecting to the device over SSH.
+        """
+        self.device = device
+        self.name = name
+        self.image = image
+        self.username = username
+
+        self.rootdir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+        self.artifacts_dir = os.path.join(self.rootdir, "build/{}".format(self.device))
+        """The directory where artifacts are stored. It's expected to contain
+        prplwrt-version, and the image file."""
+
+    def set_prompt(self, pexp: pexpect):
+        """Set the prompt to `serial_prompt` on a pexpect object."""
+        pexp.sendline("export PS1='{}'".format(self.serial_prompt))
+
+    def read_remote_version(self) -> List[str]:
+        """Read prplwrt-version on a remote device
+
+        Returns
+        -------
+        List[str]
+            The content of the prplwrt-version file on the device as a list of strings.
+        """
+        version = None
+        with pexpect.pxssh.pxssh(logfile=sys.stdout.buffer) as shell:
+            shell.login(self.name, self.username)
+            shell.sendline("cat /etc/prplwrt-version")
+            shell.expect("cat /etc/prplwrt-version")
+            shell.prompt()
+            # remove the first (empty) line:
+            version = shell.before.decode().splitlines()[1:]
+        return version
+
+    def read_artifacts_dir_version(self) -> List[str]:
+        """Reads the local prplwrt-version.
+
+        The version file is read from the artifacts (see `artifacts_dir`).
+
+        Returns
+        -------
+        List[str]
+            The content of the local prplwrt-version as a list of strings.
+        """
+        with open(os.path.join(self.artifacts_dir, "prplwrt-version")) as version_file:
+            return version_file.read().splitlines()
+
+    def needs_upgrade(self):
+        """Check if a device needs to be updated
+
+        The check is done by comparing prplwrt-version on the target
+        with a local one (see `read_artifacts_dir_version).
+        """
+        artifacts_dir_version = self.read_artifacts_dir_version()
+        remote_version = self.read_remote_version()
+        diff = difflib.unified_diff(artifacts_dir_version, remote_version,
+                                    fromfile='artifacts', tofile='device')
+        diff_str = '\n'.join(diff)
+        if diff_str:
+            print(diff_str)
+        return bool(diff_str)
+
+    def reach(self, attempts: int = 5, wait: int = 5):
+        """Check if the device is reachable via SSH (and optionally try multiple times).
+
+        Parameters
+        ----------
+        attempts: int, optional
+            How many times we try before concluding that the device is unreachable.
+        wait: int, optional
+            The number of seconds to wait between attempts.
+
+        Returns
+        -------
+        bool
+            True if the device is reachable via SSH, false otherwise.
+        """
+        for _ in range(attempts):
+            try:
+                with pexpect.pxssh.pxssh() as shell:
+                    shell.login(self.name, self.username, login_timeout=5)
+                    return True
+            except pexpect.pxssh.ExceptionPxssh:
+                print("Waiting for the device to be reachable")
+                time.sleep(wait)
+        return False
+
+    def sysupgrade(self):
+        """Upgrade the device using sysupgrade."""
+        raise NotImplementedError
+
+    def upgrade_uboot(self):
+        """Upgrade the device through uboot."""
+        raise NotImplementedError
+
+
+class NetgearRax40(PrplwrtDevice):
+    """A Netgear rax40.
+
+    At the moment, the rax40 can only be updated through uboot using a tftp server.
+    """
+
+    tftp_dir = "/srv/tftp"
+    """The root directory of the tftp server. The image will be copied there"""
+
+    uboot_prompt = "GRX500 #"
+    """The u-boot prompt on the target."""
+
+    def upgrade_uboot(self):
+        """Upgrade the device through u-boot.
+
+        It requires a running tftp server listenning on the IP the
+        target device will expect (see `ipaddr` in the uboot environment).
+        """
+        serial_path = "/dev/{}".format(self.name)
+        if not os.path.exists(serial_path):
+            raise ValueError("The serial device {} does not exist!\n".format(serial_path)
+                             + "Please make sure you have an appropriate udev rule for it.")
+        print("Copying image '{}' to '{}'".format(self.image, self.tftp_dir))
+        shutil.copy(os.path.join(self.artifacts_dir, self.image), self.tftp_dir)
+        print("Image copied to {}.".format(self.tftp_dir))
+        with serial.Serial(serial_path, self.baudrate) as ser:
+            print("Connecting to serial")
+            shell = pexpect.fdpexpect.fdspawn(ser, logfile=sys.stdout.buffer)
+            if not shell.isalive():
+                raise ValueError("Unable to connect to the serial device!")
+            print("Connected")
+            # The console might not be active yet:
+            shell.sendline("")
+            # make the shell prompt appear:
+            self.set_prompt(shell)
+            shell.expect(self.serial_prompt)
+            # reboot:
+            shell.sendline("reboot")
+            shell.expect(["Hit any key to stop autoboot:",
+                          pexpect.EOF, pexpect.TIMEOUT], timeout=120)
+            # stop autoboot:
+            shell.sendline("")
+            shell.expect(self.uboot_prompt)
+            # do the actual upgrade:
+            shell.sendline("run update_fullimage")
+            shell.expect(self.uboot_prompt, timeout=600)
+            # reboot:
+            shell.sendline("reset")
+            shell.expect("Please press Enter to activate this console", timeout=180)
+            # activate the console:
+            shell.sendline("")
+            self.set_prompt(shell)
+            shell.expect(self.serial_prompt)
+            shell.sendline("exit")
+        if not self.reach(attempts=10):
+            raise ValueError("The device was not reachable after the upgrade!")
+
+
+class Generic(PrplwrtDevice):
+    """A generic PrplwrtDevice.
+
+    Since upgrading through uboot is generally target-specific, it
+    only offers the sysupgrade option.
+    """
+
+    def sysupgrade(self):
+        serial_path = "/dev/{}".format(self.name)
+        if not os.path.exists(serial_path):
+            raise ValueError("The serial device {} does not exist!\n".format(serial_path)
+                             + "Please make sure you have an appropriate udev rule for it.")
+        print("Copying image '{}' to the target".format(self.image))
+        try:
+            subprocess.check_output(["scp",
+                                     "{}/{}".format(self.artifacts_dir, self.image),
+                                     "{}:/tmp/{}".format(self.name, self.image)])
+        except subprocess.CalledProcessError as exc:
+            print("Failed to copy the image to the target:\n{}".format(exc.output))
+            raise exc
+        with serial.Serial(serial_path, self.baudrate) as ser:
+            print("Connecting to serial")
+            shell = pexpect.fdpexpect.fdspawn(ser, logfile=sys.stdout.buffer)
+            if not shell.isalive():
+                raise ValueError("Unable to connect to the serial device!")
+            print("Connected")
+            # The console might not be active yet:
+            shell.sendline("")
+            # make the shell prompt appear:
+            self.set_prompt(shell)
+            shell.expect(self.serial_prompt)
+            # Do the upgrade
+            shell.sendline("sysupgrade -v /tmp/{}".format(self.image))
+            # first give it 30 seconds, and fail early if the upgrade didn't start:
+            shell.expect(r"Performing system upgrade\.\.\.", timeout=30)
+            # now give it more time to apply the upgrade and reboot:
+            shell.expect(r"Rebooting system\.\.\.", timeout=300)
+            shell.expect("Please press Enter to activate this console", timeout=180)
+            # activate the console:
+            shell.sendline("")
+            self.set_prompt(shell)
+            shell.expect(self.serial_prompt)
+            shell.sendline("exit")
+        if not self.reach(attempts=10):
+            raise ValueError("The device was not reachable after the upgrade!")
+
+
+def main():
+    parser = argparse.ArgumentParser(prog=sys.argv[0],
+                                     description="""Update a prplWrt device, either through u-boot
+                                     or using sysupgrade, depending on the target device.""")
+    parser.add_argument('-d', '--device',
+                        help="""Device to upgrade. Currently supported targets are: netgear-rax40
+                        glinet-b1300 turris-omnia""", required=True)
+    parser.add_argument(
+        '-t',
+        '--target-name',
+        help="Name of the target to upgrade (make sure it's reachable through ssh).", required=True)
+
+    parser.add_argument(
+        '-i',
+        '--image',
+        help="Name of the image to use for the upgrade (should exist in the artifacts folder).",
+        required=True)
+
+    args = parser.parse_args()
+
+    if args.device == "netgear-rax40":
+        dev = NetgearRax40(args.device, args.target_name, args.image)
+    else:
+        dev = Generic(args.device, args.target_name, args.image)
+
+    print("Checking if the device is reachable over ssh")
+    if not dev.reach():
+        raise ValueError("The device {} is not reachable over ssh! check your ssh configuration."
+                         .format(dev.name))
+    print("Checking if the device needs to be upgraded")
+    if dev.needs_upgrade():
+        print("The device {} will be upgraded".format(dev.name))
+        try:
+            dev.sysupgrade()
+        except NotImplementedError:
+            dev.upgrade_uboot()
+        print("Done")
+    else:
+        print("The device is already using the same version, no upgrade will be done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -95,7 +95,15 @@ RUN cp feeds.conf.default feeds.conf \
     : "Installing intel feed doesn't correctly regenerate kernel .package-info"; \
     : "force regeneration by removing it"; \
     rm -rf tmp \
-    && make defconfig \
+    && make defconfig; \
+    : "We need to keep the hashes in the firmware, to later know whether an upgrade is needed:"; \
+    mkdir -p files/etc \
+    && printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version \
+    && printf '%s=%s\n' "OPENWRT_VERSION" "$OPENWRT_VERSION" >> files/etc/prplwrt-version \
+    && printf '%s=%s\n' "PRPLMESH_VARIANT" "$PRPLMESH_VARIANT" >> files/etc/prplwrt-version \
+    && printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version \
+    && printf '%s=%s\n' "INTEL_FEED" "$INTEL_FEED" >> files/etc/prplwrt-version \
+    && printf '%s=%s\n' "IWLWAV_FEED" "$IWLWAV_FEED" >> files/etc/prplwrt-version \
     && make -j$(nproc) \
     && make package/feeds/prpl/prplmesh/clean
     # note that the result from diffconfig.sh with a minimal

--- a/tools/docker/builder/openwrt/scripts/build.sh
+++ b/tools/docker/builder/openwrt/scripts/build.sh
@@ -17,3 +17,4 @@ EOT
 find bin -name 'prplmesh*.ipk' -exec cp -v {} "artifacts/prplmesh.ipk" \;
 find bin/targets/"$TARGET_SYSTEM"/"$SUBTARGET"/ -type f -maxdepth 1 -exec cp -v {} "artifacts/" \;
 cp .config artifacts/openwrt.config
+cp files/etc/prplwrt-version artifacts/


### PR DESCRIPTION
- Store the hashes we use in the Dockerfile, in the firmware itself.
- Add a python script to check if a device needs to be upgraded by comparing hashes, and do the upgrade with sysupgrade or u-boot depending on the target.
- Use the python script in CI.

I tested that the upgrade works, and that re-trying the upgrade with the same firmware version doesn't do anything (for both the "test-on-target" jobs, and the certification testbed).

Fixes https://github.com/prplfoundation/prplMesh/issues/946