### PR TITLE
Hotfix/fix vap id related issues

### DIFF
--- a/agent/src/beerocks/monitor/monitor_rssi.cpp
+++ b/agent/src/beerocks/monitor/monitor_rssi.cpp
@@ -373,6 +373,7 @@ void monitor_rssi::send_rssi_measurement_response(std::string &sta_mac, monitor_
         response->params().rx_packets        = rx_packets;
         response->params().rx_phy_rate_100kb = sta_stats.rx_phy_rate_100kb_min;
         response->params().tx_phy_rate_100kb = sta_stats.tx_phy_rate_100kb_min;
+        response->params().vap_id            = sta_node->get_vap_id();
 
         message_com::send_cmdu(slave_socket, cmdu_tx);
         LOG(DEBUG) << "RSSI_MEASUREMENT_RESPONSE sta_mac=" << sta_mac

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -61,6 +61,8 @@ static void fill_conn_map_node(
                 // VAP
                 int vap_length = sizeof(node->data.gw_ire.radio[i].vap) /
                                  sizeof(node->data.gw_ire.radio[i].vap[0]);
+
+                // The index of of the VAP 'j' represents the VAP ID.
                 for (int j = 0; j < vap_length; j++) {
                     auto vap_mac = tlvf::mac_to_string(node->data.gw_ire.radio[i].vap[j].bssid);
                     if (vap_mac != network_utils::ZERO_MAC_STRING) {
@@ -71,6 +73,7 @@ static void fill_conn_map_node(
                                            ? node->data.gw_ire.radio[i].vap[j].ssid
                                            : std::string("N/A"));
                         v->backhaul_vap = node->data.gw_ire.radio[i].vap[j].backhaul_vap;
+                        v->vap_id       = j;
                         r->vap.push_back(v);
                     }
                 }
@@ -198,8 +201,8 @@ static void bml_utils_dump_conn_map(
                 for (auto vap = radio->vap.begin(); vap != radio->vap.end(); vap++) {
                     if ((*vap)->bssid != network_utils::ZERO_MAC_STRING) {
                         ss << ind_str << std::string((*vap)->backhaul_vap ? "b" : "f") << "VAP["
-                           << std::to_string(j) << "]:"
-                           << " " << radio->ifname << "." << std::to_string(j)
+                           << std::to_string((*vap)->vap_id) << "]:"
+                           << " " << radio->ifname << "." << std::to_string((*vap)->vap_id)
                            << " bssid: " << (*vap)->bssid << ", ssid: " << (*vap)->ssid
                            << std::endl;
                         // add clients which are connected to the vap

--- a/controller/src/beerocks/cli/beerocks_cli_bml.h
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.h
@@ -53,6 +53,7 @@ public:
                 struct vap_t {
                     std::string ssid;
                     std::string bssid;
+                    uint8_t vap_id;
                     bool backhaul_vap;
                 };
 

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2829,7 +2829,10 @@ bool master_thread::handle_cmdu_control_message(const std::string &src_mac,
                     << " | " << int(notification->params().tx_phy_rate_100kb)
                     << " is_parent=" << (is_parent ? "1" : "0")
                     << " src_module=" << int(notification->params().src_module)
-                    << " id=" << int(beerocks_header->id()));
+                    << " id=" << int(beerocks_header->id())
+                    << " bssid=" << database.get_node_parent(client_mac)
+                    << " vap_id=" << int(notification->params().vap_id));
+
         //response return from slave backhaul manager , updating the matching same band sibling.
         if (database.is_hostap_backhaul_manager(ap_mac) &&
             database.is_node_wireless(database.get_node_parent_backhaul(ap_mac)) &&


### PR DESCRIPTION
Two bug fixes:
1. Wrong vap interface name on bml_conn_map.

2. When the monitor sends CLIENT_RX_RSSI_MEASUREMENT_RESPONSE,
missing vap id field causing the measurement to not be saved on the database causing intel steering to fail. fixes #1404

🏄  😎 