### PR TITLE
[bugfix] missing supported channels

### DIFF
--- a/agent/src/beerocks/slave/ap_manager_thread.cpp
+++ b/agent/src/beerocks/slave/ap_manager_thread.cpp
@@ -1498,6 +1498,14 @@ void ap_manager_thread::handle_hostapd_attached()
                 beerocks::message::VHT_MCS_SET_SIZE, notification->params().vht_mcs_set);
 
     // Copy the channels supported by the AP
+    if (!notification->alloc_preferred_channels(
+            ap_wlan_hal->get_radio_info().preferred_channels.size())) {
+        LOG(ERROR) << "Failed to allocate preferred_channels!";
+        return;
+    }
+    auto tuple_preferred_channels = notification->preferred_channels(0);
+    std::copy_n(ap_wlan_hal->get_radio_info().preferred_channels.begin(),
+                notification->preferred_channels_size(), &std::get<1>(tuple_preferred_channels));
     if (!notification->alloc_supported_channels(
             ap_wlan_hal->get_radio_info().supported_channels.size())) {
         LOG(ERROR) << "Failed to allocate supported_channels!";
@@ -1506,10 +1514,6 @@ void ap_manager_thread::handle_hostapd_attached()
     auto tuple_supported_channels = notification->supported_channels(0);
     std::copy_n(ap_wlan_hal->get_radio_info().supported_channels.begin(),
                 notification->supported_channels_size(), &std::get<1>(tuple_supported_channels));
-    std::copy_n(ap_wlan_hal->get_radio_info().preferred_channels.begin(),
-                beerocks::message::SUPPORTED_CHANNELS_LENGTH,
-                notification->params().preferred_channels);
-
     LOG(INFO) << "send ACTION_APMANAGER_JOINED_NOTIFICATION";
     LOG(INFO) << " iface = " << ap_wlan_hal->get_iface_name();
     LOG(INFO) << " mac = " << ap_wlan_hal->get_radio_mac();

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1691,6 +1691,7 @@ bool slave_thread::handle_cmdu_ap_manager_message(Socket *sd,
             LOG(ERROR) << "getting supported channels has failed!";
             return false;
         }
+        supported_channels.clear();
         supported_channels.insert(
             supported_channels.begin(), &std::get<1>(tuple_supported_channels),
             &std::get<1>(tuple_supported_channels) + notification->supported_channels_size());
@@ -3514,8 +3515,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         }
 
         std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
-            supported_channels_arr;
-        std::copy_n(supported_channels.begin(), supported_channels_arr.size(),
+            supported_channels_arr{{}};
+        std::copy_n(supported_channels.begin(), supported_channels.size(),
                     supported_channels_arr.begin());
 
         if (!tlvf_utils::add_ap_radio_basic_capabilities(cmdu_tx, hostap_params.iface_mac,

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -201,6 +201,7 @@ private:
     beerocks_message::sNodeHostap hostap_params;
     beerocks_message::sApChannelSwitch hostap_cs_params;
     std::vector<wireless_utils::sChannelPreference> channel_preferences;
+    std::vector<beerocks::message::sWifiChannel> preferred_channels;
     std::vector<beerocks::message::sWifiChannel> supported_channels;
 
     SocketClient *platform_manager_socket = nullptr;

--- a/common/beerocks/bcl/include/bcl/beerocks_defines.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_defines.h
@@ -43,7 +43,7 @@ enum eStructsConsts {
     VERSION_LENGTH            = 16,
     NODE_NAME_LENGTH          = 32,
     IFACE_NAME_LENGTH         = 32 + 4, //need extra 1 byte for null termination + alignment
-    SUPPORTED_CHANNELS_LENGTH = 64,     //support upto # channels, every channel item is 32-bit
+    SUPPORTED_CHANNELS_LENGTH = 128,    //support upto # channels, every channel item is 32-bit
     HOSTAP_ERR_MSG_LENGTH     = 64,
     WIFI_DRIVER_VER_LENGTH    = 32 + 4,
     WIFI_SSID_MAX_LENGTH      = 32 + 1 + 3, //need extra 1 byte for null termination + alignment

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -467,6 +467,7 @@ bool ap_wlan_hal_nl80211::read_preferred_channels()
                 channel.channel_bandwidth = bw;
                 channel.tx_pow            = channel_info.tx_power;
                 channel.is_dfs_channel    = channel_info.is_dfs;
+                preferred_channels.push_back(channel);
             }
         }
     }

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_apmanager.h
@@ -63,6 +63,9 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
         }
         sNodeHostap& params();
         sApChannelSwitch& cs_params();
