### PR TITLE
boardfarm: use names of devices, instead of searching through devices

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -2,17 +2,13 @@
     "prplmesh_docker": {
         "name": "controller",
         "board_type": "prplmesh_docker",
-        "role": "controller",
+        "role": "agent",
         "conn_cmd": "",
         "devices": [
             {
-                "name": "lan",
+                "name": "wan",
                 "type": "prplmesh_docker",
-                "conn_cmd": ""
-            },
-            {
-                "name": "lan2",
-                "type": "prplmesh_docker",
+                "role": "controller",
                 "conn_cmd": ""
             },
             {
@@ -31,7 +27,7 @@
         "conn_cmd": "cu -s 115200 -l /dev/ttyUSB0",
         "devices": [
             {
-            "name": "controller",
+            "name": "wan",
             "type": "prplmesh_docker",
             "role": "controller",
             "docker_network": "prplMesh-net-rax40-1",

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
@@ -21,8 +21,8 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
 
     def runTest(self):
         # Locate test participants
-        controller = self.dev.DUT.controller_entity
-        agent = self.dev.lan.agent_entity
+        agent = self.dev.DUT.agent_entity
+        controller = self.dev.wan.controller_entity
         sta = self.dev.wifi
 
         # This test doesn't work for real HW.
@@ -33,7 +33,7 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
 
         # Regression check
         # Don't connect nonexistent Station
-        self.dev.lan.wired_sniffer.start(self.__class__.__name__ + "-" + self.dev.lan.name)
+        self.dev.DUT.wired_sniffer.start(self.__class__.__name__ + "-" + self.dev.DUT.name)
         sta_mac = "11:11:33:44:55:66"
         debug("Send link metrics query for unconnected STA")
         controller.ucc_socket.dev_send_1905(agent.mac, 0x800D,
@@ -61,4 +61,13 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
     def teardown_class(cls):
         """Teardown method, optional for boardfarm tests."""
         test = cls.test_obj
-        test.dev.lan.wired_sniffer.stop()
+        print("Sniffer - stop")
+        test.dev.DUT.wired_sniffer.stop()
+        # Send additional Ctrl+C to the device to terminate "tail -f"
+        # Which is used to read log from device. Required only for tests on HW
+        try:
+            test.dev.DUT.agent_entity.device.send('\003')
+        except AttributeError:
+            # If AttributeError was raised - we are dealing with dummy devices.
+            # We don't have to additionaly send Ctrl+C for dummy devices.
+            pass

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/initial_ap_config.py
@@ -10,35 +10,36 @@ class InitialApConfig(PrplMeshBaseTest):
     """Check initial configuration on device."""
 
     def runTest(self):
-        for dev in self.dev:
-            if dev.agent_entity:
-                dev.wired_sniffer.start(self.__class__.__name__ + "-" + dev.name)
+        # Locate test participants
+        agent = self.dev.DUT.agent_entity
 
-                self.prplmesh_status_check(dev.agent_entity)
-                self.check_log(dev.agent_entity.radios[0],
-                               r"\(WSC M2 Encrypted Settings\)")
-                self.check_log(dev.agent_entity.radios[1],
-                               r"\(WSC M2 Encrypted Settings\)")
-                self.check_log(dev.agent_entity.radios[0],
-                               r"WSC Global authentication success")
-                self.check_log(dev.agent_entity.radios[1],
-                               r"WSC Global authentication success")
-                self.check_log(dev.agent_entity.radios[0],
-                               r"KWA \(Key Wrap Auth\) success")
-                self.check_log(dev.agent_entity.radios[1],
-                               r"KWA \(Key Wrap Auth\) success")
+        self.dev.DUT.wired_sniffer.start(self.__class__.__name__ + "-" + self.dev.DUT.name)
+
+        self.prplmesh_status_check(agent)
+        self.check_log(agent.radios[0],
+                       r"\(WSC M2 Encrypted Settings\)")
+        self.check_log(agent.radios[1],
+                       r"\(WSC M2 Encrypted Settings\)")
+        self.check_log(agent.radios[0],
+                       r"WSC Global authentication success")
+        self.check_log(agent.radios[1],
+                       r"WSC Global authentication success")
+        self.check_log(agent.radios[0],
+                       r"KWA \(Key Wrap Auth\) success")
+        self.check_log(agent.radios[1],
+                       r"KWA \(Key Wrap Auth\) success")
 
     @classmethod
     def teardown_class(cls):
         """Teardown method, optional for boardfarm tests."""
         test = cls.test_obj
-        for dev in test.dev:
-            if dev.agent_entity:
-                print("Sniffer - stop")
-                # Send Ctrl+C to the device to terminate "tail -f"
-                # Which is used to read log from device. Required only for tests on HW
-                try:
-                    dev.agent_entity.device.send('\003')
-                except AttributeError:
-                    pass
-                dev.wired_sniffer.stop()
+        print("Sniffer - stop")
+        test.dev.DUT.wired_sniffer.stop()
+        # Send additional Ctrl+C to the device to terminate "tail -f"
+        # Which is used to read log from device. Required only for tests on HW
+        try:
+            test.dev.DUT.agent_entity.device.send('\003')
+        except AttributeError:
+            # If AttributeError was raised - we are dealing with dummy devices.
+            # We don't have to additionaly send Ctrl+C for dummy devices.
+            pass


### PR DESCRIPTION
## Description

In the `initial_ap_config`, `ap_config_renew` tests we are locating test participants (agents, controller and etc) by checking "agent_entity" field in the device class.
This works **only** in case if **all** devices defined in boardfarm configuration are of same class (or have this field). Adding some device, which doesn't have such field will cause tests to crash, as we are trying to reach non-existing field of class. 

In #1453, we are changing boardfarm configuration file to use names which are part of [build-in boardfarm enum](https://github.com/mattsm/boardfarm/blob/100521fde1fb67536682cafecc2f91a6e2e8a6f8/boardfarm/lib/DeviceManager.py#L25), as consequence we can address devices by name. So, we can now safely address devices by name and avoid crash described above.

## Changes

- Replace search through array of device available to test by assign of devices based name
- Related to such rename refactoring

## Notes

This PR should be merged **after** #1453.