### PR TITLE
Decouple BCL from mapfcommon

### DIFF
--- a/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.cpp
@@ -8,6 +8,7 @@
 
 #include "ap_manager_thread.h"
 
+#include <bcl/beerocks_string_utils.h>
 #include <bcl/beerocks_utils.h>
 #include <bcl/network/network_utils.h>
 #include <bcl/son/son_wireless_utils.h>
@@ -78,8 +79,8 @@ static void copy_vaps_info(std::shared_ptr<bwl::ap_wlan_hal> &ap_wlan_hal,
 
             // Copy the VAP MAC and SSID
             vaps[i].mac = tlvf::mac_from_string(curr_vap.mac);
-            mapf::utils::copy_string(vaps[i].ssid, curr_vap.ssid.c_str(),
-                                     beerocks::message::WIFI_SSID_MAX_LENGTH);
+            beerocks::string_utils::copy_string(vaps[i].ssid, curr_vap.ssid.c_str(),
+                                                beerocks::message::WIFI_SSID_MAX_LENGTH);
         }
     }
 }
@@ -1477,11 +1478,11 @@ void ap_manager_thread::handle_hostapd_attached()
         return;
     }
 
-    mapf::utils::copy_string(notification->params().iface_name,
-                             ap_wlan_hal->get_iface_name().c_str(), message::IFACE_NAME_LENGTH);
-    mapf::utils::copy_string(notification->params().driver_version,
-                             ap_wlan_hal->get_radio_driver_version().c_str(),
-                             message::WIFI_DRIVER_VER_LENGTH);
+    string_utils::copy_string(notification->params().iface_name,
+                              ap_wlan_hal->get_iface_name().c_str(), message::IFACE_NAME_LENGTH);
+    string_utils::copy_string(notification->params().driver_version,
+                              ap_wlan_hal->get_radio_driver_version().c_str(),
+                              message::WIFI_DRIVER_VER_LENGTH);
 
     notification->params().iface_type    = uint8_t(ap_wlan_hal->get_iface_type());
     notification->params().iface_mac     = tlvf::mac_from_string(ap_wlan_hal->get_radio_mac());
@@ -1632,8 +1633,8 @@ bool ap_manager_thread::handle_ap_enabled(int vap_id)
 
     // Copy the VAP MAC and SSID
     notification->vap_info().mac = tlvf::mac_from_string(vap_info.mac);
-    mapf::utils::copy_string(notification->vap_info().ssid, vap_info.ssid.c_str(),
-                             beerocks::message::WIFI_SSID_MAX_LENGTH);
+    string_utils::copy_string(notification->vap_info().ssid, vap_info.ssid.c_str(),
+                              beerocks::message::WIFI_SSID_MAX_LENGTH);
     notification->vap_info().backhaul_vap = vap_info.backhaul;
 
     message_com::send_cmdu(slave_socket, cmdu_tx);

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
@@ -1870,8 +1870,8 @@ bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event
             auto &out_result = notification->scan_results();
 
             // Arrays