+        uint8_t& preferred_channels_size();
+        std::tuple<bool, beerocks::message::sWifiChannel&> preferred_channels(size_t idx);
+        bool alloc_preferred_channels(size_t count = 1);
         uint8_t& supported_channels_size();
         std::tuple<bool, beerocks::message::sWifiChannel&> supported_channels(size_t idx);
         bool alloc_supported_channels(size_t count = 1);
@@ -75,10 +78,13 @@ class cACTION_APMANAGER_JOINED_NOTIFICATION : public BaseClass
         eActionOp_APMANAGER* m_action_op = nullptr;
         sNodeHostap* m_params = nullptr;
         sApChannelSwitch* m_cs_params = nullptr;
+        uint8_t* m_preferred_channels_size = nullptr;
+        beerocks::message::sWifiChannel* m_preferred_channels = nullptr;
+        size_t m_preferred_channels_idx__ = 0;
+        int m_lock_order_counter__ = 0;
         uint8_t* m_supported_channels_size = nullptr;
         beerocks::message::sWifiChannel* m_supported_channels = nullptr;
         size_t m_supported_channels_idx__ = 0;
-        int m_lock_order_counter__ = 0;
 };
 
 class cACTION_APMANAGER_ENABLE_APS_REQUEST : public BaseClass

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -354,22 +354,15 @@ typedef struct sNodeHostap {
     uint32_t vht_capability;
     uint8_t vht_mcs_set[beerocks::message::VHT_MCS_SET_SIZE];
     char driver_version[beerocks::message::WIFI_DRIVER_VER_LENGTH];
-    beerocks::message::sWifiChannel preferred_channels[beerocks::message::SUPPORTED_CHANNELS_LENGTH];
     void struct_swap(){
         iface_mac.struct_swap();
         tlvf_swap(8*sizeof(beerocks::eFreqType), reinterpret_cast<uint8_t*>(&frequency_band));
         tlvf_swap(8*sizeof(beerocks::eWiFiBandwidth), reinterpret_cast<uint8_t*>(&max_bandwidth));
         tlvf_swap(16, reinterpret_cast<uint8_t*>(&ht_capability));
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&vht_capability));
-        for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++){
-            (preferred_channels[i]).struct_swap();
-        }
     }
     void struct_init(){
         iface_mac.struct_init();
-            for (size_t i = 0; i < beerocks::message::SUPPORTED_CHANNELS_LENGTH; i++) {
-                (preferred_channels[i]).struct_init();
-            }
     }
 } __attribute__((packed)) sNodeHostap;
 

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_apmanager.yaml
@@ -27,6 +27,12 @@ cACTION_APMANAGER_JOINED_NOTIFICATION:
   _type: class
   params: sNodeHostap
   cs_params: sApChannelSwitch
+  preferred_channels_size:
+    _type: uint8_t
+    _length_var: True
+  preferred_channels:
+    _type: beerocks::message::sWifiChannel
+    _length: [ preferred_channels_size ]
   supported_channels_size:
     _type: uint8_t
     _length_var: True

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -270,9 +270,6 @@ sNodeHostap:
   driver_version:
     _type: char
     _length: [ "beerocks::message::WIFI_DRIVER_VER_LENGTH" ]
-  preferred_channels:
-    _type: beerocks::message::sWifiChannel
-    _length: [ "beerocks::message::SUPPORTED_CHANNELS_LENGTH" ]
 
 sVapsList:
   _type: struct

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2210,11 +2210,6 @@ bool master_thread::handle_intel_slave_join(
                    << " cs_new_event = " << intptr_t(cs_new_event);
         cs_new_event->hostap_mac = tlvf::mac_from_string(radio_mac);
         cs_new_event->cs_params  = notification->cs_params();
-        for (auto preferred_channel : notification->hostap().preferred_channels) {
-            if (preferred_channel.channel > 0) {
-                LOG(DEBUG) << "preferred_channel = " << int(preferred_channel.channel);
-            }
-        }
 
         std::copy_n(notification->backhaul_params().backhaul_scan_measurement_list,
                     beerocks::message::BACKHAUL_SCAN_MEASUREMENT_MAX_LENGTH,


### PR DESCRIPTION
When generating the Basics Radio Capabilities, some of the channels that should be supported are not preset. The channels are retrieved from the NL correctly as they appear in the log print of the ap_manager_thread.

But before they are processed by the `add_ap_radio_basic_capabilities` into the WSC autoconfig radio basic capabilities TLV, they are cut short due to the size limiter `SUPPORTED_CHANNELS_LENGTH` which is set to 64.

To fix this issue, the value of `SUPPORTED_CHANNELS_LENGTH` need to be increased