### PR TITLE
Feature/prplwrt build with a script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ run-tests:
   stage: build
   script:
     - mkdir -p "build/$TARGET_DEVICE"
-    - tools/docker/builder/openwrt/build.sh --verbose -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log" | grep -E '^[[:blank:]]?make\[[12]\]|^Step|^ --->' --color=never --line-buffered
+    - tools/docker/builder/openwrt/build.sh --verbose -d "$TARGET_DEVICE" -t "prplmesh-builder-$TARGET_DEVICE:$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID" 2>&1 | tee "build/$TARGET_DEVICE/openwrt-build.log"
   artifacts:
     paths:
       - "build/$TARGET_DEVICE/"

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update \
 RUN useradd -ms /bin/bash openwrt
 
 ####
-## Prebuilt OpenWrt and prplMesh dependencies, but not the prplMesh ipk itself
+## OpenWrt tree and scripts to build it.
 ####
-FROM openwrt-prerequisites as prplmesh-builder
+FROM openwrt-prerequisites as openwrt-builder
 
 USER openwrt
 
@@ -83,5 +83,10 @@ WORKDIR /home/openwrt/openwrt
 
 COPY --chown=openwrt:openwrt profiles_feeds/ /home/openwrt/openwrt/profiles_feeds
 COPY --chown=openwrt:openwrt scripts/build-openwrt.sh /home/openwrt/openwrt/scripts/build-openwrt.sh
+
+####
+## Prebuilt OpenWrt and prplMesh dependencies, but not the prplMesh ipk itself
+####
+FROM openwrt-builder as prplmesh-builder
 
 RUN scripts/build-openwrt.sh

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -1,3 +1,10 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
 ####
 ## OpenWrt pre-requisites and "openwrt" user
 ####
@@ -33,29 +40,38 @@ USER openwrt
 #
 # OpenWrt repository to use. Can also be a prplWrt repository:
 ARG OPENWRT_REPOSITORY
+ENV OPENWRT_REPOSITORY=$OPENWRT_REPOSITORY
 # Which OpenWrt version (commit hash) to use:
 ARG OPENWRT_VERSION
+ENV OPENWRT_VERSION=$OPENWRT_VERSION
 # The variant to build (nl80211 or dwpal)
 ARG PRPLMESH_VARIANT
+ENV PRPLMESH_VARIANT=$PRPLMESH_VARIANT
 
 # The feed to use to build prplMesh.
 ARG PRPL_FEED
+ENV PRPL_FEED=$PRPL_FEED
 # optional: intel feed to use.
 ARG INTEL_FEED
+ENV INTEL_FEED=$INTEL_FEED
 # optional: iwlwav feed to use.
 ARG IWLWAV_FEED
+ENV IWLWAV_FEED=$IWLWAV_FEED
 
 # Target to build for (CONFIG_TARGET_ will be prepended).
 # Example: TARGET_SYSTEM=mvebu
 ARG TARGET_SYSTEM
+ENV TARGET_SYSTEM=$TARGET_SYSTEM
 
 # Subtarget (CONFIG_TARGET_${TARGET_SYSTEM}_ will be prepended).
 # Example: SUBTARGET=cortexa9
 ARG SUBTARGET
+ENV SUBTARGET=$SUBTARGET
 
 # Target profile (CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_ will be prepended).
 # Example: TARGET_PROFILE=DEVICE_cznic_turris-omnia
 ARG TARGET_PROFILE
+ENV TARGET_PROFILE=$TARGET_PROFILE
 
 WORKDIR /home/openwrt
 
@@ -66,41 +82,6 @@ RUN git clone "$OPENWRT_REPOSITORY" openwrt \
 WORKDIR /home/openwrt/openwrt
 
 COPY --chown=openwrt:openwrt profiles_feeds/ /home/openwrt/openwrt/profiles_feeds
+COPY --chown=openwrt:openwrt scripts/build-openwrt.sh /home/openwrt/openwrt/scripts/build-openwrt.sh
 
