### PR TITLE
tests: sniffer: remove length check on tshark list workaround

### DIFF
--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -26,7 +26,7 @@ class TlvStruct:
                 # However, there seems to be a bug for an operating class's channel list in the
                 # channel preference TLV: the middle dictionary is left out, and only a single
                 # channel is shown. To work around this, treat the channel list specially.
-                if len(value) == 1 and not isinstance(list(value.values())[0], dict):
+                if not isinstance(list(value.values())[0], dict):
                     value = [TlvStruct(value, level + 1)]
                 else:
                     value = [TlvStruct(v, level + 1) for k, v in value.items()]


### PR DESCRIPTION
The TlvStruct class has a workaround for an apparent bug in tshark that
the middle dictionary is sometimes left out in a list-structure.
Apparently some versions of tshark have this with other TLVs than
channel preference. The check looked at the length of the value
dictionary - i.e., it only supported a single-key dictionary. That
happened to be the case for the channel preference, but others have
multiple substructure fields.

Remove the length check - whenever the values are not dictionaries
themselves, we can assume that there is no middle dictionary.

This workaround will probably have to be fixed again in the future :-(