### PR TITLE
[BHWIFI] Delay onboarding until dev_start_wps is done

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ run-tests:
   stage: build
   script:
     - mkdir -p "build/$TARGET_DEVICE"
-    - tools/docker/builder/openwrt/build.sh --verbose -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log" | grep -E '^[[:blank:]]?make\[[12]\]|^Step|^ --->' --color=never --line-buffered
+    - tools/docker/builder/openwrt/build.sh --verbose -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log"
   artifacts:
     paths:
       - "build/$TARGET_DEVICE/"

--- a/cmake/Finddwpal.cmake
+++ b/cmake/Finddwpal.cmake
@@ -5,7 +5,7 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 
-find_library(DWPAL_LIBRARY "libdwpal.so")
+find_library(DWPAL_LIBRARY "libdwpal.so" PATHS ${CMAKE_PREFIX_PATH}/opt/intel/lib)
 find_path(DWPAL_INCLUDE_DIRS 
     NAMES dwpal.h 
     PATH_SUFFIXES wav-dpal

--- a/common/beerocks/bcl/source/beerocks_version.cpp
+++ b/common/beerocks/bcl/source/beerocks_version.cpp
@@ -105,8 +105,7 @@ void beerocks::version::print_version(bool verbose, const std::string &name,
     if (description.length() > 0) {
         std::cout << description << std::endl;
     }
-    std::cout << "Copyright (c) 2018 Intel Corporation, All Rights Reserved." << std::endl
-              << std::endl;
+    std::cout << "Copyright (c) 2020 prplMesh, All Rights Reserved." << std::endl << std::endl;
 }
 
 void beerocks::version::log_version(int argc, char **argv, const std::string &logger_id)

--- a/controller/src/beerocks/bml/bml_utils.cpp
+++ b/controller/src/beerocks/bml/bml_utils.cpp
@@ -89,10 +89,11 @@ int bml_utils_node_to_string(const struct BML_NODE *node, char *buffer, int buff
     ss << ", Type: " << node_type_to_string(node->type) << " (" << std::to_string(node->type) << ")"
        << ", State: " << node_state_to_string(node->state) << " (" << std::to_string(node->state)
        << ")"
-       << ", MAC: " << node->mac << ", IP: " << network_utils::ipv4_to_string(node->ip_v4);
+       << ", MAC: " << tlvf::mac_to_string(node->mac)
+       << ", IP: " << network_utils::ipv4_to_string(node->ip_v4);
 
     if (node->type != BML_NODE_TYPE_CLIENT) {
-        ss << ", Backhaul: " << node->data.gw_ire.backhaul_mac;
+        ss << ", Backhaul: " << tlvf::mac_to_string(node->data.gw_ire.backhaul_mac);
     }
 
     if (node->channel) {
@@ -100,8 +101,8 @@ int bml_utils_node_to_string(const struct BML_NODE *node, char *buffer, int buff
     }
 
     if (node->parent_bridge[0]) {
-        ss << ", Parent Bridge: " << node->parent_bridge
-           << ", Parent BSSID: " << node->parent_bssid;
+        ss << ", Parent Bridge: " << tlvf::mac_to_string(node->parent_bridge)
+           << ", Parent BSSID: " << tlvf::mac_to_string(node->parent_bssid);
     }
 
     // New line
@@ -165,7 +166,7 @@ int bml_utils_stats_to_string(const struct BML_STATS *stats, char *buffer, int b
     ss << "Type: " << node_type_to_string(stats->type) << " (" << int(stats->type)
        << ")"
           ", MAC: "
-       << stats->mac
+       << tlvf::mac_to_string(stats->mac)
        << ", measurement_window_msec: " << std::to_string(stats->measurement_window_msec);
 
     if (stats->type == BML_STAT_TYPE_RADIO) {
@@ -265,7 +266,7 @@ int bml_utils_stats_to_string_raw(const struct BML_STATS *stats, char *buffer, i
 {
     std::stringstream ss;
 
-    ss << "Type: " << int(stats->type) << ", mac: " << stats->mac
+    ss << "Type: " << int(stats->type) << ", mac: " << tlvf::mac_to_string(stats->mac)
        << ", measurement_window_msec: " << std::to_string(stats->measurement_window_msec);
 
     if (stats->type == BML_STAT_TYPE_RADIO) {
@@ -330,42 +331,42 @@ int bml_utils_event_to_string(const struct BML_EVENT *event, char *buffer, int b
     case BML_EVENT_TYPE_BSS_TM_REQ: {
         ss << "BML_EVENT_TYPE_BSS_TM_REQ";
         auto event_data = (BML_EVENT_BSS_TM_REQ *)(event->data);
-        ss << ", target bssid: " << event_data->target_bssid << ", "
+        ss << ", target bssid: " << tlvf::mac_to_string(event_data->target_bssid) << ", "
            << "disassoc imminent: " << std::to_string(event_data->disassoc_imminent) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_BH_ROAM_REQ: {
         ss << "BML_EVENT_TYPE_BH_ROAM_REQ";
         auto event_data = (BML_EVENT_BH_ROAM_REQ *)(event->data);
-        ss << ", bssid: " << event_data->bssid << ", "
+        ss << ", bssid: " << tlvf::mac_to_string(event_data->bssid) << ", "
            << "channel: " << std::to_string(event_data->channel) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_CLIENT_ALLOW_REQ: {
         ss << "BML_EVENT_TYPE_CLIENT_ALLOW_REQ";
         auto event_data = (BML_EVENT_CLIENT_ALLOW_REQ *)(event->data);
-        ss << ", hostap_mac: " << event_data->hostap_mac << ", "
-           << "sta_mac: " << event_data->sta_mac << ", "
+        ss << ", hostap_mac: " << tlvf::mac_to_string(event_data->hostap_mac) << ", "
+           << "sta_mac: " << tlvf::mac_to_string(event_data->sta_mac) << ", "
            << "ip: " << network_utils::ipv4_to_string(event_data->ip) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_CLIENT_DISALLOW_REQ: {
         ss << "BML_EVENT_TYPE_CLIENT_DISALLOW_REQ";
         auto event_data = (BML_EVENT_CLIENT_ALLOW_REQ *)(event->data);
-        ss << ", hostap_mac: " << event_data->hostap_mac << ", sta_mac: " << event_data->sta_mac
-           << std::endl;
+        ss << ", hostap_mac: " << tlvf::mac_to_string(event_data->hostap_mac)
+           << ", sta_mac: " << tlvf::mac_to_string(event_data->sta_mac) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_ACS_START: {
         ss << "BML_EVENT_TYPE_ACS_START";
         auto event_data = (BML_EVENT_ACS_START *)(event->data);
-        ss << ", hostap_mac: " << event_data->hostap_mac << std::endl;
+        ss << ", hostap_mac: " << tlvf::mac_to_string(event_data->hostap_mac) << std::endl;
         break;
     }
     case BML_EVENT_TYPE_CSA_NOTIFICATION: {
         ss << "BML_EVENT_TYPE_CSA_NOTIFICATION";
         auto event_data = (BML_EVENT_CSA_NOTIFICATION *)(event->data);
-        ss << ", hostap_mac: " << event_data->hostap_mac
+        ss << ", hostap_mac: " << tlvf::mac_to_string(event_data->hostap_mac)
            << ", bandwidth: " << std::to_string(event_data->bandwidth)
            << ", channel: " << std::to_string(event_data->channel)
            << ", channel_ext_above_primary: "
@@ -377,7 +378,7 @@ int bml_utils_event_to_string(const struct BML_EVENT *event, char *buffer, int b
     case BML_EVENT_TYPE_CAC_STATUS_CHANGED_NOTIFICATION: {
         ss << "BML_EVENT_TYPE_CAC_STATUS_CHANGED_NOTIFICATION";
         auto event_data = (BML_EVENT_CAC_STATUS_CHANGED_NOTIFICATION *)(event->data);
-        ss << ", hostap_mac: " << event_data->hostap_mac
+        ss << ", hostap_mac: " << tlvf::mac_to_string(event_data->hostap_mac)
            << ", cac_completed: " << std::to_string(event_data->cac_completed) << std::endl;
         break;
     }

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update \
 RUN useradd -ms /bin/bash openwrt
 
 ####
-## Prebuilt OpenWrt and prplMesh dependencies, but not the prplMesh ipk itself
+## OpenWrt tree and scripts to build it.
 ####
-FROM openwrt-prerequisites as prplmesh-builder
+FROM openwrt-prerequisites as openwrt-builder
 
 USER openwrt
 
@@ -83,5 +83,10 @@ WORKDIR /home/openwrt/openwrt
 
 COPY --chown=openwrt:openwrt profiles_feeds/ /home/openwrt/openwrt/profiles_feeds
 COPY --chown=openwrt:openwrt scripts/build-openwrt.sh /home/openwrt/openwrt/scripts/build-openwrt.sh
+
+####
+## Prebuilt OpenWrt and prplMesh dependencies, but not the prplMesh ipk itself
+####
+FROM openwrt-builder as prplmesh-builder
 
 RUN scripts/build-openwrt.sh

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -1,3 +1,10 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
 ####
 ## OpenWrt pre-requisites and "openwrt" user
 ####
@@ -33,29 +40,38 @@ USER openwrt
 #
 # OpenWrt repository to use. Can also be a prplWrt repository:
 ARG OPENWRT_REPOSITORY
+ENV OPENWRT_REPOSITORY=$OPENWRT_REPOSITORY
 # Which OpenWrt version (commit hash) to use:
 ARG OPENWRT_VERSION
+ENV OPENWRT_VERSION=$OPENWRT_VERSION
 # The variant to build (nl80211 or dwpal)
 ARG PRPLMESH_VARIANT
+ENV PRPLMESH_VARIANT=$PRPLMESH_VARIANT
 
 # The feed to use to build prplMesh.
 ARG PRPL_FEED
+ENV PRPL_FEED=$PRPL_FEED
 # optional: intel feed to use.
 ARG INTEL_FEED
+ENV INTEL_FEED=$INTEL_FEED
 # optional: iwlwav feed to use.
 ARG IWLWAV_FEED
+ENV IWLWAV_FEED=$IWLWAV_FEED
 
 # Target to build for (CONFIG_TARGET_ will be prepended).
 # Example: TARGET_SYSTEM=mvebu
 ARG TARGET_SYSTEM
+ENV TARGET_SYSTEM=$TARGET_SYSTEM
 
 # Subtarget (CONFIG_TARGET_${TARGET_SYSTEM}_ will be prepended).
 # Example: SUBTARGET=cortexa9
 ARG SUBTARGET
+ENV SUBTARGET=$SUBTARGET
 
 # Target profile (CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_ will be prepended).
 # Example: TARGET_PROFILE=DEVICE_cznic_turris-omnia
 ARG TARGET_PROFILE
+ENV TARGET_PROFILE=$TARGET_PROFILE
 
 WORKDIR /home/openwrt
 
@@ -66,41 +82,6 @@ RUN git clone "$OPENWRT_REPOSITORY" openwrt \
 WORKDIR /home/openwrt/openwrt
 
 COPY --chown=openwrt:openwrt profiles_feeds/ /home/openwrt/openwrt/profiles_feeds
+COPY --chown=openwrt:openwrt scripts/build-openwrt.sh /home/openwrt/openwrt/scripts/build-openwrt.sh
 
-RUN mkdir -p files/etc \
-    #   We need to keep the hashes in the firmware, to later know if an upgrade is needed:
-    && printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version \
-    && printf '%s=%s\n' "OPENWRT_VERSION" "$OPENWRT_VERSION" >> files/etc/prplwrt-version \
-    && if [ "$TARGET_PROFILE" = DEVICE_NETGEAR_RAX40 ] ; then \
-        #       Add prplmesh to the list of packages of the profile:
-        sed -i 's/packages:/packages:\n  - prplmesh-dwpal/g' profiles/intel_mips.yml \
-        && yq write --inplace profiles/intel_mips.yml feeds -f profiles_feeds/netgear-rax40.yml \
-        && ./scripts/gen_config.py intel_mips \
-        #       Installing intel feed doesn't correctly regenerate kernel .package-info
-        #       force regeneration by removing it
-        && rm -rf tmp \
-        #       For some reason we have to run gen_config a second time to get a correct .config:
-        && ./scripts/gen_config.py intel_mips \
-        #       make sure intel's bridge-utils is the only one that gets installed:
-        && rm -rf ./package/feeds/packages/bridge-utils \
-        && scripts/feeds install -p feed_bridge_utils bridge-utils \
-        && cat profiles_feeds/netgear-rax40.yml >> files/etc/prplwrt-version ;\
-    else \
-        cp feeds.conf.default feeds.conf \
-        && echo "src-git prpl $PRPL_FEED" >> feeds.conf \
-        && scripts/feeds update -a \
-        && scripts/feeds install -a \
-        && echo "CONFIG_TARGET_${TARGET_SYSTEM}=y" >> .config \
-        && echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}=y" >> .config \
-        && echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_${TARGET_PROFILE}=y" >> .config \
-        && echo "CONFIG_PACKAGE_prplmesh${PRPLMESH_VARIANT}=y" >> .config \
-        && make defconfig \
-        && printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version ;\
-    fi ;\
-    make -j$(nproc) \
-    && make package/prplmesh/clean
-# note that the result from diffconfig.sh with a minimal
-# configuration has the 3 CONFIG_TARGET items we set here, but NOT
-# the individual CONFIG_TARGET_${SUBTARGET} and
-# CONFIG_TARGET_${TARGET_PROFILE}, which means we don't need to
-# set them.
+RUN scripts/build-openwrt.sh

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -75,7 +75,8 @@ ENV TARGET_PROFILE=$TARGET_PROFILE
 
 WORKDIR /home/openwrt
 
-RUN git clone "$OPENWRT_REPOSITORY" openwrt \
+RUN printf '\033[1;35m%s Cloning prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)" \
+    && git clone "$OPENWRT_REPOSITORY" openwrt \
     && cd openwrt \
     && git checkout "$OPENWRT_VERSION"
 

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -164,7 +164,8 @@ VERBOSE=false
 IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='bd19f9ab26ad234b6f10cce23cd0dc41b9371929'
-PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^53d1e11003ce318c043c42063bbd2f57d15aac81'
+# TODO use hash instead of branch
+PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^dev/prplmesh-enable-wireless-backhaul'
 PRPLMESH_VARIANT="-nl80211"
 
 main "$@"

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -173,8 +173,7 @@ VERBOSE=false
 IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='bd19f9ab26ad234b6f10cce23cd0dc41b9371929'
-# TODO use hash instead of branch
-PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^dev/prplmesh-enable-wireless-backhaul'
+PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^c9f9407af79dd7ae8cfbe424ab6cf31fb09f5d57'
 PRPLMESH_VARIANT="-nl80211"
 DOCKER_TARGET_STAGE="prplmesh-builder"
 

--- a/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
+++ b/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
@@ -18,7 +18,7 @@
     hash: 8b7ff7d902f35b41864fbf306d45ad4ed91eaa89
   - name: feed_prpl
     uri: https://git.prpl.dev/prplmesh/feed-prpl.git
-    hash: 6453bb7a20eff2efb031ae4aecbc51a329d68957
+    hash: c9f9407af79dd7ae8cfbe424ab6cf31fb09f5d57
   - name: feed_opensource_apps
     uri: https://intel.prpl.dev/intel/feed_opensource_apps.git
     hash: 4ab5c90e08ce40b5208e6aea3e594a275f8940e9

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -6,6 +6,7 @@
 # See LICENSE file for more details.
 ###############################################################
 
+printf '\033[1;35m%s Configuring prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)"
 mkdir -p files/etc
 #   We need to keep the hashes in the firmware, to later know if an upgrade is needed:
 printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version
@@ -43,5 +44,8 @@ else
     make defconfig
     printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version
 fi
+printf '\033[1;35m%s Building prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)"
 make -j"$(nproc)"
+
+printf '\033[1;35m%s Cleaning prplMesh\n\033[0m' "$(date --iso-8601=seconds --universal)"
 make package/prplmesh/clean

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -1,0 +1,47 @@
+#!/bin/sh -e
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+mkdir -p files/etc
+#   We need to keep the hashes in the firmware, to later know if an upgrade is needed:
+printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version
+printf '%s=%s\n' "OPENWRT_VERSION" "$OPENWRT_VERSION" >> files/etc/prplwrt-version
+if [ "$TARGET_PROFILE" = DEVICE_NETGEAR_RAX40 ] ; then
+    # Add prplmesh to the list of packages of the profile:
+    sed -i 's/packages:/packages:\n  - prplmesh-dwpal/g' profiles/intel_mips.yml
+    yq write --inplace profiles/intel_mips.yml feeds -f profiles_feeds/netgear-rax40.yml
+    ./scripts/gen_config.py intel_mips
+    # Installing intel feed doesn't correctly regenerate kernel .package-info
+    # force regeneration by removing it
+    rm -rf tmp
+    # For some reason we have to run gen_config a second time to get a correct .config:
+    ./scripts/gen_config.py intel_mips
+    #       make sure intel's bridge-utils is the only one that gets installed:
+    rm -rf ./package/feeds/packages/bridge-utils
+    scripts/feeds install -p feed_bridge_utils bridge-utils
+    cat profiles_feeds/netgear-rax40.yml >> files/etc/prplwrt-version
+else
+    cp feeds.conf.default feeds.conf
+    echo "src-git prpl $PRPL_FEED" >> feeds.conf
+    scripts/feeds update -a
+    scripts/feeds install -a
+    {
+        # note that the result from diffconfig.sh with a minimal
+        # configuration has the 3 CONFIG_TARGET items we set here, but NOT
+        # the individual CONFIG_TARGET_${SUBTARGET} and
+        # CONFIG_TARGET_${TARGET_PROFILE}, which means we don't need to
+        # set them.
+        echo "CONFIG_TARGET_${TARGET_SYSTEM}=y"
+        echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}=y"
+        echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_${TARGET_PROFILE}=y"
+        echo "CONFIG_PACKAGE_prplmesh${PRPLMESH_VARIANT}=y"
+    } >> .config
+    make defconfig
+    printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version
+fi
+make -j"$(nproc)"
+make package/prplmesh/clean

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -45,7 +45,10 @@ else
     printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version
 fi
 printf '\033[1;35m%s Building prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)"
-make -j"$(nproc)"
+make -j"$(nproc)" V=sc -Orecurse
+
+printf '\033[1;35m%s **ls -l host/bin **\n\033[0m' "$(date --iso-8601=seconds --universal)"
+ls -l staging_dir/host/bin
 
 printf '\033[1;35m%s Cleaning prplMesh\n\033[0m' "$(date --iso-8601=seconds --universal)"
 make package/prplmesh/clean

--- a/tools/docker/builder/openwrt/scripts/build.sh
+++ b/tools/docker/builder/openwrt/scripts/build.sh
@@ -6,6 +6,9 @@ cp -r /home/openwrt/prplMesh_source /home/openwrt/prplMesh
 # We want to make sure that we do not keep anything built from the host:
 rm -rf /home/openwrt/prplMesh/build
 
+# Somehow, aclocal got removed...
+cp tools/automake/files/aclocal staging_dir/host/bin/
+
 make package/prplmesh/prepare USE_SOURCE_DIR="/home/openwrt/prplMesh" V=s
 make package/prplmesh/compile V=sc -j"$(nproc)"
 mkdir -p artifacts


### PR DESCRIPTION
In wireless backhaul, the bSTA is not supposed to start onboardin until dev_start_wps is done.
Actually, it can start earlier, but it shouldn't go over the wired backaul, so this is more of a workaround until #866 is done.