### PR TITLE
nl80211: take hostapd ctl iface path from agent config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,14 @@ set(BEEROCKS_LOG_FILES_AUTO_ROLL "true" CACHE STRING "Auto rollback prplMesh log
 set(BEEROCKS_LOG_STDOUT_ENABLED  "false" CACHE STRING "Print logs to stdout")
 set(BEEROCKS_LOG_SYSLOG_ENABLED  "false" CACHE STRING "Send logs to syslog")
 
+set(BEEROCKS_HOSTAP_WLAN1_CTRL_IFACE "/var/run/hostapd/${BEEROCKS_WLAN1_IFACE}" CACHE PATH "hostapd ctrl iface path for 1st WLAN")
+set(BEEROCKS_HOSTAP_WLAN2_CTRL_IFACE "/var/run/hostapd/${BEEROCKS_WLAN2_IFACE}" CACHE PATH "hostapd ctrl iface path for 2nd WLAN")
+set(BEEROCKS_HOSTAP_WLAN3_CTRL_IFACE "/var/run/hostapd/${BEEROCKS_WLAN3_IFACE}" CACHE PATH "hostapd ctrl iface path for 3rd WLAN")
+
+set(BEEROCKS_WPA_SUPPLICANT_WLAN1_CTRL_IFACE "/var/run/wpa_supplicant/${BEEROCKS_WLAN1_IFACE}" CACHE PATH "wpa_supplicant ctrl iface path for 1st WLAN")
+set(BEEROCKS_WPA_SUPPLICANT_WLAN2_CTRL_IFACE "/var/run/wpa_supplicant/${BEEROCKS_WLAN2_IFACE}" CACHE PATH "wpa_supplicant ctrl iface path for 2nd WLAN")
+set(BEEROCKS_WPA_SUPPLICANT_WLAN3_CTRL_IFACE "/var/run/wpa_supplicant/${BEEROCKS_WLAN3_IFACE}" CACHE PATH "wpa_supplicant ctrl iface path for 3rd WLAN")
+
 # Platform specific flags
 if (TARGET_PLATFORM STREQUAL "openwrt")
     if (TARGET_PLATFORM_TYPE STREQUAL "ugw")
@@ -125,6 +133,8 @@ if (TARGET_PLATFORM STREQUAL "openwrt")
     else()
         set(BEEROCKS_WLAN2_IFACE "wlan1")
         set(BEEROCKS_WLAN2_STEERING_VAPS "wlan1.0")
+        set(BEEROCKS_HOSTAP_WLAN2_CTRL_IFACE "/var/run/hostapd/${BEEROCKS_WLAN2_IFACE}")
+        set(BEEROCKS_WPA_SUPPLICANT_WLAN2_CTRL_IFACE "/var/run/wpa_supplicant/${BEEROCKS_WLAN2_IFACE}")
     endif()
 elseif (TARGET_PLATFORM STREQUAL "rdkb")
     add_definitions(-DBEEROCKS_RDKB)

--- a/agent/config/beerocks_agent.conf.in
+++ b/agent/config/beerocks_agent.conf.in
@@ -28,18 +28,24 @@ radio_identifier=00:00:00:00:00:00
 hostap_iface_type=WIFI_INTEL
 hostap_ant_gain=0
 enable_repeater_mode=@BEEROCKS_REPEATER_MODE@
+hostap_ctrl_iface=@BEEROCKS_HOSTAP_WLAN1_CTRL_IFACE@
+wpa_supplicant_ctrl_iface=@BEEROCKS_WPA_SUPPLICANT_WLAN1_CTRL_IFACE@
 
 [agent1]
 radio_identifier=00:00:00:00:00:02
 hostap_iface_type=WIFI_INTEL
 hostap_ant_gain=0
 enable_repeater_mode=0
+hostap_ctrl_iface=@BEEROCKS_HOSTAP_WLAN2_CTRL_IFACE@
+wpa_supplicant_ctrl_iface=@BEEROCKS_WPA_SUPPLICANT_WLAN2_CTRL_IFACE@
 
 [agent2]
 radio_identifier=00:00:00:00:00:02
 hostap_iface_type=WIFI_INTEL
 hostap_ant_gain=0
 enable_repeater_mode=0
+hostap_ctrl_iface=@BEEROCKS_HOSTAP_WLAN3_CTRL_IFACE@
+wpa_supplicant_ctrl_iface=@BEEROCKS_WPA_SUPPLICANT_WLAN3_CTRL_IFACE@
 
 [log]
 log_global_levels=error,info,warning,fatal,trace,debug

--- a/agent/src/beerocks/fronthaul_manager/CMakeLists.txt
+++ b/agent/src/beerocks/fronthaul_manager/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 add_executable(${PROJECT_NAME} ${fronthaul_manager_sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,-z,defs")
-target_link_libraries(${PROJECT_NAME} bcl btlvf rt dl tlvf elpp bwl ${LIBS})
+target_link_libraries(${PROJECT_NAME} bcl btlvf rt dl tlvf elpp bwl mapfcommon bpl ${LIBS})
 
 # Install
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.cpp
@@ -93,13 +93,15 @@ using namespace beerocks;
 using namespace son;
 
 ap_manager_thread::ap_manager_thread(const std::string &slave_uds_, const std::string &iface,
-                                     beerocks::logging &logger)
+                                     beerocks::logging &logger,
+                                     const std::string &hostap_iface_ctrl)
     : socket_thread(), m_logger(logger)
 {
     thread_name = "ap_manager";
     logger.set_thread_name(thread_name);
-    slave_uds = slave_uds_;
-    m_iface   = iface;
+    slave_uds           = slave_uds_;
+    m_iface             = iface;
+    m_hostap_iface_ctrl = hostap_iface_ctrl;
     set_select_timeout(SELECT_TIMEOUT_MSC);
 }
 
@@ -113,6 +115,7 @@ bool ap_manager_thread::create_ap_wlan_hal()
 
     bwl::hal_conf_t hal_conf;
     hal_conf.ap_acs_enabled = acs_enabled;
+    hal_conf.wpa_ctrl_path  = m_hostap_iface_ctrl;
 
     // Create a new AP HAL instance
     ap_wlan_hal = bwl::ap_wlan_hal_create(

--- a/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.h
+++ b/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.h
@@ -25,7 +25,7 @@ class ap_manager_thread : public beerocks::socket_thread {
 
 public:
     ap_manager_thread(const std::string &slave_uds_, const std::string &iface,
-                      beerocks::logging &logger);
+                      beerocks::logging &logger, const std::string &hostap_iface_ctrl);
     virtual ~ap_manager_thread();
 
     virtual bool init() override;
@@ -118,6 +118,7 @@ private:
     const uint8_t HEARTBEAT_NOTIFICATION_DELAY_SEC = 1;
 
     bool acs_completed_vap_update = false;
+    std::string m_hostap_iface_ctrl;
 };
 
 } // namespace son

--- a/agent/src/beerocks/fronthaul_manager/fronthaul_manager_main.cpp
+++ b/agent/src/beerocks/fronthaul_manager/fronthaul_manager_main.cpp
@@ -230,7 +230,8 @@ int main(int argc, char *argv[])
     }
 
     // Create Monitor
