### PR TITLE
agent: monitor: avoid reporting unitialized vap stats

### DIFF
--- a/agent/src/beerocks/monitor/monitor_db.h
+++ b/agent/src/beerocks/monitor/monitor_db.h
@@ -331,6 +331,14 @@ public:
         int active_client_count_prev         = 0;
         int active_client_count_curr         = 0;
         uint32_t sta_count                   = 0;
+
+        /**
+         * Flag that signals if last VAP statistics read contain meaningful data for at least one
+         * VAP. This flag is updated whenever VAP statistics are updated.
+         * The term "available" in this context means that both transmitted and received bytes are
+         * set to a value greater than 0.
+         */
+        bool vap_stats_available = false;
     };
 
     SRadioStats &get_stats() { return m_radio_stats; }


### PR DESCRIPTION
Data included in AP Metrics Response message when channel utilization
crosses threshold value is not fresh data but the data that was
obtained in the last polling cycle. If the device in turn implements a
similar polling mechanism, returned data can be quite stale. This
behavior leads to a situation in which after detecting that channel
utilization has crossed the threshold value, statistics have never been
obtained yet (all counters are 0). This is actually the case with a
RAX40 and test 4.7.6 fails because bytes received is 0.

To avoid reporting invalid data, a `m_vap_stats_available` flag has
been created that changes to true when both transmitted and received
bytes are greater than 0 for any VAP. Then We do check the
`m_vap_stats_available` before even checking if channel utilization has
crossed the threshold value (and thus, before reporting metrics).

