### PR TITLE
Hotfix/remove disable arp feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,6 @@ if (NOT DEFINED BEEROCKS_BH_WIRE_IFACE)
     set(BEEROCKS_BH_WIRE_IFACE "eth1")
 endif()
 set(BEEROCKS_REPEATER_MODE 0)
-set(BEEROCKS_ENABLE_ARP_MONITOR 1)
 
 # Logging configuration
 set(BEEROCKS_LOG_FILES_ENABLED      "true")
@@ -133,7 +132,6 @@ elseif (TARGET_PLATFORM STREQUAL "rdkb")
     add_definitions(-DBEEROCKS_RDKB)
     set(BEEROCKS_BRIDGE_IFACE "brlan0")
     set(BEEROCKS_BH_WIRE_IFACE "nsgmii0")
-    set(BEEROCKS_ENABLE_ARP_MONITOR 0)
     # Disable file and enable syslog logging
     set(BEEROCKS_LOG_FILES_ENABLED "false")
     set(BEEROCKS_LOG_SYSLOG_ENABLED "true")

--- a/agent/config/beerocks_agent.conf.in
+++ b/agent/config/beerocks_agent.conf.in
@@ -17,7 +17,6 @@ enable_keep_alive=1
 bridge_iface=@BEEROCKS_BRIDGE_IFACE@
 enable_system_hang_test=0 # 0 - disabled
 enable_son_slaves_watchdog=0 # 0 - disabled
-debug_disable_arp=@BEEROCKS_ENABLE_ARP_MONITOR@
 
 [backhaul]
 backhaul_preferred_bssid=

--- a/agent/src/beerocks/monitor/monitor_rssi.h
+++ b/agent/src/beerocks/monitor/monitor_rssi.h
@@ -35,15 +35,12 @@ public:
 
     int conf_rx_rssi_notification_delta_db      = 8;
     int conf_rx_rssi_notification_threshold_dbm = -60;
-    bool conf_disable_arp                       = false;
     bool conf_disable_initiative_arp            = false;
     bool is_5ghz                                = false;
 
 private:
     void send_rssi_measurement_response(std::string &sta_mac, monitor_sta_node *sta_node);
     void monitor_idle_station(std::string &sta_mac, monitor_sta_node *sta_node);
-
-    bool arp_enabled() { return arp_socket > 0; }
 
     monitor_db *mon_db = nullptr;
     Socket *slave_socket;

--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -193,8 +193,6 @@ bool monitor_thread::init()
 
     received_error_notification_ack_retry = -1;
 
-    mon_rssi.conf_disable_arp = (beerocks_slave_conf.debug_disable_arp == "1");
-
     // Initialize the monitor hal
     // if(!mon_hal.init(&mon_db)){
     //     LOG(ERROR) << "mon_hal initialization failed";

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -149,7 +149,6 @@ static void fill_son_slave_config(const beerocks::config_file::sConfigSlave &bee
     son_slave_conf.ucc_listener_port =
         beerocks::string_utils::stoi(beerocks_slave_conf.ucc_listener_port);
     son_slave_conf.enable_keep_alive        = beerocks_slave_conf.enable_keep_alive == "1";
-    son_slave_conf.debug_disable_arp        = beerocks_slave_conf.debug_disable_arp == "1";
     son_slave_conf.bridge_iface             = beerocks_slave_conf.bridge_iface;
     son_slave_conf.backhaul_preferred_bssid = beerocks_slave_conf.backhaul_preferred_bssid;
     son_slave_conf.backhaul_wire_iface      = beerocks_slave_conf.backhaul_wire_iface;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -93,7 +93,7 @@ static bool fill_platform_settings(
                << " sec=" << msg->platform_settings().back_security_type
                << " mem_only_psk=" << int(msg->platform_settings().mem_only_psk) << " pass=***";
 
-    struct bpl::BPL_WLAN_PARAMS params;
+    bpl::BPL_WLAN_PARAMS params;
     if (bpl::cfg_get_wifi_params(iface_name.c_str(), &params) < 0) {
         LOG(ERROR) << "Failed reading '" << iface_name << "' parameters!";
         return false;
@@ -504,7 +504,7 @@ bool main_thread::wlan_params_changed_check()
             return false;
         }
         bool wlan_params_changed = false;
-        struct bpl::BPL_WLAN_PARAMS params;
+        bpl::BPL_WLAN_PARAMS params;
         if (bpl::cfg_get_wifi_params(elm.first.c_str(), &params) < 0) {
             LOG(ERROR) << "Failed reading '" << elm.first << "' parameters!";
             return false;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -42,7 +42,6 @@ public:
         std::string bridge_iface;
         int stop_on_failure_attempts;
         bool enable_keep_alive;
-        bool debug_disable_arp;
         bool enable_repeater_mode;
         std::string backhaul_wire_iface;
         beerocks::eIfaceType backhaul_wire_iface_type;

--- a/common/beerocks/bcl/include/bcl/beerocks_config_file.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_config_file.h
@@ -95,7 +95,6 @@ public:
         std::string ucc_listener_port;
         std::string enable_arp_monitor;
         std::string enable_keep_alive;
-        std::string debug_disable_arp;
         std::string bridge_iface;
         std::string backhaul_preferred_bssid;
         std::string backhaul_wire_iface;

--- a/common/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/common/beerocks/bcl/source/beerocks_config_file.cpp
@@ -152,7 +152,6 @@ bool config_file::read_slave_config_file(const std::string &config_file_path, sC
             std::make_tuple("ucc_listener_port=", &conf.ucc_listener_port, mandatory_slave),
             std::make_tuple("enable_arp_monitor=", &conf.enable_arp_monitor, mandatory_slave),
             std::make_tuple("enable_keep_alive=", &conf.enable_keep_alive, mandatory_slave),
-            std::make_tuple("debug_disable_arp=", &conf.debug_disable_arp, 0),
             std::make_tuple("bridge_iface=", &conf.bridge_iface, 0),
             std::make_tuple("enable_system_hang_test=", &conf.enable_system_hang_test, 0),
             std::make_tuple("enable_son_slaves_watchdog=", &conf.enable_son_slaves_watchdog, 0),


### PR DESCRIPTION
The "disable_arp" feature is causing the monitor_rssi to not send an active arp request.
The problem with this feature is that when it is enabled, Intel steering will not work,
neither client rx_rssi measurement on bml.
Remove "disable_arp" flag from monitor_rssi.