### PR TITLE
Bugfix/dwpal wps pbc update

### DIFF
--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -969,6 +969,7 @@ static bool set_vap_multiap_mode(std::vector<std::string> &vap_hostapd_config, b
         return false;
     }
     hostapd_config_set_value(vap_hostapd_config, "wps_state", fronthaul ? "2" : "");
+    hostapd_config_set_value(vap_hostapd_config, "wps_independent", "0");
     hostapd_config_set_value(vap_hostapd_config, "mesh_mode", backhaul ? "bAP" : "fAP");
     hostapd_config_set_value(vap_hostapd_config, "sFourAddrMode", backhaul ? "1" : "");
     hostapd_config_set_value(vap_hostapd_config, "max_num_sta", backhaul ? "1" : "");

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -1664,25 +1664,8 @@ bool ap_wlan_hal_dwpal::generate_connected_clients_events()
 
 bool ap_wlan_hal_dwpal::start_wps_pbc()
 {
-    // refresh vaps info just to be on the safe side since we
-    // don't know when this function will be called and we better
-    // have the latest information.
-    refresh_vaps_info(beerocks::IFACE_RADIO_ID);
-    // start wps on the first fronthaul vap since Intel hostapd (and therefore BWL DWPAL)
-    // doesn't support upstream hostapd wps_pbc command which takes no parameters.
-    auto it = std::find_if(m_radio_info.available_vaps.begin(), m_radio_info.available_vaps.end(),
-                           [&](const std::pair<int, VAPElement> &vap) -> bool {
-                               return (!vap.second.ssid.empty() && vap.second.fronthaul);
-                           });
-    if (it == m_radio_info.available_vaps.end()) {
-        LOG(ERROR) << "Failed to find fronthaul VAP for WPS";
-        return false;
-    }
-    int vap_id = (*it).first;
-    std::string ifname =
-        beerocks::utils::get_iface_string_from_iface_vap_ids(m_radio_info.iface_name, vap_id);
-    LOG(DEBUG) << "Start WPS PBC on interface " << ifname;
-    std::string cmd = "WPS_PBC " + ifname;
+    LOG(DEBUG) << "Start WPS PBC on interface " << m_radio_info.iface_name;
+    std::string cmd = "WPS_PBC";
     if (!dwpal_send_cmd(cmd)) {
         LOG(ERROR) << "start_wps_pbc() failed!";
         return false;


### PR DESCRIPTION
With the new dwpal version, "WPS_PBC <ifname>" is not supported
anymore.

Use WPS_PBC without any interface name instead, to start it on all
configured interfaces.

We also need to set wps_independent to 0 for the vaps we configure.

Fixes https://github.com/prplfoundation/prplMesh/issues/413