### PR TITLE
tests: extend combined_infra_metrics test to cover ap metrics query

### DIFF
--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -33,8 +33,13 @@ class TlvStruct:
             setattr(self, name, value)
 
     def __repr__(self):
-        return "{" + ", ".join(["{!r}: {!r}".format(k, v) for k, v in self.__dict__.items()
-                                if not k.startswith('_')]) + "}"
+        return "{" + ", ".join(["{!r}: {!r}".format(k, v) for k, v in self._d().items()]) + "}"
+
+    def _d(self):
+        return {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
+
+    def __eq__(self, other):
+        return self._d() == other._d()
 
 
 class Tlv(TlvStruct):


### PR DESCRIPTION
Use the check_cmdu functionality to validate that the ap metrics responses are correct.

While we're at it, check the combined infra metrics as well.
Turns out they are wrong - an issue will be created for it.

Lots of supporting changes to the sniffer infrastructure.