### PR TITLE
use SIGTERM instead of SIGKILL in killall_program()

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -27,7 +27,7 @@ run() {
 
 killall_program() {
     PROGRAM_NAME=$1
-    KILL_SIG=${2:-KILL}
+    KILL_SIG=${2:-TERM}
     echo "killing $PROGRAM_NAME ($KILL_SIG)"
     start-stop-daemon -K -s "$KILL_SIG" -x "$PRPLMESH_BIN_DIR"/"$PROGRAM_NAME" > /dev/null 2>&1
 }


### PR DESCRIPTION
Currently `prplmesh_utills.sh stop `sends SIGKILL to all processes.
Since SIGKILL cannot be handled monitor/agent/controller 
processes are not shutdown properly.
As a result old wpa ctrl socket are not detached and files
are not deleted.

change killall_program() to send SIGTERM instead on default.