### PR TITLE
[agent]  Add validate_channel method

### DIFF
--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -170,6 +170,7 @@ public:
     static uint8_t get_operating_class_by_channel(const beerocks::message::sWifiChannel &channel);
     static std::list<sChannelPreference>
     get_channel_preferences(const beerocks::message::sWifiChannel supported_channels[]);
+    static bool channel_validate(const uint8_t &channel);
 
 private:
     enum eAntennaFactor {

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -869,3 +869,15 @@ std::list<uint8_t> wireless_utils::string_to_wsc_oper_class(const std::string &o
         return {};
     }
 }
+
+bool wireless_utils::channel_validate(const uint8_t &channel)
+{
+    for (auto oper_class : operating_classes_list) {
+        auto ch = oper_class.second.channels.find(channel);
+
+        if (ch != oper_class.second.channels.end()) {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
For correct implementation Backhaul STA
Steering need to add new method in the
wireless_utils for the channel validation.
