### PR TITLE
PPM-5 add smart steering persistent data to db

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2419,6 +2419,85 @@ const std::list<sChannelScanResults> &db::get_channel_scan_results(const sMacAdd
 }
 
 //
+// Client Persistent Data
+//
+bool db::is_client_in_persistent_db(const sMacAddr &mac) { return false; }
+
+bool db::add_client_to_persistent_db(const sMacAddr &mac,
+                                     std::unordered_map<std::string, std::string> params)
+{
+    return true;
+}
+
+std::chrono::steady_clock::time_point db::get_client_parameters_last_edit(const sMacAddr &mac)
+{
+    return std::chrono::steady_clock::time_point::min();
+}
+
+bool db::set_client_time_life_delay(const sMacAddr &mac,
+                                    const std::chrono::seconds &time_life_delay_sec,
+                                    bool save_to_persistent_db)
+{
+    return true;
+}
+
+std::chrono::seconds db::get_client_time_life_delay(const sMacAddr &mac)
+{
+    return std::chrono::seconds::zero();
+}
+
+bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_initial_radio,
+                                          bool save_to_persistent_db)
+{
+    return true;
+}
+
+ePersistentParamBool db::get_client_stay_on_initial_radio(const sMacAddr &mac)
+{
+    return ePersistentParamBool::NOT_CONFIGURED;
+}
+
+bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_radio_mac,
+                                  bool save_to_persistent_db)
+{
+    return true;
+}
+
+sMacAddr db::get_client_initial_radio(const sMacAddr &mac) { return network_utils::ZERO_MAC; }
+
+bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_selected_band,
+                                          bool save_to_persistent_db)
+{
+    return true;
+}
+
+ePersistentParamBool db::get_client_stay_on_selected_band(const sMacAddr &mac)
+{
+    return ePersistentParamBool::NOT_CONFIGURED;
+}
+
+bool db::set_client_selected_bands(const sMacAddr &mac, beerocks::eFreqType selected_bands,
+                                   bool save_to_persistent_db)
+{
+    return true;
+}
+
+beerocks::eFreqType db::get_client_selected_bands(const sMacAddr &mac)
+{
+    return beerocks::eFreqType::FREQ_UNKNOWN;
+}
+
+bool db::clear_client_persistent_db(const sMacAddr &mac) { return true; }
+
+bool db::update_client_persistent_db(const sMacAddr &mac) { return true; }
+
+std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+db::load_persistent_db_clients()
+{
+    return {};
+}
+
+//
 // CLI
 //
 void db::add_cli_socket(Socket *sd)
@@ -3491,6 +3570,21 @@ std::shared_ptr<node> db::get_node(sMacAddr al_mac, sMacAddr ruid)
         key = tlvf::mac_to_string(al_mac) + tlvf::mac_to_string(ruid);
 
     return get_node(key);
