### PR TITLE
cmake: allow redefinition BEEROCKS_* vars from cmdline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(prplmesh
 include(cmake/multiap-helpers.cmake)
 
 if(NOT DEFINED TARGET_PLATFORM)
-set(TARGET_PLATFORM "linux")
+    set(TARGET_PLATFORM "linux")
 endif()
 
 option (BUILD_AGENT "Build EasyMesh agent" ON)
@@ -39,7 +39,7 @@ message(STATUS "CMAKE_PREFIX_PATH - ${CMAKE_PREFIX_PATH}")
 message(STATUS "CMAKE_MULTIAP_OUTPUT_DIRECTORY - ${CMAKE_MULTIAP_OUTPUT_DIRECTORY}")
 
 if(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_BUILD_TYPE "Release")
+    set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 set(CMAKE_CXX_STANDARD 11)
@@ -175,10 +175,10 @@ endif()
 add_subdirectory(framework)
 add_subdirectory(common)
 if (BUILD_AGENT)
-add_subdirectory(agent)
+    add_subdirectory(agent)
 endif()
 if (BUILD_CONTROLLER)
-add_subdirectory(controller)
+    add_subdirectory(controller)
 endif()
 
 ## Version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if ("${isSystemDir}" STREQUAL "-1")
 endif ("${isSystemDir}" STREQUAL "-1")
 set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-set(INSTALL_PATH "/opt/prplmesh")
+set(INSTALL_PATH "/opt/prplmesh" CACHE PATH "prplMesh installation directory")
 set(TMP_PATH "/tmp/beerocks")
 
 if(TARGET_PLATFORM STREQUAL "linux")
@@ -102,22 +102,20 @@ if(TARGET_PLATFORM STREQUAL "linux")
 endif()
 
 # Default values
-set(BEEROCKS_WLAN1_IFACE "wlan0")
-set(BEEROCKS_WLAN2_IFACE "wlan2")
-set(BEEROCKS_WLAN3_IFACE "wlan4")
-set(BEEROCKS_BRIDGE_IFACE "br-lan")
-if (NOT DEFINED BEEROCKS_BH_WIRE_IFACE)
-    set(BEEROCKS_BH_WIRE_IFACE "eth1")
-endif()
+set(BEEROCKS_WLAN1_IFACE   "wlan0" CACHE STRING "1st WLAN iface")
+set(BEEROCKS_WLAN2_IFACE   "wlan2" CACHE STRING "2nd WLAN iface")
+set(BEEROCKS_WLAN3_IFACE   "wlan4" CACHE STRING "3rd WLAN iface")
+set(BEEROCKS_BRIDGE_IFACE  "br-lan" CACHE STRING "LAN bridge")
+set(BEEROCKS_BH_WIRE_IFACE "eth1" CACHE STRING "Backhaul wire iface")
 set(BEEROCKS_REPEATER_MODE 0)
 
 # Logging configuration
-set(BEEROCKS_LOG_FILES_ENABLED      "true")
-set(BEEROCKS_LOG_FILES_PATH         "${TMP_PATH}/logs")
-set(BEEROCKS_LOG_FILES_SUFFIX       ".log")
-set(BEEROCKS_LOG_FILES_AUTO_ROLL    "true")
-set(BEEROCKS_LOG_STDOUT_ENABLED     "false")
-set(BEEROCKS_LOG_SYSLOG_ENABLED     "false")
+set(BEEROCKS_LOG_FILES_ENABLED   "true" CACHE STRING "Write prplMesh logs into files")
+set(BEEROCKS_LOG_FILES_PATH      "${TMP_PATH}/logs" CACHE PATH "prplMesh logs directory")
+set(BEEROCKS_LOG_FILES_SUFFIX    ".log" CACHE STRING "prplMesh logs filenames suffix")
+set(BEEROCKS_LOG_FILES_AUTO_ROLL "true" CACHE STRING "Auto rollback prplMesh logs")
+set(BEEROCKS_LOG_STDOUT_ENABLED  "false" CACHE STRING "Print logs to stdout")
+set(BEEROCKS_LOG_SYSLOG_ENABLED  "false" CACHE STRING "Send logs to syslog")
 
 # Platform specific flags
 if (TARGET_PLATFORM STREQUAL "openwrt")

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,7 +1,7 @@
 message("${BoldWhite}Preparing ${BoldGreen}common${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
 
 # Default values
-set(BEEROCKS_PLATFORM_INIT "false")
+set(BEEROCKS_PLATFORM_INIT "false" CACHE STRING "Configure minimal set of dummy WLAN ifaces and bridge")
 
 # Modules
 add_subdirectory(beerocks)

--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -10,7 +10,8 @@ file(GLOB_RECURSE bwl_common_sources ${MODULE_PATH}/common/*.c*)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 # Default defaults
-set(BWL_TYPE "DUMMY")
+set(BWL_TYPE "DUMMY" CACHE STRING "BWL type")
+set_property(CACHE BWL_TYPE PROPERTY STRINGS "DUMMY" "NL80211" "DWPAL")
 add_definitions(-DBEEROCKS_TMP_PATH="${TMP_PATH}")
 
 if (TARGET_PLATFORM STREQUAL "rdkb")


### PR DESCRIPTION
If CMake variable defined in CMakeLists.txt file like
```
    set(VARIABLE VALUE)
```
Then it's impossible to redefine it from command line.
Event tricks like next does not work:
```
    cmake ... -UVARIABLE -DVARIABLE=NEW_VALUE
```
So Yocto/RDKB recipes and OpenWrt/prplWrt makefiles cannot
redefine variables without modification CMakeLists.txt files.

As a result conf files for controller/agent/etc. generated with values unusable for RDKB/etc.

Define variables interested for redefinition following pattern:
```
    if(NOT DEFINED VARIABLE)
        set(VARIABLE DEFAUL_VALUE)
    endif()
```
