### PR TITLE
Get channel utilization in DWPAL with LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS

### DIFF
--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -1052,5 +1052,22 @@ bool base_wlan_hal_dwpal::get_channel_utilization(uint8_t &channel_utilization)
     return true;
 }
 
+bool base_wlan_hal_dwpal::dwpal_get_phy_chan_status(sPhyChanStatus &status)
+{
+    const ssize_t expected_result_size = sizeof(status) + NL_ATTR_HDR;
+    ssize_t received_result_size =
+        dwpal_nl_cmd_get(get_iface_name(), LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS,
+                         m_nl_buffer, NL_MAX_REPLY_BUFFSIZE);
+
+    if (expected_result_size != received_result_size) {
+        LOG(ERROR) << "LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS failed! expected size = "
+                   << expected_result_size << ", received size = " << received_result_size;
+        return false;
+    }
+    std::copy_n(&m_nl_buffer[NL_ATTR_HDR], sizeof(status),
+                reinterpret_cast<unsigned char *>(&status));
+    return true;
+}
+
 } // namespace dwpal
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -1037,17 +1037,13 @@ std::string base_wlan_hal_dwpal::get_radio_mac()
 
 bool base_wlan_hal_dwpal::get_channel_utilization(uint8_t &channel_utilization)
 {
-    nl80211_client::SurveyInfo survey_info;
-    if (!m_nl80211_client->get_survey_info(get_iface_name(), survey_info)) {
-        LOG(ERROR) << "Failed to get survey information for interface " << get_iface_name();
+    sPhyChanStatus status;
+    if (!dwpal_get_phy_chan_status(status)) {
+        LOG(ERROR) << "Failed to get PHY channel status";
         return false;
     }
 
-    if (!survey_info.get_channel_utilization(channel_utilization)) {
-        LOG(ERROR) << "Survey information contains no channel utilization data for interface "
-                   << get_iface_name();
-        return false;
-    }
+    channel_utilization = status.ch_util * UINT8_MAX / 100;
 
     return true;
 }

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -134,6 +134,17 @@ private:
     size_t m_wpa_ctrl_buffer_size = HOSTAPD_TO_DWPAL_MSG_LENGTH;
 
     int m_nl_get_failed_attempts = 0;
+
+    /**
+     * @brief Gets PHY channel status information
+     *
+     * Sends sub-command LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS of NL80211_CMD_VENDOR
+     * command through DWPAL and fills given structure with response obtained.
+     *
+     * @param status PHY channel status information structure to fill in.
+     * @return True on success and false otherwise.
+     */
+    bool dwpal_get_phy_chan_status(sPhyChanStatus &status);
 };
 
 } // namespace dwpal

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -9,6 +9,8 @@
 #ifndef _BWL_BASE_WLAN_HAL_DWPAL_H_
 #define _BWL_BASE_WLAN_HAL_DWPAL_H_
 
+#include "base_wlan_hal_dwpal_types.h"
+
 #include <bwl/base_wlan_hal.h>
 #include <bwl/nl80211_client.h>
 
@@ -103,6 +105,11 @@ protected:
     void *get_dwpal_nl_ctx() const { return (m_dwpal_nl_ctx); }
 
     std::unique_ptr<nl80211_client> m_nl80211_client;
+
+    /**
+     * Re-usable buffer to hold the response of NL80211_CMD_VENDOR commands
+     */
+    unsigned char m_nl_buffer[NL_MAX_REPLY_BUFFSIZE] = {'\0'};
 
     // Private data-members:
 private:

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -55,7 +55,9 @@ public:
      *
      * @see base_wlan_hal::get_channel_utilization
      *
-     * This implementation gets channel utilization through NL80211.
+     * This implementation gets channel utilization via sub-command
+     * LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS of NL80211_CMD_VENDOR command, issued through
+     * DWPAL interface.
      *
      * @param[out] channel_utilization Channel utilization value.
      *

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal_types.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal_types.h
@@ -9,11 +9,27 @@
 #ifndef _BWL_BASE_WLAN_HAL_DWPAL_TYPES_H_
 #define _BWL_BASE_WLAN_HAL_DWPAL_TYPES_H_
 
+#include <stdint.h>
+
 namespace bwl {
 namespace dwpal {
 
 #define NL_MAX_REPLY_BUFFSIZE 8192
 #define NL_ATTR_HDR 4
+
+/**
+ * @brief Phy channel status.
+ *
+ * Data structure returned by driver via sub-command LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS
+ * of NL80211_CMD_VENDOR command.
+ */
+struct sPhyChanStatus {
+    int8_t noise;                /**< noise level of channel (dBm) */
+    uint8_t ch_load;             /**< channel load [0..100%] */
+    uint8_t ch_util;             /**< total channel utilization [0..100%] */
+    uint8_t airtime;             /**< air time [0..100%] */
+    uint32_t airtime_efficiency; /**< air time efficiency (bytes/s) */
+};
 
 } // namespace dwpal
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal_types.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal_types.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _BWL_BASE_WLAN_HAL_DWPAL_TYPES_H_
+#define _BWL_BASE_WLAN_HAL_DWPAL_TYPES_H_
+
+namespace bwl {
+namespace dwpal {
+
+#define NL_MAX_REPLY_BUFFSIZE 8192
+#define NL_ATTR_HDR 4
+
+} // namespace dwpal
+} // namespace bwl
+
+#endif // _BWL_BASE_WLAN_HAL_DWPAL_TYPES_H_

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
@@ -111,8 +111,7 @@ private:
     }
 
     std::shared_ptr<char> m_temp_dwpal_value;
-    uint32_t m_nl_seq                                = 0;
-    unsigned char m_nl_buffer[NL_MAX_REPLY_BUFFSIZE] = {'\0'};
+    uint32_t m_nl_seq = 0;
 };
 
 } // namespace dwpal

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal_types.h
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal_types.h
@@ -12,9 +12,6 @@
 namespace bwl {
 namespace dwpal {
 
-#define NL_MAX_REPLY_BUFFSIZE 8192
-#define NL_ATTR_HDR 4
-
 /**
  * @brief channel scan driver configuration parameters.
  * 


### PR DESCRIPTION
Standard command NL80211_CMD_GET_SURVEY is not implemented in latest iwlwav driver for RAX40 so it cannot be used to obtain channel utilization.
    
Channel utilization is available in recent drivers however via LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS vendor nl80211 command.
    
Replace current implementation of the get_channel_utilization() method to use LTQ_NL80211_VENDOR_SUBCMD_GET_PHY_CHAN_STATUS through DWPAL instead of NL80211_CMD_GET_SURVEY through NL80211.