-RUN mkdir -p files/etc \
-    #   We need to keep the hashes in the firmware, to later know if an upgrade is needed:
-    && printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version \
-    && printf '%s=%s\n' "OPENWRT_VERSION" "$OPENWRT_VERSION" >> files/etc/prplwrt-version \
-    && if [ "$TARGET_PROFILE" = DEVICE_NETGEAR_RAX40 ] ; then \
-        #       Add prplmesh to the list of packages of the profile:
-        sed -i 's/packages:/packages:\n  - prplmesh-dwpal/g' profiles/intel_mips.yml \
-        && yq write --inplace profiles/intel_mips.yml feeds -f profiles_feeds/netgear-rax40.yml \
-        && ./scripts/gen_config.py intel_mips \
-        #       Installing intel feed doesn't correctly regenerate kernel .package-info
-        #       force regeneration by removing it
-        && rm -rf tmp \
-        #       For some reason we have to run gen_config a second time to get a correct .config:
-        && ./scripts/gen_config.py intel_mips \
-        #       make sure intel's bridge-utils is the only one that gets installed:
-        && rm -rf ./package/feeds/packages/bridge-utils \
-        && scripts/feeds install -p feed_bridge_utils bridge-utils \
-        && cat profiles_feeds/netgear-rax40.yml >> files/etc/prplwrt-version ;\
-    else \
-        cp feeds.conf.default feeds.conf \
-        && echo "src-git prpl $PRPL_FEED" >> feeds.conf \
-        && scripts/feeds update -a \
-        && scripts/feeds install -a \
-        && echo "CONFIG_TARGET_${TARGET_SYSTEM}=y" >> .config \
-        && echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}=y" >> .config \
-        && echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_${TARGET_PROFILE}=y" >> .config \
-        && echo "CONFIG_PACKAGE_prplmesh${PRPLMESH_VARIANT}=y" >> .config \
-        && make defconfig \
-        && printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version ;\
-    fi ;\
-    make -j$(nproc) \
-    && make package/prplmesh/clean
-# note that the result from diffconfig.sh with a minimal
-# configuration has the 3 CONFIG_TARGET items we set here, but NOT
-# the individual CONFIG_TARGET_${SUBTARGET} and
-# CONFIG_TARGET_${TARGET_PROFILE}, which means we don't need to
-# set them.
+RUN scripts/build-openwrt.sh

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -75,7 +75,8 @@ ENV TARGET_PROFILE=$TARGET_PROFILE
 
 WORKDIR /home/openwrt
 
