### PR TITLE
tools: deploy_firmware.py: wait at least for the CAC

### DIFF
--- a/tools/deploy_firmware.py
+++ b/tools/deploy_firmware.py
@@ -194,6 +194,8 @@ class NetgearRax40(PrplwrtDevice):
             shell.sendline("exit")
         if not self.reach(attempts=10):
             raise ValueError("The device was not reachable after the upgrade!")
+        # Wait at least for the CAC timer:
+        time.sleep(60)
 
 
 class Generic(PrplwrtDevice):


### PR DESCRIPTION
When deploying the full firmware on the rax40, the device is rebooted.

When the device boots, it takes a lot of time for the wireless
interfaces to become available. We need to make sure they are before
deploying prplMesh and starting tests.

When deploying the firmware on the rax40, wait at least for 60
seconds, which corresponds to the CAC timer.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>