### PR TITLE
CI: Port upload_to_owncloud.sh to python

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,11 +152,10 @@ upload-artifacts:
     - sed --follow-symlinks -i 's/^/machine ftp.essensium.com login prplmesh-robot-ci password /' ~/.netrc
     - |
       echo "Updating the 'latest' folder"
-      # Copying takes a lot of time, and we want the "latest" folder
-      # to be updated "as fast as possible", so we rely on the script
-      # to upload to a temporary directory first, and move it to
-      # "latest" afterwards:
-      ci/owncloud/upload_to_owncloud.sh -v "artifacts/latest" ./build
+      python3 ci/owncloud/upload_to_owncloud.py -v "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" ./build
+      # Copying takes a lot of time, and we want the "latest" folder to be updated
+      # "as fast as possible", so we make a copy and move it:
+      ci/owncloud/owncloud_definitions.sh move "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" "artifacts/latest"
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success

--- a/ci/owncloud/opts.py
+++ b/ci/owncloud/opts.py
@@ -1,0 +1,1 @@
+../../tests/opts.py

--- a/ci/owncloud/owncloud_options.json
+++ b/ci/owncloud/owncloud_options.json
@@ -1,0 +1,5 @@
+{
+    "webdav_login": "Owncloud username",
+    "webdav_password": "Owncloud Password",
+    "webdav_hostname": "https://ftp.essensium.com/owncloud/remote.php/dav/files/"
+}

--- a/ci/owncloud/upload_to_owncloud.py
+++ b/ci/owncloud/upload_to_owncloud.py
@@ -21,9 +21,9 @@ def get_credentials(options_path=None, force_netrc=True):
     options_path : str, optional
                 path to the options file
 
-    force_netrc : bool
-                flag indicating whether to skip parsing the options
-                file and skip straight to the contents of ~/.netrc
+    force_netrc : bool, optional
+                flag indicating whether to skip parsing the options file and instead directly
+                load the credentials from ~/.netrc
     Returns
     -------
     dictionary with 3 key/value pairs,

--- a/ci/owncloud/upload_to_owncloud.py
+++ b/ci/owncloud/upload_to_owncloud.py
@@ -1,0 +1,3 @@
+from webdav3.client import Client
+from opts import debug, message, opts
+

--- a/ci/owncloud/upload_to_owncloud.py
+++ b/ci/owncloud/upload_to_owncloud.py
@@ -1,3 +1,47 @@
+from os import path
+from getpass import getuser
 from webdav3.client import Client
 from opts import debug, message, opts
+
+def get_path_components(dirname):
+    """
+    get_path_components(dirname)
+
+    Gets a list of all subpaths needed to build a directory, including itself.
+
+    Parameters
+    ----------
+    dirname : str
+        A given directory path
+    Returns
+    -------
+    A python list of path strings
+    For an input 'a/b/c' returns ['a/b/c', 'a/b', 'a']
+    """
+    path_list = [dirname, ]
+    tmp = path.split(dirname)
+    while tmp[0] != "" and not path.ismount(tmp[0]):
+        path_list.append(tmp[0])
+        tmp = path.split(tmp[0])
+    path_list.reverse()
+    return path_list
+
+
+def mkdir_recursively(webdav_client, remote_path):
+    """
+    mkdir_recursively(remote_path)
+
+    Recursively creates all directories needed to create the input path.
+
+    Parameters
+    ----------
+    remote_path: str
+    """
+    pathlist = get_path_components(remote_path)
+    for p in pathlist:
+        try:
+            webdav_client.mkdir(p)
+        except BaseException as e:
+            debug(e)
+
 

--- a/ci/owncloud/upload_to_owncloud.py
+++ b/ci/owncloud/upload_to_owncloud.py
@@ -1,7 +1,45 @@
 from os import path
 from getpass import getuser
+import netrc
 from webdav3.client import Client
+import json
 from opts import debug, message, opts
+
+default_hostname = "https://ftp.essensium.com/owncloud/remote.php/dav/files/"
+
+
+def get_credentials(options_path=None, force_netrc=True):
+    """
+    get_credentials(options_path=None, force_netrc=True)
+
+    Gets the user's default credentials from either an external options file or ~/.netrc
+
+    Parameters
+    ----------
+    options_path : str, optional
+                path to the options file
+
+    force_netrc : bool
+                flag indicating whether to skip parsing the options
+                file and skip straight to the contents of ~/.netrc
+    Returns
+    -------
+    dictionary with 3 key/value pairs,
+    keys are: {webdav_login", "webdav_password","webdav_hostname")
+    """
+    if not force_netrc and path.exists(options_path):
+        with open(options_path) as options_file:
+            options = json.load(options_file)
+            return options
+
+    netrc_file = netrc.netrc()
+    credentials = netrc_file.authenticators("ftp.essensium.com")
+    return {
+        "webdav_login": credentials[0],
+        "webdav_password": credentials[2],
+        "webdav_hostname": default_hostname + credentials[0]
+    }
+
 
 def get_path_components(dirname):
     """

--- a/ci/owncloud/upload_to_owncloud.py
+++ b/ci/owncloud/upload_to_owncloud.py
@@ -1,3 +1,4 @@
+import argparse
 from os import path
 from getpass import getuser
 import netrc
@@ -129,3 +130,24 @@ def upload(webdav_client, is_direct, remote_path, local_path, unique_id=None):
     message("Success")
 
 
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--verbose", "-v", action='store_true', default=False,
+                        help="Enable verbosity.")
+    parser.add_argument("--direct", "-d", action='store_true', default=False,
+                        help="Direct upload without first uploading to a temporary directory")
+    parser.add_argument("--url", "-u", action='store', nargs=1,
+                        default="https://ftp.essensium.com/owncloud/remote.php/dav/files/{0}"
+                        .format(getuser()),
+                        help="webDAV URL")
+    parser.add_argument("local-path", nargs=1, type=str, action='store',
+                        help="Local file or folder to upload")
+    parser.add_argument("remote-path", type=str, nargs=1, action='store',
+                        help="Path in the cloud, relative to the user home to upload")
+    args = parser.parse_args()
+    args.local_path = getattr(args, "local-path")[0]
+    args.remote_path = getattr(args, "remote-path")[0]
+    opts.verbose = args.verbose
+    webdav_options = get_credentials()
+    client = Client(webdav_options)
+    upload(client, args.direct, args.remote_path, args.local_path)


### PR DESCRIPTION
Quoting from #1185:
 > As part of our efforts to clean up our scripts and workflow for certification tests, we need this to be refactored into a python script.

Therefore, port the `upload_to_owncloud.sh` script to Python3, resulting in a cleaner and more maintainable script.

Closes #1185 
