### PR TITLE
hotfix! Fix data filling in add_ap_metrics

### DIFF
--- a/agent/src/beerocks/monitor/monitor_db.h
+++ b/agent/src/beerocks/monitor/monitor_db.h
@@ -161,7 +161,7 @@ public:
     int8_t get_vap_id() { return vap_id; }
 
     void set_mac(const std::string &ap_mac_) { mac = ap_mac_; }
-    std::string get_mac() { return mac; }
+    std::string get_mac() const { return mac; }
 
     std::string get_ipv4();
 
@@ -180,7 +180,7 @@ public:
         if (sta_count > 0)
             sta_count -= 1;
     }
-    int sta_get_count() { return sta_count; }
+    int sta_get_count() const { return sta_count; }
 
     double get_rx_bit_rate();
     double get_tx_bit_rate();
@@ -307,6 +307,11 @@ public:
     };
 
     sApMetricsReportingInfo &ap_metrics_reporting_info() { return m_ap_metrics_reporting_info; }
+
+    uint8_t get_channel_utilization() const
+    {
+        return m_ap_metrics_reporting_info.ap_metrics_channel_utilization_reporting_value;
+    }
 
     // Statistics //
     struct SRadioStats {

--- a/agent/src/beerocks/monitor/monitor_stats.cpp
+++ b/agent/src/beerocks/monitor/monitor_stats.cpp
@@ -435,7 +435,9 @@ void monitor_stats::process()
     }
 }
 
-bool monitor_stats::add_ap_metrics(ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &bssid)
+bool monitor_stats::add_ap_metrics(ieee1905_1::CmduMessageTx &cmdu_tx,
+                                   const monitor_vap_node &vap_node,
+                                   const monitor_radio_node &radio_node) const
 {
     auto ap_metrics_response_tlv = cmdu_tx.addClass<wfa_map::tlvApMetrics>();
 
@@ -444,10 +446,14 @@ bool monitor_stats::add_ap_metrics(ieee1905_1::CmduMessageTx &cmdu_tx, const sMa
         return false;
     }
 
-    //TODO: fill ap_metrics_response_tlv with valid data (now valid just bssid_response)
-    ap_metrics_response_tlv->bssid()                                      = bssid;
-    ap_metrics_response_tlv->channel_utilization()                        = 10;
-    ap_metrics_response_tlv->number_of_stas_currently_associated()        = 2;
+    auto bssid               = tlvf::mac_from_string(vap_node.get_mac());
+    auto channel_utilization = radio_node.get_channel_utilization();
+    auto sta_count           = vap_node.sta_get_count();
+
+    ap_metrics_response_tlv->bssid()                               = bssid;
+    ap_metrics_response_tlv->channel_utilization()                 = channel_utilization;
+    ap_metrics_response_tlv->number_of_stas_currently_associated() = sta_count;
+    //TODO: fill ap_metrics_response_tlv->estimated_service_parameters() with correct value
     ap_metrics_response_tlv->estimated_service_parameters().include_ac_be = 1;
 
     if (!ap_metrics_response_tlv->alloc_estimated_service_info_field(3)) {

--- a/agent/src/beerocks/monitor/monitor_stats.h
+++ b/agent/src/beerocks/monitor/monitor_stats.h
@@ -32,7 +32,8 @@ public:
     void process();
 
     /** Collect AP metrics and create AP Metrics TLV */
-    bool add_ap_metrics(ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &bssid);
+    bool add_ap_metrics(ieee1905_1::CmduMessageTx &cmdu_tx, const monitor_vap_node &vap_node,
+                        const monitor_radio_node &radio_node) const;
     bool add_ap_assoc_sta_traffic_stat(ieee1905_1::CmduMessageTx &cmdu_tx,
                                        const monitor_sta_node &sta_node);
     bool add_ap_assoc_sta_link_metric(ieee1905_1::CmduMessageTx &cmdu_tx, const sMacAddr &bssid,


### PR DESCRIPTION
Add correct values for number_of_stas_currently_associated and
channel_utilization.
