### PR TITLE
tests: sniffer: use dumpcap instead of tcpdump

### DIFF
--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -112,15 +112,16 @@ class Sniffer:
         os.makedirs(os.path.join(self.tcpdump_log_dir, 'logs'), exist_ok=True)
         self.current_outputfile = os.path.join(self.tcpdump_log_dir, outputfile_basename) + ".pcap"
         self.checkpoint_frame_number = 0
-        command = ["tcpdump", "-i", self.interface, '-U', '-w', self.current_outputfile,
+        # '-q' avoids the output, which we don't need.
+        command = ["dumpcap", "-i", self.interface, '-q', '-w', self.current_outputfile, "-f",
                    "ether proto 0x88CC or ether proto 0x893A"]
         self.tcpdump_proc = subprocess.Popen(command, stderr=subprocess.PIPE)
-        # tcpdump takes a while to start up. Wait for the appropriate output before continuing.
-        # poll() so we exit the loop if tcpdump terminates for any reason.
+        # dumpcap takes a while to start up. Wait for the appropriate output before continuing.
+        # poll() so we exit the loop if dumpcap terminates for any reason.
         while not self.tcpdump_proc.poll():
             line = self.tcpdump_proc.stderr.readline()
             debug(line.decode()[:-1])  # strip off newline
-            if line.startswith(b"tcpdump: listening on " + self.interface.encode()):
+            if line.startswith(b"File: " + self.current_outputfile.encode()):
                 # Make sure it doesn't block due to stderr buffering
                 self.tcpdump_proc.stderr.close()
                 break

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -35,9 +35,9 @@ The docker runner image can be used to run prplMesh inside containers using `run
 
 The runner docker allows running multiple containers, for example one with a controller+agent, the other with an agent only:
 The 2 containers are connected using a docker network (bridge), so can
-communicate + sniffed by running `wireshark` / `tcpdump` on the bridge from the host to see 1905 packets.
+communicate + sniffed by running `wireshark` / `tshark` / `tcpdump` on the bridge from the host to see 1905 packets.
 This is what is done by the test scripts in the tests/ directory.
-Therefore they require tcpdump and tshark to be installed in order to work.
+Therefore they require dumpcap and tshark to be installed in order to work.
 
 ## Docker all
 

--- a/tools/docker/tests-runner/Dockerfile
+++ b/tools/docker/tests-runner/Dockerfile
@@ -6,7 +6,6 @@ RUN apk add --update --no-cache \
     python3 \
     grep \
     coreutils \
-    tcpdump \
     tshark
 
 COPY entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
Apparently tcpdump sometimes doesn't capture everything, so switch to dumpcap.
