### PR TITLE
PPM-83 unified agent infrastructure

### DIFF
--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include <iostream>
+#include <memory>
+#include <mutex>
+
+namespace beerocks {
+
+/**
+ * @brief AgentDB is a class used by all main Agent threads on the Agent process to store the Agent
+ * common data.
+ * 
+ * The class is implemented using singleton design pattern.
+ * It is thread safe and being locked and released automatically.
+ * 
+ * How to use:
+ * @code
+ * auto db = AgentDB::get();            // Get DB and automatically lock it. The lock will be
+ *                                      // Released when 'db' will be destructed.
+ * 
+ * db->foo = 42;                        // Change database member 'foo' to value 42.
+ * db->bar = "prpl"                     // Set another database member.
+ * auto &my_foo = db->foo;              // Get a refernce to a member.
+ * 
+ * AgentDB::get()->foo = 44;            // Set database member directly.
+ * 
+ * 
+ * Unsafe operation which should never be done:
+ * auto my_foo = AgentDB::get()->foo;   // Unsafe! Don't do it! The database might be unlocked,
+ *                                      // if used on ranged loop. So better not use it.
+ * 
+ * auto &foo = AgentDB::get()->foo;     // Unsafe! Don't do it! The database will be unlocked,
+ *                                      // but the reference will remain.
+ * 
+ * std::string &get_foo() {             // Unsafe! Don't do it! Returning refernce to the database
+ *     auto db = AgentDB::get();        // on a wrapper function is unsafe because the database will
+ *     return db->foo;                  // be unlocked when the function ends, and the caller will
+ * }                                    // hold a refernce to it.                                 // hold a refernce to it.
+ * @endcode
+ */
+class AgentDB {
+public:
+    class SafeDB {
+    public:
+        SafeDB(AgentDB &db) : m_db(db) { m_db.db_lock(); }
+        ~SafeDB() { m_db.db_unlock(); }
+        AgentDB *operator->() { return &m_db; }
+
+    private:
+        AgentDB &m_db;
+    };
+    static SafeDB get()
+    {
+        // Guaranteed to be destroyed.
+        // Instantiated on first use.
+        static AgentDB instance;
+        return SafeDB(instance);
+    }
+    AgentDB(const AgentDB &) = delete;
+    void operator=(const AgentDB &) = delete;
+
+private:
+    // Private constructor so that no objects can be created.
+    AgentDB() = default;
+    std::recursive_mutex m_db_mutex;
+    void db_lock() { m_db_mutex.lock(); }
+    void db_unlock() { m_db_mutex.unlock(); }
+
+public:
+    /* Put here database members used by the Agent modules */
+};
+
+} // namespace beerocks


### PR DESCRIPTION
This PR features new database and tasks infrastructure to the future unified agent.
#1082 - Phase 2

Discussion:
The featured database on this PR is planned to be used among all the main agent threads (agent, backhaul, platform).
The database needs to be thread-safe, therefore I have written an automatic lock and release mechanism to the database. It works like this:
```cpp
// When getting the db instance the db is automatically being locked. The release occurs when 'db' is destructed.
auto db = AgentDB::get();
db->foo = 42;
```
A problem pops out if someone will try to get a reference to a database member:
```cpp
auto &my_foo = AgentDB::get()->foo;
my_foo = 5;
```
After getting the reference the lock is released since the instance of the db is destroyed, and changing the value is unsafe.
There are 3 options that we could choose.

This is the table that sum it up. (Detailed explanation is below the table).

  |   | Convinient | Preformance | Code Size | Readbility | Adding/Editing   Code | Memory   Consumption | Safty | Implementation   Time
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Multhread   Shared-DB | Direct Access | Best | Best- | Best | Best | Best | Best | Data Validation   Issue     Hard to detect on review | Low
Multhread   Shared-DB | Setters   Getters | Medium | Medium+ | Medium | Medium | Best- | Best | Data   Validation Issue     Easier to detect on review | Medium
Single Thread DB |   | Best | Best- | Worst | Worst | Worst | Worst | Safe | High

Please vote:
❤️ - Option 1
🚀 - Option 2
👀 - Option 3


