### PR TITLE
Port test_initial_ap_config to boardfarm for prplWRT device

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -83,3 +83,10 @@ class PrplMeshDocker(PrplMeshBase):
         States that device is operational and its consoles are accessible.
         """
         return True
+
+    def prprlmesh_status_check(self) -> bool:
+        """Check prplMesh status by executing status command to initd service.
+        Return True if operational.
+        """
+        self.check_status()
+        return True

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -51,14 +51,14 @@ class PrplMeshDocker(PrplMeshBase):
             self._run_shell_cmd(docker_cmd, docker_args)
 
             time.sleep(self.delay)
-            self.controller_entity = ALEntityDocker(self.name, is_controller=True)
+            self.controller_entity = ALEntityDocker(self.name, device=self, is_controller=True)
         else:
             # Spawn dockerized agent
             docker_args.append("start-agent")
             self._run_shell_cmd(docker_cmd, docker_args)
 
             time.sleep(self.delay)
-            self.agent_entity = ALEntityDocker(self.name, is_controller=False)
+            self.agent_entity = ALEntityDocker(self.name, device=self, is_controller=False)
 
         self.wired_sniffer = Sniffer(_get_bridge_interface(self.docker_network),
                                      boardfarm.config.output_dir)

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
@@ -100,7 +100,7 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if self.prplMesh_check_state():
+            if self.get_prplMesh_status():
                 break
             time.sleep(5)
         else:
@@ -115,7 +115,7 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         """
         return True
 
