### PR TITLE
Hotfix/Fix disappearing messages bug

### DIFF
--- a/common/beerocks/bcl/include/bcl/beerocks_socket_thread.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_socket_thread.h
@@ -42,7 +42,10 @@ protected:
     {
         return false;
     }
-    virtual bool skip_filtered_message_type(ieee1905_1::eMessageType msg_type) { return false; }
+    virtual bool skip_filtered_message_type(Socket *sd, ieee1905_1::eMessageType msg_type)
+    {
+        return false;
+    }
     virtual std::string print_cmdu_types(const message::sUdsHeader *cmdu_header)
     {
         return std::string();

--- a/common/beerocks/bcl/source/beerocks_socket_thread.cpp
+++ b/common/beerocks/bcl/source/beerocks_socket_thread.cpp
@@ -185,7 +185,7 @@ bool socket_thread::handle_cmdu_message_uds(Socket *sd)
     }
 
     // On UDS bus, unsubscribed messages needs to be filtered manually.
-    if (skip_filtered_message_type(cmdu_rx.getMessageType())) {
+    if (skip_filtered_message_type(sd, cmdu_rx.getMessageType())) {
         return true;
     }
 

--- a/common/beerocks/btl/btl_uds.cpp
+++ b/common/beerocks/btl/btl_uds.cpp
@@ -125,8 +125,14 @@ bool transport_socket_thread::bus_send(ieee1905_1::CmduMessage &cmdu, const std:
 
 bool transport_socket_thread::from_bus(Socket *sd) { return sd == bus; }
 
-bool transport_socket_thread::skip_filtered_message_type(ieee1905_1::eMessageType msg_type)
+bool transport_socket_thread::skip_filtered_message_type(Socket *sd,
+                                                         ieee1905_1::eMessageType msg_type)
 {
+    // Don't filter out internal messages
+    if (!from_bus(sd)) {
+        return false;
+    }
+
     if (m_subscribed_messages.find(msg_type) == m_subscribed_messages.end()) {
         return true;
     }

--- a/common/beerocks/btl/include/btl/btl.h
+++ b/common/beerocks/btl/include/btl/btl.h
@@ -62,7 +62,7 @@ private:
     int poll_timeout_ms = 500;
 
 #ifdef UDS_BUS
-    bool skip_filtered_message_type(ieee1905_1::eMessageType msg_type) override;
+    bool skip_filtered_message_type(Socket *sd, ieee1905_1::eMessageType msg_type) override;
 
     Socket *bus = nullptr;
     std::unique_ptr<SocketServer> bus_server_socket;


### PR DESCRIPTION
Commit 2a1c86a3 added a filter that filters out message types that the BTL derived
class is not registered to them on UDS_BUS.
This caused a bug that some messages from son_slave like TOPOLOGY_NOTIFICATION
did not reach their destination (Controller) since they were filtered out.
The reason for that is the fact that indeed TOPOLOGY_NOTIFICATION is not a message
that the Agent should get from the BUS and it is not registered to it. But it is normal
behavior to get such a message from an internal socket such as the son_slave.

To solve this add a socket argument to the filter function so that the function will filter
out only messages that come from the bus and not from internal sockets.

Fixes #1310 