### PR TITLE
prplmesh_utils.sh.in: use BEEROCKS vars instead of hard-coded wlan0/2

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -41,11 +41,11 @@ platform_init() {
     control_ip=192.168.250.140
 
     ip link add @BEEROCKS_BRIDGE_IFACE@ address "${base_mac}:00:00" type bridge
-    ip link add wlan0 address "${base_mac}:00:10" type dummy
-    ip link add wlan2 address "${base_mac}:00:20" type dummy
-    ip link set dev wlan0 up
-    ip link set dev wlan2 up
-    for iface in wlan0 wlan2 $DATA_IFACE
+    ip link add @BEEROCKS_WLAN1_IFACE@ address "${base_mac}:00:10" type dummy
+    ip link add @BEEROCKS_WLAN2_IFACE@ address "${base_mac}:00:20" type dummy
+    ip link set dev @BEEROCKS_WLAN1_IFACE@ up
+    ip link set dev @BEEROCKS_WLAN2_IFACE@ up
+    for iface in @BEEROCKS_WLAN1_IFACE@ @BEEROCKS_WLAN2_IFACE@ $DATA_IFACE
     do
         echo "add $iface to @BEEROCKS_BRIDGE_IFACE@"
         nmcli d set "$iface" managed no
@@ -61,14 +61,14 @@ platform_deinit() {
     echo "platform deinit"
     [ -z "$DATA_IFACE" ] && err "DATA_IFACE not set, abort" && exit 1
     [ -z "$CONTROL_IFACE" ] && err "CONTROL_IFACE not set, abort" && exit 1
-    for iface in wlan0 wlan2 $DATA_IFACE
+    for iface in @BEEROCKS_WLAN1_IFACE@ @BEEROCKS_WLAN2_IFACE@ $DATA_IFACE
     do
         echo "remove $iface from @BEEROCKS_BRIDGE_IFACE@"
         ip link set dev "$iface" nomaster
         nmcli d set "$iface" managed yes
     done
-    ip link del wlan0
-    ip link del wlan2
+    ip link del @BEEROCKS_WLAN1_IFACE@
+    ip link del @BEEROCKS_WLAN2_IFACE@
     ip link del @BEEROCKS_BRIDGE_IFACE@
 }
 


### PR DESCRIPTION
Replace hard-coded wlan ifaces names in "prplmesh_utils.sh.in"

  wlan0 -> @BEEROCKS_WLAN1_IFACE@
  wlan2 -> @BEEROCKS_WLAN2_IFACE@
