### PR TITLE
hotfix! Change bssid type for roam() method

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1537,7 +1537,7 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
         if (roam_flag) {
             selected_bssid         = roam_selected_bssid;
             selected_bssid_channel = roam_selected_bssid_channel;
-            if (!active_hal->roam(selected_bssid, selected_bssid_channel)) {
+            if (!active_hal->roam(tlvf::mac_from_string(selected_bssid), selected_bssid_channel)) {
                 platform_notify_error(bpl::eErrorCode::BH_ROAMING,
                                       "BSSID='" + selected_bssid + "'");
                 stop_on_failure_attempts--;

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.cpp
@@ -43,7 +43,7 @@ bool sta_wlan_hal_dummy::connect(const std::string &ssid, const std::string &pas
 
 bool sta_wlan_hal_dummy::disconnect() { return true; }
 
-bool sta_wlan_hal_dummy::roam(const std::string &bssid, uint8_t channel) { return true; }
+bool sta_wlan_hal_dummy::roam(const sMacAddr &bssid, uint8_t channel) { return true; }
 
 bool sta_wlan_hal_dummy::get_4addr_mode() { return true; }
 

--- a/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
+++ b/common/beerocks/bwl/dummy/sta_wlan_hal_dummy.h
@@ -43,7 +43,7 @@ public:
 
     virtual bool disconnect() override;
 
-    virtual bool roam(const std::string &bssid, uint8_t channel) override;
+    virtual bool roam(const sMacAddr &bssid, uint8_t channel) override;
 
     virtual bool get_4addr_mode() override;
     virtual bool set_4addr_mode(bool enable) override;

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.cpp
@@ -288,7 +288,7 @@ bool sta_wlan_hal_dwpal::disconnect()
     return true;
 }
 
-bool sta_wlan_hal_dwpal::roam(const std::string &bssid, uint8_t channel)
+bool sta_wlan_hal_dwpal::roam(const sMacAddr &bssid, uint8_t channel)
 {
     if (m_active_network_id == -1) {
         LOG(ERROR) << "Incorrect active network " << m_active_network_id;
@@ -300,7 +300,9 @@ bool sta_wlan_hal_dwpal::roam(const std::string &bssid, uint8_t channel)
         return false;
     }
 
-    const std::string cmd = "ROAM " + bssid;
+    auto bssid_str = tlvf::mac_to_string(bssid);
+
+    const std::string cmd = "ROAM " + bssid_str;
     if (!dwpal_send_cmd(cmd)) {
         LOG(ERROR) << get_iface_name() << " ROAM failed!";
         return false;
@@ -313,7 +315,7 @@ bool sta_wlan_hal_dwpal::roam(const std::string &bssid, uint8_t channel)
     }
 
     // Update the active channel and bssid
-    m_active_bssid.assign(bssid);
+    m_active_bssid.assign(bssid_str);
     m_active_channel = channel;
 
     return false;

--- a/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.h
+++ b/common/beerocks/bwl/dwpal/sta_wlan_hal_dwpal.h
@@ -41,7 +41,7 @@ public:
 
     virtual bool disconnect() override;
 
-    virtual bool roam(const std::string &bssid, uint8_t channel) override;
+    virtual bool roam(const sMacAddr &bssid, uint8_t channel) override;
 
     virtual bool get_4addr_mode() override;
     virtual bool set_4addr_mode(bool enable) override;

--- a/common/beerocks/bwl/include/bwl/sta_wlan_hal.h
+++ b/common/beerocks/bwl/include/bwl/sta_wlan_hal.h
@@ -50,7 +50,7 @@ public:
 
     virtual bool disconnect() = 0;
 
-    virtual bool roam(const std::string &bssid, uint8_t channel) = 0;
+    virtual bool roam(const sMacAddr &bssid, uint8_t channel) = 0;
 
     virtual bool get_4addr_mode()            = 0;
     virtual bool set_4addr_mode(bool enable) = 0;

--- a/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.cpp
@@ -42,7 +42,7 @@ bool sta_wlan_hal_nl80211::connect(const std::string &ssid, const std::string &p
 
 bool sta_wlan_hal_nl80211::disconnect() { return true; }
 
-bool sta_wlan_hal_nl80211::roam(const std::string &bssid, uint8_t channel) { return true; }
+bool sta_wlan_hal_nl80211::roam(const sMacAddr &bssid, uint8_t channel) { return true; }
 
 bool sta_wlan_hal_nl80211::get_4addr_mode() { return true; }
 

--- a/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.h
+++ b/common/beerocks/bwl/nl80211/sta_wlan_hal_nl80211.h
@@ -43,7 +43,7 @@ public:
 
     virtual bool disconnect() override;
 
-    virtual bool roam(const std::string &bssid, uint8_t channel) override;
+    virtual bool roam(const sMacAddr &bssid, uint8_t channel) override;
 
     virtual bool get_4addr_mode() override;
     virtual bool set_4addr_mode(bool enable) override;


### PR DESCRIPTION
All bssid which passes as method parameters
should be with type sMacAddr instead string.

roam() method will be used in the Backhaul
STA Steering impelemntation. That activity
triggered to do hotfix for the bssid type.

Also fixed roam() call in the backhaul manager:
tranformed give argument from string to the
sMacAddr structure.
