### PR TITLE
Refactor creation of AP Metrics Response message in monitor thread

### DIFF
--- a/agent/src/beerocks/monitor/monitor_db.cpp
+++ b/agent/src/beerocks/monitor/monitor_db.cpp
@@ -298,6 +298,15 @@ int monitor_db::get_vap_id(const std::string &bssid)
     return beerocks::IFACE_ID_INVALID;
 }
 
+void monitor_db::get_bssid_list(std::vector<sMacAddr> &bssid_list) const
+{
+    for (const auto &vap : vap_nodes) {
+        const auto &vap_node = vap.second;
+        auto bssid           = tlvf::mac_from_string(vap_node->get_mac());
+        bssid_list.emplace_back(bssid);
+    }
+}
+
 monitor_sta_node *monitor_db::sta_find(const std::string &sta_mac)
 {
     auto it = sta_nodes.find(sta_mac);

--- a/agent/src/beerocks/monitor/monitor_db.h
+++ b/agent/src/beerocks/monitor/monitor_db.h
@@ -379,6 +379,13 @@ public:
     int get_vap_count() { return vap_nodes.size(); }
     void vap_erase_all();
 
+    /**
+     * @brief Gets a list containing the BSSID of all VAPs.
+     *
+     * @param[out] bssid_list list of BSSID to fill in.
+     */
+    void get_bssid_list(std::vector<sMacAddr> &bssid_list) const;
+
     // STA's //
     monitor_sta_node *sta_add(const std::string &sta_mac, const int8_t vap_id);
     void sta_erase(const std::string &sta_mac);

--- a/agent/src/beerocks/monitor/monitor_thread.h
+++ b/agent/src/beerocks/monitor/monitor_thread.h
@@ -73,8 +73,13 @@ private:
 
     /**
      * @brief Creates AP Metrics Response message
+     *
+     * @param mid Message ID.
+     * @param bssid_list list of BSSID of BSS operated by the Multi-AP Agent to include in the AP
+     * Metrics Response message.
+     * @return True on success and false otherwise.
      */
-    bool create_ap_metrics_response();
+    bool create_ap_metrics_response(uint16_t mid, const std::vector<sMacAddr> &bssid_list);
 
     bool update_ap_stats();
     bool update_sta_stats();


### PR DESCRIPTION
AP Metrics Response message must be created in two different
situations: when AP Metrics Query message is received and when channel
utilization threshold has been crossed.

Refactor existing code that creates AP Metrics Response message so it
can be used in both cases without duplicating code.

