### PR TITLE
bcl: UCC listener: prevent buffer overflow

### DIFF
--- a/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
+++ b/common/beerocks/bcl/source/beerocks_ucc_listener.cpp
@@ -438,9 +438,15 @@ bool beerocks_ucc_listener::custom_message_handler(Socket *sd, uint8_t *rx_buffe
                                                    size_t rx_buffer_size)
 {
     std::string command_string;
-    auto available_bytes       = sd->readBytes(rx_buffer, rx_buffer_size, true);
+    auto available_bytes = sd->readBytes(rx_buffer, rx_buffer_size, true);
+
+    if (available_bytes <= 0) {
+        LOG(ERROR) << "Cannot read from socket";
+        return true;
+    }
+
     rx_buffer[available_bytes] = '\0';
-    command_string.assign(reinterpret_cast<char *>(rx_buffer));
+    command_string.assign(reinterpret_cast<char *>(rx_buffer), available_bytes);
 
     beerocks::string_utils::trim(command_string);
 


### PR DESCRIPTION
The code inside `beerocks_ucc_listener::custom_message_handler`
does not check the value returned by `readBytes`.
It is treated as a length of a string, the assumed end of the string is then marked by '\0'.

This approach has two issues:
* if `readBytes` returns an error (negative number) memory before the read buffer is written
* if `readBytes` returns a number equal to the length of the buffer, '\0' is written right after the buffer.

This commit prevents these issues.

Signed-off-by: Vitalii Komisarenko <vitalii.komisarenko@gmail.com>