### PR TITLE
Hotfix/fix missing client capabilities

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -123,7 +123,7 @@ bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, st
             value = "missing ssid";
             return false;
         }
-        auto ruid = tlvf::mac_to_string(std::stoull(params["ruid"], nullptr, 16));
+        auto ruid = tlvf::mac_to_string(std::strtoull(params["ruid"].c_str(), nullptr, 16));
         auto ssid = params["ssid"];
 
         auto it = vaps_map.find(ruid);

--- a/ci/cppcheck/cppcheck_existing_issues.txt
+++ b/ci/cppcheck/cppcheck_existing_issues.txt
@@ -116,10 +116,8 @@ controller/src/beerocks/cli/beerocks_cli_socket.cpp: performance: Function param
 controller/src/beerocks/cli/beerocks_cli_socket.cpp: performance: Function parameter 'temp_path_' should be passed by const reference. [passedByValue]cli_socket::cli_socket(std::string temp_path_, std::string proxy_ip_)
 controller/src/beerocks/master/beerocks_master_main.cpp: style: Parameter 'main_master_conf' can be declared with const [constParameter]                               beerocks::config_file::sConfigMaster &main_master_conf)
 controller/src/beerocks/master/beerocks_master_main.cpp: style: Variable 'bridge_iface' can be declared with const [constVariable]    auto &bridge_iface = beerocks_slave_conf.bridge_iface;
-controller/src/beerocks/master/controller_ucc_listener.cpp: style: Variable 'authentication_type_str' can be declared with const [constVariable]    auto &authentication_type_str = confs[3];
 controller/src/beerocks/master/controller_ucc_listener.cpp: style: Variable 'bit_5_str' can be declared with const [constVariable]    auto &bit_5_str = confs[7];
 controller/src/beerocks/master/controller_ucc_listener.cpp: style: Variable 'bit_6_str' can be declared with const [constVariable]    auto &bit_6_str = confs[6];
-controller/src/beerocks/master/controller_ucc_listener.cpp: style: Variable 'encryption_type_str' can be declared with const [constVariable]    auto &encryption_type_str = confs[4];
 controller/src/beerocks/master/controller_ucc_listener.cpp: style: Variable 'operating_class_str' can be declared with const [constVariable]    auto &operating_class_str = confs[1];
 controller/src/beerocks/master/db/db.cpp: performance: Function parameter 'iface_name' should be passed by const reference. [passedByValue]bool db::set_hostap_iface_name(const std::string &mac, std::string iface_name)
 controller/src/beerocks/master/db/db.cpp: performance: Function parameter 'name' should be passed by const reference. [passedByValue]bool db::set_node_name(const std::string &mac, std::string name)

--- a/common/beerocks/bcl/include/bcl/beerocks_message_structs.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_message_structs.h
@@ -50,7 +50,7 @@ typedef struct sRadioCapabilities {
     uint8_t btm_supported         = 0;
     uint8_t nr_enabled            = 0;
     uint8_t cell_capa             = 0;
-    uint8_t cap_flag              = 0;
+    uint8_t valid                 = 0;
     uint8_t rrm_supported         = 0;
     uint8_t band_2g_capable       = 0;
     uint8_t band_5g_capable       = 0;
@@ -88,7 +88,7 @@ typedef struct sRadioCapabilities {
         btm_supported        = 0;
         nr_enabled           = 0;
         cell_capa            = 0;
-        cap_flag             = 0;
+        valid                = 0;
     }
 } __attribute__((packed)) sRadioCapabilities;
 

--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -671,7 +671,7 @@ void beerocks_ucc_listener::handle_wfa_ca_command(const std::string &command)
         std::transform(dest_alid.begin(), dest_alid.end(), dest_alid.begin(), ::tolower);
 
         auto &message_type_str = params["messagetypevalue"];
