### PR TITLE
Implement AP Metrics reporting with channel utilization

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.h
+++ b/agent/src/beerocks/monitor/monitor_thread.h
@@ -59,6 +59,23 @@ private:
     void stop_monitor_thread();
     bool hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr);
 
+    /**
+     * @brief Executes when channel utilization measurement period has elapsed.
+     *
+     * This method is periodically invoked if AP Metrics Channel Utilization Reporting Threshold
+     * has been set to a non-zero value in last received Metric Reporting Policy TLV.
+     * Measurement period is set to an implementation-specific value.
+     * On invocation, method shall measure current channel utilization on the radio. If difference
+     * with respect to the previous measurement has crossed the reporting threshold, it shall send
+     * an AP Metrics Response message to the controller.
+     */
+    void on_channel_utilization_measurement_period_elapsed();
+
+    /**
+     * @brief Creates AP Metrics Response message
+     */
+    bool create_ap_metrics_response();
+
     bool update_ap_stats();
     bool update_sta_stats();
 

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -442,5 +442,22 @@ std::string base_wlan_hal_dummy::get_radio_mac()
     return mac;
 }
 
+bool base_wlan_hal_dummy::get_channel_utilization(uint8_t &channel_utilization)
+{
+    const uint8_t min_value   = 0;
+    const uint8_t max_value   = UINT8_MAX;
+    static uint8_t last_value = max_value;
+
+    if (max_value == last_value) {
+        channel_utilization = min_value;
+    } else {
+        channel_utilization = last_value + 1;
+    }
+
+    last_value = channel_utilization;
+
+    return true;
+}
+
 } // namespace dummy
 } // namespace bwl

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
@@ -51,6 +51,19 @@ public:
     virtual bool process_nl_events() override;
     virtual std::string get_radio_mac() override;
 
