### PR TITLE
Basic integration of googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,21 @@ elseif (TARGET_PLATFORM STREQUAL "linux")
     set(BEEROCKS_BH_WIRE_IFACE "eth0")
 endif()
 
+# Test support
+option(BUILD_TESTS "build multiap unit tests" OFF)
+if (BUILD_TESTS)
+    enable_testing()
+    message(STATUS "Tests are enabled")
+    # GTest is optional. gtest-based test have to check GTest_FOUND (which implies BUILD_TESTS)
+    # and link with GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main as appropriate
+    # CMake-bundled FindGTest doesn't support gmock, so force the one installed by GTest itself.
+    find_package(GTest CONFIG)
+    if (NOT GTest_FOUND)
+        message(STATUS "GTest not found, most tests are disabled")
+    endif()
+endif()
+
+
 ## Components
 
 add_subdirectory(framework)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,9 +1,6 @@
 project(multiap_framework C CXX)
 
-enable_testing()
-
 option(BUILD_EXAMPLES "build examples" OFF)
-option(BUILD_TESTS "build multiap unit tests" OFF)
 
 set(MSGLIB "zmq" CACHE STRING "Which messaging library backend to use")
 set_property(CACHE MSGLIB PROPERTY STRINGS "zmq" "nng" "None")

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     gcc \
     git \
+    googletest \
     libjson-c-dev \
     libncurses-dev \
     libnl-genl-3-dev \


### PR DESCRIPTION
This PR adds the basic integration of googletest in our build system:
- in CMakeLists.txt;
- in the builder docker image.

After this, it *should* (untested) be sufficient to follow https://github.com/google/googletest/blob/master/googletest/docs/primer.md to set up a test.
To link it, use:
```
if (GTest_FOUND)
    add_executable(testapp testapp.cpp)
    target_link_libraries(testapp GTest::gtest_main)
    install(TARGETS testapp DESTINATION bin/tests)
    add_test(testapp testapp)
endif()
```

We currently don't have a test executor yet, so the test has to be called manually.
Add the following to .gitlab-ci.yml:
```
testapp:
  extends: .run-test-in-docker
```

Note: the above should be added to README.md once it has been validated that it actually works.

Note that gmock requires more investigation.