### PR TITLE
tlvf: CmduMessage: move getClass down to CmduMessageRx

### DIFF
--- a/framework/tlvf/src/include/tlvf/CmduMessage.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessage.h
@@ -36,13 +36,6 @@ public:
     uint16_t getMessageId();
     void setMessageId(uint16_t mid);
 
-    // Forward wrapper functions
-    // TODO check which of them can be removed
-    template <class T> std::shared_ptr<T> getClass() const { return msg.getClass<T>(); };
-    template <class T> std::list<std::shared_ptr<T>> getClassList() const
-    {
-        return msg.getClassList<T>();
-    };
     size_t getMessageLength() const { return msg.getMessageLength(); };
     size_t getMessageBuffLength() const { return msg.getMessageBuffLength(); };
     uint8_t *getMessageBuff() const { return msg.getMessageBuff(); };

--- a/framework/tlvf/src/include/tlvf/CmduMessageRx.h
+++ b/framework/tlvf/src/include/tlvf/CmduMessageRx.h
@@ -19,6 +19,14 @@ public:
     CmduMessageRx() = delete;
     CmduMessageRx(uint8_t *buff, size_t buff_len) : CmduMessage(buff, buff_len){};
     ~CmduMessageRx(){};
+
+    // Forward wrapper functions
+    template <class T> std::shared_ptr<T> getClass() const { return msg.getClass<T>(); };
+    template <class T> std::list<std::shared_ptr<T>> getClassList() const
+    {
+        return msg.getClassList<T>();
+    };
+
     bool parse();
     CmduMessageRx &operator=(const CmduMessageRx &) = delete;
 


### PR DESCRIPTION
The getClass and getClassList functions should never be used on a
CmduMessageTx, only on CmduMessageRx. Therefore, move them down into
CmduMessageRx.

Ideally it should also be renamed to getTlv, but that's a bigger change.

This was triggered by my review of #1274 which incorrectly uses getClass on a CmduMessageTx.