+    /**
+     * @brief Gets channel utilization.
+     *
+     * @see base_wlan_hal::get_channel_utilization
+     *
+     * Returns a fake channel utilization value, varying from 0 to UINT8_MAX on each call.
+     *
+     * @param[out] channel_utilization Channel utilization value.
+     *
+     * @return True on success and false otherwise.
+     */
+    bool get_channel_utilization(uint8_t &channel_utilization) override;
+
     // Protected methods
 protected:
     base_wlan_hal_dummy(HALType type, const std::string &iface_name, hal_event_cb_t callback,

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.cpp
@@ -111,18 +111,18 @@ bool nl80211_client_dummy::get_sta_info(const std::string &interface_name,
 }
 
 bool nl80211_client_dummy::get_survey_info(const std::string &interface_name,
-                                           std::vector<sSurveyInfo> &survey_info_list)
+                                           SurveyInfo &survey_info)
 {
     for (size_t i = 0; i < 8; i++) {
-        sSurveyInfo survey_info;
+        sChannelSurveyInfo channel_survey_info;
 
-        survey_info.in_use        = (0 == i);
-        survey_info.frequency_mhz = 2412 + i * 5;
-        survey_info.noise_dbm     = i;
-        survey_info.time_on_ms    = i * 2000;
-        survey_info.time_busy_ms  = i * 1000;
+        channel_survey_info.in_use        = (0 == i);
+        channel_survey_info.frequency_mhz = 2412 + i * 5;
+        channel_survey_info.noise_dbm     = i;
+        channel_survey_info.time_on_ms    = i * 2000;
+        channel_survey_info.time_busy_ms  = i * 1000;
 
-        survey_info_list.push_back(survey_info);
+        survey_info.data.push_back(channel_survey_info);
     }
 
     return true;

--- a/common/beerocks/bwl/dummy/nl80211_client_dummy.h
+++ b/common/beerocks/bwl/dummy/nl80211_client_dummy.h
@@ -67,8 +67,7 @@ public:
      *
      * This implementation returns fixed survey info for the first 8 2.4GHz channels.
      */
-    bool get_survey_info(const std::string &interface_name,
-                         std::vector<sSurveyInfo> &survey_info_list) override;
+    bool get_survey_info(const std::string &interface_name, SurveyInfo &survey_info) override;
 
     /**
      * @brief Set the tx power limit

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -1035,5 +1035,22 @@ std::string base_wlan_hal_dwpal::get_radio_mac()
     return mac;
 }
 
+bool base_wlan_hal_dwpal::get_channel_utilization(uint8_t &channel_utilization)
+{
+    nl80211_client::SurveyInfo survey_info;
+    if (!m_nl80211_client->get_survey_info(get_iface_name(), survey_info)) {
+        LOG(ERROR) << "Failed to get survey information for interface " << get_iface_name();
+        return false;
+    }
+
+    if (!survey_info.get_channel_utilization(channel_utilization)) {
+        LOG(ERROR) << "Survey information contains no channel utilization data for interface "
+                   << get_iface_name();
+        return false;
+    }
+
+    return true;
+}
+
 } // namespace dwpal
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -48,6 +48,19 @@ public:
     virtual bool process_nl_events() override;
     virtual std::string get_radio_mac() override;
 
+    /**
+     * @brief Gets channel utilization.
+     *
+     * @see base_wlan_hal::get_channel_utilization
+     *
+     * This implementation gets channel utilization through NL80211.
+     *
+     * @param[out] channel_utilization Channel utilization value.
+     *
+     * @return True on success and false otherwise.
+     */
+    bool get_channel_utilization(uint8_t &channel_utilization) override;
+
     // Protected methods
 protected:
     base_wlan_hal_dwpal(HALType type, const std::string &iface_name, hal_event_cb_t callback,

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal.h
@@ -110,6 +110,20 @@ public:
      */
     virtual bool process_int_events();
 
+    /**
+     * @brief Gets channel utilization.
+     *
+     * The channel utilization is defined as the percentage of time, linearly scaled with 255
+     * representing 100%, that the AP sensed the medium was busy. When more than one channel
+     * is in use for the BSS, the channel utilization value is calculated only for the primary
+     * channel.
+     *
+     * @param[out] channel_utilization Channel utilization value.
+     *
+     * @return True on success and false otherwise.
+     */
+    virtual bool get_channel_utilization(uint8_t &channel_utilization) = 0;
+
     // Public getter methods:
 public:
     /*!

--- a/common/beerocks/bwl/include/bwl/nl80211_client.h
+++ b/common/beerocks/bwl/include/bwl/nl80211_client.h
@@ -298,12 +298,12 @@ public:
     };
 
     /**
-     * @brief Survey information
+     * @brief Survey information for a channel.
      *
      * Information obtained with NL80211_CMD_GET_SURVEY command through a NL80211 socket.
      * See NL80211_SURVEY_INFO* in <linux/nl80211.h> for a description of each field.
      */
-    struct sSurveyInfo {
+    struct sChannelSurveyInfo {
         /**
          * Center frequency of channel.
          */
@@ -349,6 +349,34 @@ public:
          * Time (in ms) the radio spent for scan (on this channel or globally).
          */
         uint64_t time_scan_ms = 0;
+    };
+
+    class SurveyInfo {
+    public:
+        /**
+         * List of survey information structures, one for each channel, as returned by the
+         * NL80211_CMD_GET_SURVEY command.
+         */
+        std::vector<sChannelSurveyInfo> data;
+
+        /**
+         * @brief Gets channel utilization.
+         *
+         * The channel utilization is defined as the percentage of time, linearly scaled with 255
+         * representing 100%, that the AP sensed the medium was busy. When more than one channel
+         * is in use for the BSS, the channel utilization value is calculated only for the primary
+         * channel.
+         *
+         * This percentage is computed using the formula:
+         * channel_utilization = (channel busy time * 255) / channel on time
+         *
+         * @param[out] channel_utilization Channel utilization value on success and 0 if it cannot
+         * be obtained.
+         *
+         * @return True on success and false if there is no channel in use or time on is zero
+         * (i.e.: no data available) or time busy is greater than time on.
+         */
+        bool get_channel_utilization(uint8_t &channel_utilization) const;
     };
 
     /**
@@ -403,13 +431,12 @@ public:
      * Survey information includes channel occupation and noise level.
      *
      * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
-     * @param[out] survey_info_list List of survey information structures, one for each channel,
+     * @param[out] survey_info List of survey information structures, one for each channel,
      * as returned by the NL80211_CMD_GET_SURVEY command.
      *
      * @return True on success and false otherwise.
      */
-    virtual bool get_survey_info(const std::string &interface_name,
-                                 std::vector<sSurveyInfo> &survey_info_list) = 0;
+    virtual bool get_survey_info(const std::string &interface_name, SurveyInfo &survey_info) = 0;
 
     /**
      * @brief Set the tx power limit

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -994,5 +994,22 @@ bool base_wlan_hal_nl80211::send_nl80211_msg(uint8_t command, int flags,
     return true;
 }
 
+bool base_wlan_hal_nl80211::get_channel_utilization(uint8_t &channel_utilization)
+{
+    nl80211_client::SurveyInfo survey_info;
+    if (!m_nl80211_client->get_survey_info(get_iface_name(), survey_info)) {
+        LOG(ERROR) << "Failed to get survey information for interface " << get_iface_name();
+        return false;
+    }
+
+    if (!survey_info.get_channel_utilization(channel_utilization)) {
+        LOG(ERROR) << "Survey information contains no channel utilization data for interface "
+                   << get_iface_name();
+        return false;
+    }
+
+    return true;
+}
+
 } // namespace nl80211
 } // namespace bwl

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.h
@@ -56,6 +56,19 @@ public:
     virtual bool process_nl_events() override;
     virtual std::string get_radio_mac() override;
 
+    /**
+     * @brief Gets channel utilization.
+     *
+     * @see base_wlan_hal::get_channel_utilization
+     *
+     * This implementation gets channel utilization through NL80211.
+     *
+     * @param[out] channel_utilization Channel utilization value.
+     *
+     * @return True on success and false otherwise.
+     */
+    bool get_channel_utilization(uint8_t &channel_utilization) override;
+
     // Protected methods
 protected:
     base_wlan_hal_nl80211(HALType type, const std::string &iface_name, hal_event_cb_t callback,

--- a/common/beerocks/bwl/shared/nl80211_client.cpp
+++ b/common/beerocks/bwl/shared/nl80211_client.cpp
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "bwl/nl80211_client.h"
+
+namespace bwl {
+
+bool nl80211_client::SurveyInfo::get_channel_utilization(uint8_t &channel_utilization) const
+{
+    channel_utilization = 0;
+
+    /**
+     * TODO: Calculate channel utilization for the primary channel #1312
+     *
+     * According to 802.11 spec section 9.4.2.28: "When more than one channel is in use for the
+     * BSS, the Channel Utilization field value is calculated only for the primary channel".
+     *
+     * For simplicity, if there is more than one channel in use, currently we take the first
+     * channel found as the primary channel.
+     *
+     * A more elaborate solution shall correctly identify which is the primary channel.
+     */
+    auto it =
+        std::find_if(data.begin(), data.end(), [](const sChannelSurveyInfo &channel_survey_info) {
+            return channel_survey_info.in_use;
+        });
+
+    /**
+     * No channel in use, no data available
+     */
+    if (it == data.end()) {
+        return false;
+    }
+
+    auto survey_info = *it;
+
+    /**
+     * No data available
+     */
+    if (0 == survey_info.time_on_ms) {
+        return false;
+    }
+
+    /**
+     * This should never happen but if it does, then return error
+     */
+    if (survey_info.time_busy_ms > survey_info.time_on_ms) {
+        return false;
+    }
+
+    /**
+     * The channel utilization is defined as the percentage of time, linearly scaled with 255
+     * representing 100%, that the AP sensed the medium was busy.
+     */
+    channel_utilization = (survey_info.time_busy_ms * UINT8_MAX) / survey_info.time_on_ms;
+
+    return true;
+}
+
+} // namespace bwl

--- a/common/beerocks/bwl/shared/nl80211_client_impl.cpp
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.cpp
@@ -576,7 +576,7 @@ bool nl80211_client_impl::get_sta_info(const std::string &interface_name,
 }
 
 bool nl80211_client_impl::get_survey_info(const std::string &interface_name,
-                                          std::vector<sSurveyInfo> &survey_info_list)
+                                          SurveyInfo &survey_info)
 {
     if (!m_socket) {
         LOG(ERROR) << "Socket is NULL!";
@@ -635,49 +635,55 @@ bool nl80211_client_impl::get_survey_info(const std::string &interface_name,
                 return;
             }
 
-            sSurveyInfo survey_info;
-            survey_info.in_use = sinfo[NL80211_SURVEY_INFO_IN_USE];
+            sChannelSurveyInfo channel_survey_info;
+            channel_survey_info.in_use = sinfo[NL80211_SURVEY_INFO_IN_USE];
 
             if (sinfo[NL80211_SURVEY_INFO_FREQUENCY]) {
-                survey_info.frequency_mhz = nla_get_u32(sinfo[NL80211_SURVEY_INFO_FREQUENCY]);
+                channel_survey_info.frequency_mhz =
+                    nla_get_u32(sinfo[NL80211_SURVEY_INFO_FREQUENCY]);
             } else {
                 LOG(ERROR) << "NL80211_SURVEY_INFO_FREQUENCY attribute is missing";
                 return;
             }
 
             if (sinfo[NL80211_SURVEY_INFO_NOISE]) {
-                survey_info.noise_dbm = (int8_t)nla_get_u8(sinfo[NL80211_SURVEY_INFO_NOISE]);
+                channel_survey_info.noise_dbm =
+                    (int8_t)nla_get_u8(sinfo[NL80211_SURVEY_INFO_NOISE]);
             } else {
                 LOG(TRACE) << "NL80211_SURVEY_INFO_NOISE attribute is missing";
             }
 
             if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME]) {
-                survey_info.time_on_ms = nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME]);
+                channel_survey_info.time_on_ms =
+                    nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME]);
             }
 
             if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY]) {
-                survey_info.time_busy_ms =
+                channel_survey_info.time_busy_ms =
                     nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_BUSY]);
             }
 
             if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_EXT_BUSY]) {
-                survey_info.time_ext_busy_ms =
+                channel_survey_info.time_ext_busy_ms =
                     nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_EXT_BUSY]);
             }
 
             if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_RX]) {
-                survey_info.time_rx_ms = nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_RX]);
+                channel_survey_info.time_rx_ms =
+                    nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_RX]);
             }
 
             if (sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_TX]) {
-                survey_info.time_tx_ms = nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_TX]);
+                channel_survey_info.time_tx_ms =
+                    nla_get_u64(sinfo[NL80211_SURVEY_INFO_CHANNEL_TIME_TX]);
             }
 
             if (sinfo[NL80211_SURVEY_INFO_TIME_SCAN]) {
-                survey_info.time_scan_ms = nla_get_u64(sinfo[NL80211_SURVEY_INFO_TIME_SCAN]);
+                channel_survey_info.time_scan_ms =
+                    nla_get_u64(sinfo[NL80211_SURVEY_INFO_TIME_SCAN]);
             }
 
