### PR TITLE
Port ApConfigRenew test of test_flow.py to boardfarm

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/ap_config_renew.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/ap_config_renew.py
@@ -1,0 +1,67 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+import time
+
+from .prplmesh_base_test import PrplMeshBaseTest
+from capi import tlv
+
+
+class ApConfigRenew(PrplMeshBaseTest):
+    """Check initial configuration on device."""
+
+    def runTest(self):
+        # Locate agents and controller
+        for dev in self.dev:
+            if dev.controller_entity:
+                controller = dev.controller_entity
+            if dev.agent_entity:
+                agent = dev.agent_entity
+
+        dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
+        # Regression test: MAC address should be case insensitive
+        mac_repeater1_upper = agent.mac.upper()
+        controller.ucc_socket.cmd_reply("DEV_RESET_DEFAULT")
+        controller.ucc_socket.cmd_reply(
+            "DEV_SET_CONFIG,"
+            "bss_info1,{} 8x Multi-AP-24G-1 0x0020 0x0008 maprocks1 0 1,"
+            "bss_info2,{} 8x Multi-AP-24G-2 0x0020 0x0008 maprocks2 1 0"
+            .format(mac_repeater1_upper, agent.mac))
+        controller.ucc_socket.dev_send_1905(agent.mac, 0x000A,
+                                            tlv(0x01, 0x0006, "{" + controller.mac + "}"),
+                                            tlv(0x0F, 0x0001, "{0x00}"),
+                                            tlv(0x10, 0x0001, "{0x00}"))
+
+        time.sleep(30)
+        self.check_log(agent.radios[0],
+                       r"ssid: Multi-AP-24G-1 .*"
+                       r"fronthaul: true backhaul: false",
+                       timeout=60)
+        self.check_log(agent.radios[0],
+                       r"ssid: Multi-AP-24G-2 .*"
+                       r"fronthaul: false backhaul: true",
+                       timeout=60)
+        self.check_log(agent.radios[1],
+                       r"tear down radio",
+                       timeout=60)
+        bssid1 = agent.ucc_socket.dev_get_parameter('macaddr',
+                                                    ruid='0x' +
+                                                    agent.radios[0].mac.replace(':', ''),
+                                                    ssid='Multi-AP-24G-1')
+        if not bssid1:
+            self.fail("repeater1 didn't configure Multi-AP-24G-1")
+        # simulate wps onboarding to the backhaul vap
+        agent.ucc_socket.start_wps_registration("24G")
+        self.check_log(agent.radios[0], r"Start WPS PBC", timeout=60)
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown method, optional for boardfarm tests."""
+        test = cls.test_obj
+        for dev in test.dev:
+            if dev.agent_entity:
+                print("Sniffer - stop")
+                dev.wired_sniffer.stop()

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
@@ -5,3 +5,4 @@
 
 [test_flows]
 InitialApConfig
+ApConfigRenew

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -458,7 +458,7 @@ class ALEntityPrplWrt(ALEntity):
         # Multiply timeout by 100, as test sets it in float.
         return _device_wait_for_log(self.device,
                                     "{}/beerocks_{}.log".format(self.log_folder, program),
-                                    regex, start_line, timeout*100)
+                                    regex, start_line, timeout)
 
     def prprlmesh_status_check(self):
         return self.device.prprlmesh_status_check()
@@ -483,7 +483,7 @@ class RadioHostapd(Radio):
         ''' Poll the Radio's logfile until it match regular expression '''
         # Multiply timeout by 100, as test sets it in float.
         return _device_wait_for_log(self.agent.device, "{}/beerocks_agent_{}.log".format(
-            self.log_folder, self.iface_name), regex, timeout*100, start_line)
+            self.log_folder, self.iface_name), regex, timeout, start_line)
 
 
 class VirtualAPHostapd(VirtualAP):


### PR DESCRIPTION
## Description
This PR brings port of `ApConfigRenew` test of `test_flows.py` to boardfarm and include it to the general test suite.

## Changes

- Keep MAC of radios in dummy docker and real devices as part of relevant classes. 
- Keep `ucc_socket` which provides methods to communicate with devices over IEEE1905.1 for dummy docker devices and real devices as part of relevant classes.


## Notes

Log of SSID setting was changed comparing to the original `ApConfigRenew` of `test_flows.py` as dummy docker implementation and RAX40 board has different logs about incoming configuration event.
`time.sleep(30)` is required to pass test on RAX40. This should be replaced by wait of unique log in future.