+}
+
+std::shared_ptr<node> db::get_node_verify_type(const sMacAddr &mac, beerocks::eType type)
+{
+    auto node = get_node(mac);
+    if (!node) {
+        LOG(ERROR) << "node not found for mac " << mac;
+        return nullptr;
+    } else if (node->get_type() != type) {
+        LOG(ERROR) << __FUNCTION__ << "node " << mac << " type(" << node->get_type()
+                   << ") != requested-type(" << type << ")";
+        return nullptr;
+    }
+
+    return node;
 }
 
 std::shared_ptr<node::radio> db::get_hostap_by_mac(const sMacAddr &mac)

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2431,63 +2431,204 @@ bool db::add_client_to_persistent_db(const sMacAddr &mac,
 
 std::chrono::steady_clock::time_point db::get_client_parameters_last_edit(const sMacAddr &mac)
 {
-    return std::chrono::steady_clock::time_point::min();
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return std::chrono::steady_clock::time_point::min();
+    }
+
+    return node->client_parameters_last_edit;
 }
 
 bool db::set_client_time_life_delay(const sMacAddr &mac,
                                     const std::chrono::seconds &time_life_delay_sec,
                                     bool save_to_persistent_db)
 {
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return false;
+    }
+
+    LOG(DEBUG) << "time_life_delay_sec = " << time_life_delay_sec.count();
+
+    auto timestamp = std::chrono::steady_clock::now();
+    if (save_to_persistent_db) {
+        LOG(DEBUG) << "configuring persistent-db, timelife = " << time_life_delay_sec.count();
+    }
+
+    node->client_time_life_delay_sec  = time_life_delay_sec;
+    node->client_parameters_last_edit = timestamp;
+
     return true;
 }
 
 std::chrono::seconds db::get_client_time_life_delay(const sMacAddr &mac)
 {
-    return std::chrono::seconds::zero();
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return std::chrono::seconds::zero();
+    }
+
+    return node->client_time_life_delay_sec;
 }
 
 bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_initial_radio,
                                           bool save_to_persistent_db)
 {
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return false;
+    }
+
+    LOG(DEBUG) << "stay_on_initial_radio = " << stay_on_initial_radio;
+
+    auto timestamp = std::chrono::steady_clock::now();
+    if (save_to_persistent_db) {
+        LOG(DEBUG) << "configuring persistent-db, initial_radio_enable = " << stay_on_initial_radio;
+    }
+
+    node->client_stay_on_initial_radio =
+        (stay_on_initial_radio) ? ePersistentParamBool::ENABLE : ePersistentParamBool::DISABLE;
+    node->client_parameters_last_edit = timestamp;
+
     return true;
 }
 
 ePersistentParamBool db::get_client_stay_on_initial_radio(const sMacAddr &mac)
 {
-    return ePersistentParamBool::NOT_CONFIGURED;
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return ePersistentParamBool::NOT_CONFIGURED;
+    }
+
+    return node->client_stay_on_initial_radio;
 }
 
 bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_radio_mac,
                                   bool save_to_persistent_db)
 {
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return false;
+    }
+
+    LOG(DEBUG) << "initial_radio = " << initial_radio_mac;
+
+    auto timestamp = std::chrono::steady_clock::now();
+    if (save_to_persistent_db) {
+        LOG(DEBUG) << "configuring persistent-db, initial_radio = " << initial_radio_mac;
+    }
+
+    node->client_initial_radio        = initial_radio_mac;
+    node->client_parameters_last_edit = timestamp;
+
     return true;
 }
 
-sMacAddr db::get_client_initial_radio(const sMacAddr &mac) { return network_utils::ZERO_MAC; }
+sMacAddr db::get_client_initial_radio(const sMacAddr &mac)
+{
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return network_utils::ZERO_MAC;
+    }
+
+    return node->client_initial_radio;
+}
 
 bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_selected_band,
                                           bool save_to_persistent_db)
 {
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return false;
+    }
+
+    LOG(DEBUG) << "stay_on_selected_band = " << stay_on_selected_band;
+
+    auto timestamp = std::chrono::steady_clock::now();
+    if (save_to_persistent_db) {
+        LOG(DEBUG) << "configuring persistent-db, selected_band_enable = " << stay_on_selected_band;
+    }
+
+    node->client_stay_on_selected_band =
+        (stay_on_selected_band) ? ePersistentParamBool::ENABLE : ePersistentParamBool::DISABLE;
+    node->client_parameters_last_edit = timestamp;
+
     return true;
 }
 
 ePersistentParamBool db::get_client_stay_on_selected_band(const sMacAddr &mac)
 {
-    return ePersistentParamBool::NOT_CONFIGURED;
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return ePersistentParamBool::NOT_CONFIGURED;
+    }
+
+    return node->client_stay_on_selected_band;
 }
 
 bool db::set_client_selected_bands(const sMacAddr &mac, beerocks::eFreqType selected_bands,
                                    bool save_to_persistent_db)
 {
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return false;
+    }
+
+    LOG(DEBUG) << "selected_band = " << int(selected_bands);
+
+    auto timestamp = std::chrono::steady_clock::now();
+    if (save_to_persistent_db) {
+        LOG(DEBUG) << ", configuring persistent-db, selected_bands = " << int(selected_bands);
+    }
+
+    node->client_selected_bands       = selected_bands;
+    node->client_parameters_last_edit = timestamp;
+
     return true;
 }
 
 beerocks::eFreqType db::get_client_selected_bands(const sMacAddr &mac)
 {
-    return beerocks::eFreqType::FREQ_UNKNOWN;
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return beerocks::eFreqType::FREQ_UNKNOWN;
+    }
+
+    return node->client_selected_bands;
 }
 
