### PR TITLE
remove steer on vaps list dependency

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1558,6 +1558,32 @@ std::string db::get_hostap_ssid(const std::string &mac)
     return std::string();
 }
 
+bool db::is_vap_on_steer_list(const std::string &bssid)
+{
+    if (config.load_steer_on_vaps.empty()) {
+        return true;
+    }
+
+    auto vap_name = get_hostap_iface_name(bssid);
+    if (vap_name == "INVALID") {
+        LOG(ERROR) << "vap name is invalid for bssid " << bssid;
+        return false;
+    }
+
+    auto vap_id = get_hostap_vap_id(bssid);
+    if (vap_id == IFACE_ID_INVALID) {
+        LOG(ERROR) << "vap id is invalid for bssid " << bssid;
+        return false;
+    }
+
+    vap_name         = utils::get_iface_string_from_iface_vap_ids(vap_name, vap_id);
+    auto &steer_vaps = config.load_steer_on_vaps;
+    if (steer_vaps.find(vap_name) == std::string::npos) {
+        return false;
+    }
+    return true;
+}
+
 std::string db::get_hostap_vap_with_ssid(const std::string &mac, const std::string &ssid)
 {
     auto n = get_node(mac);

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1595,18 +1595,15 @@ std::string db::get_hostap_vap_with_ssid(const std::string &mac, const std::stri
         return std::string();
     }
 
-    auto vap_name = get_hostap_iface_name(mac);
-    vap_name.append(".");
+    auto it = std::find_if(
+        n->hostap->vaps_info.begin(), n->hostap->vaps_info.end(),
+        [&](const std::pair<int8_t, sVapElement> &vap) { return vap.second.ssid == ssid; });
 
-    for (auto const &it : n->hostap->vaps_info) {
-        auto tmp_vap_name = vap_name;
-        tmp_vap_name.append(std::to_string(get_hostap_vap_id(it.second.mac)));
-        if ((it.second.ssid == ssid) &&
-            (config.load_steer_on_vaps.find(tmp_vap_name) != std::string::npos)) {
-            return it.second.mac;
-        }
+    if (it == n->hostap->vaps_info.end()) {
+        // no vap with same ssid is found
+        return std::string();
     }
-    return std::string();
+    return it->second.mac;
 }
 
 std::string db::get_hostap_vap_mac(const std::string &mac, const int vap_id)

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -346,6 +346,13 @@ public:
                  bool backhual);
 
     std::string get_hostap_ssid(const std::string &mac);
+    /**
+     * @brief checks if vap name is on the steer list.
+     * 
+     * @param[in] bssid vap mac address.
+     * @return true if vap name is on the steer list.
+     */
+    bool is_vap_on_steer_list(const std::string &bssid);
     std::string get_hostap_vap_with_ssid(const std::string &mac, const std::string &ssid);
     std::string get_hostap_vap_mac(const std::string &mac, const int vap_id);
     std::string get_node_parent_radio(const std::string &mac);

--- a/controller/src/beerocks/master/tasks/optimal_path_task.h
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.h
@@ -75,6 +75,7 @@ private:
     std::string current_hostap;
     std::string current_hostap_ssid;
     std::string chosen_hostap;
+    std::string chosen_bssid;
 
     enum states {
         //common states:

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -144,20 +144,20 @@ int cfg_get_load_steer_on_vaps(int num_of_interfaces,
     std::string load_steer_on_vaps_str;
     char hostap_iface_steer_vaps[BPL_LOAD_STEER_ON_VAPS_LEN] = {0};
     for (int index = 0; index < num_of_interfaces; index++) {
-        if (cfg_get_hostap_iface_steer_vaps(index, hostap_iface_steer_vaps) == RETURN_ERR) {
-            MAPF_ERR("failed to get wifi interface steer vaps for agent" << index);
-        } else {
+        if (cfg_get_hostap_iface_steer_vaps(index, hostap_iface_steer_vaps) == RETURN_OK) {
             if (std::string(hostap_iface_steer_vaps).length() > 0) {
                 if (!load_steer_on_vaps_str.empty()) {
                     load_steer_on_vaps_str.append(",");
                 }
-                // for linux implementation the wlan?.0 vaps are used for band steering
                 load_steer_on_vaps_str.append(std::string(hostap_iface_steer_vaps));
+                MAPF_DBG("adding interface " << hostap_iface_steer_vaps
+                                             << " to the steer on vaps list");
             }
         }
     }
+
     if (load_steer_on_vaps_str.empty()) {
-        MAPF_DBG("steer vaps list is empty");
+        MAPF_DBG("steer on vaps list is not configured");
         return RETURN_OK;
     }
 


### PR DESCRIPTION
Steer on vaps list is a feature that allows user to disable/enable steering on specific VAPs.
prplmesh UCI database parameter get_hostap_vap_with_ssid holds vap names that are allowed to steer.
The problem is that each platform has different vap names but some use the same UCI database. 
for example
RAX40 has 2 vaps WLAN0.1 and WLAN2.0  (UCI default)
Axe6000 has 2 vaps WLAN0.1 and **WLAN2.2**


Same UCI  configuration applies to both since they are openWRT that use the same device name ( /tmp/sysinfo/board_name).

As a result on AXE6000 , optimal path aborted every time we are trying to steer to/from WLAN2.2

Since this feature is needed only for RDKB platform the solution is to remove it from all platforms except RDKB and modify the steering/optimal path task code  to allow all vaps to steer in case the list is missing or empty.