### PR TITLE
[agent]: Refactor handlers for AP_METRICS_RESPONSE_MES…

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1260,7 +1260,6 @@ bool backhaul_manager::send_slave_ap_metric_query_message(uint16_t mid,
         std::get<0>(list) = true;
         std::get<1>(list) = mac;
         i++;
-        m_ap_metric_query.push_back({nullptr, mac}); // Old implementation will be removed
     }
 
     auto ret = false;
@@ -2555,11 +2554,10 @@ bool backhaul_manager::handle_ap_metrics_query(ieee1905_1::CmduMessageRx &cmdu_r
             LOG(ERROR) << "Failed to get bssid " << bssid_idx << " from AP_METRICS_QUERY";
             return false;
         }
-        auto mac = std::get<1>(bssid_tuple);
 
         m_expected_ap_metrics_response.expected_bssids.push_back(
-            std::get<1>(bssid_tuple));               //New implementation
-        m_ap_metric_query.push_back({nullptr, mac}); // Old implementation will be removed
+            std::get<1>(bssid_tuple)); //New implementation
+
         LOG(DEBUG) << "Received AP_METRICS_QUERY_MESSAGE, mid=" << std::hex << int(mid)
                    << "  bssid " << std::get<1>(bssid_tuple);
     }

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1025,21 +1025,16 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
                 for (const auto &socket : slaves_sockets) {
                     if (socket) {
                         for (int i = 0; i < beerocks::IFACE_TOTAL_VAPS; ++i) {
-                            if (socket->vaps_list.vaps[i].mac != network_utils::ZERO_MAC) {
+                            if ((socket->vaps_list.vaps[i].mac != network_utils::ZERO_MAC) &&
+                                (socket->vaps_list.vaps[i].ssid[0] != '\0')) {
                                 bssid_list.push_back(socket->vaps_list.vaps[i].mac);
                             }
                         }
                     }
                 }
-                // We must generate a new MID for the periodic AP Metrics Response messages that
-                // do not correspond to an AP Metrics Query message.
-                // We cannot set MID to 0 here because we must also differentiate periodic
-                // AP Metrics Response messages and messages received from monitor thread
-                // due to channel utilization crossed configured threshold value.
-                // As a temporary solution, set MID to UINT16_MAX here.
-                // TODO: to be fixed as part of #1328
+
                 if (!bssid_list.empty()) {
-                    send_slave_ap_metric_query_message(UINT16_MAX, bssid_list);
+                    send_slave_ap_metric_query_message(0, bssid_list);
                 } else {
                     LOG(DEBUG) << "Skipping AP_METRICS_QUERY for slave, empty BSSID list";
                 }
@@ -1235,51 +1230,52 @@ bool backhaul_manager::send_autoconfig_search_message(std::shared_ptr<sRadioInfo
 bool backhaul_manager::send_slave_ap_metric_query_message(uint16_t mid,
                                                           const std::vector<sMacAddr> &bssid_list)
 {
-    bool ret = false;
+
+    // Save mid and clear previous query
+    m_expected_ap_metrics_response.mid = mid;
+    m_expected_ap_metrics_response.expected_bssids.clear();
+    m_expected_ap_metrics_response.response.create(
+        mid, ieee1905_1::eMessageType::AP_METRICS_RESPONSE_MESSAGE);
+
+    auto forward = cmdu_tx.create(mid, ieee1905_1::eMessageType::AP_METRICS_QUERY_MESSAGE);
+    if (!forward) {
+        LOG(ERROR) << "Failed to create AP_METRICS_QUERY_MESSAGE";
+        return false;
+    }
+
+    auto query = cmdu_tx.addClass<wfa_map::tlvApMetricQuery>();
+    if (!query) {
+        LOG(ERROR) << "Failed addClass<wfa_map::tlvApMetricQuery>";
+        return false;
+    }
+
+    if (!query->alloc_bssid_list(bssid_list.size())) {
+        LOG(ERROR) << "Failed allocate memory for bssid_list, size: " << bssid_list.size();
+        return false;
+    }
+
+    int i = 0;
+    for (const auto &mac : bssid_list) {
+        auto list         = query->bssid_list(i);
+        std::get<0>(list) = true;
+        std::get<1>(list) = mac;
+        i++;
+        m_ap_metric_query.push_back({nullptr, mac}); // Old implementation will be removed
+    }
+
+    auto ret = false;
     for (auto socket : slaves_sockets) {
-        for (const auto &mac : bssid_list) {
-            int i = 0;
-            if (mac == socket->vaps_list.vaps[i].mac) {
-                LOG(DEBUG) << "Forwarding AP_METRICS_QUERY_MESSAGE message to son_slave, bssid: "
-                           << std::hex << tlvf::mac_to_string(mac);
-
-                auto forward =
-                    cmdu_tx.create(mid, ieee1905_1::eMessageType::AP_METRICS_QUERY_MESSAGE);
-                if (!forward) {
-                    LOG(ERROR) << "Failed to create AP_METRICS_QUERY_MESSAGE";
-                    return false;
-                }
-
-                auto query = cmdu_tx.addClass<wfa_map::tlvApMetricQuery>();
-                if (!query) {
-                    LOG(ERROR) << "Failed addClass<wfa_map::tlvApMetricQuery>";
-                    return false;
-                }
-
-                if (!query->alloc_bssid_list(1)) {
-                    LOG(ERROR) << "Failed allocate memory for bssid_list";
-                    return false;
-                }
-
-                auto list         = query->bssid_list(0);
-                std::get<0>(list) = true;
-                std::get<1>(list) = mac;
-
-                if (!message_com::send_cmdu(socket->slave, cmdu_tx)) {
-                    LOG(ERROR) << "Failed forwarding AP_METRICS_QUERY_MESSAGE message to son_slave";
-                    ret = false;
-                    continue;
-                } else {
-                    ret = true;
-                    // Fill a query vector
-                    m_ap_metric_query.push_back({socket->slave, mac});
-                }
-            }
-            i++;
+        if (!message_com::send_cmdu(socket->slave, cmdu_tx)) {
+            LOG(ERROR) << "Failed forwarding AP_METRICS_QUERY_MESSAGE message to son_slave";
+            ret = false;
+            continue;
+        } else {
+            ret = true;
         }
     }
+
     return ret;
-}
+} // namespace beerocks
 
 bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
 {
@@ -2585,32 +2581,20 @@ bool backhaul_manager::handle_slave_ap_metrics_response(ieee1905_1::CmduMessageR
                                                         const std::string &src_mac)
 {
     auto mid = cmdu_rx.getMessageId();
+
+    if (mid != m_expected_ap_metrics_response.mid) {
+        LOG(ERROR) << "Received AP_METRICS_RESPONSE_MESSAGE with bad mid=" << std::hex << int(mid);
+        return false;
+    }
+
+    if (mid == 0) {
+        LOG(DEBUG) << "Forward AP_METRICS_RESPONSE_MESSAGE to controller, mid=" << std::hex
+                   << int(mid);
+        return send_cmdu_to_bus(cmdu_rx, controller_bridge_mac, bridge_info.mac,
+                                cmdu_rx.getMessageLength());
+    }
+
     LOG(DEBUG) << "Received AP_METRICS_RESPONSE_MESSAGE, mid=" << std::hex << int(mid);
-
-    /**
-     * If AP Metrics Response message does not correspond to a previously received and forwarded
-     * AP Metrics Query message (which we know because message id is not set), then forward message
-     * to controller.
-     * This might happen when channel utilization value has crossed configured threshold or when
-     * periodic metrics reporting interval has elapsed.
-     */
-    if (0 == mid) {
-        uint16_t length = message_com::get_uds_header(cmdu_rx)->length;
-        cmdu_rx.swap(); //swap back before forwarding
-        return send_cmdu_to_bus(cmdu_rx, controller_bridge_mac, bridge_info.mac, length);
-    }
-
-    /**
-     * When periodic metrics reporting interval has elapsed, we emulate that we have received an
-     * AP Metrics Query message from controller. To differentiate real queries from emulated ones,
-     * we use a "special" mid value.
-     * Note that this design is flaw as a real query might also have this special mid value. This
-     * is just a quick and dirty fix to pass 4.7.5 and 4.7.6 for M1
-     * TODO: to be fixed as part of #1328
-     */
-    if (UINT16_MAX == mid) {
-        mid = 0;
-    }
 
     auto ap_metrics_tlv = cmdu_rx.getClass<wfa_map::tlvApMetrics>();
     if (!ap_metrics_tlv) {
@@ -2759,7 +2743,7 @@ bool backhaul_manager::handle_slave_ap_metrics_response(ieee1905_1::CmduMessageR
 
     LOG(DEBUG) << "Sending AP_METRICS_RESPONSE_MESSAGE, mid=" << std::hex << int(mid);
     return send_cmdu_to_bus(cmdu_tx, controller_bridge_mac, bridge_info.mac);
-}
+} // namespace beerocks
 
 /**
  * @brief Handles 1905 Topology Query message

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -529,44 +529,6 @@ private:
 
     sExpectedApMetricsResponse m_expected_ap_metrics_response;
 
-    struct sStaTrafficStats {
-        sMacAddr sta_mac;
-        uint32_t byte_sent;
-        uint32_t byte_recived;
-        uint32_t packets_sent;
-        uint32_t packets_recived;
-        uint32_t tx_packets_error;
-        uint32_t rx_packets_error;
-        uint32_t retransmission_count;
-    };
-
-    struct sStaLinkMetrics {
-        sMacAddr sta_mac;
-        wfa_map::tlvAssociatedStaLinkMetrics::sBssidInfo bssid_info;
-    };
-
-    struct sApMetricsQuery {
-        Socket *soc;
-        sMacAddr bssid;
-    };
-
-    struct sApMetrics {
-        sMacAddr bssid;
-        uint8_t channel_utilization;
-        uint16_t number_of_stas_currently_associated;
-        wfa_map::tlvApMetrics::sEstimatedService estimated_service_parameters;
-        std::vector<uint8_t> estimated_service_info_field;
-    };
-
-    struct sApMetricsResponse {
-        sApMetrics metric;
-        std::vector<sStaTrafficStats> sta_traffic_stats;
-        std::vector<sStaLinkMetrics> sta_link_metrics;
-    };
-
-    std::vector<sApMetricsQuery> m_ap_metric_query;
-    std::vector<sApMetricsResponse> m_ap_metric_response;
-
     struct sChannelSelectionResponse {
         sMacAddr radio_mac;
         wfa_map::tlvChannelSelectionResponse::eResponseCode response_code;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -24,6 +24,7 @@
 #include <tlvf/ieee_1905_1/eLinkMetricsType.h>
 #include <tlvf/ieee_1905_1/eMediaType.h>
 
+#include <tlvf/CmduMessageTx.h>
 #include <tlvf/wfa_map/tlvApMetrics.h>
 #include <tlvf/wfa_map/tlvAssociatedStaLinkMetrics.h>
 #include <tlvf/wfa_map/tlvChannelSelectionResponse.h>
@@ -518,6 +519,15 @@ private:
     bool add_link_metrics(const sMacAddr &reporter_al_mac, const sLinkInterface &link_interface,
                           const sLinkNeighbor &link_neighbor, const sLinkMetrics &link_metrics,
                           ieee1905_1::eLinkMetricsType link_metrics_type);
+
+    struct sExpectedApMetricsResponse {
+        uint16_t mid;
+        std::vector<sMacAddr> expected_bssids;
+        uint8_t response_buffer[message::MESSAGE_BUFFER_LENGTH];
+        ieee1905_1::CmduMessageTx response = {response_buffer, sizeof(response_buffer)};
+    };
+
+    sExpectedApMetricsResponse m_expected_ap_metrics_response;
 
     struct sStaTrafficStats {
         sMacAddr sta_mac;


### PR DESCRIPTION
Create new structure sExpectedApMetricsResponse for
saving mid, bssid vector, cmdutx message. Update
current implementation of handle_ap_metrics_query:
clear bssid vector, cmdutx message, save mid, change
sending message to the son_slave on simple forwarding.

Add new structure and member of structure, update
handle_ap_metrics_query method.
