### PR TITLE
.gitlab-ci.yml: upload to the latest folder directly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,10 +149,11 @@ upload-artifacts:
     - sed --follow-symlinks -i 's/^/machine ftp.essensium.com login prplmesh-robot-ci password /' ~/.netrc
     - |
       echo "Updating the 'latest' folder"
-      ci/owncloud/upload_to_owncloud.sh -v "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" ./build
-      # Copying takes a lot of time, and we want the "latest" folder to be updated
-      # "as fast as possible", so we make a copy and move it:
-      ci/owncloud/owncloud_definitions.sh move "artifacts/$CI_COMMIT_SHA-$CI_JOB_ID" "artifacts/latest"
+      # Copying takes a lot of time, and we want the "latest" folder
+      # to be updated "as fast as possible", so we rely on the script
+      # to upload to a temporary directory first, and move it to
+      # "latest" afterwards:
+      ci/owncloud/upload_to_owncloud.sh -v "artifacts/latest" ./build
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success


### PR DESCRIPTION
The upload script did first upload to a temporary directory, then move
it to a folder named after the commit hash and the job id. Only then
was the folder moved to the "latest" folder.

The last move did fail all the time in CI with an HTTP 500 because the
folder was "locked".

Since the script anyway first uploads to a temporary directory, we can
skip the last manual move step and call the script with
"artifacts/latest" directly.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>