### PR TITLE
docker: openwrt: pass build-arg variables explicitly

### DIFF
--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -30,16 +30,16 @@ usage() {
 build_image() {
     # We first need to build the corresponding images
     docker build --tag "$image_tag" \
-           --build-arg OPENWRT_REPOSITORY \
-           --build-arg OPENWRT_VERSION \
-           --build-arg TARGET_SYSTEM \
-           --build-arg SUBTARGET \
-           --build-arg TARGET_PROFILE \
-           --build-arg PRPL_FEED \
-           --build-arg PRPLMESH_VARIANT \
-           --build-arg INTEL_FEED \
-           --build-arg IWLWAV_FEED \
-           --build-arg BASE_CONFIG \
+           --build-arg OPENWRT_REPOSITORY="$OPENWRT_REPOSITORY" \
+           --build-arg OPENWRT_VERSION="$OPENWRT_VERSION" \
+           --build-arg TARGET_SYSTEM="$TARGET_SYSTEM" \
+           --build-arg SUBTARGET="$SUBTARGET" \
+           --build-arg TARGET_PROFILE="$TARGET_PROFILE" \
+           --build-arg PRPL_FEED="$PRPL_FEED" \
+           --build-arg PRPLMESH_VARIANT="$PRPLMESH_VARIANT" \
+           --build-arg INTEL_FEED="$INTEL_FEED" \
+           --build-arg IWLWAV_FEED="$IWLWAV_FEED" \
+           --build-arg BASE_CONFIG="$BASE_CONFIG" \
            "$scriptdir/"
 }
 


### PR DESCRIPTION
When the --build-arg option is given without a value for the argument,
docker will use an environment variable with the same name. However,
podman (a "drop-in" replacement for docker with better non-privileged
support) doesn't behave like that. Therefore, give the arguments
explicitly.