### PR TITLE
mergify: allow status check failures

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0" # Changes requested blocks the merge
       - "label=ready for merge" # Must have ready for merge label
       - "label!=don't merge" # Don't merge label blocks the merge
-      - "#status-failure=0"
       # Just to be sure that we don't consider it as passed when the status checks haven't even
       # started yet.
       - "#status-success>=3"


### PR DESCRIPTION
We have a requirement for mergify that no status checks should fail.
This is kind of redundant, because mergify will only do the merge if no
*required* status checks fail anyway.

Since we now have a non-required status check (UTAF) that often fails,
we really need to remove that redundant requirement.