-    son::monitor_thread monitor(agent_uds, fronthaul_iface, beerocks_slave_conf, *g_logger_monitor);
+    son::monitor_thread monitor(agent_uds, fronthaul_iface, beerocks_slave_conf, *g_logger_monitor,
+                                beerocks_slave_conf.hostap_ctrl_iface[iface_num]);
 
     auto touch_time_stamp_timeout = std::chrono::steady_clock::now();
     while (g_running) {

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
@@ -38,7 +38,7 @@ static constexpr uint8_t ap_metrics_channel_utilization_measurement_period_s = 1
 
 monitor_thread::monitor_thread(const std::string &slave_uds_, const std::string &monitor_iface_,
                                beerocks::config_file::sConfigSlave &beerocks_slave_conf_,
-                               beerocks::logging &logger_)
+                               beerocks::logging &logger_, const std::string &hostap_ctrl_iface)
     : socket_thread(), monitor_iface(monitor_iface_), beerocks_slave_conf(beerocks_slave_conf_),
       bridge_iface(beerocks_slave_conf.bridge_iface), slave_uds(slave_uds_), logger(logger_),
       mon_rssi(cmdu_tx),
@@ -64,9 +64,12 @@ monitor_thread::monitor_thread(const std::string &slave_uds_, const std::string 
 
     using namespace std::placeholders; // for `_1`
 
+    bwl::hal_conf_t hal_conf;
+    hal_conf.wpa_ctrl_path = hostap_ctrl_iface;
+
     // Create new Monitor HAL instance
     mon_wlan_hal = bwl::mon_wlan_hal_create(
-        monitor_iface_, std::bind(&monitor_thread::hal_event_handler, this, _1));
+        monitor_iface_, std::bind(&monitor_thread::hal_event_handler, this, _1), hal_conf);
 
     LOG_IF(!mon_wlan_hal, FATAL) << "Failed creating HAL instance!";
 }

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.h
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.h
@@ -31,7 +31,7 @@ class monitor_thread : public beerocks::socket_thread {
 public:
     monitor_thread(const std::string &slave_uds_, const std::string &monitor_iface_,
                    beerocks::config_file::sConfigSlave &beerocks_slave_conf_,
-                   beerocks::logging &logger_);
+                   beerocks::logging &logger_, const std::string &hostap_ctrl_iface);
     virtual ~monitor_thread();
 
     virtual bool init() override;

