### PR TITLE
tests: sniffer: Fix problem with multiple tlvs of same type

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -289,7 +289,8 @@ class TestFlows:
                 if str(ae):
                     self.fail("{}".format(ae))
                 elif not self.check_error:
-                    self.fail("Assertion failed")
+                    self.fail("Assertion failed\n{}"
+                              .format(traceback.format_exc()))
 
             except Exception as e:
                 self.fail("Test failed unexpectedly: {}\n{}"


### PR DESCRIPTION
Sniffer only returns one of the tlvs if there are multiple tlvs of the same type in a ieee1905 packet. This is caused by tshark creating an invalid JSON with duplicate keys, using the same key for all the tlvs of same type.

Now subsequent tlvs will have a counter after the key name.