### PR TITLE
tests: sniffer: ignore tshark exit code

### DIFF
--- a/tests/sniffer.py
+++ b/tests/sniffer.py
@@ -140,9 +140,9 @@ class Sniffer:
         tshark_result = subprocess.run(tshark_command, stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE)
         if tshark_result.returncode != 0:
-            err(tshark_result.stderr)
-            err("tshark failed: {}".format(tshark_result.returncode))
-            return []
+            debug(tshark_result.stderr)
+            debug("tshark failed: {}".format(tshark_result.returncode))
+        # Regardless of the exit code, try to make something of the JSON that comes out, if any.
         try:
             capture = json.loads(tshark_result.stdout)
             return [Packet(x) for x in capture]


### PR DESCRIPTION
Apparently it is possible that dumpcap writes partial packets to the
output file. When this is read by tshark, it errors out with

The file "..." appears to have been cut short in the middle of a packet

We then ignore all the rest of the tshark output and return an empty
list.

At the time we do the capture, the packet we are looking for should
already have been written. Therefore, it is presumably OK to ignore this
error and instead return the rest of the output.

Therefore, ignore the error (still output it as debug).

A better solution would be to do the capture with tshark and keep it
running in a pipe rather than restarting tshark all the time. However,
that would be a lot more work to get right. Therefore, this solution is
used as a (temporary?) workaround.