### PR TITLE
bwl: Fix parsing of DFS-CAC-COMPLETED dwpal event

### DIFF
--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -2356,7 +2356,7 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         FieldsToParse fieldsToParse[] = {
             {NULL /*opCode*/, &numOfValidArgs[0], DWPAL_STR_PARAM, NULL, 0},
             {NULL, &numOfValidArgs[1], DWPAL_STR_PARAM, NULL, 0},
-            {(void *)&msg->params.success, &numOfValidArgs[2], DWPAL_CHAR_PARAM, "success=", 0},
+            {(void *)&msg->params.success, &numOfValidArgs[2], DWPAL_CHAR_PARAM, "cac_status=", 0},
             {(void *)&msg->params.frequency, &numOfValidArgs[3], DWPAL_INT_PARAM, "freq=", 0},
             {(void *)&msg->params.timeout, &numOfValidArgs[4], DWPAL_INT_PARAM, "timeout=", 0},
             {(void *)&chan_width, &numOfValidArgs[5], DWPAL_CHAR_PARAM, "chan_width=", 0},
@@ -2370,8 +2370,9 @@ bool ap_wlan_hal_dwpal::process_dwpal_event(char *buffer, int bufLen, const std:
         }
 
         /* TEMP: Traces... */
+        // HOSTAPD_CAC_STAT_FAILED = 0, HOSTAPD_CAC_STAT_SUCCESS = 1, HOSTAPD_CAC_STAT_PAUSED = 2
         LOG(DEBUG) << "numOfValidArgs[2]= " << numOfValidArgs[2]
-                   << " success= " << (int)msg->params.success;
+                   << " cac_status= " << (int)msg->params.success;
         LOG(DEBUG) << "numOfValidArgs[3]= " << numOfValidArgs[3]
                    << " freq= " << msg->params.frequency;
         LOG(DEBUG) << "numOfValidArgs[4]= " << numOfValidArgs[4]


### PR DESCRIPTION
The cac completed event string has changed to (dwpal):
"<3>DFS-CAC-COMPLETED wlan2 cac_status=1 freq=5180 ht_enabled=0
chan_offset=0 chan_width=5 cf1=5250 cf2=0 timeout=60"

"success" field is no longer, so it was replaced with "cac_status".