--- a/agent/src/beerocks/slave/beerocks_slave_main.cpp
+++ b/agent/src/beerocks/slave/beerocks_slave_main.cpp
@@ -168,6 +168,10 @@ static void fill_son_slave_config(const beerocks::config_file::sConfigSlave &bee
         beerocks::string_utils::stoi(beerocks_slave_conf.sta_iface_filter_low[slave_num]);
     son_slave_conf.backhaul_wireless_iface_type = son_slave_conf.hostap_iface_type;
 
+    son_slave_conf.hostap_ctrl_iface = beerocks_slave_conf.hostap_ctrl_iface[slave_num];
+    son_slave_conf.wpa_supplicant_ctrl_iface =
+        beerocks_slave_conf.wpa_supplicant_ctrl_iface[slave_num];
+
     // disable stopping on failure initially. Later on, it will be read from BPL as part of
     // cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE
     son_slave_conf.stop_on_failure_attempts = 0;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -52,6 +52,8 @@ public:
         beerocks::eIfaceType hostap_iface_type;
         int hostap_ant_gain;
         std::string radio_identifier; //mAP RUID
+        std::string hostap_ctrl_iface;
+        std::string wpa_supplicant_ctrl_iface;
     } sSlaveConfig;
 
     typedef struct {

--- a/common/beerocks/bcl/include/bcl/beerocks_config_file.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_config_file.h
@@ -109,6 +109,8 @@ public:
         std::string sta_iface[IRE_MAX_SLAVES];
         std::string sta_iface_filter_low[IRE_MAX_SLAVES];
         std::string hostap_ant_gain[IRE_MAX_SLAVES];
+        std::string hostap_ctrl_iface[IRE_MAX_SLAVES];
+        std::string wpa_supplicant_ctrl_iface[IRE_MAX_SLAVES];
         //[log]
         SConfigLog sLog;
     } sConfigSlave;

--- a/common/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/common/beerocks/bcl/source/beerocks_config_file.cpp
@@ -193,6 +193,9 @@ bool config_file::read_slave_config_file(const std::string &config_file_path, sC
                             mandatory_slave),
             std::make_tuple("hostap_ant_gain=", &conf.hostap_ant_gain[slave_num], mandatory_slave),
             std::make_tuple("sta_iface_filter_low=", &conf.sta_iface_filter_low[slave_num], 0),
