### PR TITLE
easylogging: log uint8_t as int

### DIFF
--- a/framework/external/easylogging/easylogging++.h
+++ b/framework/external/easylogging/easylogging++.h
@@ -2897,6 +2897,9 @@ return *this;\
   inline MessageBuilder& operator<<(const std::string& msg) {
     return operator<<(msg.c_str());
   }
+  inline MessageBuilder& operator<<(uint8_t c) {
+    return operator<<(+c);
+  }
   ELPP_SIMPLE_LOG(char)
   ELPP_SIMPLE_LOG(bool)
   ELPP_SIMPLE_LOG(signed short)


### PR DESCRIPTION
In many places, we need to log values of type uint8_t. Unfortunately,
uint8_t is a char type, which means it gets logged as an ASCII
character. To overcome this, we use the + operator or we cast to int.
Still, it's easy to forget to do that kind of conversion.

To fix all this in one fell swoop, add an operator<< overload for
uint8_t to easylogging++. It converts to int using the + operator.

This PR was triggered by https://github.com/prplfoundation/prplMesh/pull/1316#issuecomment-637491112