1. I have added to the class 'how to use documentation' explanation about it, asking from the user not to use it that way.
It is important to understand that this is a general C/C++ problem. This language allows a developer to do unsafe memory operation, so since we are careful to not do it generally, then we need to be careful here as well since it is the same thing.

   ***Convenient: BEST*** 
      - On a single call, it is possible to get by copy/reference and set members directly.
      <br />

   ***Performance: BEST-***
      - Since accessing db members it is required to allocate db subclass on the stack which locks the mutex and unlock it on destruction. The lock and unlock could be used once for several member access, and not for each one.
      - Since getting members by reference is possible.
      - Since the database is used by a few threads, then sending data between threads is no longer needed.
      <br />

   ***Code size: BEST***
      - The db contains only members and therefore it is slim.
      - Since it is shared between threads, there is no need to save a copy of memory on each thread and the tlvf code will decrease too.
      <br />

   ***Readability: BEST***
      - Since the db contain only members, its class is not gigantic and therefore more readable.
      - Since it is shared between threads on a single location, no need to track messages to see the whole flow and lifetime and copies of some configuration.
      <br />

   ***Adding/Editing code: BEST***
      - Since adding/changing only in one place - db class.
      <br />

   ***Memory consumption: BEST***
      - Since it is shared between threads, there is no need to save a copy of memory on each thread.
      <br />

   ***Safety: C/C++ Safty - Harder to detect on code review***
      - The mechanism has a general C/C++ safety issue which allows touching shared memory without being protected by a mutex if using the db API incorrectly. It is important to understand that it cannot cause to a crash, only to invalid data set/get.
      - Since it not using setters and getter the wrong use of the DB can be anywhere on the code, and potentially it will be harder to notice it on code review.
<br />

2. Using getters and setters with restriction of getting values only by copy. The problem still remains with setters and getters since the getter could be written with returning by reference, but the places where the mistake could be done is only on the getters/setters function on the db, instead of all over the code.
The disadvantage of it is that it is much more convenient to no use setters/getters and just use directly the member is needed, also it will make the database class more than 3 times longer.
Each getter will have to strict the return value to be a copy.

   ***Convenient: MEDIUM*** 
      - Using getters and setters is less convenient than accessing class members directly.
      <br />

   ***Performance: MEDIUM+***
      - Since accessing db members it is required to allocate db subclass on the stack which locks the mutex and unlock it on destruction. The lock and unlock could be used once for several member access, and not for each one.
      - Since getting members by reference is not possible.
      - Since the database is used by a few threads, then sending data between threads is no longer needed.
      <br />

   ***Code size: MEDIUM***
      - The db contains members and getter and setter for each one which increases code size.
      - Since it is shared between threads, there is no need to save a copy of memory on each thread.
      <br />

   ***Readability: MEDIUM***
      - Since the db contains setter and getter for each member it will be gigantic (like the controller DB) and therefore less readable.
      - Since it is shared between threads on a single location, no need to track messages to see the whole flow and lifetime and copies of some configuration.
      <br />

   ***Adding/Editing code: BEST-***
      - Since adding/changing only in one place - db class, but need to add setter and getter.
      <br />

   ***Memory consumption: BEST***
      - Since it is shared between threads, there is no need to save a copy of memory on each thread.
      <br />

   ***Safety: C/C++ Safty - Easier to detect on code review***
      - The mechanism has a general C/C++ safety issue which allows touching shared memory without being protected by a mutex if using the db API incorrectly. It is important to understand that it cannot cause a crash, only to invalid data set/get.
      - Since using setters and getter the wrong use of the DB can only on the DB class, so it will be written once, and so there is a higher chance to detect it on code review.
      <br />

3. Not to use shared memory and creating a thread-local copy of memory which is sent by messages.

   ***Convenient: BEST*** 
      - Since each data has a local copy of the access to it easiest.
      <br />

   ***Performance: BEST-*** 
      - Since each configuration has a local copy the performance accessing it is the best.
      - Since each configuration needs to be sent on a CMDU.
      <br />

   ***Code size: WORST***
      - Since the code contains a copy of memory on each thread.
      - Since there is a code containing the data on messages, code that copy the data to a message to send it, and code that handles the message and saves it on a local copy.
      <br />

   ***Readability: WORST***
      - Since there is a code containing the data on messages, code that copy the data to a message to send it, and code that handles the message and saves it on a local copy.
      <br />

   ***Adding/Editing code: WORST***
      - Add/Change the code on each thread the copy of data exists, and also on tlvf.
      <br />

   ***Memory consumption: WORST***
      - Since it there is a local copy on each thread.
      <br />

   ***Safety: Safe***
      - No safety issue.
      <br />