-bool db::clear_client_persistent_db(const sMacAddr &mac) { return true; }
+bool db::clear_client_persistent_db(const sMacAddr &mac)
+{
+    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
+    if (!node) {
+        LOG(ERROR) << "client node not found for mac " << mac;
+        return false;
+    }
+
+    LOG(DEBUG) << "setting client " << mac << " runtime info to default values";
+
+    node->client_parameters_last_edit  = std::chrono::steady_clock::time_point::min();
+    node->client_time_life_delay_sec   = std::chrono::seconds::zero();
+    node->client_stay_on_initial_radio = ePersistentParamBool::NOT_CONFIGURED;
+    node->client_initial_radio         = network_utils::ZERO_MAC;
+    node->client_stay_on_selected_band = ePersistentParamBool::NOT_CONFIGURED;
+    node->client_selected_bands        = beerocks::eFreqType::FREQ_UNKNOWN;
+
+    LOG(DEBUG) << "removing client " << mac << " from persistent db";
+
+    return true;
+}
 
 bool db::update_client_persistent_db(const sMacAddr &mac) { return true; }
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -10,6 +10,7 @@
 
 #include <bcl/beerocks_utils.h>
 #include <bcl/son/son_wireless_utils.h>
+#include <bpl/bpl_db.h>
 #include <easylogging++.h>
 
 #include <algorithm>
@@ -3991,4 +3992,23 @@ void db::set_prplmesh(const sMacAddr &mac)
         add_node(mac, beerocks::net::network_utils::ZERO_MAC, ire_type);
     }
     get_node(mac)->is_prplmesh = true;
+}
+
+bool db::update_client_entry_in_persistent_db(
+    const sMacAddr &mac, std::unordered_map<std::string, std::string> values_map)
+{
+    auto db_entry        = client_db_entry_from_mac(mac);
+    auto type_client_str = type_to_string(beerocks::eType::TYPE_CLIENT);
+
+    if (!bpl::db_has_entry(type_client_str, db_entry)) {
+        if (!add_client_to_persistent_db(mac, values_map)) {
+            LOG(ERROR) << "failed to add client entry in persistent-db for " << mac;
+            return false;
+        }
+    } else if (!bpl::db_set_entry(type_client_str, db_entry, values_map)) {
+        LOG(ERROR) << "failed to set client in persistent-db for " << mac;
+        return false;
+    }
+
+    return true;
 }

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -19,6 +19,59 @@ using namespace beerocks_message;
 using namespace son;
 using namespace net;
 