-    def prplMesh_check_state(self) -> bool:
+    def get_prplMesh_status(self) -> bool:
         """ Check prplMesh status. Return True if operational."""
         self.sendline("/etc/init.d/prplmesh status")
         self.expect(

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
@@ -6,19 +6,28 @@
 ###############################################################
 
 import boardfarm
-from boardfarm.devices import OpenWrtRouter
-from environment import ALEntityPrplWrt, _get_bridge_interface
+import json
+import os
+import pexpect
+import subprocess
+import sys
+
 from .prplmesh_base import PrplMeshBase
+from boardfarm.devices import connection_decider
+from boardfarm.devices.openwrt_router import OpenWrtRouter
+from environment import ALEntityPrplWrt, _get_bridge_interface
+from ipaddress import IPv4Network, IPv4Address
 from sniffer import Sniffer
 
 
 class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
     """prplWRT burned device with prplMesh installed."""
 
-    model = "prplWRT"
+    model = ("prplWRT")
     prompt = ['root\\@OpenWrt:/#', '/#', '@OpenWrt:/#']
     wan_iface = "eth1"
     uboot_eth = "eth0_1"
+    linesep = "\r"
     agent_entity = None
     controller_entity = None
 
@@ -27,17 +36,41 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         self.args = args
         self.kwargs = kwargs
         config = kwargs.get("config", kwargs)
+
+        self.unique_id = os.getenv("SUDO_USER", os.getenv("USER", ""))
         self.docker_network = config.get("docker_network",
                                          "prplMesh-net-{}".format(self.unique_id))
         self.role = config.get("role", "agent")
-        if self.role == "controller":
-            self.controller_entity = ALEntityPrplWrt(self.name, is_controller=True)
-        else:
-            self.agent_entity = ALEntityPrplWrt(self.name, is_controller=False)
+        self.connection_type = config.get("connection_type", None)
+        self.conn_cmd = config.get("conn_cmd", None)
 
+        self.connection = connection_decider.connection(device=self,
+                                                        conn_type=kwargs['connection_type'],
+                                                        **kwargs)
+        self.connection.connect()
+
+        self.name = "-".join((config.get("name", "rax40"), self.unique_id))
+        self.consoles = [self]
+        self.logfile_read = sys.stdout
+
+        self.wan_network = self.get_docker_subnet(self.docker_network)
+        self.set_iface_to_bridge(self.wan_iface)
+        self.set_iface_ip("br-lan", self.wan_network[+245], self.wan_network.prefixlen)
         self.wired_sniffer = Sniffer(_get_bridge_interface(self.docker_network),
                                      boardfarm.config.output_dir)
-        self.check_status()
+        if self.role == "controller":
+            self.controller_entity = ALEntityPrplWrt(self, is_controller=True)
+        else:
+            self.agent_entity = ALEntityPrplWrt(self, is_controller=False)
+            self.prplMesh_start_agent()
+
+    def _prplMesh_exec(self, mode: str):
+        """Send line to prplmesh initd script."""
+        self.sendline("/etc/init.d/prplmesh {}".format(mode))
+
+    def kill_console_at_exit(self):
+        """Kill connections on device termination."""
+        self.connection.close()
 
     def check_status(self) -> bool:
         """Check status of device, return bool to indicate state.
@@ -45,11 +78,15 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         It is used by boardfarm to indicate that spawned device instance is ready for test
         and also after test - to insure that device still operational.
         """
+        return True
+
+    def prplMesh_check_state(self) -> bool:
+        """ Check prplMesh status. Return True if operational."""
         self.sendline("/etc/init.d/prplmesh status")
         match = self.expect(
-                ["OPERATIONAL", self.device.pexpect.EOF, self.device.pexpect.TIMEOUT],
+                ["operational", "FAIL", pexpect.EOF, pexpect.TIMEOUT],
                 timeout=10)
-        if match == 1:
+        if match == 0:
             return True
         else:
             return False
@@ -67,3 +104,36 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         Purpose is to keep consoles active, so they don't disconnect for long running activities.
         """
         pass
+
+    def get_docker_subnet(self, docker_network: str) -> IPv4Network:
+        """Get subnet used by docker network."""
+        docker_network_inspect_cmd = ('docker', 'network', 'inspect', docker_network)
+        inspect_raw = subprocess.run(docker_network_inspect_cmd, stdout=subprocess.PIPE)
+        if inspect_raw.returncode != 0:
+            # Assume network doesn't exist yet. Create it.
+            # Raise an exception if it fails (check=True).
+            subprocess.run(('docker', 'network', 'create', docker_network), check=True,
+                           stdout=subprocess.DEVNULL)
+            # Inspect again, now raise if it fails (check=True).
+            inspect_raw = subprocess.run(docker_network_inspect_cmd, check=True,
+                                         stdout=subprocess.PIPE)
+        inspect_json = json.loads(inspect_raw.stdout)
+
+        return IPv4Network(inspect_json[0]["IPAM"]["Config"][0]["Subnet"])
+
+    def set_iface_to_bridge(self, iface: str) -> bool:
+        """Add specified interface to the specified bridge."""
+        ip_command = ("ip link set {} master br-lan".format(iface))
+        self.sendline(ip_command)
+        self.expect(self.prompt, timeout=10)
+
+    def set_iface_ip(self, iface: str, ip: IPv4Address, prefixlen :int) -> bool:
+        """Set interface IPv4 address."""
+        self.sendline("ip a add {}/{} dev {}".format(ip, prefixlen, iface))
+        self.expect(self.prompt, timeout=10)
+
+    def prplMesh_start_agent(self) -> bool:
+        """Start prplMesh in certification_mode agent. Return true if done."""
+        self._prplMesh_exec("certification_mode agent")
+        self.expect_exact("CAC timer expired", timeout=120)
+        self.expect_exact("device br-lan entered promiscuous mode", timeout=40)

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
@@ -9,8 +9,10 @@ import boardfarm
 import json
 import os
 import pexpect
+import signal
 import subprocess
 import sys
+import time
 
 from .prplmesh_base import PrplMeshBase
 from boardfarm.devices import connection_decider
@@ -23,8 +25,8 @@ from sniffer import Sniffer
 class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
     """prplWRT burned device with prplMesh installed."""
 
-    model = ("prplWRT")
-    prompt = ['root\\@OpenWrt:/#', '/#', '@OpenWrt:/#']
+    model = "prplWRT"
+    prompt = ['root\\@OpenWrt:/#', '/#', '@OpenWrt:/#', "@OpenWrt:~#"]
     wan_iface = "eth1"
     uboot_eth = "eth0_1"
     linesep = "\r"
@@ -43,34 +45,67 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         self.role = config.get("role", "agent")
         self.connection_type = config.get("connection_type", None)
         self.conn_cmd = config.get("conn_cmd", None)
+        self.wan_ip = config.get("wan_ip", None)
+        self.username = config.get("username", "root")
 
-        self.connection = connection_decider.connection(device=self,
-                                                        conn_type=kwargs['connection_type'],
-                                                        **kwargs)
-        self.connection.connect()
+        self.name = "-".join((config.get("name", "netgear-rax40"), self.unique_id))
 
-        self.name = "-".join((config.get("name", "rax40"), self.unique_id))
-        self.consoles = [self]
-        self.logfile_read = sys.stdout
+        # If no WAN IP is set in config file retrieve IP from docker network set in config
+        # X.X.X.245 IP will be selected from docker network
+        if not self.wan_ip:
+            self.connection = connection_decider.connection(device=self,
+                                                            conn_type="local_serial",
+                                                            **kwargs)
+            self.connection.connect()
+            self.consoles = [self]
+            self.logfile_read = sys.stdout
+            self.wan_network = self.get_docker_subnet()
+            self.wan_ip = self.wan_network[+245]
+            self.set_iface_ip("br-lan", self.wan_ip, self.wan_network.prefixlen)
+            self.connection.close()
+            self.kill(signal.SIGTERM)
+            # Removal of PID is required by pexpect in order to spawn a new process
+            # serial connection should be terminated by 2 commands above
+            self.pid = None
 
-        self.wan_network = self.get_docker_subnet(self.docker_network)
-        self.set_iface_to_bridge(self.wan_iface)
-        self.set_iface_ip("br-lan", self.wan_network[+245], self.wan_network.prefixlen)
         self.wired_sniffer = Sniffer(_get_bridge_interface(self.docker_network),
                                      boardfarm.config.output_dir)
+        self.connection = connection_decider.connection(device=self,
+                                                        conn_type="ssh",
+                                                        conn_cmd="ssh {}@{}".format(
+                                                            self.username, self.wan_ip))
+        self.connection.connect()
+        # Append active connection to the general array for logging
+        self.consoles = [self]
+        # Point what to log as data read from child process of pexpect
+        # Result: boardfarm will log communication in separate file
+        self.logfile_read = sys.stdout
+        self.add_iface_to_bridge(self.wan_iface, "br-lan")
+
         if self.role == "controller":
             self.controller_entity = ALEntityPrplWrt(self, is_controller=True)
         else:
             self.agent_entity = ALEntityPrplWrt(self, is_controller=False)
-            self.prplMesh_start_agent()
+            self.prplmesh_start_agent()
 
     def _prplMesh_exec(self, mode: str):
         """Send line to prplmesh initd script."""
         self.sendline("/etc/init.d/prplmesh {}".format(mode))
 
-    def kill_console_at_exit(self):
-        """Kill connections on device termination."""
-        self.connection.close()
+    def _prplmesh_status_poll(self, timeout: int = 120) -> bool:
+        """Poll prplMesh status for timeout time.
+
+        Main agent and wlan0, wlan2 radios should be operational.
+        Return True if status is operational and timeout not reached.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.prplMesh_check_state():
+                break
+            time.sleep(5)
+        else:
+            return False
+        return True
 
     def check_status(self) -> bool:
         """Check status of device, return bool to indicate state.
@@ -83,10 +118,12 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
     def prplMesh_check_state(self) -> bool:
         """ Check prplMesh status. Return True if operational."""
         self.sendline("/etc/init.d/prplmesh status")
-        match = self.expect(
-                ["operational", "FAIL", pexpect.EOF, pexpect.TIMEOUT],
-                timeout=10)
-        if match == 0:
+        self.expect(
+                ["(?P<main_agent>OK) Main agent.+"
+                 "(?P<wlan0>OK) wlan0.+"
+                 "(?P<wlan2>OK) wlan2", pexpect.TIMEOUT],
+                timeout=5)
+        if self.match is not pexpect.TIMEOUT:
             return True
         else:
             return False
@@ -105,14 +142,14 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
         """
         pass
 
-    def get_docker_subnet(self, docker_network: str) -> IPv4Network:
+    def get_docker_subnet(self) -> IPv4Network:
         """Get subnet used by docker network."""
-        docker_network_inspect_cmd = ('docker', 'network', 'inspect', docker_network)
+        docker_network_inspect_cmd = ('docker', 'network', 'inspect', self.docker_network)
         inspect_raw = subprocess.run(docker_network_inspect_cmd, stdout=subprocess.PIPE)
         if inspect_raw.returncode != 0:
             # Assume network doesn't exist yet. Create it.
             # Raise an exception if it fails (check=True).
-            subprocess.run(('docker', 'network', 'create', docker_network), check=True,
+            subprocess.run(('docker', 'network', 'create', self.docker_network), check=True,
                            stdout=subprocess.DEVNULL)
             # Inspect again, now raise if it fails (check=True).
             inspect_raw = subprocess.run(docker_network_inspect_cmd, check=True,
@@ -121,19 +158,25 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
 
         return IPv4Network(inspect_json[0]["IPAM"]["Config"][0]["Subnet"])
 
-    def set_iface_to_bridge(self, iface: str) -> bool:
+    def add_iface_to_bridge(self, iface: str, bridge: str) -> bool:
         """Add specified interface to the specified bridge."""
-        ip_command = ("ip link set {} master br-lan".format(iface))
+        ip_command = ("ip link set {} master {}".format(iface, bridge))
         self.sendline(ip_command)
         self.expect(self.prompt, timeout=10)
 
-    def set_iface_ip(self, iface: str, ip: IPv4Address, prefixlen :int) -> bool:
+    def set_iface_ip(self, iface: str, ip: IPv4Address, prefixlen: int) -> bool:
         """Set interface IPv4 address."""
         self.sendline("ip a add {}/{} dev {}".format(ip, prefixlen, iface))
         self.expect(self.prompt, timeout=10)
 
-    def prplMesh_start_agent(self) -> bool:
+    def prplmesh_start_agent(self) -> bool:
         """Start prplMesh in certification_mode agent. Return true if done."""
         self._prplMesh_exec("certification_mode agent")
-        self.expect_exact("CAC timer expired", timeout=120)
-        self.expect_exact("device br-lan entered promiscuous mode", timeout=40)
+        self.expect(self.prompt)
+        return True
+
+    def prprlmesh_status_check(self) -> bool:
+        """Check prplMesh status by executing status command to initd service.
+        Return True if operational.
+        """
+        return self._prplmesh_status_poll()

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -16,5 +16,22 @@
                 "conn_cmd": ""
             }
         ]
+    },
+    "netgear-rax40-1": {
+        "name": "agent-rax40",
+        "board_type": "prplWRT",
+        "role": "agent",
+        "docker_network": "prplMesh-net-rax40-1",
+        "connection_type": "local_serial",
+        "conn_cmd": "cu -s 115200 -l /dev/ttyUSB0",
+        "devices": [
+            {
+            "name": "controller",
+            "type": "prplmesh_docker",
+            "role": "controller",
+            "docker_network": "prplMesh-net-rax40-1",
+            "conn_cmd": ""
+            }
+        ]
     }
 }

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -22,7 +22,6 @@
         "board_type": "prplWRT",
         "role": "agent",
         "docker_network": "prplMesh-net-rax40-1",
