### PR TITLE
tests: boardfarm: port Client association link metrics test

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_docker.py
@@ -5,10 +5,10 @@
 
 import os
 import time
-
 import boardfarm
-from environment import ALEntityDocker, _get_bridge_interface
+
 from .prplmesh_base import PrplMeshBase
+from environment import ALEntityDocker, _get_bridge_interface
 from sniffer import Sniffer
 
 rootdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..'))
@@ -33,7 +33,8 @@ class PrplMeshDocker(PrplMeshBase):
         # Getting unic ID to distinguish devices and network they belong to
         self.unique_id = os.getenv("SUDO_USER", os.getenv("USER", ""))
 
-        self.name = "-".join((config.get("name", "prplmesh_docker"), self.unique_id))
+        self.name = config.get("name", "prplmesh_docker")
+        self.docker_name = "-".join((config.get("name", "prplmesh_docker"), self.unique_id))
         self.role = config.get("role", "agent")
         self.cleanup_cmd = config.get("cleanup_cmd", None)
         self.conn_cmd = config.get("conn_cmd", None)
@@ -42,7 +43,7 @@ class PrplMeshDocker(PrplMeshBase):
                                          "prplMesh-net-{}".format(self.unique_id))
 
         docker_cmd = os.path.join(rootdir, "tools", "docker", "run.sh")