+            std::make_tuple("hostap_ctrl_iface=", &conf.hostap_ctrl_iface[slave_num], 0),
+            std::make_tuple(
+                "wpa_supplicant_ctrl_iface=", &conf.wpa_supplicant_ctrl_iface[slave_num], 0),
         };
         std::string config_type = "agent" + std::to_string(slave_num);
         if (!read_config_file(config_file_path, slave_conf_args, config_type)) {

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp
@@ -103,7 +103,7 @@ static ap_wlan_hal::Event dummy_to_bwl_event(const std::string &opcode)
 // NOTE: Since *base_wlan_hal_dummy* inherits *base_wlan_hal* virtually, we
 //       need to explicitly call it's from any deriving class
 ap_wlan_hal_dummy::ap_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback,
-                                     hal_conf_t hal_conf)
+                                     const hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::AccessPoint, iface_name, IfaceType::Intel, callback, hal_conf),
       base_wlan_hal_dummy(bwl::HALType::AccessPoint, iface_name, callback, hal_conf)
 {

--- a/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/ap_wlan_hal_dummy.h
@@ -28,7 +28,8 @@ public:
      * @param [in] iface_name AP interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    ap_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback, hal_conf_t hal_conf);
+    ap_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback,
+                      const hal_conf_t &hal_conf);
 
     virtual ~ap_wlan_hal_dummy();
 

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.cpp
@@ -230,7 +230,7 @@ void base_wlan_hal_dummy::parsed_obj_debug(parsed_obj_listed_map_t &obj)
 }
 
 base_wlan_hal_dummy::base_wlan_hal_dummy(HALType type, const std::string &iface_name,
-                                         hal_event_cb_t callback, hal_conf_t hal_conf)
+                                         hal_event_cb_t callback, const hal_conf_t &hal_conf)
     : base_wlan_hal(type, iface_name, IfaceType::Intel, callback, hal_conf),
       beerocks::beerocks_fsm<dummy_fsm_state, dummy_fsm_event>(dummy_fsm_state::Delay)
 {

--- a/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/base_wlan_hal_dummy.h
@@ -67,7 +67,7 @@ public:
     // Protected methods
 protected:
     base_wlan_hal_dummy(HALType type, const std::string &iface_name, hal_event_cb_t callback,
-                        hal_conf_t hal_conf = {});
+                        const hal_conf_t &hal_conf = {});
 
     void parsed_obj_debug(parsed_obj_map_t &obj);
     void parsed_obj_debug(parsed_obj_listed_map_t &obj);

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
@@ -66,9 +66,10 @@ static mon_wlan_hal_dummy::Data dummy_to_bwl_data(const std::string &opcode)
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-mon_wlan_hal_dummy::mon_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback)
+mon_wlan_hal_dummy::mon_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback,
+                                       const bwl::hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::Monitor, iface_name, IfaceType::Intel, callback),
-      base_wlan_hal_dummy(bwl::HALType::Monitor, iface_name, callback)
+      base_wlan_hal_dummy(bwl::HALType::Monitor, iface_name, callback, hal_conf)
 {
 }
 
@@ -422,9 +423,10 @@ bool mon_wlan_hal_dummy::set(const std::string &param, const std::string &value,
 } // namespace dummy
 
 std::shared_ptr<mon_wlan_hal> mon_wlan_hal_create(std::string iface_name,
-                                                  base_wlan_hal::hal_event_cb_t callback)
+                                                  base_wlan_hal::hal_event_cb_t callback,
+                                                  const bwl::hal_conf_t &hal_conf)
 {
-    return std::make_shared<dummy::mon_wlan_hal_dummy>(iface_name, callback);
+    return std::make_shared<dummy::mon_wlan_hal_dummy>(iface_name, callback, hal_conf);
 }
 
 } // namespace bwl

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -32,7 +32,8 @@ public:
      * @param [in] iface_name Monitor interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    mon_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback);
+    mon_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback,
+                       const bwl::hal_conf_t &hal_conf);
     virtual ~mon_wlan_hal_dummy();
 
     virtual bool update_radio_stats(SRadioStats &radio_stats) override;

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
@@ -16,9 +16,10 @@
 namespace bwl {
 namespace dummy {
 
-sta_wlan_hal_dummy::sta_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback)
+sta_wlan_hal_dummy::sta_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback,
+                                       const bwl::hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::Station, iface_name, IfaceType::Intel, callback, {}),
-      base_wlan_hal_dummy(bwl::HALType::Station, iface_name, callback, {})
+      base_wlan_hal_dummy(bwl::HALType::Station, iface_name, callback, hal_conf)
 {
 }
 
