### PR TITLE
Hotfix/use iface name instead of index in topology db

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -3329,6 +3329,13 @@ bool backhaul_manager::handle_1905_topology_discovery(const std::string &src_mac
         return false;
     }
 
+    uint32_t if_index   = message_com::get_uds_header(cmdu_rx)->if_index;
+    std::string if_name = network_utils::linux_get_iface_name(if_index);
+    if (if_name.empty()) {
+        LOG(ERROR) << "Failed getting interface name for index: " << if_index;
+        return false;
+    }
+
     auto new_device =
         m_1905_neighbor_devices.find(tlvAlMac->mac()) == m_1905_neighbor_devices.end();
 
@@ -3336,7 +3343,7 @@ bool backhaul_manager::handle_1905_topology_discovery(const std::string &src_mac
     sNeighborDevice neighbor_device;
     neighbor_device.al_mac    = tlvAlMac->mac();
     neighbor_device.mac       = tlvMac->mac();
-    neighbor_device.if_index  = message_com::get_uds_header(cmdu_rx)->if_index;
+    neighbor_device.if_name   = if_name;
     neighbor_device.timestamp = std::chrono::steady_clock::now();
 
     m_1905_neighbor_devices[tlvAlMac->mac()] = neighbor_device;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -473,8 +473,8 @@ private:
             ZERO_MAC; /**< 1905.1 AL MAC address of the Topology Discovery message transmitting device. */
         sMacAddr mac = beerocks::net::network_utils::
             ZERO_MAC; /**< MAC address of the interface on which the Topology Discovery message is transmitted. */
-        uint32_t if_index =
-            0; /**< Index of the network interface the Topology Discovery message was received on */
+        std::string
+            if_name; /**< Name of the network interface the Topology Discovery message was received on */
         std::chrono::steady_clock::time_point
             timestamp; /**< Timestamp of the last Topology Discovery message received from this neighbor device. */
     };

--- a/common/beerocks/bcl/include/bcl/network/network_utils.h
+++ b/common/beerocks/bcl/include/bcl/network/network_utils.h
@@ -119,6 +119,15 @@ public:
      * @return interface index or 0 if no interface exists with the name given.
      */
     static uint32_t linux_get_iface_index(const std::string &iface_name);
+
+    /**
+     * @brief Gets the interface name corresponding to a particular index.
+     *
+     * @param iface_index The index of the network interface.
+     * @return interface name or empty string if no interface exists with the index given.
+     */
+    static std::string linux_get_iface_name(uint32_t iface_index);
+
     static bool linux_add_iface_to_bridge(const std::string &bridge, const std::string &iface);
     static bool linux_remove_iface_from_bridge(const std::string &bridge, const std::string &iface);
     static bool linux_iface_ctrl(const std::string &iface, bool up, std::string ip = "",

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -533,6 +533,18 @@ uint32_t network_utils::linux_get_iface_index(const std::string &iface_name)
     return iface_index;
 }
 
+std::string network_utils::linux_get_iface_name(uint32_t iface_index)
+{
+    char iface_name[IF_NAMESIZE] = {0};
+    if (!if_indextoname(iface_index, iface_name)) {
+        LOG(ERROR) << "Failed to read the name of interface with index " << iface_index << ": "
+                   << strerror(errno);
+        return "";
+    }
+
+    return iface_name;
+}
+
 bool network_utils::linux_add_iface_to_bridge(const std::string &bridge, const std::string &iface)
 {
     LOG(DEBUG) << "add iface " << iface << " to bridge " << bridge;


### PR DESCRIPTION
As explained in this comment, it is better to use interface name instead of interface index.

This PR is a hotfix for #1440 where we started storing interface index in topology database.