### PR TITLE
Hotfix/controller fix is prplmesh

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -3667,10 +3667,13 @@ bool db::is_prplmesh(const sMacAddr &mac)
     }
     return node->is_prplmesh;
 }
+
 void db::set_prplmesh(const sMacAddr &mac)
 {
+    auto local_bridge_mac = tlvf::mac_from_string(get_local_bridge_mac());
+    auto ire_type         = local_bridge_mac == mac ? beerocks::TYPE_GW : beerocks::TYPE_IRE;
     if (!get_node(mac)) {
-        add_node(mac);
+        add_node(mac, beerocks::net::network_utils::ZERO_MAC, ire_type);
     }
     get_node(mac)->is_prplmesh = true;
 }

--- a/controller/src/beerocks/master/son_actions.cpp
+++ b/controller/src/beerocks/master/son_actions.cpp
@@ -461,6 +461,10 @@ bool son_actions::send_cmdu_to_agent(const std::string &dest_mac,
                                      const std::string &radio_mac)
 {
     if (cmdu_tx.getMessageType() == ieee1905_1::eMessageType::VENDOR_SPECIFIC_MESSAGE) {
+        if (!database.is_prplmesh(tlvf::mac_from_string(dest_mac))) {
+            // skip non-prplmesh agents
+            return false;
+        }
         auto beerocks_header = message_com::get_beerocks_header(cmdu_tx);
         if (!beerocks_header) {
             LOG(ERROR) << "Failed getting beerocks_header!";

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -1530,6 +1530,11 @@ bool master_thread::handle_cmdu_1905_topology_notification(const std::string &sr
         return true;
     }
 
+    if (!database.is_prplmesh(tlvf::mac_from_string(src_mac))) {
+        LOG(DEBUG) << "Non-prplMesh agent, skipping VS parsing";
+        return true;
+    }
+
     std::shared_ptr<beerocks_message::tlvVsClientAssociationEvent> vs_tlv = nullptr;
     auto beerocks_header = message_com::parse_intel_vs_message(cmdu_rx);
     if (beerocks_header) {


### PR DESCRIPTION
Fix database.set_prplmesh() which never worked and use it now in order to not send VS CMDUs and TLVS to non prplmesh agents.