+// static
+std::string db::type_to_string(beerocks::eType type)
+{
+    switch (type) {
+    case beerocks::eType::TYPE_GW:
+        return "gateway";
+    case beerocks::eType::TYPE_IRE:
+        return "ire";
+    case beerocks::eType::TYPE_IRE_BACKHAUL:
+        return "ire_bh";
+    case beerocks::eType::TYPE_SLAVE:
+        return "slave";
+    case beerocks::eType::TYPE_CLIENT:
+        return "client";
+    case beerocks::eType::TYPE_ETH_SWITCH:
+        return "eth_switch";
+    case beerocks::eType::TYPE_ANY:
+        return "any";
+    default:
+        return {};
+    }
+}
+
+std::string db::client_db_entry_from_mac(const sMacAddr &mac)
+{
+    std::string db_entry = tlvf::mac_to_string(mac);
+    std::replace(db_entry.begin(), db_entry.end(), ':', '_');
+
+    return db_entry;
+}
+
+sMacAddr db::client_db_entry_to_mac(const std::string &db_entry)
+{
+    std::string entry = db_entry;
+
+    std::replace(entry.begin(), entry.end(), '_', ':');
+
+    return tlvf::mac_from_string(entry);
+}
+
+std::string db::timestamp_to_string_seconds(const std::chrono::steady_clock::time_point timestamp)
+{
+    return std::to_string(
+        std::chrono::duration_cast<std::chrono::seconds>(timestamp.time_since_epoch()).count());
+}
+
+std::chrono::steady_clock::time_point db::timestamp_from_seconds(int timestamp_sec)
+{
+    return std::chrono::steady_clock::time_point(std::chrono::seconds(timestamp_sec));
+}
+
+// static - end
+
 void db::set_log_level_state(const beerocks::eLogLevel &log_level, const bool &new_state)
 {
     logger.set_log_level_state(log_level, new_state);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1081,6 +1081,9 @@ private:
     void rewind();
     bool get_next_node(std::shared_ptr<node> &n, int &hierarchy);
     bool get_next_node(std::shared_ptr<node> &n);
+    bool
+    update_client_entry_in_persistent_db(const sMacAddr &mac,
+                                         std::unordered_map<std::string, std::string> values_map);
 
     int network_optimization_task_id = -1;
     int channel_selection_task_id    = -1;

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -161,6 +161,48 @@ public:
     }
     ~db(){};
 
+    //static
+    /**
+     * @brief Get string representation of node type.
+     * 
+     * @param type Type of a node.
+     * @return std::string the string representation of the type.
+     */
+    static std::string type_to_string(beerocks::eType type);
+
+    /**
+     * @brief Get db entry from MAC address.
+     * 
+     * @param mac MAC address of a client.
+     * @return std::string the string representation of the MAC address with ':' replaced with '_' removed.
+     */
+    static std::string client_db_entry_from_mac(const sMacAddr &mac);
+
+    /**
+     * @brief Get client MAC address from db entry.
+     * 
+     * @param db_entry Client entry name in persistent db.
+     * @return sMacAddr MAC address of the client the db_entry is representing.
+     */
+    static sMacAddr client_db_entry_to_mac(const std::string &db_entry);
+
+    /**
+     * @brief Get string representation of number of seconds in timestamp.
+     * 
+     * @param timestamp A time-point.
+     * @return std::string the string representation of the integer number of seconds in the timestamp.
+     */
+    static std::string
+    timestamp_to_string_seconds(const std::chrono::steady_clock::time_point timestamp);
+
+    /**
+     * @brief Translate an integer number of seconds to a timepoint.
+     * 
+     * @param timestamp_sec Number of seconds in the timestamp.
+     * @return std::chrono::steady_clock::time_point a time-point representation of the number of seconds.
+     */
+    static std::chrono::steady_clock::time_point timestamp_from_seconds(int timestamp_sec);
+
     //logger
     void set_log_level_state(const beerocks::eLogLevel &log_level, const bool &new_state);
 

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -594,6 +594,157 @@ public:
                                                                    bool single_scan);
 
     //
