### PR TITLE
ci: run_easymesh_cert.sh: upload to google sheets

### DIFF
--- a/ci/run_easymesh_cert.sh
+++ b/ci/run_easymesh_cert.sh
@@ -76,6 +76,10 @@ upgrade_prplmesh() {
 }
 
 main() {
+    if [ "$EUID" -ne 0 ]
+        then echo "this script has to be run as root, aborting"
+        exit 1
+    fi
     if ! OPTS=$(getopt -o 'hvb:o:e:d:s:' --long help,verbose,log-folder:,easymesh-cert:,device:,ssh:,owncloud-upload,owncloud-path:,skip-upgrade -n 'parse-options' -- "$@"); then
         err "Failed parsing options." >&2
         usage
@@ -117,7 +121,7 @@ main() {
     }
     
     info "Start running tests"
-    sudo "$EASYMESH_CERT_PATH"/run_test_file.py -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" ${VERBOSE:+ -v}
+    "$EASYMESH_CERT_PATH"/run_test_file.py ${OWNCLOUD_UPLOAD:+ -u} -o "$LOG_FOLDER" -d "$TARGET_DEVICE" "$TESTS" ${VERBOSE:+ -v}
 
     if [ -n "$OWNCLOUD_UPLOAD" ]; then
         if is_prplmesh_device "$TARGET_DEVICE"; then


### PR DESCRIPTION
easymesh_cert run_test_file.py supports -u|--upload option which uploads
the results of the tests to google sheets.
The run_easymesh_cert.sh script is using upload_to_owncloud.sh to upload
the logs to owncloud to which the google sheet refer.
This is really weird cause one script is uploading the logs and another
is uploading the sheet, but it is what it is at the moment.

For now, add the -u option when --upload-to-owncloud is set, so the
google sheet will also be updated by the underlying run_test_file.py.

Use the -E option to pass user environment variables in order to make
sure proxy settings are passed on to sudo, which is required in the
Intel PTK1 testbed.

Example: https://docs.google.com/spreadsheets/d/1hsX5humi4pK8cUg5e7slEnxDw5rvEGNaDMXeYS4YOJY/edit#gid=1589998135

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>