@@ -79,9 +80,10 @@ bool sta_wlan_hal_dummy::update_status()
 } // namespace dummy
 
 std::shared_ptr<sta_wlan_hal> sta_wlan_hal_create(const std::string &iface_name,
-                                                  base_wlan_hal::hal_event_cb_t callback)
+                                                  base_wlan_hal::hal_event_cb_t callback,
+                                                  const bwl::hal_conf_t &hal_conf)
 {
-    return std::make_shared<dummy::sta_wlan_hal_dummy>(iface_name, callback);
+    return std::make_shared<dummy::sta_wlan_hal_dummy>(iface_name, callback, hal_conf);
 }
 
 } // namespace bwl

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
@@ -28,7 +28,8 @@ public:
      * @param [in] iface_name STA/Client interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    sta_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback);
+    sta_wlan_hal_dummy(const std::string &iface_name, hal_event_cb_t callback,
+                       const bwl::hal_conf_t &hal_conf);
     virtual ~sta_wlan_hal_dummy();
 
     virtual bool detach() override;

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp
@@ -709,7 +709,7 @@ update_vap_credentials_configure_wpa(const std::string &vap_if,
 // NOTE: Since *base_wlan_hal_dwpal* inherits *base_wlan_hal* virtually, we
 //       need to explicitly call it's from any deriving class
 ap_wlan_hal_dwpal::ap_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback,
-                                     hal_conf_t hal_conf)
+                                     const hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::AccessPoint, iface_name, IfaceType::Intel, callback, hal_conf),
       base_wlan_hal_dwpal(bwl::HALType::AccessPoint, iface_name, callback, hal_conf)
 {

--- a/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.h
@@ -28,7 +28,8 @@ public:
      * @param [in] iface_name AP interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    ap_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback, hal_conf_t hal_conf);
+    ap_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback,
+                      const hal_conf_t &hal_conf);
 
     virtual ~ap_wlan_hal_dwpal();
 

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -76,7 +76,7 @@ std::ostream &operator<<(std::ostream &out, const dwpal_fsm_event &value)
 //////////////////////////////////////////////////////////////////////////////
 
 base_wlan_hal_dwpal::base_wlan_hal_dwpal(HALType type, const std::string &iface_name,
-                                         hal_event_cb_t callback, hal_conf_t hal_conf)
+                                         hal_event_cb_t callback, const hal_conf_t &hal_conf)
     : base_wlan_hal(type, iface_name, IfaceType::Intel, callback, hal_conf),
       beerocks::beerocks_fsm<dwpal_fsm_state, dwpal_fsm_event>(dwpal_fsm_state::Delay),
       m_nl80211_client(nl80211_client_factory::create_instance())

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.h
@@ -68,7 +68,7 @@ public:
     // Protected methods
 protected:
     base_wlan_hal_dwpal(HALType type, const std::string &iface_name, hal_event_cb_t callback,
-                        hal_conf_t hal_conf = {});
+                        const hal_conf_t &hal_conf = {});
 
     // Process dwpal event
     virtual bool process_dwpal_event(char *buffer, int bufLen, const std::string &opcode) = 0;

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp
@@ -541,9 +541,10 @@ static std::shared_ptr<char> generate_client_assoc_event(const std::string &even
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-mon_wlan_hal_dwpal::mon_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback)
+mon_wlan_hal_dwpal::mon_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback,
+                                       const bwl::hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::Monitor, iface_name, IfaceType::Intel, callback),
-      base_wlan_hal_dwpal(bwl::HALType::Monitor, iface_name, callback)
+      base_wlan_hal_dwpal(bwl::HALType::Monitor, iface_name, callback, hal_conf)
 {
 }
 