-            mapf::utils::copy_string(out_result.ssid, in_result.ssid,
-                                     beerocks::message::WIFI_SSID_MAX_LENGTH);
+            string_utils::copy_string(out_result.ssid, in_result.ssid,
+                                      beerocks::message::WIFI_SSID_MAX_LENGTH);
             std::copy_n(in_result.bssid.oct, sizeof(out_result.bssid.oct), out_result.bssid.oct);
             std::copy(in_result.basic_data_transfer_rates_kbps.begin(),
                       in_result.basic_data_transfer_rates_kbps.end(),

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -456,7 +456,8 @@ void backhaul_manager::platform_notify_error(bpl::eErrorCode code, const std::st
 
     error->code() = uint32_t(code);
 
-    mapf::utils::copy_string(error->data(0), error_data.c_str(), message::PLATFORM_ERROR_DATA_SIZE);
+    string_utils::copy_string(error->data(0), error_data.c_str(),
+                              message::PLATFORM_ERROR_DATA_SIZE);
 
     LOG(ERROR) << "platform_notify_error: " << error_data;
 

--- a/agent/src/beerocks/slave/gate/1905_beacon_query_to_vs.cpp
+++ b/agent/src/beerocks/slave/gate/1905_beacon_query_to_vs.cpp
@@ -1,7 +1,7 @@
 
 #include "1905_beacon_query_to_vs.h"
 #include <bcl/beerocks_defines.h>
-#include <mapf/common/utils.h>
+#include <bcl/beerocks_string_utils.h>
 
 namespace beerocks {
 namespace gate {
@@ -49,8 +49,8 @@ bool load(std::shared_ptr<beerocks_message::cACTION_MONITOR_CLIENT_BEACON_11K_RE
     lhs_params.mandatory_duration = 0;
     lhs_params.use_optional_ssid  = 0;
 
-    mapf::utils::copy_string(lhs_params.ssid, beacon_metrics_query->ssid_str().c_str(),
-                             beerocks::message::WIFI_SSID_MAX_LENGTH);
+    string_utils::copy_string(lhs_params.ssid, beacon_metrics_query->ssid_str().c_str(),
+                              beerocks::message::WIFI_SSID_MAX_LENGTH);
 
     // how many elements in the list of channels, we support only 1 at the moment
     auto ap_ch_report_length = beacon_metrics_query->ap_channel_reports_list_length();

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -430,7 +430,7 @@ void main_thread::send_dhcp_notification(const std::string &op, const std::strin
 
     dhcp_notif->mac()  = tlvf::mac_from_string(mac);
     dhcp_notif->ipv4() = network_utils::ipv4_from_string(ip);
-    mapf::utils::copy_string(dhcp_notif->hostname(0), hostname.c_str(), message::NODE_NAME_LENGTH);
+    string_utils::copy_string(dhcp_notif->hostname(0), hostname.c_str(), message::NODE_NAME_LENGTH);
 
     // Get a slave socket
     Socket *sd = get_backhaul_socket();
@@ -745,7 +745,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             response->result() = 1;
         }
 
-        mapf::utils::copy_string(response->params().user_password, pass, message::USER_PASS_LEN);
+        string_utils::copy_string(response->params().user_password, pass, message::USER_PASS_LEN);
 
         // Sent with unsafe because BML is reachable only on platform thread
         message_com::send_cmdu(sd, cmdu_tx);
@@ -764,10 +764,10 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             return false;
         }
         if (!master_version.empty() && !slave_version.empty()) {
-            mapf::utils::copy_string(response->versions().master_version, master_version.c_str(),
-                                     message::VERSION_LENGTH);
-            mapf::utils::copy_string(response->versions().slave_version, slave_version.c_str(),
-                                     message::VERSION_LENGTH);
+            string_utils::copy_string(response->versions().master_version, master_version.c_str(),
+                                      message::VERSION_LENGTH);
+            string_utils::copy_string(response->versions().slave_version, slave_version.c_str(),
+                                      message::VERSION_LENGTH);
             response->result() = 1;
         } else {
             response->result() = 0;
@@ -928,8 +928,8 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
                 }
             }
 
-            mapf::utils::copy_string(msg_ssid, ssid, message::WIFI_SSID_MAX_LENGTH);
-            mapf::utils::copy_string(msg_pass, pass, message::WIFI_PASS_MAX_LENGTH);
+            string_utils::copy_string(msg_ssid, ssid, message::WIFI_SSID_MAX_LENGTH);
+            string_utils::copy_string(msg_pass, pass, message::WIFI_PASS_MAX_LENGTH);
 
             //clear the pwd in the memory
             memset(&pass, 0, sizeof(pass));
@@ -1020,22 +1020,22 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             response->result() = 1;
         }
 
-        mapf::utils::copy_string(params.manufacturer, bpl_device_info.manufacturer,
-                                 message::DEV_INFO_STR_MAX_LEN);
-        mapf::utils::copy_string(params.model_name, bpl_device_info.model_name,
-                                 message::DEV_INFO_STR_MAX_LEN);
-        mapf::utils::copy_string(params.serial_number, bpl_device_info.serial_number,
-                                 message::DEV_INFO_STR_MAX_LEN);
+        string_utils::copy_string(params.manufacturer, bpl_device_info.manufacturer,
+                                  message::DEV_INFO_STR_MAX_LEN);
+        string_utils::copy_string(params.model_name, bpl_device_info.model_name,
+                                  message::DEV_INFO_STR_MAX_LEN);
+        string_utils::copy_string(params.serial_number, bpl_device_info.serial_number,
+                                  message::DEV_INFO_STR_MAX_LEN);
 
         // LAN
-        mapf::utils::copy_string(params.lan_iface_name, bpl_device_info.lan_iface_name,
-                                 message::IFACE_NAME_LENGTH);
+        string_utils::copy_string(params.lan_iface_name, bpl_device_info.lan_iface_name,
+                                  message::IFACE_NAME_LENGTH);
         params.lan_ip_address   = bpl_device_info.lan_ip_address;
         params.lan_network_mask = bpl_device_info.lan_network_mask;
 
         // WAN
-        mapf::utils::copy_string(params.wan_iface_name, bpl_device_info.wan_iface_name,
-                                 message::IFACE_NAME_LENGTH);
+        string_utils::copy_string(params.wan_iface_name, bpl_device_info.wan_iface_name,
+                                  message::IFACE_NAME_LENGTH);
         params.wan_ip_address   = bpl_device_info.wan_ip_address;
         params.wan_network_mask = bpl_device_info.wan_network_mask;
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -186,7 +186,8 @@ void slave_thread::platform_notify_error(beerocks::bpl::eErrorCode code,
     }
 
     error->code() = uint32_t(code);
-    mapf::utils::copy_string(error->data(0), error_data.c_str(), message::PLATFORM_ERROR_DATA_SIZE);
+    string_utils::copy_string(error->data(0), error_data.c_str(),
+                              message::PLATFORM_ERROR_DATA_SIZE);
 
     // Send the message
     message_com::send_cmdu(platform_manager_socket, cmdu_tx);
@@ -867,8 +868,8 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         if (request_in->params().use_optional_ssid &&
             std::string((char *)request_in->params().ssid).empty()) {
             //LOG(DEBUG) << "ssid field is empty! using slave ssid -> " << config.ssid;
-            mapf::utils::copy_string(request_in->params().ssid, platform_settings.front_ssid,
-                                     message::WIFI_SSID_MAX_LENGTH);
+            string_utils::copy_string(request_in->params().ssid, platform_settings.front_ssid,
+                                      message::WIFI_SSID_MAX_LENGTH);
         }
 
         auto request_out = message_com::create_vs_message<
@@ -1544,9 +1545,9 @@ bool slave_thread::handle_cmdu_platform_manager_message(
 
                 master_notification->mac()  = notification->mac();
                 master_notification->ipv4() = notification->ipv4();
-                mapf::utils::copy_string(master_notification->name(message::NODE_NAME_LENGTH),
-                                         notification->hostname(message::NODE_NAME_LENGTH),
-                                         message::NODE_NAME_LENGTH);
+                string_utils::copy_string(master_notification->name(message::NODE_NAME_LENGTH),
+                                          notification->hostname(message::NODE_NAME_LENGTH),
+                                          message::NODE_NAME_LENGTH);
                 send_cmdu_to_controller(cmdu_tx);
             }
 
@@ -3134,8 +3135,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 return false;
             }
 
-            mapf::utils::copy_string(request->iface_name(message::IFACE_NAME_LENGTH),
-                                     config.hostap_iface.c_str(), message::IFACE_NAME_LENGTH);
+            string_utils::copy_string(request->iface_name(message::IFACE_NAME_LENGTH),
+                                      config.hostap_iface.c_str(), message::IFACE_NAME_LENGTH);
             message_com::send_cmdu(platform_manager_socket, cmdu_tx);
 
             LOG(TRACE) << "send ACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST";
@@ -3193,12 +3194,12 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         if (platform_settings.local_gw || config.backhaul_wireless_iface.empty()) {
             memset(request->sta_iface(message::IFACE_NAME_LENGTH), 0, message::IFACE_NAME_LENGTH);
         } else {
-            mapf::utils::copy_string(request->sta_iface(message::IFACE_NAME_LENGTH),
-                                     config.backhaul_wireless_iface.c_str(),
-                                     message::IFACE_NAME_LENGTH);
+            string_utils::copy_string(request->sta_iface(message::IFACE_NAME_LENGTH),
+                                      config.backhaul_wireless_iface.c_str(),
+                                      message::IFACE_NAME_LENGTH);
         }
-        mapf::utils::copy_string(request->hostap_iface(message::IFACE_NAME_LENGTH),
-                                 config.hostap_iface.c_str(), message::IFACE_NAME_LENGTH);
+        string_utils::copy_string(request->hostap_iface(message::IFACE_NAME_LENGTH),
+                                  config.hostap_iface.c_str(), message::IFACE_NAME_LENGTH);
 
         request->local_master()         = platform_settings.local_master;
         request->local_gw()             = platform_settings.local_gw;
@@ -3315,19 +3316,19 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             // TODO: On passive mode, mem_only_psk is always be set, so supplying the credentials
             // to the backhaul manager will no longer be necessary, and therefore should be be
             // removed completely from beerocks including the BPL.
-            mapf::utils::copy_string(bh_enable->ssid(message::WIFI_SSID_MAX_LENGTH),
-                                     platform_settings.back_ssid, message::WIFI_SSID_MAX_LENGTH);
-            mapf::utils::copy_string(bh_enable->pass(message::WIFI_PASS_MAX_LENGTH),
-                                     platform_settings.back_pass, message::WIFI_PASS_MAX_LENGTH);
+            string_utils::copy_string(bh_enable->ssid(message::WIFI_SSID_MAX_LENGTH),
+                                      platform_settings.back_ssid, message::WIFI_SSID_MAX_LENGTH);
+            string_utils::copy_string(bh_enable->pass(message::WIFI_PASS_MAX_LENGTH),
+                                      platform_settings.back_pass, message::WIFI_PASS_MAX_LENGTH);
             bh_enable->security_type() = static_cast<uint32_t>(
                 platform_to_bwl_security(platform_settings.back_security_type));
             bh_enable->mem_only_psk() = platform_settings.mem_only_psk;
             bh_enable->backhaul_preferred_radio_band() =
                 platform_settings.backhaul_preferred_radio_band;
 
-            mapf::utils::copy_string(bh_enable->wire_iface(message::IFACE_NAME_LENGTH),
-                                     config.backhaul_wire_iface.c_str(),
-                                     message::IFACE_NAME_LENGTH);
+            string_utils::copy_string(bh_enable->wire_iface(message::IFACE_NAME_LENGTH),
+                                      config.backhaul_wire_iface.c_str(),
+                                      message::IFACE_NAME_LENGTH);
 
             bh_enable->wire_iface_type()     = config.backhaul_wire_iface_type;
             bh_enable->wireless_iface_type() = config.backhaul_wireless_iface_type;
@@ -3336,9 +3337,9 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
         bh_enable->iface_mac()       = hostap_params.iface_mac;
         bh_enable->preferred_bssid() = tlvf::mac_from_string(config.backhaul_preferred_bssid);
 
-        mapf::utils::copy_string(bh_enable->sta_iface(message::IFACE_NAME_LENGTH),
-                                 config.backhaul_wireless_iface.c_str(),
-                                 message::IFACE_NAME_LENGTH);
+        string_utils::copy_string(bh_enable->sta_iface(message::IFACE_NAME_LENGTH),
+                                  config.backhaul_wireless_iface.c_str(),
+                                  message::IFACE_NAME_LENGTH);
 
         bh_enable->frequency_band() = hostap_params.frequency_band;
         bh_enable->max_bandwidth()  = hostap_params.max_bandwidth;
@@ -3517,8 +3518,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             is_backhual_reconf              = false;
 
             // Version
-            mapf::utils::copy_string(notification->slave_version(message::VERSION_LENGTH),
-                                     BEEROCKS_VERSION, message::VERSION_LENGTH);
+            string_utils::copy_string(notification->slave_version(message::VERSION_LENGTH),
+                                      BEEROCKS_VERSION, message::VERSION_LENGTH);
 
             // Platform Configuration
             notification->low_pass_filter_on()   = config.backhaul_wireless_iface_filter_low;
@@ -4237,10 +4238,10 @@ bool slave_thread::parse_intel_join_response(Socket *sd, beerocks::beerocks_head
             return false;
         }
 
-        mapf::utils::copy_string(notification->versions().master_version, master_version.c_str(),
-                                 sizeof(beerocks_message::sVersions::master_version));
-        mapf::utils::copy_string(notification->versions().slave_version, BEEROCKS_VERSION,
-                                 sizeof(beerocks_message::sVersions::slave_version));
+        string_utils::copy_string(notification->versions().master_version, master_version.c_str(),
+                                  sizeof(beerocks_message::sVersions::master_version));
+        string_utils::copy_string(notification->versions().slave_version, BEEROCKS_VERSION,
+                                  sizeof(beerocks_message::sVersions::slave_version));
         message_com::send_cmdu(platform_manager_socket, cmdu_tx);
     }
 
