### PR TITLE
deploy_firmware.py: try to kill the prplMesh init script first

### DIFF
--- a/tools/deploy_firmware.py
+++ b/tools/deploy_firmware.py
@@ -174,8 +174,12 @@ class NetgearRax40(PrplwrtDevice):
             # make the shell prompt appear:
             self.set_prompt(shell)
             shell.expect(self.serial_prompt)
+            # kill any instance of the init script, if the current
+            # firmware doesn't have working wireless interfaces it
+            # will prevent it from rebooting:
+            shell.sendline("pgrep -f 'S99prplmesh boot' | xargs kill")
             # reboot:
-            shell.sendline("reboot")
+            shell.sendline("reboot -f")
             shell.expect(["Hit any key to stop autoboot:",
                           pexpect.EOF, pexpect.TIMEOUT], timeout=120)
             # stop autoboot:


### PR DESCRIPTION
When the rax40 has a firmware with non-working wireless interfaces,
the S99prplmesh script prevents it from rebooting.

Try to kill it first, before doing a reboot.

Fixes https://github.com/prplfoundation/prplMesh/issues/1436.

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>