+    // Client Persistent Data
+    //
+    /**
+     * @brief Check if client exists in persistent db.
+     * 
+     * @param mac MAC address of a client.
+     * @return true if client exists, false otherwise.
+     */
+    bool is_client_in_persistent_db(const sMacAddr &mac);
+
+    /**
+     * @brief Adds a client to the persistent db, if already exists, remove old entry and add a new one.
+     * 
+     * @param mac MAC address of a client.
+     * @param params An unordered map of key-value of client parameters.
+     * @return true on success, otherwise false.
+     */
+    bool add_client_to_persistent_db(const sMacAddr &mac,
+                                     std::unordered_map<std::string, std::string> params =
+                                         std::unordered_map<std::string, std::string>());
+
+    /**
+     * @brief Get the client's parameters last edit time.
+     * 
+     * @param mac MAC address of a client.
+     * @return Client persistent data last edit time (even if edit was done only to runtime-dbb and not saved to persistent db), or time_point::min() if not-configured or failure.
+     */
+    std::chrono::steady_clock::time_point get_client_parameters_last_edit(const sMacAddr &mac);
+
+    /**
+     * @brief Set the client's time-life delay.
+     * 
+     * @param mac MAC address of a client.
+     * @param time_life_delay_sec Client-specific aging time.
+     * @param save_to_persistent_db If set to true, update the persistent-db (write-through), default is true.
+     * @return true on success, otherwise false.
+     */
+    bool set_client_time_life_delay(const sMacAddr &mac,
+                                    const std::chrono::seconds &time_life_delay_sec,
+                                    bool save_to_persistent_db = true);
+
+    /**
+     * @brief Get the client's time-life delay.
+     * 
+     * @param mac MAC address of a client.
+     * @return Client time-life delay, value of 0 means not-configured.
+     */
+    std::chrono::seconds get_client_time_life_delay(const sMacAddr &mac);
+
+    /**
+     * @brief Set the client's stay-on-initial-radio.
+     * 
+     * @param mac MAC address of a client.
+     * @param stay_on_initial_radio Enable client stay on the radio it initially connected to.
+     * @param save_to_persistent_db If set to true, update the persistent-db (write-through), default is true.
+     * @return true on success, otherwise false.
+     */
+    bool set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_initial_radio,
+                                          bool save_to_persistent_db = true);
+
+    /**
+     * @brief Get the client's stay-on-initial-radio.
+     * 
+     * @param mac MAC address of a client.
+     * @return Enable client stay on the radio it initially connected to.
+     */
+    ePersistentParamBool get_client_stay_on_initial_radio(const sMacAddr &mac);
+
+    /**
+     * @brief Set the client's initial-radio.
+     * 
+     * @param mac MAC address of a client.
+     * @param initial_radio_mac The MAC address of the radio that the client has initially connected to.
+     * @param save_to_persistent_db If set to true, update the persistent-db (write-through), default is true.
+     * @return true on success, otherwise false.
+     */
+    bool set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_radio_mac,
+                                  bool save_to_persistent_db = true);
+
+    /**
+     * @brief Get the client's initial-radio.
+     * 
+     * @param mac MAC address of a client.
+     * @return MAC adddress of the radio that the client has initially connected to.
+     */
+    sMacAddr get_client_initial_radio(const sMacAddr &mac);
+
+    /**
+     * @brief Set the client's stay-on-selected-band.
+     * 
+     * @param mac MAC address of a client.
+     * @param stay_on_selected_band Enable client stay on the selected band/bands.
+     * @param save_to_persistent_db If set to true, update the persistent-db (write-through), default is true.
+     * @return true on success, otherwise false.
+     */
+    bool set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_selected_band,
+                                          bool save_to_persistent_db = true);
+
+    /**
+     * @brief Get the client's stay-on-selected-band.
+     * 
+     * @param mac MAC address of a client.
+     * @return Enable client stay on the selected band/bands.
+     */
+    ePersistentParamBool get_client_stay_on_selected_band(const sMacAddr &mac);
+
+    /**
+     * @brief Set the client's selected-bands.
+     * 
+     * @param mac MAC address of a client.
+     * @param selected_bands Client selected band/bands. FREQ_UNKNOWN is considered as "not-configured".
+     * @param save_to_persistent_db If set to true, update the persistent-db (write-through), default is true.
+     * @return true on success, otherwise false.
+     */
+    bool set_client_selected_bands(const sMacAddr &mac, beerocks::eFreqType selected_bands,
+                                   bool save_to_persistent_db = true);
+
+    /**
+     * @brief Get the client's selected-bands.
+     * 
+     * @param mac MAC address of a client.
+     * @return Selected band/bands.
+     */
+    beerocks::eFreqType get_client_selected_bands(const sMacAddr &mac);
+
+    /**
+     * @brief Clear client's persistent information.
+     * 
+     * @param mac MAC address of a client.
+     * @return true on success, otherwise false.
+     */
+    bool clear_client_persistent_db(const sMacAddr &mac);
+
+    /**
+     * @brief Update client's persistent information with the runtime information.
+     * 
+     * @param mac MAC address of a client.
+     * @return true on success, otherwise false.
+     */
+    bool update_client_persistent_db(const sMacAddr &mac);
+
+    /**
+     * @brief Load all clients from persistent db.
+     * 
+     * @return An unordered map of clients, for each client unordered map of params as key-value.
+     * @return An empty map of clients is returned if the persistent db is empty.
+     */
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+    load_persistent_db_clients();
+
+    //
     // CLI
     //
     void add_cli_socket(Socket *sd);
