### PR TITLE
[BUGFIX] bml: fix unknown type name during build

### DIFF
--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -164,7 +164,7 @@ int bml_nw_map_query(BML_CTX ctx)
     return (pBML->nw_map_query());
 }
 
-int bml_device_oper_radios_query(BML_CTX ctx, BML_DEVICE_DATA *device_data)
+int bml_device_oper_radios_query(BML_CTX ctx, struct BML_DEVICE_DATA *device_data)
 {
     if (!ctx)
         return (-BML_RET_INVALID_ARGS);

--- a/controller/src/beerocks/bml/bml.h
+++ b/controller/src/beerocks/bml/bml.h
@@ -118,7 +118,7 @@ int bml_nw_map_query(BML_CTX ctx);
  *
  * @return BML_RET_OK on success.
  */
-int bml_device_oper_radios_query(BML_CTX ctx, BML_DEVICE_DATA *device_data);
+int bml_device_oper_radios_query(BML_CTX ctx, struct BML_DEVICE_DATA *device_data);
 
 /**
  * Registers a callback function to periodic statistics update from 


### PR DESCRIPTION
When building for RDKB, the bml is imported by a C compiler, which
causes the struct `BML_DEVICE_DATA` be ne unrecognized.
The signature  of `bml_device_oper_radios_query` need to updated to be C compatible.