### PR TITLE
Bugfix/existing clients association

### DIFF
--- a/agent/src/beerocks/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/monitor/monitor_thread.cpp
@@ -308,6 +308,9 @@ void monitor_thread::after_select(bool timeout)
                 thread_last_error_code = MONITOR_THREAD_ERROR_NL_ATTACH_FAIL;
             }
 
+            // Generate pre-existing client STA_Connected
+            mon_wlan_hal->generate_connected_clients_events();
+
             // start local monitors //
             LOG(TRACE) << "mon_stats.start()";
             if (!mon_stats.start(&mon_db, slave_socket)) {

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp
@@ -167,6 +167,12 @@ bool mon_wlan_hal_dummy::channel_scan_dump_results()
     return false;
 }
 
+bool mon_wlan_hal_dummy::generate_connected_clients_events()
+{
+    LOG(TRACE) << __func__ << " - NOT IMPLEMENTED";
+    return false;
+}
+
 bool mon_wlan_hal_dummy::process_dummy_data(parsed_obj_map_t &parsed_obj)
 {
     char *tmp_str;

--- a/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/mon_wlan_hal_dummy.h
@@ -46,6 +46,7 @@ public:
     virtual bool channel_scan_trigger(int dwell_time_msec,
                                       const std::vector<unsigned int> &channel_pool) override;
     virtual bool channel_scan_dump_results() override;
+    virtual bool generate_connected_clients_events() override;
     // Protected methods:
 protected:
     virtual bool process_dummy_event(parsed_obj_map_t &parsed_obj) override;

--- a/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.h
@@ -43,6 +43,7 @@ public:
     virtual bool channel_scan_trigger(int dwell_time_msec,
                                       const std::vector<unsigned int> &channel_pool) override;
     virtual bool channel_scan_dump_results() override;
+    virtual bool generate_connected_clients_events() override;
     // Protected methods:
 protected:
     virtual bool process_dwpal_event(char *buffer, int bufLen, const std::string &opcode) override;

--- a/common/beerocks/bwl/include/bwl/mon_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/mon_wlan_hal.h
@@ -60,6 +60,7 @@ public:
     virtual bool channel_scan_trigger(int dwell_time_msec,
                                       const std::vector<unsigned int> &channel_pool)     = 0;
     virtual bool channel_scan_dump_results()                                             = 0;
+    virtual bool generate_connected_clients_events()                                     = 0;
 };
 
 // mon HAL factory types

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.cpp
@@ -402,6 +402,12 @@ bool mon_wlan_hal_nl80211::channel_scan_dump_results()
     return false;
 }
 
+bool mon_wlan_hal_nl80211::generate_connected_clients_events()
+{
+    LOG(TRACE) << __func__ << " - NOT IMPLEMENTED";
+    return false;
+}
+
 bool mon_wlan_hal_nl80211::process_nl80211_event(parsed_obj_map_t &parsed_obj)
 {
     // Filter out empty events

--- a/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/mon_wlan_hal_nl80211.h
@@ -43,6 +43,7 @@ public:
     virtual bool channel_scan_trigger(int dwell_time_msec,
                                       const std::vector<unsigned int> &channel_pool) override;
     virtual bool channel_scan_dump_results() override;
+    virtual bool generate_connected_clients_events() override;
     // Protected methods:
 protected:
     virtual bool process_nl80211_event(parsed_obj_map_t &parsed_obj) override;


### PR DESCRIPTION
Currently there is an issue described here #1369
After looking into the client association sequence, I noticed that pre-existing clients were not added to the monitor's DB which causes the association sequence to fail during the `CLIENT_START_MONITORING` handling

To fix this issue, the `generate_connected_clients_events` that exists in the `ap_wlan_hal` needs to be copied to the `mon_wlan_hal` and implemented using the DWPAL.