-            survey_info_list.emplace_back(survey_info);
+            survey_info.data.emplace_back(channel_survey_info);
         });
 }
 

--- a/common/beerocks/bwl/shared/nl80211_client_impl.h
+++ b/common/beerocks/bwl/shared/nl80211_client_impl.h
@@ -88,13 +88,12 @@ public:
      * Survey information includes channel occupation and noise level.
      *
      * @param[in] interface_name Interface name, either radio or Virtual AP (VAP).
-     * @param[out] survey_info_list List of survey information structures, one for each channel,
+     * @param[out] survey_info List of survey information structures, one for each channel,
      * as returned by the NL80211_CMD_GET_SURVEY command.
      *
      * @return True on success and false otherwise.
      */
-    bool get_survey_info(const std::string &interface_name,
-                         std::vector<sSurveyInfo> &survey_info_list) override;
+    bool get_survey_info(const std::string &interface_name, SurveyInfo &survey_info) override;
 
     /**
      * @brief Set the tx power limit


### PR DESCRIPTION
If a Multi-AP Agent receives a Metric Reporting Policy TLV with AP Metrics Channel Utilization Reporting Threshold field set to a non-zero value for a given radio, it shall measure the channel utilization on that radio in each consecutive implementation-specific measurement period and, if the most recently measured channel utilization has crossed the reporting threshold in either direction (with respect to the previous measurement), it shall send an AP Metrics Response message     to the Multi-AP Controller containing one AP Metrics TLV for each of the BSSs on that radio.
    
This PR also adds a placeholder for AP Metrics Response message creation in a method that will also be called when processing AP Metrics Query message.