### PR TITLE
.mergify.yml: remove status-neutral check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,12 +5,10 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0" # Changes requested blocks the merge
       - "label=ready for merge" # Must have ready for merge label
       - "label!=don't merge" # Don't merge label blocks the merge
-      # All status checks must pass. Since mergify itself is a status check, this is a bit
-      # recursive... So, explicitly say that there should be no unfinished (= neutral) status
-      # check, no failures obviously, and that at least two status checks are successful.
-      - "#status-neutral=0"
       - "#status-failure=0"
-      - "#status-success>=2"
+      # Just to be sure that we don't consider it as passed when the status checks haven't even
+      # started yet.
+      - "#status-success>=3"
     actions:
       merge:
         method: rebase # Merge with rebase


### PR DESCRIPTION
It seems that the mergify status check itself now stays neutral, so
status-neutral can never be zero. Therefore, remove that check.

Instead, increase the minimal number of successes to 3 (DCO, intel-ci,
gitlab-ci).

It looks like the status-success check isn't really needed, because
apparently mergify delays its check until all status checks have
finished. But it doesn't hurt to add this, just to be on the safe side.