### PR TITLE
tools:docker: openwrt builder bump feed_prpl hash

### DIFF
--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -173,7 +173,7 @@ VERBOSE=false
 IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='bd19f9ab26ad234b6f10cce23cd0dc41b9371929'
-PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^53d1e11003ce318c043c42063bbd2f57d15aac81'
+PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^f2869ffecfcee449321cb53cd66dd6daab25ceee'
 PRPLMESH_VARIANT="-nl80211"
 DOCKER_TARGET_STAGE="prplmesh-builder"
 

--- a/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
+++ b/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
@@ -18,7 +18,7 @@
     hash: 8b7ff7d902f35b41864fbf306d45ad4ed91eaa89
   - name: feed_prpl
     uri: https://git.prpl.dev/prplmesh/feed-prpl.git
-    hash: 6453bb7a20eff2efb031ae4aecbc51a329d68957
+    hash: f2869ffecfcee449321cb53cd66dd6daab25ceee
   - name: feed_opensource_apps
     uri: https://intel.prpl.dev/intel/feed_opensource_apps.git
     hash: 4ab5c90e08ce40b5208e6aea3e594a275f8940e9


### PR DESCRIPTION
Bump feed_prpl hash to fix build error with wrong openssl dependency.
Relevant PR in feed_prpl:
https://git.prpl.dev/prplmesh/feed-prpl/-/merge_requests/6

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>