-        docker_args = ["--verbose", "--detach", "--force", "--name", self.name,
+        docker_args = ["--verbose", "--detach", "--force", "--name", self.docker_name,
                        "--network", self.docker_network, "--expose", "8002"]
 
         if self.role == "controller":
@@ -51,14 +52,16 @@ class PrplMeshDocker(PrplMeshBase):
             self._run_shell_cmd(docker_cmd, docker_args)
 
             time.sleep(self.delay)
-            self.controller_entity = ALEntityDocker(self.name, device=self, is_controller=True)
+            self.controller_entity = ALEntityDocker(self.docker_name,
+                                                    device=self, is_controller=True)
         else:
             # Spawn dockerized agent
             docker_args.append("start-agent")
             self._run_shell_cmd(docker_cmd, docker_args)
 
             time.sleep(self.delay)
-            self.agent_entity = ALEntityDocker(self.name, device=self, is_controller=False)
+            self.agent_entity = ALEntityDocker(self.docker_name,
+                                               device=self, is_controller=False)
 
         self.wired_sniffer = Sniffer(_get_bridge_interface(self.docker_network),
                                      boardfarm.config.output_dir)

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_station_dummy.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_station_dummy.py
@@ -1,0 +1,38 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+from .prplmesh_base import PrplMeshBase
+from environment import VirtualAPDocker
+from opts import err
+
+
+class PrplMeshStationDummy(PrplMeshBase):
+
+    model = "STA_dummy"
+    __mac_base = 0
+
+    def __init__(self, *args, **kwargs):
+        '''Generate dummy Station.'''
+        self.args = args
+        self.kwargs = kwargs
+        config = kwargs.get("config", kwargs)
+
+        self.name = config.get("name", "station")
+        self.mac = config.get("mac", None)
+
+        if self.mac is None:
+            raise ValueError(err("{} device \"{}\" has no MAC!".format(self.model, self.name)))
+
+    def wifi_connect(self, vap: VirtualAPDocker) -> bool:
+        """Connect to the Access Point. Return True if successful."""
+        vap.radio.send_bwl_event("EVENT AP-STA-CONNECTED {}".format(self.mac))
+        return True
+
+    def wifi_disconnect(self, vap: VirtualAPDocker) -> bool:
+        '''Disassociate "sta" from this VAP.'''
+        vap.radio.send_bwl_event("EVENT AP-STA-DISCONNECTED {}".format(self.mac))
+        return True

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -1,18 +1,24 @@
 {
     "prplmesh_docker": {
-        "name": "dockerized_device",
+        "name": "controller",
         "board_type": "prplmesh_docker",
         "role": "controller",
         "conn_cmd": "",
         "devices": [
             {
-                "name": "repeater1",
+                "name": "lan",
                 "type": "prplmesh_docker",
                 "conn_cmd": ""
             },
             {
-                "name": "repeater2",
+                "name": "lan2",
                 "type": "prplmesh_docker",
+                "conn_cmd": ""
+            },
+            {
+                "name": "wifi",
+                "type": "STA_dummy",
+                "mac": "51:a1:10:20:00:01",
                 "conn_cmd": ""
             }
         ]

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
@@ -1,0 +1,64 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+import time
+
+from .prplmesh_base_test import PrplMeshBaseTest
+from capi import tlv
+from environment import Station
+from opts import debug
+
+
+class ClientAssociationLinkMetrics(PrplMeshBaseTest):
+    ''' This test verifies that a MAUT with an associated STA responds to
+    an Associated STA Link Metrics Query message with an Associated STA Link Metrics
+    Response message containing an Associated STA Link Metrics TLV for the associated STA.'''
+
+    def runTest(self):
+        # Locate test participants in array
+        for dev in self.dev:
+            if dev.controller_entity:
+                controller = dev.controller_entity
+            if dev.agent_entity:
+                agent = dev.agent_entity
+
+        # Regression check
+        # Don't connect not existing STAtion
+        dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
+        sta_mac = "11:11:33:44:55:66"
+        debug("Send link metrics query for unconnected STA")
+        controller.ucc_socket.dev_send_1905(agent.mac, 0x800D,
+                                            tlv(0x95, 0x0006, '{sta_mac}'.format(sta_mac=sta_mac)))
+        self.check_log(agent,
+                       "client with mac address {sta_mac} not found".format(sta_mac=sta_mac),
+                       timeout=30)
+        time.sleep(1)
+
+        sta = Station.create()
+        debug('sta: {}'.format(sta.mac))
+
+        agent.radios[0].vaps[0].associate(sta)
+
+        time.sleep(1)
+
+        mid = controller.ucc_socket.dev_send_1905(agent.mac, 0x800D,
+                                                  tlv(0x95, 0x0006,
+                                                      '{sta_mac}'.format(sta_mac=sta.mac)))
+        time.sleep(1)
+        self.check_log(agent,
+                       "Send AssociatedStaLinkMetrics to controller, mid = {}".format(mid),
+                       timeout=30)
+        dev.agent_entity.radios[0].vaps[0].disassociate(sta)
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown method, optional for boardfarm tests."""
+        test = cls.test_obj
+        for dev in test.dev:
+            if dev.agent_entity:
+                print("Sniffer - stop")
+                dev.wired_sniffer.stop()

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
@@ -6,3 +6,4 @@
 [test_flows]
 InitialApConfig
 ApConfigRenew
+ClientAssociationLinkMetrics


### PR DESCRIPTION
## Description

Port test_client_association_link_metrics from test_flows.py to
boardfarm.

## Changes

- Port `test_client_association_link_metrics` from `test_flows.py`
- Create new device to represent dummy station (`PrplMeshStationDummy`)
- Use new device in ported test
- Change naming scheme in boardfarm configuration file, so we can address devices directly by name
- Split dummy device docker image name and name of device.
In order to address devices by name, name set in configuration file should be a member of boardfarm build-in [enum](https://github.com/mattsm/boardfarm/blob/100521fde1fb67536682cafecc2f91a6e2e8a6f8/boardfarm/lib/DeviceManager.py#L25).  But name of docker images will be same, so different user's won't be able to run test at same time. To avoid it, split name of device and name of docker image spawned by the test.


## Notes

Those changes breaking all other tests, due to introduction of new device. As boardfarm isn't used at the moment it's not critical. Fix of other tests are introduced in #1486 PR, to ease review of this PR.
Part of: https://jira.prplfoundation.org/browse/PPM-12