### PR TITLE
boardfarm: add "prplWRT_STA" device

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_prplwrt.py
@@ -62,7 +62,7 @@ class PrplMeshPrplWRT(OpenWrtRouter, PrplMeshBase):
             self.wan_network = self.get_docker_subnet()
             self.wan_ip = self.wan_network[+245]
             self.set_iface_ip("br-lan", self.wan_ip, self.wan_network.prefixlen)
-            self.connection.close()
+            self.close()
             self.kill(signal.SIGTERM)
             # Removal of PID is required by pexpect in order to spawn a new process
             # serial connection should be terminated by 2 commands above

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_station.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_station.py
@@ -1,0 +1,71 @@
+###############################################################
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+###############################################################
+
+from boardfarm.devices.debian_wifi import DebianWifi
+from boardfarm.devices import connection_decider
+from environment import VirtualAPHostapd
+
+
+class PrplMeshStation(DebianWifi):
+    """Client of prplMesh enabled Access Point."""
+
+    linesep = "\r"
+    model = "prplWRT_STA"
+    prompt = ['.*:~', '/.*#']
+
+    def __init__(self, *args, **kwargs):
+        """Init station and wlan iface."""
+        self.args = args
+        self.kwargs = kwargs
+
+        config = kwargs.get("config", kwargs)
+        self.connection_type = config.get("connection_type", None)
+        self.connection = connection_decider.connection(device=self,
+                                                        conn_type=self.connection_type,
+                                                        **kwargs)
+        self.connection.connect()
+        self.consoles = [self]
+        super(PrplMeshStation, self).__init__(*args, **kwargs)
+        self.iface_dut = self.iface_wifi = self.kwargs.get(
+            'iface', 'wlan0')
+        self.driver_name = config.get("driver", "nl80211,wext")
+        self.mac = self.get_mac()
+
+        self.wifi_disconnect()
+        # kill all wpa_supplicant relevant to active interface
+
+    def wifi_connect(self, vap: VirtualAPHostapd) -> bool:
+        """Connect to the Access Point. Return True if successful."""
+        config_file_name = "boardfarm_tmp.conf"
+        config_file_path = "/tmp/{}".format(config_file_name)
+
+        # Create network configuration for SSID
+        bssid = "bssid={}".format(vap.bssid)
+        ssid = "ssid=\"{}\"".format(vap.get_ssid())
+        key = "psk=\"{}\"".format(vap.get_psk())
+        network_config = "network={{\n{}\n{}\n{}\n}}".format(bssid, ssid, key)
+        # Clean up previous configuration
+        self.sendline("rm -f \"{}\"".format(config_file_path))
+        self.expect(self.prompt)
+        self.sendline("echo \'{}\' > \"{}\"".format(network_config, config_file_path))
+        self.expect(self.prompt)
+        # Start wpa_supplicant with created configuration
+        # Typical coommand on RPI: wpa_supplicant -B -c/tmp/temp.conf -iwlan0 -Dnl80211,wext
+        self.sudo_sendline("wpa_supplicant -B -D{} -i {} -c {}".format(
+            self.driver_name, self.iface_wifi, config_file_path))
+        self.expect("Successfully initialized wpa_supplicant")
+        return bool(self.match)
+
+    def get_mac(self) -> str:
+        """Get MAC of STA iface"""
+        self.sendline("iw {} info".format(self.iface_dut))
+        # We are looking for MAC definition of STA
+        # wdev 0x1
+        # addr 96:4e:c9:cc:7a:2c
+        # type managed
+        self.expect("addr (?P<mac>..:..:..:..:..:..)\r\n\ttype")
+        return self.match.group('mac')

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_station_dummy.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/devices/prplmesh_station_dummy.py
@@ -36,3 +36,11 @@ class PrplMeshStationDummy(PrplMeshBase):
         '''Disassociate "sta" from this VAP.'''
         vap.radio.send_bwl_event("EVENT AP-STA-DISCONNECTED {}".format(self.mac))
         return True
+
+    def wifi_connect_check(self, vap: VirtualAPDocker) -> bool:
+        """Connect and verify connection"""
+        return self.wifi_connect(vap)
+
+    def disable_wifi(self) -> bool:
+        """Disable wifi connection"""
+        return True

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -32,6 +32,15 @@
             "role": "controller",
             "docker_network": "prplMesh-net-rax40-1",
             "conn_cmd": ""