-        "connection_type": "local_serial",
         "conn_cmd": "cu -s 115200 -l /dev/ttyUSB0",
         "devices": [
             {

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -15,6 +15,10 @@ class InitialApConfig(PrplMeshBaseTest):
                 dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
 
                 self.check_log(dev.agent_entity.radios[0],
+                               r"Controller configuration \(WSC M2 Encrypted Settings\)")
+                self.check_log(dev.agent_entity.radios[1],
+                               r"Controller configuration \(WSC M2 Encrypted Settings\)")
+                self.check_log(dev.agent_entity.radios[0],
                                r"WSC Global authentication success")
                 self.check_log(dev.agent_entity.radios[1],
                                r"WSC Global authentication success")
@@ -22,13 +26,13 @@ class InitialApConfig(PrplMeshBaseTest):
                                r"KWA \(Key Wrap Auth\) success")
                 self.check_log(dev.agent_entity.radios[1],
                                r"KWA \(Key Wrap Auth\) success")
-                self.check_log(dev.agent_entity.radios[0],
-                               r".* Controller configuration \(WSC M2 Encrypted Settings\)")
-                self.check_log(dev.agent_entity.radios[1],
-                               r".* Controller configuration \(WSC M2 Encrypted Settings\)")
-
-                dev.wired_sniffer.stop()
 
     @classmethod
     def teardown_class(cls):
         """Teardown method, optional for boardfarm tests."""
+        test = cls.test_obj
+        for dev in test.dev:
+            if dev.agent_entity:
+                print("Sniffer - stop")
+                dev.agent_entity.device.send('\003')
+                dev.wired_sniffer.stop()

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -14,7 +14,7 @@ class InitialApConfig(PrplMeshBaseTest):
             if dev.agent_entity:
                 dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
 
-                self.prplmesh_status_check(dev.agent_entity.device)
+                self.prplmesh_status_check(dev.agent_entity)
                 self.check_log(dev.agent_entity.radios[0],
                                r"\(WSC M2 Encrypted Settings\)")
                 self.check_log(dev.agent_entity.radios[1],
@@ -35,5 +35,10 @@ class InitialApConfig(PrplMeshBaseTest):
         for dev in test.dev:
             if dev.agent_entity:
                 print("Sniffer - stop")
-                dev.agent_entity.device.send('\003')
+                # Send Ctrl+C to the device to terminate "tail -f"
+                # Which is used to read log from device. Required only for tests on HW
+                try:
+                    dev.agent_entity.device.send('\003')
+                except AttributeError:
+                    pass
                 dev.wired_sniffer.stop()

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -14,10 +14,11 @@ class InitialApConfig(PrplMeshBaseTest):
             if dev.agent_entity:
                 dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
 
+                self.prplmesh_status_check(dev.agent_entity.device)
                 self.check_log(dev.agent_entity.radios[0],
-                               r"Controller configuration \(WSC M2 Encrypted Settings\)")
+                               r"\(WSC M2 Encrypted Settings\)")
                 self.check_log(dev.agent_entity.radios[1],
-                               r"Controller configuration \(WSC M2 Encrypted Settings\)")
+                               r"\(WSC M2 Encrypted Settings\)")
                 self.check_log(dev.agent_entity.radios[0],
                                r"WSC Global authentication success")
                 self.check_log(dev.agent_entity.radios[1],

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
@@ -16,7 +16,7 @@ class PrplMeshBaseTest(bft_base_test.BftBaseTest):
     """
 
     def check_log(self, entity_or_radio: Union[env.ALEntity, env.Radio], regex: str,
-                  start_line: int = 0, timeout: float = 0.3) -> bool:
+                  start_line: int = 0, timeout: float = 0.6) -> bool:
         result, line, match = entity_or_radio.wait_for_log(regex, start_line, timeout)
         if not result:
             raise Exception

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
@@ -21,3 +21,12 @@ class PrplMeshBaseTest(bft_base_test.BftBaseTest):
         if not result:
             raise Exception
         return result, line, match
+
+    def prplmesh_status_check(self, entity_or_radio: Union[env.ALEntity, env.Radio]) -> bool:
+        """Check prplMesh status by executing status command to initd service.
+        Return True if operational.
+        """
+        result = entity_or_radio.prprlmesh_status_check()
+        if not result:
+            raise Exception
+        return result

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -422,40 +422,17 @@ class ALEntityPrplWrt(ALEntity):
         else:
             self.config_file_name = '/opt/prplmesh/config/beerocks_agent.conf'
 
-<<<<<<< HEAD
-        ucc_port = self.command(("grep \"ucc_listener_port\" {} "
-                                "| cut -d'=' -f2 | cut -d\" \" -f 1").format(self.config_file_name))
-
-        device_ip_output = self.command(
-            "ip -f inet addr show {} | head -n 2".format(self.bridge_name))
-        device_ip = re.search(
-            r'inet (?P<ip>[0-9.]+)', device_ip_output.decode('utf-8')).group('ip')
-        self.log_folder = self.command(
-            "grep log_files_path {} | cut -d=\'=\' -f2".format(self.config_file_name))
-
-        ucc_socket = UCCSocket(device_ip, ucc_port)
-=======
         ucc_port_raw = self.command("grep \"ucc_listener_port\" {}".format(self.config_file_name))
         ucc_port = int(re.search(r'ucc_listener_port=(?P<port>[0-9]+)',
                                  ucc_port_raw).group('port'))
         bridge_name_raw = self.command("grep \"bridge_iface\" {}".format(self.config_file_name))
         self.bridge_name = re.search(r'bridge_iface=(?P<bridge>.+)\r\n',
                                      bridge_name_raw).group('bridge')
-
-        # Multiple IPs may be set to same interface. We are interested in the last one, which is set
-        # by test during board init procedure.
-        device_ip_raw = self.command(
-            "ip -family inet addr show {} | tail -n 2".format(self.bridge_name))
-        self.device_ip = re.search(r'inet (?P<ip>[0-9.]+)',
-                                   device_ip_raw).group('ip')
-
         log_folder_raw = self.command(
             "grep log_files_path {}".format(self.config_file_name))
         self.log_folder = re.search(r'log_files_path=(?P<log_path>[a-zA-Z0-9_\/]+)',
                                     log_folder_raw).group('log_path')
-
-        ucc_socket = UCCSocket(self.device_ip, int(ucc_port))
->>>>>>> tests:  environment.py: complete prplWRT entities
+        ucc_socket = UCCSocket(str(self.device.wan_ip), int(ucc_port))
         mac = ucc_socket.dev_get_parameter('ALid')
 
         super().__init__(mac, ucc_socket, installdir, is_controller)


### PR DESCRIPTION
## Description
This PR partially resolves #1072 .
Main goal is to bring InitialApConfig to RAX40.

**Prerequisite**:
1.  Interface, which has RAX40 connected, is included in docker bridge.
1.  Name of this docker network is stated in `boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json` 

This network is used for dockerized controller -> RAX40's agent. In order to add iface to the bridge, `sudo` powers are required. Currently, we do not plan to run `bft` with `sudo` power. Thus, docker network preparation and manual include of interface is required.

## Changes
- `prplWRT` device class to handle RAX40
- prplMesh specific entities for `environment.py`
- `rax40-1`RAX40 board added to boardfarm configuration