@@ -1439,9 +1440,10 @@ bool mon_wlan_hal_dwpal::process_dwpal_nl_event(struct nl_msg *msg)
 } // namespace dwpal
 
 std::shared_ptr<mon_wlan_hal> mon_wlan_hal_create(std::string iface_name,
-                                                  base_wlan_hal::hal_event_cb_t callback)
+                                                  base_wlan_hal::hal_event_cb_t callback,
+                                                  const bwl::hal_conf_t &hal_conf)
 {
-    return std::make_shared<dwpal::mon_wlan_hal_dwpal>(iface_name, callback);
+    return std::make_shared<dwpal::mon_wlan_hal_dwpal>(iface_name, callback, hal_conf);
 }
 
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
@@ -29,7 +29,8 @@ public:
      * @param [in] iface_name Monitor interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    mon_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback);
+    mon_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback,
+                       const bwl::hal_conf_t &hal_conf);
     virtual ~mon_wlan_hal_dwpal();
 
     virtual bool update_radio_stats(SRadioStats &radio_stats) override;

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
@@ -91,9 +91,10 @@ static std::string dwpal_security_val(WiFiSec sec)
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-sta_wlan_hal_dwpal::sta_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback)
+sta_wlan_hal_dwpal::sta_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback,
+                                       const bwl::hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::Station, iface_name, IfaceType::Intel, callback),
-      base_wlan_hal_dwpal(bwl::HALType::Station, iface_name, callback)
+      base_wlan_hal_dwpal(bwl::HALType::Station, iface_name, callback, hal_conf)
 {
 }
 
@@ -834,9 +835,10 @@ bool sta_wlan_hal_dwpal::parse_fapi_event(const std::string& opcode, std::shared
 } // namespace dwpal
 
 std::shared_ptr<sta_wlan_hal> sta_wlan_hal_create(const std::string &iface_name,
-                                                  base_wlan_hal::hal_event_cb_t callback)
+                                                  base_wlan_hal::hal_event_cb_t callback,
+                                                  const bwl::hal_conf_t &hal_conf)
 {
-    return std::make_shared<dwpal::sta_wlan_hal_dwpal>(iface_name, callback);
+    return std::make_shared<dwpal::sta_wlan_hal_dwpal>(iface_name, callback, hal_conf);
 }
 
 } // namespace bwl

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.h
@@ -28,7 +28,8 @@ public:
              * @param [in] iface_name STA/Client interface name.
              * @param [in] callback Callback for handling internal events.
              */
-    sta_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback);
+    sta_wlan_hal_dwpal(const std::string &iface_name, hal_event_cb_t callback,
+                       const bwl::hal_conf_t &hal_conf);
     virtual ~sta_wlan_hal_dwpal();
 
     virtual bool initiate_scan() override;

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -100,6 +100,7 @@ struct RadioInfo {
 
 struct hal_conf_t {
     bool ap_acs_enabled = false;
+    std::string wpa_ctrl_path;
 };
 
 //sta_wlan_hal

--- a/common/beerocks/bwl/include/bwl/mon_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/mon_wlan_hal.h
@@ -65,7 +65,8 @@ public:
 
 // mon HAL factory types
 std::shared_ptr<mon_wlan_hal> mon_wlan_hal_create(std::string iface_name,
-                                                  base_wlan_hal::hal_event_cb_t cb);
+                                                  base_wlan_hal::hal_event_cb_t cb,
+                                                  const bwl::hal_conf_t &hal_conf);
 
 } // namespace bwl
 

--- a/common/beerocks/bwl/include/bwl/sta_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/sta_wlan_hal.h
@@ -68,7 +68,8 @@ public:
 
 // STA HAL factory types
 std::shared_ptr<sta_wlan_hal> sta_wlan_hal_create(const std::string &iface_name,
-                                                  base_wlan_hal::hal_event_cb_t cb);
+                                                  base_wlan_hal::hal_event_cb_t cb,
+                                                  const bwl::hal_conf_t &hal_conf);
 
 } // namespace bwl
 

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.cpp
@@ -113,9 +113,9 @@ static uint8_t wpa_bw_to_beerocks_bw(const std::string &chan_width)
 // NOTE: Since *base_wlan_hal_nl80211* inherits *base_wlan_hal* virtually, we
 //       need to explicitly call it's from any deriving class
 ap_wlan_hal_nl80211::ap_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback,
