### PR TITLE
Bugfix / Fix issues with "scan all channels"

### DIFF
--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -471,6 +471,7 @@ enum class eChannelScanOperationCode : uint8_t {
 };
 
 #define CHANNEL_SCAN_INVALID_PARAM -1
+#define SCAN_ALL_CHANNELS 0
 
 } // namespace beerocks
 

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -30,6 +30,48 @@ using namespace beerocks;
 using namespace net;
 using namespace son;
 
+//////////////////////////////////////////////////////////////////////////////
+/////////////////////////// Local Module Functions ///////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @brief Check if the given channel pool fulfils the "all-channel" scan requirement.
+ * @param channel_pool_set: Unordered set containing the current channel pool.
+ * @return true if pool matches the "all-channel" scan requirement
+ * @return false if not.
+ */
+bool is_scan_all_channels_request(std::unordered_set<uint8_t> &channel_pool_set)
+{
+    return channel_pool_set.size() == 1 && *channel_pool_set.begin() == SCAN_ALL_CHANNELS;
+}
+
+/**
+ * @brief Get the channel pool containing all the supported channels.
+ * @param channel_pool_set:  Set containing the current channel pool.
+ * @param channel_pool_size: Size of the given set.
+ * @param database:          Reference to the DB.
+ * @param radio_mac:         MAC address of radio.
+ */
+static bool get_pool_of_all_supported_channels(std::unordered_set<uint8_t> &channel_pool_set,
+                                               db &database, const sMacAddr &radio_mac)
+{
+    LOG(DEBUG) << "Setting channel pool to all channels";
+    channel_pool_set.clear();
+    auto all_channels = database.get_hostap_supported_channels(tlvf::mac_to_string(radio_mac));
+    if (all_channels.empty()) {
+        LOG(ERROR) << "Supported channel list is empty, failed to set channel pool!";
+        return false;
+    }
+    std::transform(all_channels.begin(), all_channels.end(),
+                   std::inserter(channel_pool_set, channel_pool_set.end()),
+                   [](beerocks::message::sWifiChannel &c) -> uint8_t { return c.channel; });
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+/////////////////////////////// Implementation ///////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
 void son_management::handle_cli_message(Socket *sd,
                                         std::shared_ptr<beerocks_header> beerocks_header,
                                         ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
@@ -1952,9 +1994,19 @@ void son_management::handle_bml_message(Socket *sd,
             op_error_code == eChannelScanOperationCode::SUCCESS) {
             auto channel_pool_set =
                 std::unordered_set<uint8_t>(channel_pool, channel_pool + channel_pool_size);
-            op_error_code = database.set_channel_scan_pool(radio_mac, channel_pool_set, false)
-                                ? op_error_code
-                                : eChannelScanOperationCode::INVALID_PARAMS_CHANNELPOOL;
+            // Check if "all-channel" scan is requested
+            if (is_scan_all_channels_request(channel_pool_set)) {
+                op_error_code =
+                    get_pool_of_all_supported_channels(channel_pool_set, database, radio_mac)
+                        ? op_error_code
+                        : eChannelScanOperationCode::INVALID_PARAMS_CHANNELPOOL;
+            }
+            // Set the channel pool
+            if (op_error_code == eChannelScanOperationCode::SUCCESS) {
+                op_error_code = database.set_channel_scan_pool(radio_mac, channel_pool_set, false)
+                                    ? op_error_code
+                                    : eChannelScanOperationCode::INVALID_PARAMS_CHANNELPOOL;
+            }
         }
         response->op_error_code() = uint8_t(op_error_code);
         //send response to bml
@@ -2218,7 +2270,14 @@ void son_management::handle_bml_message(Socket *sd,
             break;
         }
 
-        LOG(DEBUG) << "set_channel_scan_pool " << channel_pool_size;
+        if (is_scan_all_channels_request(channel_pool_set))
+            if (!get_pool_of_all_supported_channels(channel_pool_set, database, radio_mac)) {
+                LOG(ERROR) << "set_channel_scan_pool failed";
+                response->op_error_code() =
+                    uint8_t(eChannelScanOperationCode::INVALID_PARAMS_CHANNELPOOL);
+                message_com::send_cmdu(sd, cmdu_tx);
+                break;
+            }
         if (!database.set_channel_scan_pool(radio_mac, channel_pool_set, true)) {
             LOG(ERROR) << "set_channel_scan_pool failed";
             response->op_error_code() =

--- a/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
+++ b/controller/src/beerocks/master/tasks/dynamic_channel_selection_task.cpp
@@ -44,6 +44,10 @@ beerocks::eChannelScanStatusCode dynamic_channel_selection_task::dcs_request_sca
     // get the parent node to send the CMDU to the agent
     auto radio_mac_str = tlvf::mac_to_string(m_radio_mac);
     auto ire           = database.get_node_parent_ire(radio_mac_str);
+    if (ire.empty()) {
+        LOG(ERROR) << "Failed to get node_parent_ire!";
+        return beerocks::eChannelScanStatusCode::INTERNAL_FAILURE;
+    }
     son_actions::send_cmdu_to_agent(ire, cmdu_tx, database, radio_mac_str);
 
     return beerocks::eChannelScanStatusCode::SUCCESS;
@@ -52,54 +56,46 @@ beerocks::eChannelScanStatusCode dynamic_channel_selection_task::dcs_request_sca
 {
     // When a scan is requested send the scan parameters Channel pool & Dwell time
 
-    auto radio_mac_str = tlvf::mac_to_string(m_radio_mac);
-
     auto request = beerocks::message_com::create_vs_message<
         beerocks_message::cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST>(cmdu_tx);
     if (!request) {
         LOG(ERROR) << "Failed building message cACTION_CONTROL_CHANNEL_SCAN_TRIGGER_SCAN_REQUEST";
         return beerocks::eChannelScanStatusCode::INTERNAL_FAILURE;
     }
-    request->scan_params().radio_mac = m_radio_mac;
 
-    //Get dwell time, if dwell time invalid fail scan.
     int32_t dwell_time_msec = database.get_channel_scan_dwell_time_msec(m_radio_mac, m_single_scan);
     if (dwell_time_msec <= 0) {
         LOG(ERROR) << "invalid dwell_time=" << int(dwell_time_msec);
         return beerocks::eChannelScanStatusCode::INVALID_PARAMS;
     }
-    request->scan_params().dwell_time_ms = dwell_time_msec;
 
-    // Get channel pool;
-    // if pool is set to "all channel": use the supported channels instead.
-    // if the costum channel pool is empty or too big: fail scan and return error accordingly.
+    //get current channel pool from DB
     auto &curr_channel_pool = database.get_channel_scan_pool(m_radio_mac, m_single_scan);
-    if (curr_channel_pool.size() == 1 && (*curr_channel_pool.begin()) == 0) {
-        LOG(DEBUG) << "Using all supported channels for channel scan on mac=" << m_radio_mac;
-        auto supported_channels = database.get_hostap_supported_channels(radio_mac_str);
-        request->scan_params().channel_pool_size = supported_channels.size();
-        std::transform(supported_channels.begin(), supported_channels.end(),
-                       request->scan_params().channel_pool,
-                       [](beerocks::message::sWifiChannel &c) -> uint8_t { return c.channel; });
-    } else {
-        LOG(DEBUG) << "Using custom set channels for channel scan on mac=" << m_radio_mac;
-        if (curr_channel_pool.empty()) {
-            LOG(ERROR) << "empty channel pool is not supported. please set channel pool for mac="
-                       << m_radio_mac;
-            return beerocks::eChannelScanStatusCode::INVALID_PARAMS;
-        }
-        if (curr_channel_pool.size() > beerocks::message::SUPPORTED_CHANNELS_LENGTH) {
-            LOG(ERROR) << "channel_pool is too big [" << int(curr_channel_pool.size())
-                       << "] on mac=" << m_radio_mac;
-            return beerocks::eChannelScanStatusCode::POOL_TOO_BIG;
-        }
-        request->scan_params().channel_pool_size = curr_channel_pool.size();
-        std::copy(curr_channel_pool.begin(), curr_channel_pool.end(),
-                  request->scan_params().channel_pool);
+    if (curr_channel_pool.empty()) {
+        LOG(ERROR) << "empty channel pool is not supported. please set channel pool for mac="
+                   << m_radio_mac;
+        return beerocks::eChannelScanStatusCode::INVALID_PARAMS;
     }
 
+    if (curr_channel_pool.size() > beerocks::message::SUPPORTED_CHANNELS_LENGTH) {
+        LOG(ERROR) << "channel_pool is too big [" << int(curr_channel_pool.size())
+                   << "] on mac=" << m_radio_mac;
+        return beerocks::eChannelScanStatusCode::POOL_TOO_BIG;
+    }
+
+    request->scan_params().radio_mac         = m_radio_mac;
+    request->scan_params().dwell_time_ms     = dwell_time_msec;
+    request->scan_params().channel_pool_size = curr_channel_pool.size();
+    std::copy(curr_channel_pool.begin(), curr_channel_pool.end(),
+              request->scan_params().channel_pool);
+
     // get the parent node to send the CMDU to the agent
-    auto ire = database.get_node_parent_ire(radio_mac_str);
+    auto radio_mac_str = tlvf::mac_to_string(m_radio_mac);
+    auto ire           = database.get_node_parent_ire(radio_mac_str);
+    if (ire.empty()) {
+        LOG(ERROR) << "Failed to get node_parent_ire!";
+        return beerocks::eChannelScanStatusCode::INTERNAL_FAILURE;
+    }
     son_actions::send_cmdu_to_agent(ire, cmdu_tx, database, radio_mac_str);
 
     return beerocks::eChannelScanStatusCode::SUCCESS;


### PR DESCRIPTION
As part of the new "Scan on all channels" the client can requests a scan
with a specific pool what will indicate they wish to run a scan on all
the radio's supported channels.
A channel pool with only a single channel with a value of '0' will
indicate that the client wants to use the "Scan on all channels".