@@ -865,6 +1016,15 @@ private:
     std::shared_ptr<node> get_node(std::string key); //key can be <mac> or <al_mac>_<ruid>
     std::shared_ptr<node> get_node(sMacAddr mac);
     std::shared_ptr<node> get_node(sMacAddr al_mac, sMacAddr ruid);
+    /**
+     * @brief Returns the node object after verifing node type.
+     * if node is found but type is not requested type a nullptr is returned.
+     * 
+     * @param mac MAC address of the node.
+     * @param type The type of node used for node-type verification.
+     * @return std::shared_ptr<node> pointer to the node on success, nullptr otherwise.
+     */
+    std::shared_ptr<node> get_node_verify_type(const sMacAddr &mac, beerocks::eType type);
     std::shared_ptr<node::radio> get_hostap_by_mac(const sMacAddr &mac);
     int get_node_hierarchy(std::shared_ptr<node> n);
     std::set<std::shared_ptr<node>> get_node_subtree(std::shared_ptr<node> n);

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -29,6 +29,18 @@ node::node(beerocks::eType type_, const std::string &mac_)
 }
 
 namespace son {
+std::ostream &operator<<(std::ostream &os, ePersistentParamBool value)
+{
+    if (value == ePersistentParamBool::DISABLE) {
+        os << "Disabled";
+    } else if (value == ePersistentParamBool::ENABLE) {
+        os << "Enabled";
+    } else {
+        os << "Not-Configured";
+    }
+    return os;
+}
+
 std::ostream &operator<<(std::ostream &os, const node &n)
 {
     std::chrono::steady_clock::time_point tCurrTime = std::chrono::steady_clock::now();
@@ -121,6 +133,26 @@ std::ostream &operator<<(std::ostream &os, const node &n)
                << "   Failed5ghzSteerAttemps: " << int(n.failed_5ghz_steer_attemps) << std::endl
                << "   Failed24ghzSteerAttemps: " << int(n.failed_24ghz_steer_attemps) << std::endl;
         }
+
+        // persistent db
+        if (node_type == beerocks::TYPE_CLIENT) {
+            auto client_parameters_last_edit_hours = std::chrono::duration_cast<std::chrono::hours>(
+                                                         tCurrTime - n.client_parameters_last_edit)
+                                                         .count();
+            auto client_time_life_delay_hours =
+                std::chrono::duration_cast<std::chrono::hours>(n.client_time_life_delay_sec)
+                    .count();
+            os << "Persistent configuration and data:" << std::endl
+               << "   ClientParametersLastEdit: " << (client_parameters_last_edit_hours / 24)
+               << " days, " << (client_parameters_last_edit_hours % 24) << " hours" << std::endl
+               << "   ClientTimeLifeDelay: " << (client_time_life_delay_hours / 24) << " days, "
+               << (client_time_life_delay_hours % 24) << " hours" << std::endl
+               << "   ClientStayOnInitialRadio: " << n.client_stay_on_initial_radio << std::endl
+               << "   ClientInitialRadio: " << n.client_initial_radio << std::endl
+               << "   ClientStayOnSelectedBand: " << n.client_stay_on_selected_band << std::endl
+               << "   ClientSelectedBands: " << n.client_selected_bands << std::endl;
+        }
+
     } else if (node_type == beerocks::TYPE_SLAVE) {
         os << " Type: HOSTAP" << std::endl
            << " IfaceType: " << utils::get_iface_type_string(n.hostap->iface_type) << std::endl

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -35,6 +35,14 @@ typedef struct {
     bool backhaul_vap;
 } sVapElement;
 
+/**
+ * @brief Extended boolean parameter to support "not configured" value for persistent configuration.
+ * For persistent data, it is important to differ between configured enable/disable to uncofigured value.
+ */
+enum class ePersistentParamBool : int8_t { NOT_CONFIGURED = -1, DISABLE = 0, ENABLE = 1 };
+
+std::ostream &operator<<(std::ostream &os, ePersistentParamBool value);
+
 class node {
 public:
     node(beerocks::eType type_, const std::string &mac_);
@@ -266,6 +274,38 @@ public:
 
     friend std::ostream &operator<<(std::ostream &os, const node &node);
     friend std::ostream &operator<<(std::ostream &os, const node *node);
+
+    /*
+     * Persistent configurations - start
+     * Client persistent configuration aging is refreshed on persistent configurations set
+     * persistent configuration of aged clients removed from the persistent-db and cleared in the runtime-db
+     */
+
+    // Indicates when client parameters were last updated (even if not updated yet to persistent-db)
+    // minimal value is used as invalid value.
+    std::chrono::steady_clock::time_point client_parameters_last_edit =
+        std::chrono::steady_clock::time_point::min();
+
+    // Optional - if configured the client has its own configured timelife delay.
+    std::chrono::seconds client_time_life_delay_sec = std::chrono::seconds::zero();
+
+    // If enabled, the client will be steered to the initial radio it connected to - save at client_initial_radio.
+    ePersistentParamBool client_stay_on_initial_radio = ePersistentParamBool::NOT_CONFIGURED;
+
+    // The client_initial_radio bssid must be set.
+    sMacAddr client_initial_radio;
+
+    // If enabled, the client will be steered to pre-selected-bands defined by client_selected_bands.
+    // Not enforced if client_selected_bands is not set.
+    ePersistentParamBool client_stay_on_selected_band = ePersistentParamBool::NOT_CONFIGURED;
+
+    // The selected bands the client should be steered to if the client_stay_on_selected_band is set.
+    // Default value is FREQ_UNKNOWN (also indicates value is not configured)
+    beerocks::eFreqType client_selected_bands = beerocks::eFreqType::FREQ_UNKNOWN;
+
+    /*
+     * Persistent configurations - end
+     */
 
 private:
     class rssi_measurement {


### PR DESCRIPTION
This PR introduces client parameters to enable smart-steering capabilities and persistency of those parameters across prplmesh restarts and system reboots.

The BPL provides the interface to the persistent DB and the 

The added configuration is saved to the persistent DB via BPL and enables a per-client steering configuration persistent across prplmesh-restarts/reboots.

This PR includes:
Add the client parameters to the Node class (runtime controller DB).
Add setters/getters APIs to the client parameters (get is from runtime DB, set can be to runtime DB or also to persistent DB (write-through))
Add APIs to clear/update client persistent information.
Add API to get all clients from persistent DB