-                                         hal_conf_t hal_conf)
-    : base_wlan_hal(bwl::HALType::AccessPoint, iface_name, IfaceType::Intel, callback, hal_conf),
-      base_wlan_hal_nl80211(bwl::HALType::AccessPoint, iface_name, callback, BUFFER_SIZE)
+                                         const hal_conf_t &hal_conf)
+    : base_wlan_hal(bwl::HALType::AccessPoint, iface_name, IfaceType::Intel, callback),
+      base_wlan_hal_nl80211(bwl::HALType::AccessPoint, iface_name, callback, BUFFER_SIZE, hal_conf)
 {
 }
 

--- a/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/ap_wlan_hal_nl80211.h
@@ -29,7 +29,7 @@ public:
      * @param [in] callback Callback for handling internal events.
      */
     ap_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback,
-                        hal_conf_t hal_conf);
+                        const hal_conf_t &hal_conf);
 
     virtual ~ap_wlan_hal_nl80211();
 

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -218,17 +218,7 @@ base_wlan_hal_nl80211::base_wlan_hal_nl80211(HALType type, const std::string &if
         });
     }
 
-    m_wpa_ctrl_path = BASE_CTRL_PATH;
-    if (get_type() == HALType::AccessPoint || get_type() == HALType::Monitor) {
-        m_wpa_ctrl_path += "hostapd/";
-    } else if (get_type() == HALType::Station) {
-        m_wpa_ctrl_path += "wpa_supplicant/";
-    } else {
-        LOG(ERROR) << "Unsupported HAL Type: " << int(get_type());
-        return; // HACK TODO what should we do in that case?
-    }
-
-    m_wpa_ctrl_path += m_radio_info.iface_name;
+    m_wpa_ctrl_path = hal_conf.wpa_ctrl_path;
 
     // Initialize the FSM
     fsm_setup();

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -202,7 +202,7 @@ static void parsed_obj_debug(base_wlan_hal_nl80211::parsed_obj_listed_map_t &obj
 
 base_wlan_hal_nl80211::base_wlan_hal_nl80211(HALType type, const std::string &iface_name,
                                              hal_event_cb_t callback, int wpa_ctrl_buffer_size,
-                                             hal_conf_t hal_conf)
+                                             const hal_conf_t &hal_conf)
     : base_wlan_hal(type, iface_name, IfaceType::Intel, callback, hal_conf),
       beerocks::beerocks_fsm<nl80211_fsm_state, nl80211_fsm_event>(nl80211_fsm_state::Delay),
       m_nl80211_client(nl80211_client_factory::create_instance()),

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.h
@@ -72,7 +72,7 @@ public:
     // Protected methods
 protected:
     base_wlan_hal_nl80211(HALType type, const std::string &iface_name, hal_event_cb_t callback,
-                          int wpa_ctrl_buffer_size, hal_conf_t hal_conf = {});
+                          int wpa_ctrl_buffer_size, const hal_conf_t &hal_conf = {});
 
     // Process hostapd/wpa_supplicant event
     virtual bool process_nl80211_event(parsed_obj_map_t &event) = 0;

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
@@ -88,9 +88,10 @@ static void calc_curr_traffic(std::string buff, uint64_t &total, uint32_t &curr)
 /////////////////////////////// Implementation ///////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-mon_wlan_hal_nl80211::mon_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback)
+mon_wlan_hal_nl80211::mon_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback,
+                                           const bwl::hal_conf_t &hal_conf)
     : base_wlan_hal(bwl::HALType::Monitor, iface_name, IfaceType::Intel, callback),
-      base_wlan_hal_nl80211(bwl::HALType::Monitor, iface_name, callback, BUFFER_SIZE)
+      base_wlan_hal_nl80211(bwl::HALType::Monitor, iface_name, callback, BUFFER_SIZE, hal_conf)
 {
 }
 
