### PR TITLE
tools: docker: env variable for image override

### DIFF
--- a/tools/docker/build.sh
+++ b/tools/docker/build.sh
@@ -13,6 +13,7 @@ rootdir="${scriptdir%/*/*}"
 . "${rootdir}/tools/functions.sh"
 
 main() {
+    image=${PRPLMESH_BUILDER_IMAGE-"${DOCKER_REGISTRY}"prplmesh-builder}
     # Default docker arguments
     docker_args=(
         --workdir "${rootdir}"
@@ -27,7 +28,7 @@ main() {
         docker_args+=(-v "${PRPLMESH_PLATFORM_BASE_DIR}:${PRPLMESH_PLATFORM_BASE_DIR}")
     fi
 
-    run docker container run "${docker_args[@]}" --rm "${DOCKER_REGISTRY}prplmesh-builder" build "$@"
+    run docker container run "${docker_args[@]}" --rm "${image}" build "$@"
 }
 
 main "$@"

--- a/tools/docker/run.sh
+++ b/tools/docker/run.sh
@@ -55,7 +55,7 @@ main() {
         esac
     done
 
-    image="${DOCKER_REGISTRY}prplmesh-runner$TAG"
+    image=${PRPLMESH_RUNNER_IMAGE-"${DOCKER_REGISTRY}prplmesh-runner$TAG"}
     dbg "VERBOSE=${VERBOSE}"
     dbg "DETACH=${DETACH}"
     dbg "NETWORK=${NETWORK}"


### PR DESCRIPTION
On some occasions, it is useful to override the default docker image
when running build.sh which uses prplmesh-builder image or run.sh which
uses prplmesh-runner image.

One such example is when we want to explicitely use a specific image for
build - assume that CI failed building only with ubuntu:16.04 image. The
user now needs to manually create a container and run the commands
interactively in order to reproduce.

This commit adds capability to build.sh and run.sh to override the
default image if PRPLMESH_BUILDER_IMAGE / PRPLMESH_RUNNER_IMAGE environment variable is defined - for example,
building with the ubuntu:16.04 image:
PRPLMESH_BUILDER_IMAGE=prplmesh-builder:ubuntu-16.04 ./build.sh <maptools.py build args>

Using environment variable rather than adding command line options is
preferred since it keeps the usage simpler. If we instead used an
option, the usage would have been less intuitive:
./tools/docker/build.py -i <image> -- <maptools.py build args>

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>