-RUN git clone "$OPENWRT_REPOSITORY" openwrt \
+RUN printf '\033[1;35m%s Cloning prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)" \
+    && git clone "$OPENWRT_REPOSITORY" openwrt \
     && cd openwrt \
     && git checkout "$OPENWRT_VERSION"
 

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -1,4 +1,10 @@
 #!/bin/sh -e
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
 
 scriptdir="$(cd "${0%/*}"; pwd)"
 rootdir="${scriptdir%/*/*/*/*}"
@@ -12,6 +18,7 @@ usage() {
     echo "      -h|--help - show this help menu"
     echo "      -v|--verbose - increase the script's verbosity"
     echo "      -d|--target-device the device to build for"
+    echo "      --docker-target-stage docker target build stage (implies -i)"
     echo "      -i|--image - build the docker image only"
     echo "      -o|--openwrt-version - the openwrt version to use"
     echo "      -r|--openwrt-repository - the openwrt repository to use"
@@ -34,6 +41,7 @@ build_image() {
            --build-arg TARGET_PROFILE="$TARGET_PROFILE" \
            --build-arg PRPL_FEED="$PRPL_FEED" \
            --build-arg PRPLMESH_VARIANT="$PRPLMESH_VARIANT" \
+           --target="$DOCKER_TARGET_STAGE" \
            "$scriptdir/"
 }
 
@@ -67,7 +75,7 @@ main() {
         exit 1
     fi
 
-    if ! OPTS=$(getopt -o 'hvd:io:r:t:' --long help,verbose,target-device:,image,openwrt-version:,openwrt-repository:,tag: -n 'parse-options' -- "$@"); then
+    if ! OPTS=$(getopt -o 'hvd:io:r:t:' --long help,verbose,target-device:,docker-target-stage:,image,openwrt-version:,openwrt-repository:,tag: -n 'parse-options' -- "$@"); then
         err "Failed parsing options." >&2
         usage
         exit 1
@@ -82,6 +90,7 @@ main() {
             -h | --help)               usage; exit 0; shift ;;
             -v | --verbose)            VERBOSE=true; shift ;;
             -d | --target-device)      TARGET_DEVICE="$2"; shift ; shift ;;
+            --docker-target-stage)     DOCKER_TARGET_STAGE="$2"; IMAGE_ONLY=true; shift 2 ;;
             -i | --image)              IMAGE_ONLY=true; shift ;;
             -o | --openwrt-version)    OPENWRT_VERSION="$2"; shift; shift ;;
             -r | --openwrt-repository) OPENWRT_REPOSITORY="$2"; shift; shift ;;
@@ -132,7 +141,7 @@ main() {
     if [ -n "$TAG" ] ; then
         image_tag="$TAG"
     else
-        image_tag="prplmesh-builder-${TARGET_DEVICE}:${OPENWRT_VERSION}"
+        image_tag="${DOCKER_TARGET_STAGE}-${TARGET_DEVICE}:${OPENWRT_VERSION}"
         dbg "image tag not set, using default value $image_tag"
     fi
 
@@ -166,5 +175,6 @@ OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='bd19f9ab26ad234b6f10cce23cd0dc41b9371929'
 PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^53d1e11003ce318c043c42063bbd2f57d15aac81'
 PRPLMESH_VARIANT="-nl80211"
+DOCKER_TARGET_STAGE="prplmesh-builder"
 
 main "$@"

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -6,6 +6,7 @@
 # See LICENSE file for more details.
 ###############################################################
 
+printf '\033[1;35m%s Configuring prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)"
 mkdir -p files/etc
 #   We need to keep the hashes in the firmware, to later know if an upgrade is needed:
 printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version
@@ -43,5 +44,8 @@ else
     make defconfig
     printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version
 fi
+printf '\033[1;35m%s Building prplWrt\n\033[0m' "$(date --iso-8601=seconds --universal)"
 make -j"$(nproc)"
+
+printf '\033[1;35m%s Cleaning prplMesh\n\033[0m' "$(date --iso-8601=seconds --universal)"
 make package/prplmesh/clean

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -1,0 +1,47 @@
+#!/bin/sh -e
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+mkdir -p files/etc
+#   We need to keep the hashes in the firmware, to later know if an upgrade is needed:
+printf '%s=%s\n' "OPENWRT_REPOSITORY" "$OPENWRT_REPOSITORY" >> files/etc/prplwrt-version
+printf '%s=%s\n' "OPENWRT_VERSION" "$OPENWRT_VERSION" >> files/etc/prplwrt-version
+if [ "$TARGET_PROFILE" = DEVICE_NETGEAR_RAX40 ] ; then
+    # Add prplmesh to the list of packages of the profile:
+    sed -i 's/packages:/packages:\n  - prplmesh-dwpal/g' profiles/intel_mips.yml
+    yq write --inplace profiles/intel_mips.yml feeds -f profiles_feeds/netgear-rax40.yml
+    ./scripts/gen_config.py intel_mips
+    # Installing intel feed doesn't correctly regenerate kernel .package-info
+    # force regeneration by removing it
+    rm -rf tmp
+    # For some reason we have to run gen_config a second time to get a correct .config:
+    ./scripts/gen_config.py intel_mips
+    #       make sure intel's bridge-utils is the only one that gets installed:
+    rm -rf ./package/feeds/packages/bridge-utils
+    scripts/feeds install -p feed_bridge_utils bridge-utils
+    cat profiles_feeds/netgear-rax40.yml >> files/etc/prplwrt-version
+else
+    cp feeds.conf.default feeds.conf
+    echo "src-git prpl $PRPL_FEED" >> feeds.conf
+    scripts/feeds update -a
+    scripts/feeds install -a
+    {
+        # note that the result from diffconfig.sh with a minimal
+        # configuration has the 3 CONFIG_TARGET items we set here, but NOT
+        # the individual CONFIG_TARGET_${SUBTARGET} and
+        # CONFIG_TARGET_${TARGET_PROFILE}, which means we don't need to
+        # set them.
+        echo "CONFIG_TARGET_${TARGET_SYSTEM}=y"
+        echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}=y"
+        echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_${TARGET_PROFILE}=y"
+        echo "CONFIG_PACKAGE_prplmesh${PRPLMESH_VARIANT}=y"
+    } >> .config
+    make defconfig
+    printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version
+fi
+make -j"$(nproc)"
+make package/prplmesh/clean


### PR DESCRIPTION
Openwrt: move the build to a separate script, and add an option to build an "openwrt-builder" image only.

Moving the build part to a script makes it more readable, and easier
to maintain.

It also makes it easier to repeat the same steps in a container
interactively, to debug a failing build for example.

As a bonus, it makes it possible to run shellcheck and formatting
tools on it.

Some developers like to build OpenWrt interactively, to configure
different build options for example, or to be able to debug failing
builds more easily than what can be done when building a docker image.

With these changes, it's now possible to build the "openwrt-builder"
image:

tools/docker/builder/openwrt/build.sh --docker-target-stage
openwrt-builder --target-device netgear-rax40

The image can then be used to compile OpenWrt interactively.