-        auto message_type      = (uint16_t)(std::stoul(message_type_str, nullptr, 16));
+        auto message_type      = (uint16_t)(std::strtoul(message_type_str.c_str(), nullptr, 16));
         if (!ieee1905_1::eMessageTypeValidate::check(message_type)) {
             err_string = "invalid param value '0x" + message_type_str +
                          "' for param name 'MessageTypeValue', message type not found";
@@ -806,7 +806,7 @@ bool tlvPrefilledData::add_tlv_value_hex_string(const std::string &value, uint16
         if (length == 0) {
             return false;
         }
-        *m_buff_ptr__ = std::stoi(value.substr(char_idx, 2), nullptr, 16);
+        *m_buff_ptr__ = std::strtoul(value.substr(char_idx, 2).c_str(), nullptr, 16);
         m_buff_ptr__++;
         length--;
     }
@@ -831,7 +831,7 @@ bool tlvPrefilledData::add_tlv_value_decimal_string(const std::string &value, ui
         num_of_bytes++;
     }
     ss << "0x" << std::setw(num_of_bytes * 2) << std::setfill('0') << std::hex
-       << std::stoi(value.substr(2, value.length()));
+       << string_utils::stoi(value.substr(2, value.length()));
 
     return add_tlv_value_hex_string(ss.str(), length);
 }
@@ -849,7 +849,7 @@ bool tlvPrefilledData::add_tlv_value_binary_string(const std::string &value, uin
         if (length == 0) {
             return false;
         }
-        *m_buff_ptr__ = std::stoi(value.substr(char_idx, 8), nullptr, 2);
+        *m_buff_ptr__ = std::strtoul(value.substr(char_idx, 8).c_str(), nullptr, 2);
         m_buff_ptr__++;
         length--;
     }
@@ -869,7 +869,7 @@ bool tlvPrefilledData::add_tlv_value_mac(const std::string &value, uint16_t &len
         if (length == 0) {
             return false;
         }
-        *m_buff_ptr__ = std::stoi(value.substr(char_idx, 2), nullptr, 16);
+        *m_buff_ptr__ = std::strtoul(value.substr(char_idx, 2).c_str(), nullptr, 16);
         m_buff_ptr__++;
         length--;
     }
