### PR TITLE
controller: optimal-path-task: fix vap bssid on rrm beacon

### DIFF
--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -270,9 +270,18 @@ void optimal_path_task::work()
                             beerocks::BEACON_MEASURE_DEFAULT_ACTIVE_DURATION;
                     }
                     // ap_mac is a radio mac, but we need to request measurment on some vap since radio don't beacon
-                    const std::string vap_mac   = *database.get_hostap_vaps_bssids(ap_mac).begin();
-                    measurement_request.bssid   = tlvf::mac_from_string(vap_mac);
-                    measurement_request.channel = database.get_node_channel(ap_mac);
+                    const std::string vap_mac =
+                        database.get_hostap_vap_with_ssid(ap_mac, current_hostap_ssid);
+                    if (vap_mac.empty()) {
+                        LOG(ERROR) << "Failed to get vap for client beacon request, skipping "
+                                      "measurement for "
+                                   << ap_mac;
+                        iterator_element_counter++;
+                        ++potential_ap_iter;
+                        continue;
+                    }
+                    measurement_request.bssid                  = tlvf::mac_from_string(vap_mac);
+                    measurement_request.channel                = database.get_node_channel(ap_mac);
                     measurement_request.expected_reports_count = 1;
 
                     /////////////// FOR DEBUG ONLY ////////////////


### PR DESCRIPTION
changed the VAP used for RRM beaconing to be the VAP that has SSID that
matches current-hostapd-ssid.
added a check of returned value - if returned vap_mac is empty the AP is
skipped and the beacon is not sent.

This PR is a hotfix to an issue observed where on UGW it was seen that optimal_path_task sent beacon-request with VAP-mac of zeros - might be due to VAP-list being corrupted in DB.

we could not reproduce the issue added this fix to improve the robustness of the optimal_path_task.

Signed-off-by: Adam Dov <adamx.dov@intel.com>