### PR TITLE
readme: update docket build script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ Its [README file](tools/beerocks_analyzer/README.md) explains how to use it.
 If master branch does not work / does not pass tests on your computer make sure that:
 
 - you loaded ebtables kernel module: `sudo modprobe ebtables`
-- you updated your docker images with `tools/docker/image-build.sh`
+- you updated your docker images with `tools/docker/build.sh`


### PR DESCRIPTION
The correct script to update docker images is `tools/docker/build.sh`.
This commit updates troubleshooting section of README file to refer to this script