### PR TITLE
bugfix / beerocks crashes after receiving DFS_NOP_FINISHED

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -1895,6 +1895,10 @@ bool db::set_supported_channel_radar_affected(const std::string &mac, std::vecto
     }
     auto channels_count = channels.size();
     LOG(DEBUG) << " channels_count = " << int(channels_count);
+    if (channels_count < 1) {
+        LOG(ERROR) << "the given channel list must contain at least one value";
+        return false;
+    }
     auto it =
         find_if(std::begin(n->hostap->supported_channels), std::end(n->hostap->supported_channels),
                 [&](beerocks::message::sWifiChannel supported_channel) {


### PR DESCRIPTION
We noticed that the `set_supported_channel_radar_affected` could receive an empty channel list,
and when that happens, the function reaches a **segmentation fault**

To fix this, a validation of the channel list's size is needed.
In case an empty channel list is sent, print an appropriate error message & return false 