+            },
+            {
+                "name": "wifi",
+                "type": "prplWRT_STA",
+                "iface": "wlan0",
+                "driver": "nl80211,wext",
+                "connection_type": "local_cmd",
+                "conn_cmd": "bash",
+                "color": "yellow"
             }
         ]
     }

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
@@ -8,8 +8,6 @@
 import time
 
 from .prplmesh_base_test import PrplMeshBaseTest
-# TODO: Remove as soon, as test works for prplWRT device
-from ..devices.prplmesh_prplwrt import PrplMeshPrplWRT
 from capi import tlv
 from opts import debug
 
@@ -25,12 +23,6 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
         controller = self.dev.wan.controller_entity
         sta = self.dev.wifi
 
-        # This test doesn't work for real HW.
-        # Skip it for prplWRT device.
-        # TODO: Remove as soon, as test works for prplWRT device
-        if self.dev.DUT is PrplMeshPrplWRT:
-            self.skipTest("This test isn't ready for prplWRT devices")
-
         # Regression check
         # Don't connect nonexistent Station
         self.dev.DUT.wired_sniffer.start(self.__class__.__name__ + "-" + self.dev.DUT.name)
@@ -39,12 +31,11 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
         controller.ucc_socket.dev_send_1905(agent.mac, 0x800D,
                                             tlv(0x95, 0x0006, '{sta_mac}'.format(sta_mac=sta_mac)))
         self.check_log(agent,
-                       "client with mac address {sta_mac} not found".format(sta_mac=sta_mac),
-                       timeout=30)
+                       "client with mac address {sta_mac} not found".format(sta_mac=sta_mac))
         time.sleep(1)
 
         debug('sta: {}'.format(sta.mac))
-        sta.wifi_connect(agent.radios[0].vaps[0])
+        sta.wifi_connect_check(agent.radios[0].vaps[0])
 
         time.sleep(1)
 
@@ -54,8 +45,7 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
         time.sleep(1)
         self.check_log(agent,
                        "Send AssociatedStaLinkMetrics to controller, mid = {}".format(mid),
-                       timeout=30)
-        sta.wifi_disconnect(agent.radios[0].vaps[0])
+                       timeout=20)
 
     @classmethod
     def teardown_class(cls):
@@ -71,3 +61,4 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
             # If AttributeError was raised - we are dealing with dummy devices.
             # We don't have to additionaly send Ctrl+C for dummy devices.
             pass
+        test.dev.wifi.disable_wifi()

--- a/tests/environment.py
+++ b/tests/environment.py
@@ -458,7 +458,7 @@ class ALEntityPrplWrt(ALEntity):
         # Multiply timeout by 100, as test sets it in float.
         return _device_wait_for_log(self.device,
                                     "{}/beerocks_{}.log".format(self.log_folder, program),
-                                    regex, start_line, timeout)
+                                    regex, timeout, start_line)
 
     def prprlmesh_status_check(self):
         return self.device.prprlmesh_status_check()


### PR DESCRIPTION
## Description

This PR introduces HW representation of station and includes in `netgear-rax40-1` boardfarm configuration.
Changes the way, how `VirtualAPHostad`s which represent real AP are spawned in Radio.
Adds methods required to connect and verify that station is associated with AP.

## Changes

- Add `prplWRT_STA` device
- Add `get_ssid` and `get_psk` methods to the `VirtualAPHostapd`
- Fix `_device_wait_for_log` usage
- Add `wifi_connect` and related methods to the `prplWRT_STA` to associate station and verify connection to the AP

## Notes

`prplWRT_STA` class was tested using RPI3 as host. Commands and utilities used in that class are generic (`ip`, `wpa_supplicant` and etc), so it should work on any other platform (e.g: OpenWRT board, Debian-based host with USB WiFi adapter).
In order to `prplWRT_STA` class to work, user must be able to run `wpa_supplicant` without sudo. `sudo_sendline` method which should deal with `sudo` of boardfarm seems to be broken and doesn't work.

Part of: https://jira.prplfoundation.org/browse/PPM-12
Also, resolved https://jira.prplfoundation.org/browse/PPM-1 on the go.