### PR TITLE
Feature / update the prplMesh utils operation test to use BML 

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -246,6 +246,17 @@ stop_function() {
     [ "$DELETE_LOGS" = "true" ] && prplmesh_delete_logs
 }
 
+execute_beerocks_command() {
+    dbg "Executing beerocks cli command: $*"
+    if [ -e $PRPLMESH_BIN_DIR/beerocks_cli ]; then
+        output=$(${PRPLMESH_BIN_DIR}/beerocks_cli -c "$@")
+        return $?
+    else
+        err "BML CLI not found"
+        return 1
+    fi
+}
+
 # Note: Apparently on some Linux version space is added to the process name.
 # Therefore added "($|[[:blank:]])" to the end of the regex expression which means the end of the
 # line ($) or blank character ([[:blank:]])

--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -253,6 +253,7 @@ execute_beerocks_command() {
         return $?
     else
         err "BML CLI not found"
+        output=""
         return 1
     fi
 }
@@ -287,21 +288,45 @@ status_function() {
     pgrep -l ieee1905_transport
     pgrep -l local_bus
 
-    # check for operational status
-    LOGS_PATH=@BEEROCKS_LOG_FILES_PATH@
+    bridge_mac="$(ip link show dev @BEEROCKS_BRIDGE_IFACE@ | awk '/^ *link\/ether / {print $2}')"
+    bml_cmd="bml_get_device_operational_radios $bridge_mac"
 
-    error=0
-    report "Main agent operational" main_agent_operational $LOGS_PATH
-    report "@BEEROCKS_WLAN1_IFACE@ radio agent operational" radio_agent_operational $LOGS_PATH @BEEROCKS_WLAN1_IFACE@
-    report "@BEEROCKS_WLAN2_IFACE@ radio agent operational" radio_agent_operational $LOGS_PATH @BEEROCKS_WLAN2_IFACE@
+    if  pgrep -l beerocks_cont ; then
+        if execute_beerocks_command "$bml_cmd" ; then
+            # Expecting
+            # > OK Main radio agent operational
+            # > OK wlan0 radio agent operational
+            # > OK wlan2 radio agent operational
+            OK_Count=$(echo "$output" | grep -c -e "OK.*operational")
+            if [ "$OK_Count" -eq 3 ]; then
+                success "operational test success!"
+                exit 0
+            else
+                err "operational test failed!"
+                err "$output"
+                exit 1
+            fi
+        else
+            err "Beerocks command failed to execute!"
+            exit 1
+        fi
+    else
+        # check for operational status
+        LOGS_PATH=@BEEROCKS_LOG_FILES_PATH@
 
-    [ "$VERBOSE" = "true" ] && [  $error = 1 ] && {
-        cat $LOGS_PATH/beerocks_agent@BEEROCKS_LOG_FILES_SUFFIX@
-        cat $LOGS_PATH/beerocks_agent_@BEEROCKS_WLAN1_IFACE@@BEEROCKS_LOG_FILES_SUFFIX@
-        cat $LOGS_PATH/beerocks_agent_@BEEROCKS_WLAN2_IFACE@@BEEROCKS_LOG_FILES_SUFFIX@
-    }
+        error=0
+        report "Main agent operational" main_agent_operational $LOGS_PATH
+        report "@BEEROCKS_WLAN1_IFACE@ radio agent operational" radio_agent_operational $LOGS_PATH @BEEROCKS_WLAN1_IFACE@
+        report "@BEEROCKS_WLAN2_IFACE@ radio agent operational" radio_agent_operational $LOGS_PATH @BEEROCKS_WLAN2_IFACE@
 
-    exit $error
+        [ "$VERBOSE" = "true" ] && [  $error = 1 ] && {
+            cat $LOGS_PATH/beerocks_agent@BEEROCKS_LOG_FILES_SUFFIX@
+            cat $LOGS_PATH/beerocks_agent_@BEEROCKS_WLAN1_IFACE@@BEEROCKS_LOG_FILES_SUFFIX@
+            cat $LOGS_PATH/beerocks_agent_@BEEROCKS_WLAN2_IFACE@@BEEROCKS_LOG_FILES_SUFFIX@
+        }
+
+        exit $error
+    fi
 }
 
 usage() {


### PR DESCRIPTION
prplmesh_utils.sh status returns an operational status determined by parsing the logs.
In some platforms logs wrap around could return "fail" status although system is operational state.
Currently, prplmesh_utils.sh status returns an operational status determined by parsing the logs.

To fix this, the prplmesh_utils can use the BML command `bml_get_device_operational_radios` 