### PR TITLE
[agent] Add validate_channel method

### DIFF
--- a/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
+++ b/common/beerocks/bcl/include/bcl/son/son_wireless_utils.h
@@ -171,6 +171,15 @@ public:
     static std::list<sChannelPreference>
     get_channel_preferences(const beerocks::message::sWifiChannel supported_channels[]);
 
+    /**
+    * @brief Match channel number in the given operating class.
+    *
+    * @param operating_class operating class
+    * @param channel channel number
+    * @return True if channel matches to operating class
+    */
+    static bool is_channel_in_operating_class(uint8_t operating_class, uint8_t channel);
+
 private:
     enum eAntennaFactor {
         ANT_FACTOR_1X1 = 0,

--- a/common/beerocks/bcl/source/son/son_wireless_utils.cpp
+++ b/common/beerocks/bcl/source/son/son_wireless_utils.cpp
@@ -869,3 +869,10 @@ std::list<uint8_t> wireless_utils::string_to_wsc_oper_class(const std::string &o
         return {};
     }
 }
+
+bool wireless_utils::is_channel_in_operating_class(uint8_t operating_class, uint8_t channel)
+{
+    auto channel_set = operating_class_to_channel_set(operating_class);
+
+    return (channel_set.find(channel) != channel_set.end());
+}


### PR DESCRIPTION
For correct implementation Backhaul STA
Steering need to add new method in the
wireless_utils for the channel validation.

Add implementation for the method.