@@ -4262,10 +4263,10 @@ bool slave_thread::parse_intel_join_response(Socket *sd, beerocks::beerocks_head
             LOG(ERROR) << "Failed building message!";
             return false;
         }
-        mapf::utils::copy_string(notification->versions().master_version, master_version.c_str(),
-                                 sizeof(beerocks_message::sVersions::master_version));
-        mapf::utils::copy_string(notification->versions().slave_version, BEEROCKS_VERSION,
-                                 sizeof(beerocks_message::sVersions::slave_version));
+        string_utils::copy_string(notification->versions().master_version, master_version.c_str(),
+                                  sizeof(beerocks_message::sVersions::master_version));
+        string_utils::copy_string(notification->versions().slave_version, BEEROCKS_VERSION,
+                                  sizeof(beerocks_message::sVersions::slave_version));
         message_com::send_cmdu(platform_manager_socket, cmdu_tx);
         LOG(DEBUG) << "send ACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION";
 
@@ -4298,9 +4299,9 @@ bool slave_thread::parse_non_intel_join_response(Socket *sd)
     //            LOG(ERROR) << "Failed building message!";
     //            return false;
     //        }
-    //        mapf::utils::copy_string(notification->versions().master_version, master_version.c_str(),
+    //        string_utils::copy_string(notification->versions().master_version, master_version.c_str(),
     //                                  sizeof(beerocks_message::sVersions::master_version));
-    //        mapf::utils::copy_string(notification->versions().slave_version, BEEROCKS_VERSION,
+    //        string_utils::copy_string(notification->versions().slave_version, BEEROCKS_VERSION,
     //                                  sizeof(beerocks_message::sVersions::slave_version));
     //        message_com::send_cmdu(platform_manager_socket, cmdu_tx);
     //        LOG(DEBUG) << "send ACTION_PLATFORM_MASTER_SLAVE_VERSIONS_NOTIFICATION";