@@ -888,9 +888,9 @@ bool tlvPrefilledData::add_tlvs_from_list(std::list<beerocks_ucc_listener::tlv_h
 {
     for (const auto &tlv : tlv_hex_list) {
 
-        uint8_t type = std::stoi(*tlv.type, nullptr, 16);
+        uint8_t type = std::strtoul((*tlv.type).c_str(), nullptr, 16);
 
-        uint16_t length = std::stoi(*tlv.length, nullptr, 16);
+        uint16_t length = std::strtoul((*tlv.length).c_str(), nullptr, 16);
 
         // "+3" = size of type and length fields
         if (getBuffRemainingBytes() < unsigned(length + 3)) {

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -144,7 +144,7 @@ void network_utils::ipv4_from_string(uint8_t *buf, const std::string &ip_str)
 
         for (int i = 0; i < IP_ADDR_LEN; i++) {
             std::getline(ipv4_ss, token, '.');
-            buf[i] = std::stoi(token);
+            buf[i] = string_utils::stoi(token);
         }
     }
 }

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -261,6 +261,8 @@ static void print_sta_capabilities(beerocks::message::sRadioCapabilities &sta_ca
                << std::endl
                << "vht_ss = " << ((int(sta_caps.vht_ss)) ? std::to_string(sta_caps.vht_ss) : "n/a")
                << std::endl
+               << "vht_mcs = "
+               << ((int(sta_caps.vht_mcs)) ? std::to_string(sta_caps.vht_mcs) : "n/a") << std::endl
                << "vht_bw = "
                << ((sta_caps.vht_bw != 0xFF)
                        ? std::to_string(beerocks::utils::convert_bandwidth_to_int(

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -372,14 +372,14 @@ static std::shared_ptr<char> generate_client_assoc_event(const std::string &even
     for (uint i = 0; (i < 8) && (i < sizeof(ht_mcs)); i++) {
         ht_mcs_str[2] = ht_mcs[2 * i];
         ht_mcs_str[3] = ht_mcs[2 * i + 1];
-        HT_MCS[i]     = beerocks::string_utils::stoi(ht_mcs_str);
+        HT_MCS[i]     = std::stoul(ht_mcs_str, nullptr, 16);
     }
 
     vht_mcs_str[2] = vht_mcs[0];
     vht_mcs_str[3] = vht_mcs[1];
     vht_mcs_str[4] = vht_mcs[2];
     vht_mcs_str[5] = vht_mcs[3];
-    VHT_MCS[0]     = beerocks::string_utils::stoi(vht_mcs_str);
+    VHT_MCS[0]     = std::stoul(vht_mcs_str, nullptr, 16);
 
     LOG(DEBUG) << "client_mac      : " << client_mac;
     LOG(DEBUG) << "supported_rates : " << std::dec << supported_rates[0]

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -134,7 +134,7 @@ static void get_ht_mcs_capabilities(int *HT_MCS, std::string &ht_cap_str,
     sta_caps.ht_bw        = 0xFF;
 
     if (!ht_cap_str.empty() && (HT_MCS != nullptr)) {
-        uint16_t ht_cap = uint16_t(std::stoul(ht_cap_str, nullptr, 16));
+        uint16_t ht_cap = uint16_t(std::strtoul(ht_cap_str.c_str(), nullptr, 16));
         sta_caps.ht_bw  = (ht_cap & HT_CAP_INFO_SUPP_CHANNEL_WIDTH_SET) != 0; // 20 == 0 / 40 == 1
         sta_caps.ht_sm_power_save = ((ht_cap & HT_CAP_INFO_SMPS_MASK) >> 2) &
                                     0x03; // 0=static, 1=dynamic, 2=reserved, 3=disabled
@@ -179,7 +179,7 @@ static void get_vht_mcs_capabilities(int16_t *VHT_MCS, std::string &vht_cap_str,
     sta_caps.vht_bw = 0xFF;
 
     if (!vht_cap_str.empty() && (VHT_MCS != nullptr)) {
-        uint32_t vht_cap          = uint16_t(std::stoul(vht_cap_str, nullptr, 16));
+        uint32_t vht_cap          = uint16_t(std::strtoul(vht_cap_str.c_str(), nullptr, 16));
         uint8_t supported_bw_bits = (vht_cap >> 2) & 0x03;
 
         if (supported_bw_bits == 0x03) { // reserved mode
@@ -372,14 +372,14 @@ static std::shared_ptr<char> generate_client_assoc_event(const std::string &even
     for (uint i = 0; (i < 8) && (i < sizeof(ht_mcs)); i++) {
         ht_mcs_str[2] = ht_mcs[2 * i];
         ht_mcs_str[3] = ht_mcs[2 * i + 1];
-        HT_MCS[i]     = std::stoul(ht_mcs_str, nullptr, 16);
+        HT_MCS[i]     = std::strtoul(ht_mcs_str.c_str(), nullptr, 16);
     }
 
     vht_mcs_str[2] = vht_mcs[0];
     vht_mcs_str[3] = vht_mcs[1];
     vht_mcs_str[4] = vht_mcs[2];
     vht_mcs_str[5] = vht_mcs[3];
-    VHT_MCS[0]     = std::stoul(vht_mcs_str, nullptr, 16);
+    VHT_MCS[0]     = std::strtoul(vht_mcs_str.c_str(), nullptr, 16);
 
     LOG(DEBUG) << "client_mac      : " << client_mac;
     LOG(DEBUG) << "supported_rates : " << std::dec << supported_rates[0]

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -127,9 +127,11 @@ typedef struct {
 //ap_wlan_hal
 
 enum eWiFiBandwidth : uint8_t {
-    BANDWIDTH_20 = 0,
+    BANDWIDTH_UNKNOWN = 0,
+    BANDWIDTH_20,
     BANDWIDTH_40,
     BANDWIDTH_80,
+    BANDWIDTH_80_80,
     BANDWIDTH_160,
     BANDWIDTH_MAX,
 };

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
@@ -505,50 +505,50 @@ bool mon_wlan_hal_nl80211::process_nl80211_event(parsed_obj_map_t &parsed_obj)
         int idx = 0;
 
         // op_class
-        resp->op_class = std::stoi(report.substr(idx, 2), 0, 16);
+        resp->op_class = std::strtoul(report.substr(idx, 2).c_str(), 0, 16);
         idx += 2;
 
         // channel
-        resp->channel = std::stoi(report.substr(idx, 2), 0, 16);
+        resp->channel = std::strtoul(report.substr(idx, 2).c_str(), 0, 16);
         idx += 2;
 
         // start_time
-        resp->start_time = std::stoull(report.substr(idx, 16), 0, 16);
+        resp->start_time = std::strtoull(report.substr(idx, 16).c_str(), 0, 16);
         resp->start_time = be64toh(resp->start_time);
         idx += 16;
 
         // measurement_duration
-        resp->duration = std::stoi(report.substr(idx, 4), 0, 16);
+        resp->duration = std::strtoul(report.substr(idx, 4).c_str(), 0, 16);
         resp->duration = be16toh(resp->duration);
         idx += 4;
 
         // phy_type
-        resp->phy_type = std::stoi(report.substr(idx, 2), 0, 16);
+        resp->phy_type = std::strtoul(report.substr(idx, 2).c_str(), 0, 16);
         idx += 2;
 
         // rcpi
-        resp->rcpi = std::stoi(report.substr(idx, 2), 0, 16);
+        resp->rcpi = std::strtol(report.substr(idx, 2).c_str(), 0, 16);
         idx += 2;
 
         // rsni
-        resp->rsni = std::stoi(report.substr(idx, 2), 0, 16);
+        resp->rsni = std::strtol(report.substr(idx, 2).c_str(), 0, 16);
         idx += 2;
 
         // bssid
-        resp->bssid.oct[0] = std::stoi(report.substr(idx + 0, 2), 0, 16);
-        resp->bssid.oct[1] = std::stoi(report.substr(idx + 2, 2), 0, 16);
-        resp->bssid.oct[2] = std::stoi(report.substr(idx + 4, 2), 0, 16);
-        resp->bssid.oct[3] = std::stoi(report.substr(idx + 6, 2), 0, 16);
-        resp->bssid.oct[4] = std::stoi(report.substr(idx + 8, 2), 0, 16);
-        resp->bssid.oct[5] = std::stoi(report.substr(idx + 10, 2), 0, 16);
+        resp->bssid.oct[0] = std::strtoul(report.substr(idx + 0, 2).c_str(), 0, 16);
+        resp->bssid.oct[1] = std::strtoul(report.substr(idx + 2, 2).c_str(), 0, 16);
+        resp->bssid.oct[2] = std::strtoul(report.substr(idx + 4, 2).c_str(), 0, 16);
+        resp->bssid.oct[3] = std::strtoul(report.substr(idx + 6, 2).c_str(), 0, 16);
+        resp->bssid.oct[4] = std::strtoul(report.substr(idx + 8, 2).c_str(), 0, 16);
+        resp->bssid.oct[5] = std::strtoul(report.substr(idx + 10, 2).c_str(), 0, 16);
         idx += 12;
 
         // ant_id
-        resp->ant_id = std::stoi(report.substr(idx, 2), 0, 16);
+        resp->ant_id = std::strtoul(report.substr(idx, 2).c_str(), 0, 16);
         idx += 2;
 
         // parent_tsf
-        resp->parent_tsf = std::stoull(report.substr(idx, 8), 0, 16);
+        resp->parent_tsf = std::strtoull(report.substr(idx, 8).c_str(), 0, 16);
         idx += 8;
 
         // TODO: Ignore everything else?

--- a/controller/src/beerocks/master/controller_ucc_listener.cpp
+++ b/controller/src/beerocks/master/controller_ucc_listener.cpp
@@ -63,7 +63,7 @@ bool controller_ucc_listener::handle_dev_get_param(
             value = "missing ssid";
             return false;
         }
-        auto ruid = tlvf::mac_to_string(std::stoull(params["ruid"], nullptr, 16));
+        auto ruid = tlvf::mac_to_string(std::strtoull(params["ruid"].c_str(), nullptr, 16));
         auto ssid = params["ssid"];
         auto vaps = m_database.get_hostap_vap_list(ruid);
         if (vaps.empty()) {
@@ -218,7 +218,7 @@ controller_ucc_listener::parse_bss_info(const std::string &bss_info_str,
         return std::string();
     }
 
-    uint16_t authentication_type = std::stoi(authentication_type_str, nullptr, 16);
+    uint16_t authentication_type = std::strtol(authentication_type_str.c_str(), nullptr, 16);
 
     if (!WSC::eWscAuthValidate::check(authentication_type)) {
         err_string = "invalid authentication type value";
@@ -233,7 +233,7 @@ controller_ucc_listener::parse_bss_info(const std::string &bss_info_str,
         return std::string();
     }
 
-    uint16_t encryption_type = std::stoi(encryption_type_str, nullptr, 16);
+    uint16_t encryption_type = std::strtol(encryption_type_str.c_str(), nullptr, 16);
 
     if (!WSC::eWscEncrValidate::check(encryption_type)) {
         err_string = "invalid encryption type value";

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1064,14 +1064,14 @@ bool db::set_station_capabilities(const std::string &client_mac,
     }
 
     if (is_node_5ghz(parent_radio)) {
-        n->m_sta_5ghz_capabilities          = sta_cap;
-        n->m_sta_5ghz_capabilities.cap_flag = true;
-        n->capabilities                     = n->m_sta_5ghz_capabilities;
+        n->m_sta_5ghz_capabilities       = sta_cap;
+        n->m_sta_5ghz_capabilities.valid = true;
+        n->capabilities                  = n->m_sta_5ghz_capabilities;
 
     } else {
-        n->m_sta_24ghz_capabilities          = sta_cap;
-        n->m_sta_24ghz_capabilities.cap_flag = true;
-        n->capabilities                      = n->m_sta_24ghz_capabilities;
+        n->m_sta_24ghz_capabilities       = sta_cap;
+        n->m_sta_24ghz_capabilities.valid = true;
+        n->capabilities                   = n->m_sta_24ghz_capabilities;
     }
     return true;
 }
@@ -1087,13 +1087,13 @@ db::get_station_capabilities(const std::string &client_mac, bool is_bandtype_5gh
     }
 
     if (is_bandtype_5ghz) {
-        if (n->m_sta_5ghz_capabilities.cap_flag == true) {
+        if (n->m_sta_5ghz_capabilities.valid == true) {
             return &n->m_sta_5ghz_capabilities;
         } else {
             return nullptr;
         }
     } else {
-        if (n->m_sta_24ghz_capabilities.cap_flag == true) {
+        if (n->m_sta_24ghz_capabilities.valid == true) {
             return &n->m_sta_24ghz_capabilities;
         } else {
             return nullptr;

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1052,13 +1052,14 @@ bool db::set_station_capabilities(const std::string &client_mac,
     auto n = get_node(client_mac);
 
     if (!n) {
-        LOG(ERROR) << "station node not found.... ";
+        LOG(ERROR) << "client node not found " << client_mac;
         return false;
     }
 
     auto parent_radio = get_node_parent_radio(client_mac);
 
     if (parent_radio.empty()) {
+        LOG(ERROR) << "parent radio node found for client " << client_mac;
         return false;
     }
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1064,26 +1064,14 @@ bool db::set_station_capabilities(const std::string &client_mac,
     }
 
     if (is_node_5ghz(parent_radio)) {
-        if (n->m_sta_5ghz_capabilities.cap_flag == true) {
-            //skip setting 5Ghz station parameters if it is already learned once
-            LOG(INFO) << "m_sta_5ghz_capabilities already set once";
-        } else {
-            n->m_sta_5ghz_capabilities          = sta_cap;
-            n->m_sta_5ghz_capabilities.cap_flag = true;
-        }
-
-        n->capabilities = n->m_sta_5ghz_capabilities;
+        n->m_sta_5ghz_capabilities          = sta_cap;
+        n->m_sta_5ghz_capabilities.cap_flag = true;
+        n->capabilities                     = n->m_sta_5ghz_capabilities;
 
     } else {
-        if (n->m_sta_24ghz_capabilities.cap_flag == true) {
-            //skip setting 2.4Ghz station parameters if it is already learned once
-            LOG(INFO) << "m_sta_24ghz_capabilities already set once";
-        } else {
-            n->m_sta_24ghz_capabilities          = sta_cap;
-            n->m_sta_24ghz_capabilities.cap_flag = true;
-        }
-
-        n->capabilities = n->m_sta_24ghz_capabilities;
+        n->m_sta_24ghz_capabilities          = sta_cap;
+        n->m_sta_24ghz_capabilities.cap_flag = true;
+        n->capabilities                      = n->m_sta_24ghz_capabilities;
     }
     return true;
 }

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -24,8 +24,8 @@ node::node(beerocks::eType type_, const std::string &mac_)
         hostap             = std::make_shared<radio>();
         hostap->stats_info = std::make_shared<radio::ap_stats_params>();
     }
-    m_sta_5ghz_capabilities.cap_flag  = false;
-    m_sta_24ghz_capabilities.cap_flag = false;
+    m_sta_5ghz_capabilities.valid  = false;
+    m_sta_24ghz_capabilities.valid = false;
 }
 
 namespace son {

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -429,7 +429,9 @@ void optimal_path_task::work()
             auto hostap_is_5ghz = database.is_node_5ghz(hostap);
             if (!force_signal_strength_decision &&
                 !database.settings_client_optimal_path_roaming_prefer_signal_strength()) {
-                //get sta capabilities....
+                // Get sta capabilities
+                TASK_LOG(DEBUG) << "getting capabilities for sta_mac " << sta_mac << " on band "
+                                << (hostap_is_5ghz ? "5GHz" : "2.4GHz");
                 sta_capabilities = database.get_station_capabilities(sta_mac, hostap_is_5ghz);
                 if (sta_capabilities == nullptr) {
                     get_station_default_capabilities(hostap_is_5ghz, default_sta_cap);
@@ -931,7 +933,9 @@ void optimal_path_task::work()
                 continue;
             }
 
-            //get sta capabilities....
+            // Get STA capabilities
+            TASK_LOG(DEBUG) << "getting capabilities for sta_mac " << sta_mac << " on band "
+                            << (hostap_params.is_5ghz ? "5GHz" : "2.4GHz");
             sta_capabilities = database.get_station_capabilities(sta_mac, hostap_params.is_5ghz);
             if (sta_capabilities == nullptr) {
                 TASK_LOG(WARNING) << "STA capabilities are empty - use default capabilities";

--- a/framework/common/test/socket_test.cpp
+++ b/framework/common/test/socket_test.cpp
@@ -264,15 +264,15 @@ void ProcessArgs(int argc, char **argv)
 
         switch (opt) {
         case 'd':
-            g_cfg.init_delay = std::stoi(optarg);
+            g_cfg.init_delay = std::strtoul(optarg, nullptr, 10);
             std::cout << "Init Delay[us]: " << g_cfg.init_delay << std::endl;
             break;
         case 'i':
-            g_cfg.iterations = std::stoi(optarg);
+            g_cfg.iterations = std::strtoul(optarg, nullptr, 10);
             std::cout << "Iterations: " << g_cfg.iterations << std::endl;
             break;
         case 'a':
-            g_cfg.max_attempts = std::stoi(optarg);
+            g_cfg.max_attempts = std::strtoul(optarg, nullptr, 10);
             std::cout << "Max Attempts (slow joiner): " << g_cfg.max_attempts << std::endl;
             break;
         case 't':

--- a/framework/platform/bpl/common/utils/utils_net.cpp
+++ b/framework/platform/bpl/common/utils/utils_net.cpp
@@ -53,7 +53,7 @@ void mac_from_string(uint8_t *buf, const std::string &mac)
 
         for (int i = 0; i < BPL_MAC_ADDR_OCTETS_LEN; i++) {
             std::getline(mac_ss, token, ':');
-            buf[i] = std::stoul(token, nullptr, 16);
+            buf[i] = std::strtoul(token.c_str(), nullptr, 16);
         }
     }
 }
@@ -93,7 +93,7 @@ void ipv4_from_string(uint8_t *buf, const std::string &ip_str)
 
         for (int i = 0; i < BPL_IPV4_ADDR_OCTETS_LEN; i++) {
             std::getline(ipv4_ss, token, '.');
-            buf[i] = std::stoi(token);
+            buf[i] = std::strtoul(token.c_str(), nullptr, 10);
         }
     }
 }

--- a/framework/tlvf/src/src/tlvftypes.cpp
+++ b/framework/tlvf/src/src/tlvftypes.cpp
@@ -63,7 +63,7 @@ void mac_from_string(uint8_t *buf, const std::string &mac)
 
             for (int i = 0; i < ETH_ALEN; i++) {
                 std::getline(mac_ss, token, mac_bytes_separator);
-                buf[i] = std::stoul(token, nullptr, 16);
+                buf[i] = std::strtoul(token.c_str(), nullptr, 16);
             }
         }
     }


### PR DESCRIPTION
@amritak23 has discovered issues on weighted phyrate while testing the platform.
The bug root cause was on the parsing of the client capabilities which occurred the function that generates connect events to a client that are connected to the ap before beerocks has brought up.
Also, there was a bug on the bandwidth enum on the station capabilities report.