@@ -593,9 +594,10 @@ bool mon_wlan_hal_nl80211::process_nl80211_event(parsed_obj_map_t &parsed_obj)
 } // namespace nl80211
 
 std::shared_ptr<mon_wlan_hal> mon_wlan_hal_create(std::string iface_name,
-                                                  base_wlan_hal::hal_event_cb_t callback)
+                                                  base_wlan_hal::hal_event_cb_t callback,
+                                                  const bwl::hal_conf_t &hal_conf)
 {
-    return std::make_shared<nl80211::mon_wlan_hal_nl80211>(iface_name, callback);
+    return std::make_shared<nl80211::mon_wlan_hal_nl80211>(iface_name, callback, hal_conf);
 }
 
 } // namespace bwl

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.h
@@ -28,7 +28,8 @@ public:
      * @param [in] iface_name Monitor interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    mon_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback);
+    mon_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback,
+                         const bwl::hal_conf_t &hal_conf);
     virtual ~mon_wlan_hal_nl80211();
 
     virtual bool update_radio_stats(SRadioStats &radio_stats) override;

--- a/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.cpp
@@ -16,8 +16,10 @@
 namespace bwl {
 namespace nl80211 {
 
-sta_wlan_hal_nl80211::sta_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback)
-    : base_wlan_hal(), base_wlan_hal_nl80211(bwl::HALType::Station, iface_name, callback, {})
+sta_wlan_hal_nl80211::sta_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback,
+                                           const bwl::hal_conf_t &hal_conf)
+    : base_wlan_hal(),
+      base_wlan_hal_nl80211(bwl::HALType::Station, iface_name, callback, BUFFER_SIZE, hal_conf)
 {
 }
 
@@ -70,9 +72,10 @@ bool sta_wlan_hal_nl80211::update_status() { return false; }
 } // namespace nl80211
 
 std::shared_ptr<sta_wlan_hal> sta_wlan_hal_create(const std::string &iface_name,
-                                                  base_wlan_hal::hal_event_cb_t callback)
+                                                  base_wlan_hal::hal_event_cb_t callback,
+                                                  const bwl::hal_conf_t &hal_conf)
 {
-    return std::make_shared<nl80211::sta_wlan_hal_nl80211>(iface_name, callback);
+    return std::make_shared<nl80211::sta_wlan_hal_nl80211>(iface_name, callback, hal_conf);
 }
 
 } // namespace bwl

--- a/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.h
@@ -12,6 +12,8 @@
 #include "base_wlan_hal_nl80211.h"
 #include <bwl/sta_wlan_hal.h>
 
+#define BUFFER_SIZE 4096
+
 namespace bwl {
 namespace nl80211 {
 
@@ -28,7 +30,8 @@ public:
      * @param [in] iface_name STA/Client interface name.
      * @param [in] callback Callback for handling internal events.
      */
-    sta_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback);
+    sta_wlan_hal_nl80211(const std::string &iface_name, hal_event_cb_t callback,
+                         const bwl::hal_conf_t &hal_conf);
     virtual ~sta_wlan_hal_nl80211();
 
     virtual bool detach() override;


### PR DESCRIPTION
During porting prplMesh to RDKB on RPi it has been founded that
prplMesh assumptions for hostapd ctrl ifaces paths are not
valid for RPi.

Instead of "/var/run/hostapd/<wlan-iface-name>" the paths are
```
    /var/run/hostapd0/wlan0
    /var/run/hostapd1/wlan1
    /var/run/hostapd4/wlan2
```
Add variables for hostapd and wpa supplicant ctrl ifaces for
each agent at beerocks_agent.conf:

    hostap_ctrl_iface
    wpa_supplicant_ctrl_iface

Default values were kept the same:
```
    [agent0]
    ...
    hostap_ctrl_iface=/var/run/hostapd/wlan0
    wpa_supplicant_ctrl_iface=/var/run/wpa_supplicant/wlan0

    [agent1]
    ...
    hostap_ctrl_iface=/var/run/hostapd/wlan2
    wpa_supplicant_ctrl_iface=/var/run/wpa_supplicant/wlan2

    [agent2]
    ...
    hostap_ctrl_iface=/var/run/hostapd/wlan4
    wpa_supplicant_ctrl_iface=/var/run/wpa_supplicant/wlan4
```

https://jira.prplfoundation.org/browse/PPM-232