--- a/common/beerocks/bcl/CMakeLists.txt
+++ b/common/beerocks/bcl/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(${PROJECT_NAME}
         $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC nl-3 nl-route-3 tlvf elpp mapfcommon)
+target_link_libraries(${PROJECT_NAME} PUBLIC nl-3 nl-route-3 tlvf elpp)
 
 install(TARGETS ${PROJECT_NAME} EXPORT bclConfig
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -61,7 +61,7 @@ if (BUILD_TESTS)
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
-    target_link_libraries(${TEST_PROJECT_NAME} nl-3 nl-route-3 tlvf elpp mapfcommon)
+    target_link_libraries(${TEST_PROJECT_NAME} nl-3 nl-route-3 tlvf elpp)
     target_link_libraries(${TEST_PROJECT_NAME} gtest_main gmock)
     install(TARGETS ${TEST_PROJECT_NAME} DESTINATION bin/tests)
     add_test(NAME ${TEST_PROJECT_NAME} COMMAND $<TARGET_FILE:${TEST_PROJECT_NAME}>)

--- a/common/beerocks/bcl/include/bcl/beerocks_string_utils.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_string_utils.h
@@ -83,6 +83,8 @@ public:
 
     static std::string int_to_hex_string(const unsigned int integer,
                                          const uint8_t number_of_digits);
+
+    static void copy_string(char *dst, const char *src, size_t dst_len);
 };
 } // namespace beerocks
 

--- a/common/beerocks/bcl/include/bcl/beerocks_utils.h
+++ b/common/beerocks/bcl/include/bcl/beerocks_utils.h
@@ -9,8 +9,6 @@
 #ifndef _BEEROCKS_UTILS_H_
 #define _BEEROCKS_UTILS_H_
 
-#include <mapf/common/utils.h>
-
 #include "beerocks_defines.h"
 #include "beerocks_string_utils.h"
 

--- a/common/beerocks/bcl/source/beerocks_string_utils.cpp
+++ b/common/beerocks/bcl/source/beerocks_string_utils.cpp
@@ -133,3 +133,18 @@ std::string string_utils::int_to_hex_string(const unsigned int integer,
 
     return ss_hex_string.str();
 };
+
+void string_utils::copy_string(char *dst, const char *src, size_t dst_len)
+{
+    const char *src_end = std::find(src, src + dst_len, '\0');
+    std::copy(src, src_end, dst);
+    std::ptrdiff_t src_size = src_end - src;
+    std::ptrdiff_t dst_size = dst_len;
+    if (src_size < dst_size) {
+        dst[src_size] = 0;
+    } else {
+        dst[dst_size - 1] = 0;
+        LOG(ERROR) << "copy_string() overflow, src string:'" << src << "'"
+                   << " dst_size=" << dst_size;
+    }
+}

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -9,7 +9,6 @@
 #include <bcl/beerocks_string_utils.h>
 #include <bcl/network/network_utils.h>
 #include <bcl/network/swap.h>
-#include <mapf/common/utils.h>
 
 #include <arpa/inet.h>
 #include <dirent.h>
@@ -60,7 +59,7 @@ static int read_iface_flags(const std::string &strIface, struct ifreq &if_req)
         return errno;
 
     // Read the interface flags
-    mapf::utils::copy_string(if_req.ifr_name, strIface.c_str(), sizeof(if_req.ifr_name));
+    beerocks::string_utils::copy_string(if_req.ifr_name, strIface.c_str(), sizeof(if_req.ifr_name));
     int rv = ioctl(socId, SIOCGIFFLAGS, &if_req);
     close(socId);
 
@@ -225,7 +224,7 @@ bool network_utils::get_raw_iface_info(const std::string &iface_name, raw_iface_
 
     // MAC Address
     ifr = {};
-    mapf::utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
+    string_utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
     if ((ioctl(fd, SIOCGIFHWADDR, &ifr)) == -1) {
         LOG(ERROR) << "ioctl failed: " << strerror(errno);
         close(fd);
@@ -235,7 +234,7 @@ bool network_utils::get_raw_iface_info(const std::string &iface_name, raw_iface_
 
     // IP Address
     ifr = {};
-    mapf::utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
+    string_utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
     if ((ioctl(fd, SIOCGIFADDR, &ifr)) == -1) {
         LOG(ERROR) << "ioctl failed: " << strerror(errno);
         close(fd);
@@ -245,7 +244,7 @@ bool network_utils::get_raw_iface_info(const std::string &iface_name, raw_iface_
 
     // Network Mask
     ifr = {};
-    mapf::utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
+    string_utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
     if ((ioctl(fd, SIOCGIFNETMASK, &ifr)) == -1) {
         LOG(ERROR) << "ioctl failed: " << strerror(errno);
         close(fd);
@@ -255,7 +254,7 @@ bool network_utils::get_raw_iface_info(const std::string &iface_name, raw_iface_
 
     // Broadcast Address
     ifr = {};
-    mapf::utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
+    string_utils::copy_string(ifr.ifr_name, iface_name.c_str(), IF_NAMESIZE);
     if ((ioctl(fd, SIOCGIFBRDADDR, &ifr)) == -1) {
         LOG(ERROR) << "ioctl failed: " << strerror(errno);
         close(fd);
@@ -563,7 +562,7 @@ bool network_utils::linux_add_iface_to_bridge(const std::string &bridge, const s
         return false;
     }
 
-    mapf::utils::copy_string(ifr.ifr_name, bridge.c_str(), IFNAMSIZ);
+    string_utils::copy_string(ifr.ifr_name, bridge.c_str(), IFNAMSIZ);
 #ifdef SIOCBRADDIF
     ifr.ifr_ifindex = ifindex;
     err             = ioctl(br_socket_fd, SIOCBRADDIF, &ifr);
@@ -607,7 +606,7 @@ bool network_utils::linux_remove_iface_from_bridge(const std::string &bridge,
         return false;
     }
 
-    mapf::utils::copy_string(ifr.ifr_name, bridge.c_str(), IFNAMSIZ);
+    string_utils::copy_string(ifr.ifr_name, bridge.c_str(), IFNAMSIZ);
 #ifdef SIOCBRDELIF
     ifr.ifr_ifindex = ifindex;
     err             = ioctl(br_socket_fd, SIOCBRDELIF, &ifr);
@@ -654,7 +653,7 @@ bool network_utils::linux_iface_ctrl(const std::string &iface, bool up, std::str
         return false;
     }
 
-    mapf::utils::copy_string(ifr.ifr_name, iface.c_str(), IFNAMSIZ);
+    string_utils::copy_string(ifr.ifr_name, iface.c_str(), IFNAMSIZ);
     while (up) {
         ifr.ifr_addr.sa_family = AF_INET;
         if (!ip.empty()) {
@@ -722,7 +721,7 @@ bool network_utils::linux_iface_get_mac(const std::string &iface, std::string &m
     }
 
     ifr.ifr_addr.sa_family = AF_INET;
-    mapf::utils::copy_string(ifr.ifr_name, iface.c_str(), IFNAMSIZ);
+    string_utils::copy_string(ifr.ifr_name, iface.c_str(), IFNAMSIZ);
     if (ioctl(fd, SIOCGIFHWADDR, &ifr) == -1) {
         LOG(ERROR) << "SIOCGIFHWADDR";
         close(fd);
@@ -769,7 +768,7 @@ bool network_utils::linux_iface_get_ip(const std::string &iface, std::string &ip
     }
 
     ifr.ifr_addr.sa_family = AF_INET;
-    mapf::utils::copy_string(ifr.ifr_name, iface.c_str(), IFNAMSIZ);
+    string_utils::copy_string(ifr.ifr_name, iface.c_str(), IFNAMSIZ);
 
     if (ioctl(fd, SIOCGIFADDR, &ifr) == -1) {
         LOG(ERROR) << "SIOCGIFADDR";
@@ -871,7 +870,7 @@ bool network_utils::linux_iface_get_speed(const std::string &iface, uint32_t &sp
         } ecmd;
         int rc;
 
-        mapf::utils::copy_string(ifr.ifr_name, iface.c_str(), sizeof(ifr.ifr_name));
+        string_utils::copy_string(ifr.ifr_name, iface.c_str(), sizeof(ifr.ifr_name));
         ifr.ifr_data = reinterpret_cast<char *>(&ecmd);
 
         /* Handshake with kernel to determine number of words for link
@@ -1010,7 +1009,7 @@ std::vector<network_utils::ip_info> network_utils::get_ip_list()
             ip_info.iface = std::string(rtInfo->ifName);
 
             ifr.ifr_addr.sa_family = AF_INET;
-            mapf::utils::copy_string(ifr.ifr_name, rtInfo->ifName, IFNAMSIZ);
+            string_utils::copy_string(ifr.ifr_name, rtInfo->ifName, IFNAMSIZ);
 
             if (ioctl(fd, SIOCGIFADDR, &ifr) == -1) {
                 continue; // skip, if can't read ip

--- a/common/beerocks/bcl/source/network/socket.cpp
+++ b/common/beerocks/bcl/source/network/socket.cpp
@@ -22,7 +22,6 @@ typedef int socklen_t;
 #include <sys/un.h>
 
 #include <bcl/beerocks_string_utils.h>
-#include <mapf/common/utils.h>
 
 #define closesocket close
 #define ioctlsocket ioctl
@@ -248,7 +247,7 @@ SocketServer::SocketServer(const std::string &uds_path, int connections, SocketM
 
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    mapf::utils::copy_string(addr.sun_path, uds_path.c_str(), sizeof(addr.sun_path));
+    beerocks::string_utils::copy_string(addr.sun_path, uds_path.c_str(), sizeof(addr.sun_path));
 
     if (mode == SocketModeNonBlocking) {
         u_long arg = 1;
@@ -357,7 +356,7 @@ SocketClient::SocketClient(const std::string &uds_path, long readTimeout)
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    mapf::utils::copy_string(addr.sun_path, uds_path.c_str(), sizeof(addr.sun_path));
+    beerocks::string_utils::copy_string(addr.sun_path, uds_path.c_str(), sizeof(addr.sun_path));
 
     if (::connect(m_socket, (sockaddr *)&addr, sizeof(addr))) {
         m_error = "connect() to " + uds_path + " failed: " + strerror(errno);

--- a/common/beerocks/btl/btl_local_bus.cpp
+++ b/common/beerocks/btl/btl_local_bus.cpp
@@ -111,17 +111,17 @@ bool transport_socket_thread::configure_ieee1905_transport_interfaces(
     using Flags = mapf::InterfaceConfigurationRequestMessage::Flags;
 
     uint32_t n = 0;
-    mapf::utils::copy_string(interface_configuration_request_msg.metadata()->interfaces[n].ifname,
-                             bridge_iface.c_str(), IF_NAMESIZE);
+    string_utils::copy_string(interface_configuration_request_msg.metadata()->interfaces[n].ifname,
+                              bridge_iface.c_str(), IF_NAMESIZE);
     interface_configuration_request_msg.metadata()->interfaces[n].flags |= Flags::IS_BRIDGE;
     n++;
     THREAD_LOG(DEBUG) << "adding bridge " << bridge_iface
                       << " to ieee1905 transport, bridge iface=" << bridge_iface;
     for (const auto &iface : ifaces) {
-        mapf::utils::copy_string(
+        string_utils::copy_string(
             interface_configuration_request_msg.metadata()->interfaces[n].ifname, iface.c_str(),
             IF_NAMESIZE);
-        mapf::utils::copy_string(
+        string_utils::copy_string(
             interface_configuration_request_msg.metadata()->interfaces[n].bridge_ifname,
             bridge_iface.c_str(), IF_NAMESIZE);
         interface_configuration_request_msg.metadata()->interfaces[n].flags |=

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -9,9 +9,9 @@
 #include "bml.h"
 #include "internal/bml_internal.h"
 
+#include <bcl/beerocks_string_utils.h>
 #include <bcl/network/network_utils.h>
 #include <bcl/son/son_wireless_utils.h>
-#include <mapf/common/utils.h>
 
 #include <easylogging++.h>
 
@@ -319,7 +319,7 @@ int bml_get_serial_number(BML_CTX ctx, char *serial_number)
     }
 
     // Copy only the serial number
-    mapf::utils::copy_string(serial_number, device_info.serial_number, BML_DEV_INFO_LEN);
+    beerocks::string_utils::copy_string(serial_number, device_info.serial_number, BML_DEV_INFO_LEN);
 
     return 0;
 }
@@ -540,8 +540,8 @@ int bml_get_master_slave_versions(BML_CTX ctx, char *master_version, char *slave
 
     bml_internal *pBML = (bml_internal *)ctx;
     if (pBML->is_local_master()) {
-        mapf::utils::copy_string(master_version, bml_get_bml_version(), BML_VERSION_LEN);
-        mapf::utils::copy_string(slave_version, bml_get_bml_version(), BML_VERSION_LEN);
+        beerocks::string_utils::copy_string(master_version, bml_get_bml_version(), BML_VERSION_LEN);
+        beerocks::string_utils::copy_string(slave_version, bml_get_bml_version(), BML_VERSION_LEN);
         return BML_RET_OK;
     }
 

--- a/controller/src/beerocks/bml/bml_utils.cpp
+++ b/controller/src/beerocks/bml/bml_utils.cpp
@@ -8,6 +8,7 @@
 
 #include "bml_utils.h"
 
+#include <bcl/beerocks_string_utils.h>
 #include <bcl/beerocks_utils.h>
 #include <bcl/network/network_utils.h>
 
@@ -154,7 +155,7 @@ int bml_utils_node_to_string(const struct BML_NODE *node, char *buffer, int buff
         std::cout << "ERROR: bml_node length > given buffer length" << std::endl;
         return 0;
     } else {
-        mapf::utils::copy_string(buffer, ss.str().c_str(), buffer_len);
+        beerocks::string_utils::copy_string(buffer, ss.str().c_str(), buffer_len);
         return offset;
     }
 }
@@ -257,7 +258,7 @@ int bml_utils_stats_to_string(const struct BML_STATS *stats, char *buffer, int b
         std::cout << "ERROR: bml_stats length > given buffer length" << std::endl;
         return 0;
     } else {
-        mapf::utils::copy_string(buffer, ss.str().c_str(), buffer_len);
+        beerocks::string_utils::copy_string(buffer, ss.str().c_str(), buffer_len);
         return offset;
     }
 }
@@ -318,7 +319,7 @@ int bml_utils_stats_to_string_raw(const struct BML_STATS *stats, char *buffer, i
         std::cout << "ERROR: bml_stats length > given buffer length" << std::endl;
         return 0;
     } else {
-        mapf::utils::copy_string(buffer, ss.str().c_str(), buffer_len);
+        beerocks::string_utils::copy_string(buffer, ss.str().c_str(), buffer_len);
         return offset;
     }
 }
@@ -434,7 +435,7 @@ int bml_utils_event_to_string(const struct BML_EVENT *event, char *buffer, int b
         std::cout << "ERROR: bml_stats length > given buffer length" << std::endl;
         return 0;
     } else {
-        mapf::utils::copy_string(buffer, ss.str().c_str(), buffer_len);
+        beerocks::string_utils::copy_string(buffer, ss.str().c_str(), buffer_len);
         return offset;
     }
 }

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -67,7 +67,8 @@ static void config_logger(const std::string log_file = std::string())
 static void translate_channel_scan_results(const beerocks_message::sChannelScanResults &res_in,
                                            BML_NEIGHBOR_AP &res_out)
 {
-    mapf::utils::copy_string(res_out.ap_SSID, res_in.ssid, beerocks::message::WIFI_SSID_MAX_LENGTH);
+    string_utils::copy_string(res_out.ap_SSID, res_in.ssid,
+                              beerocks::message::WIFI_SSID_MAX_LENGTH);
     std::copy_n(res_in.bssid.oct, BML_MAC_ADDR_LEN, res_out.ap_BSSID);
     std::copy_n(res_in.security_mode_enabled, beerocks::message::CHANNEL_SCAN_LIST_LENGTH,
                 res_out.ap_SecurityModeEnabled);
@@ -1256,12 +1257,12 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             // Signal any waiting threads
             if (m_prmMasterSlaveVersions) {
                 if (m_master_slave_versions != nullptr) {
-                    mapf::utils::copy_string(m_master_slave_versions->master_version,
-                                             response->versions().master_version,
-                                             message::VERSION_LENGTH);
-                    mapf::utils::copy_string(m_master_slave_versions->slave_version,
-                                             response->versions().slave_version,
-                                             message::VERSION_LENGTH);
+                    string_utils::copy_string(m_master_slave_versions->master_version,
+                                              response->versions().master_version,
+                                              message::VERSION_LENGTH);
+                    string_utils::copy_string(m_master_slave_versions->slave_version,
+                                              response->versions().slave_version,
+                                              message::VERSION_LENGTH);
                     m_prmMasterSlaveVersions->set_value(response->result() == 0);
                 } else {
                     LOG(DEBUG) << "m_master_slave_versions == nullptr !";
@@ -1927,9 +1928,9 @@ int bml_internal::device_oper_radios_query(BML_DEVICE_DATA *device_data)
         device_data->radios[idx].is_connected = true;
         device_data->radios[idx].is_operational =
             (iface_status == beerocks::eNodeState::STATE_CONNECTED) ? true : false;
-        mapf::utils::copy_string(device_data->radios[idx].iface_name,
-                                 DeviceData.radios[idx].iface_name,
-                                 beerocks::message::IFACE_NAME_LENGTH);
+        string_utils::copy_string(device_data->radios[idx].iface_name,
+                                  DeviceData.radios[idx].iface_name,
+                                  beerocks::message::IFACE_NAME_LENGTH);
     }
 
     return iRet;
@@ -2393,9 +2394,9 @@ int bml_internal::get_wifi_credentials(int vap_id, char *ssid, char *pass, int *
     // Clear the promise holder
     m_prmWiFiCredentialsGet = nullptr;
 
-    mapf::utils::copy_string(ssid, sWifiCredentials.ssid, BML_NODE_SSID_LEN);
+    string_utils::copy_string(ssid, sWifiCredentials.ssid, BML_NODE_SSID_LEN);
     if (pass != nullptr) {
-        mapf::utils::copy_string(pass, sWifiCredentials.pass, BML_NODE_PASS_LEN);
+        string_utils::copy_string(pass, sWifiCredentials.pass, BML_NODE_PASS_LEN);
     }
     *sec = sWifiCredentials.sec;
 
@@ -2504,8 +2505,8 @@ int bml_internal::bml_wps_onboarding(const char *iface)
         return (-BML_RET_OP_FAILED);
     }
 
-    mapf::utils::copy_string(request->iface_name(message::IFACE_NAME_LENGTH), iface,
-                             message::IFACE_NAME_LENGTH);
+    string_utils::copy_string(request->iface_name(message::IFACE_NAME_LENGTH), iface,
+                              message::IFACE_NAME_LENGTH);
 
     if (!message_com::send_cmdu(m_sockPlatform, cmdu_tx)) {
         LOG(ERROR) << "Failed sending ACTION_PLATFORM_WPS_ONBOARDING_REQUEST message!";
@@ -2567,7 +2568,8 @@ int bml_internal::get_administrator_credentials(char *user_password)
     // Clear the promise holder
     m_prmAdminCredentialsGet = nullptr;
 
-    mapf::utils::copy_string(user_password, AdminCredentials.user_password, BML_NODE_USER_PASS_LEN);
+    string_utils::copy_string(user_password, AdminCredentials.user_password,
+                              BML_NODE_USER_PASS_LEN);
 
     //clear the memory with password in it.
     volatile char *creds_pass = const_cast<volatile char *>(AdminCredentials.user_password);
@@ -2624,19 +2626,20 @@ int bml_internal::get_device_info(BML_DEVICE_INFO &device_info)
     // Clear the promise holder
     m_prmDeviceInfoGet = nullptr;
 
-    mapf::utils::copy_string(device_info.manufacturer, DeviceInfo.manufacturer, BML_DEV_INFO_LEN);
-    mapf::utils::copy_string(device_info.model_name, DeviceInfo.model_name, BML_DEV_INFO_LEN);
-    mapf::utils::copy_string(device_info.serial_number, DeviceInfo.serial_number, BML_DEV_INFO_LEN);
+    string_utils::copy_string(device_info.manufacturer, DeviceInfo.manufacturer, BML_DEV_INFO_LEN);
+    string_utils::copy_string(device_info.model_name, DeviceInfo.model_name, BML_DEV_INFO_LEN);
+    string_utils::copy_string(device_info.serial_number, DeviceInfo.serial_number,
+                              BML_DEV_INFO_LEN);
 
     // LAN
-    mapf::utils::copy_string(device_info.lan_iface_name, DeviceInfo.lan_iface_name,
-                             BML_IFACE_NAME_LEN);
+    string_utils::copy_string(device_info.lan_iface_name, DeviceInfo.lan_iface_name,
+                              BML_IFACE_NAME_LEN);
     device_info.lan_ip_address   = DeviceInfo.lan_ip_address;
     device_info.lan_network_mask = DeviceInfo.lan_network_mask;
 
     // WAN
-    mapf::utils::copy_string(device_info.wan_iface_name, DeviceInfo.wan_iface_name,
-                             BML_IFACE_NAME_LEN);
+    string_utils::copy_string(device_info.wan_iface_name, DeviceInfo.wan_iface_name,
+                              BML_IFACE_NAME_LEN);
     device_info.wan_ip_address   = DeviceInfo.wan_ip_address;
     device_info.wan_network_mask = DeviceInfo.wan_network_mask;
 
@@ -3076,8 +3079,8 @@ int bml_internal::get_master_slave_versions(char *master_version, char *slave_ve
     // Clear the promise holder
     m_prmMasterSlaveVersions = nullptr;
 
-    mapf::utils::copy_string(master_version, sVersion.master_version, message::VERSION_LENGTH);
-    mapf::utils::copy_string(slave_version, sVersion.slave_version, message::VERSION_LENGTH);
+    string_utils::copy_string(master_version, sVersion.master_version, message::VERSION_LENGTH);
+    string_utils::copy_string(slave_version, sVersion.slave_version, message::VERSION_LENGTH);
 
     if (iRet != BML_RET_OK) {
         LOG(ERROR) << "master_slave_versions request failed!";

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -641,7 +641,7 @@ void cli_bml::map_query_cb(const struct BML_NODE_ITER *node_iter, bool to_consol
                 std::cout << "ERROR: MARK sign > print_buffer available length" << std::endl;
                 return;
             } else {
-                mapf::utils::copy_string(p, ss.str().c_str(), sizeof(pThis->print_buffer));
+                string_utils::copy_string(p, ss.str().c_str(), sizeof(pThis->print_buffer));
                 p += offset;
             }
         }

--- a/controller/src/beerocks/cli/beerocks_cli_main.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_main.cpp
@@ -18,7 +18,6 @@
 #include <bcl/beerocks_string_utils.h>
 #include <bcl/beerocks_version.h>
 #include <easylogging++.h>
-#include <mapf/common/utils.h>
 
 #include <chrono>
 
@@ -110,7 +109,7 @@ static char *dupstr(const std::string &s)
         sigterm_handler(0);
         return nullptr;
     }
-    mapf::utils::copy_string(r, s.c_str(), r_len);
+    beerocks::string_utils::copy_string(r, s.c_str(), r_len);
     return r;
 }
 

--- a/controller/src/beerocks/cli/beerocks_cli_socket.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_socket.cpp
@@ -810,8 +810,8 @@ int cli_socket::client_beacon_11k_req(std::string client_mac, std::string bssid,
 
     if (!ssid.empty()) {
         request->use_optional_ssid() = true;
-        mapf::utils::copy_string(reinterpret_cast<char *>(request->ssid()), ssid.c_str(),
-                                 message::WIFI_SSID_MAX_LENGTH);
+        string_utils::copy_string(reinterpret_cast<char *>(request->ssid()), ssid.c_str(),
+                                  message::WIFI_SSID_MAX_LENGTH);
     }
     wait_response = true;
     message_com::send_cmdu(master_socket, cmdu_tx);

--- a/controller/src/beerocks/master/db/network_map.cpp
+++ b/controller/src/beerocks/master/db/network_map.cpp
@@ -245,7 +245,7 @@ std::ptrdiff_t network_map::fill_bml_node_data(db &database, std::shared_ptr<nod
     }
 
     network_utils::ipv4_from_string(node->ip_v4, n->ipv4);
-    mapf::utils::copy_string(node->name, n->name.c_str(), sizeof(node->name));
+    string_utils::copy_string(node->name, n->name.c_str(), sizeof(node->name));
 
     // GW/IRE specific parameters
     if (n_type != beerocks::TYPE_CLIENT) {
@@ -264,9 +264,9 @@ std::ptrdiff_t network_map::fill_bml_node_data(db &database, std::shared_ptr<nod
                                       c->mac); // local parent backhaul
 
                 // Copy the interface name
-                mapf::utils::copy_string(node->data.gw_ire.radio[i].iface_name,
-                                         database.get_hostap_iface_name(c->mac).c_str(),
-                                         BML_NODE_IFACE_NAME_LEN);
+                string_utils::copy_string(node->data.gw_ire.radio[i].iface_name,
+                                          database.get_hostap_iface_name(c->mac).c_str(),
+                                          BML_NODE_IFACE_NAME_LEN);
 
                 // Radio Vendor
                 switch (database.get_hostap_iface_type(c->mac)) {
@@ -278,9 +278,9 @@ std::ptrdiff_t network_map::fill_bml_node_data(db &database, std::shared_ptr<nod
                 }
 
                 // Copy the driver version string
-                mapf::utils::copy_string(node->data.gw_ire.radio[i].driver_version,
-                                         database.get_hostap_driver_version(c->mac).c_str(),
-                                         BML_WLAN_DRIVER_VERSION_LEN);
+                string_utils::copy_string(node->data.gw_ire.radio[i].driver_version,
+                                          database.get_hostap_driver_version(c->mac).c_str(),
+                                          BML_WLAN_DRIVER_VERSION_LEN);
 
                 node->data.gw_ire.radio[i].channel       = !c->channel ? 255 : c->channel;
                 node->data.gw_ire.radio[i].cac_completed = c->hostap->cac_completed;
@@ -297,9 +297,9 @@ std::ptrdiff_t network_map::fill_bml_node_data(db &database, std::shared_ptr<nod
                      vap_id < int8_t(c->hostap->vaps_info.size()); vap_id++) {
                     const auto &vap = (c->hostap->vaps_info[vap_id]);
                     tlvf::mac_from_string(node->data.gw_ire.radio[i].vap[vap_id].bssid, vap.mac);
-                    mapf::utils::copy_string(node->data.gw_ire.radio[i].vap[vap_id].ssid,
-                                             vap.ssid.c_str(),
-                                             sizeof(node->data.gw_ire.radio[i].vap[0].ssid));
+                    string_utils::copy_string(node->data.gw_ire.radio[i].vap[vap_id].ssid,
+                                              vap.ssid.c_str(),
+                                              sizeof(node->data.gw_ire.radio[i].vap[0].ssid));
                     node->data.gw_ire.radio[i].vap[vap_id].backhaul_vap = vap.backhaul_vap;
                 }
                 ++i;

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -523,8 +523,8 @@ void son_management::handle_cli_message(Socket *sd,
         // Optional:
         if (cli_request->use_optional_ssid()) {
             request->params().use_optional_ssid = 1; // bool
-            mapf::utils::copy_string(request->params().ssid, (char *)cli_request->ssid(),
-                                     beerocks::message::WIFI_SSID_MAX_LENGTH);
+            string_utils::copy_string(request->params().ssid, (char *)cli_request->ssid(),
+                                      beerocks::message::WIFI_SSID_MAX_LENGTH);
         } else {
             request->params().use_optional_ssid = 0;
         }

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -2035,8 +2035,8 @@ bool master_thread::handle_intel_slave_join(
     auto slave_version_s  = version::version_from_string(slave_version);
     auto master_version_s = version::version_from_string(BEEROCKS_VERSION);
 
-    mapf::utils::copy_string(join_response->master_version(), BEEROCKS_VERSION,
-                             message::VERSION_LENGTH);
+    string_utils::copy_string(join_response->master_version(), BEEROCKS_VERSION,
+                              message::VERSION_LENGTH);
 
     // check if fatal mismatch
     if (slave_version_s.major != master_version_s.major ||
@@ -2047,8 +2047,8 @@ bool master_thread::handle_intel_slave_join(
         LOG(INFO) << " bridge_mac=" << bridge_mac << " bridge_ipv4=" << bridge_ipv4;
 
         join_response->err_code() = beerocks::JOIN_RESP_VERSION_MISMATCH;
-        mapf::utils::copy_string(join_response->master_version(message::VERSION_LENGTH),
-                                 BEEROCKS_VERSION, message::VERSION_LENGTH);
+        string_utils::copy_string(join_response->master_version(message::VERSION_LENGTH),
+                                  BEEROCKS_VERSION, message::VERSION_LENGTH);
         return son_actions::send_cmdu_to_agent(src_mac, cmdu_tx, database);
     }
 
@@ -2172,8 +2172,8 @@ bool master_thread::handle_intel_slave_join(
     // send JOINED_RESPONSE with son config
     {
 
-        mapf::utils::copy_string(join_response->master_version(message::VERSION_LENGTH),
-                                 BEEROCKS_VERSION, message::VERSION_LENGTH);
+        string_utils::copy_string(join_response->master_version(message::VERSION_LENGTH),
+                                  BEEROCKS_VERSION, message::VERSION_LENGTH);
         join_response->config().monitor_total_ch_load_notification_hi_th_percent =
             database.config.monitor_total_ch_load_notification_hi_th_percent;
         join_response->config().monitor_total_ch_load_notification_lo_th_percent =

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -155,7 +155,7 @@ void association_handling_task::work()
             parent_mac); // the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
         //measurement_request.params.use_optional_ssid = true;
         measurement_request->params().expected_reports_count = 1;
-        //mapf::utils::copy_string(measurement_request.params.ssid, database.get_hostap_vap_ssid(parent_mac).c_str(), sizeof(measurement_request.params.ssid));
+        //string_utils::copy_string(measurement_request.params.ssid, database.get_hostap_vap_ssid(parent_mac).c_str(), sizeof(measurement_request.params.ssid));
         add_pending_mac(radio_mac, beerocks_message::ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE);
         TASK_LOG(DEBUG) << "requested beacon measurement request from sta: " << sta_mac
                         << " on hostap: " << parent_mac;


### PR DESCRIPTION
BCL depend on mapf::common for a single function [copy_string()](https://github.com/prplfoundation/prplMesh/blob/master/framework/common/utils.cpp#L29).

As a small step towards https://github.com/prplfoundation/prplMesh/pull/1373, break this dependency by copying the implementation of this function to the `beerocks::string_utils` class.

This change is separate from the https://github.com/prplfoundation/prplMesh/pull/1373 PR, as it may be required for the ZMQ replacement.