### PR TITLE
PPM-216 [unified agent phase 3] Move all data needed by topology task to the agent db and use them

### DIFF
--- a/agent/src/beerocks/slave/agent_db.cpp
+++ b/agent/src/beerocks/slave/agent_db.cpp
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * SPDX-FileCopyrightText: 2019-2020 the prplMesh contributors (see AUTHORS.md)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#include "agent_db.h"
+
+#include <easylogging++.h>
+
+namespace beerocks {
+
+AgentDB::sRadio *AgentDB::radio(const std::string &iface_name)
+{
+    if (iface_name.empty()) {
+        LOG(ERROR) << "Given radio iface name is empty";
+        return nullptr;
+    }
+
+    auto radio_it = std::find_if(m_radios.begin(), m_radios.end(), [&](const sRadio &radio_entry) {
+        return iface_name == radio_entry.front.iface_name ||
+               iface_name == radio_entry.back.iface_name;
+    });
+
+    return radio_it == m_radios.end() ? nullptr : &(*radio_it);
+}
+
+bool AgentDB::add_radio(const std::string &front_iface_name, const std::string &back_iface_name)
+{
+    if (front_iface_name.empty() && back_iface_name.empty()) {
+        LOG(ERROR) << "Both front and back interface names are empty!";
+        return false;
+    }
+
+    if (!front_iface_name.empty() && radio(front_iface_name)) {
+        LOG(DEBUG) << "Radio entry of front iface " << front_iface_name
+                   << " already exists. Ignore.";
+        return true;
+    }
+
+    if (!back_iface_name.empty() && radio(back_iface_name)) {
+        LOG(DEBUG) << "Radio entry of back iface " << back_iface_name << " already exists. Ignore.";
+        return true;
+    }
+
+    m_radios.emplace_back(front_iface_name, back_iface_name);
+    m_radios_list.push_back(&m_radios.back());
+
+    return true;
+}
+
+AgentDB::sRadio *AgentDB::get_radio_by_mac(const sMacAddr &mac, eMacType mac_type_hint)
+{
+    bool all_mac_types = mac_type_hint == eMacType::ALL;
+    auto radio_it = std::find_if(m_radios.begin(), m_radios.end(), [&](const sRadio &radio_entry) {
+        if (all_mac_types || mac_type_hint == eMacType::RADIO) {
+            if (radio_entry.front.iface_mac == mac || radio_entry.back.iface_mac == mac) {
+                return true;
+            }
+        }
+        if (all_mac_types || mac_type_hint == eMacType::BSSID) {
+            auto &bssid_list = radio_entry.front.bssids;
+            auto bssid_it =
+                std::find_if(bssid_list.begin(), bssid_list.end(),
+                             [&](const sRadio::sFront::sBssid &bssid) { return bssid.mac == mac; });
+            if (bssid_it != bssid_list.end()) {
+                return true;
+            }
+        }
+        if (all_mac_types || mac_type_hint == eMacType::CLIENT) {
+            auto client_it = radio_entry.associated_clients.find(mac);
+            return client_it != radio_entry.associated_clients.end();
+        }
+        // MAC is not one of the front\back radio MACs nor bssid MAC.
+        return false;
+    });
+
+    return radio_it == m_radios.end() ? nullptr : &(*radio_it);
+}
+
+void AgentDB::erase_client(const sMacAddr &client_mac, sMacAddr bssid)
+{
+    if (bssid != net::network_utils::ZERO_MAC) {
+        auto radio = get_radio_by_mac(bssid, eMacType::BSSID);
+        if (!radio) {
+            return;
+        }
+        radio->associated_clients.erase(client_mac);
+        return;
+    }
+
+    for (auto &radio : m_radios) {
+        radio.associated_clients.erase(client_mac);
+    }
+}
+
+} // namespace beerocks

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -5,6 +5,9 @@
  * This code is subject to the terms of the BSD+Patent license.
  * See LICENSE file for more details.
  */
+#include <bcl/beerocks_defines.h>
+#include <bcl/network/network_utils.h>
+#include <bwl/sta_wlan_hal.h>
 
 #include <iostream>
 #include <memory>
@@ -41,14 +44,14 @@ namespace beerocks {
  * std::string &get_foo() {             // Unsafe! Don't do it! Returning refernce to the database
  *     auto db = AgentDB::get();        // on a wrapper function is unsafe because the database will
  *     return db->foo;                  // be unlocked when the function ends, and the caller will
- * }                                    // hold a refernce to it.                                 // hold a refernce to it.
+ * }                                    // hold a refernce to it.
  * @endcode
  */
 class AgentDB {
 public:
     class SafeDB {
     public:
-        SafeDB(AgentDB &db) : m_db(db) { m_db.db_lock(); }
+        explicit SafeDB(AgentDB &db) : m_db(db) { m_db.db_lock(); }
         ~SafeDB() { m_db.db_unlock(); }
         AgentDB *operator->() { return &m_db; }
 
@@ -72,8 +75,169 @@ private:
     void db_lock() { m_db_mutex.lock(); }
     void db_unlock() { m_db_mutex.unlock(); }
 
+    /* Put down from here database members and functions used by the Agent modules */
+
 public:
-    /* Put here database members used by the Agent modules */
+    /* Agent Configuration */
+    struct sDeviceConf {
+        struct sFrontRadio {
+
+        } front_radio;
+
+        struct sBackRadio {
+
+        } back_radio;
+
+        bool local_gw;
+        bool local_controller;
+    } device_conf;
+
+    /** 
+     * Agent Sub Entities Data
+     */
+    struct sBridge {
+        sMacAddr mac;
+        std::string iface_name;
+    } bridge;
+
+    struct sBackhaul {
+        enum class eConnectionType { Invalid = 0, Wired, Wireless } connection_type;
+        std::string selected_iface_name;
+    } backhaul;
+
+    struct sEthernet {
+        sMacAddr mac;
+        std::string iface_name;
+    } ethernet;
+
+    struct sRadio {
+        sRadio(const std::string &front_iface_name, const std::string &back_iface_name)
+            : front(front_iface_name), back(back_iface_name)
+        {
+        }
+
+        struct sFront {
+            explicit sFront(const std::string &iface_name_)
+                : iface_name(iface_name_), max_supported_bw(eWiFiBandwidth::BANDWIDTH_UNKNOWN),
+                  freq_type(eFreqType::FREQ_UNKNOWN)
+            {
+            }
+            std::string iface_name;
+            sMacAddr iface_mac;
+            eWiFiBandwidth max_supported_bw;
+            eFreqType freq_type;
+
+            struct sBssid {
+                sMacAddr mac;
+                std::string ssid;
+                enum class eType { fAP, bAP } type;
+            };
+            std::array<sBssid, eBeeRocksIfaceIds::IFACE_TOTAL_VAPS> bssids;
+        } front;
+
+        struct sBack {
+            explicit sBack(const std::string &iface_name_) : iface_name(iface_name_) {}
+            std::string iface_name;
+            sMacAddr iface_mac;
+        } back;
+
+        struct sClient {
+            sClient(sMacAddr bssid_, size_t association_frame_length_, uint8_t *association_frame_)
+                : bssid(bssid_), association_time(std::chrono::steady_clock::now()),
+                  association_frame_length(association_frame_length_)
+            {
+                std::copy_n(association_frame_, association_frame_length_,
+                            association_frame.begin());
+            }
+            sMacAddr bssid;
+            std::chrono::steady_clock::time_point association_time;
+            size_t association_frame_length;
+            std::array<uint8_t, ASSOCIATION_FRAME_SIZE> association_frame;
+        };
+        // Associated clients grouped by Client MAC.
+        std::unordered_map<sMacAddr, sClient> associated_clients;
+    };
+
+    /**
+     * @brief Get pointer to the radio data struct of a specific interface. The function can
+     * accepts either front or back interface name.
+     * 
+     * @param iface_name Interface name of a radio, front or back.
+     * @return std::unique_ptr<sRadio> to the radio struct if exist, otherwise, nullptr.
+     */
+    sRadio *radio(const std::string &iface_name);
+
+    /**
+     * @brief Add radio node to the database. At least one of the input arguments must not be empty.
+     * This function should be called only once with valid arguments. If called once and then called
+     * again, the radio struct on the database will not be updated with new arguments, and the
+     * function will return false.
+     * 
+     * @param front_iface_name Front interface name.
+     * @param back_iface_name Back interface name.
+     * @return true if a radio struct has been added to the database, otherwise return false.
+     */
+    bool add_radio(const std::string &front_iface_name, const std::string &back_iface_name);
+
+    /**
+     * @brief Get list of all radio objects on the database.
+     * This function shall be used in order to iterate over all the radios. 
+     * 
+     * @return const std::vector<std::string &>& Intefaces names list.
+     */
+    const std::vector<sRadio *> &get_radios_list() { return m_radios_list; };
+
+    /* Helper enum for get_radio_by_mac() function */
+    enum class eMacType : uint8_t { ALL, RADIO, BSSID, CLIENT };
+
+    /**
+     * @brief Get a pointer to the parent radio struct of given MAC address. 
+     * 
+     * @param mac MAC address of radio interface or bssid.
+     * @param mac_type_hint Hint for the MAC type, for faster lookup.
+     * @return sRadio* A pointer to the radio struct containing the given MAC address.
+     */
+    sRadio *get_radio_by_mac(const sMacAddr &mac, eMacType mac_type_hint = eMacType::ALL);
+
+    /**
+     * @brief Erase client from associated_clients list.
+     * If @a bssid is given, then remove client only from its radio, otherwise remove from all
+     * radios.
+     * 
+     * @param client_mac The client MAC address.
+     * @param bssid The bssid that the client will be removed from its radio.
+     */
+    void erase_client(const sMacAddr &client_mac, sMacAddr bssid = net::network_utils::ZERO_MAC);
+
+    /**
+     * @brief 1905.1 Neighbor device information
+     * Information gathered from a neighbor device upon reception of a Topology Discovery message.
+     */
+    struct sNeighborDevice {
+        // MAC address of the interface on which the Topology Discovery message is transmitted.
+        sMacAddr transmitting_iface_mac;
+
+        // Timestamp of the last Topology Discovery message received from this neighbor device.
+        std::chrono::steady_clock::time_point timestamp;
+    };
+
+    /*
+     * @brief List of known 1905 neighbor devices.
+     * 
+     * Upper key: Local interface MAC on which the Topology Discovery message was received from.
+     * Upper value: Map containing 1905.1 device information ordered by neighbor device al_mac -
+     *  Sub-key: 1905.1 AL MAC address of the Topology Discovery message transmitting device.
+     *  Sub-value: 1905.1 device information.
+     * 
+     * Devices are being added to the list when receiving a 1905.1 Topology Discovery message from
+     * an unknown 1905.1 device. Every 1905.1 device shall send this message every 60 seconds, and
+     * we update the time stamp in which the message is received.
+     */
+    std::unordered_map<sMacAddr, std::unordered_map<sMacAddr, sNeighborDevice>> neighbor_devices;
+
+private:
+    std::list<sRadio> m_radios;
+    std::vector<sRadio *> m_radios_list;
 };
 
 } // namespace beerocks

--- a/agent/src/beerocks/slave/agent_ucc_listener.h
+++ b/agent/src/beerocks/slave/agent_ucc_listener.h
@@ -76,7 +76,6 @@ private:
     bool m_in_reset        = false;
     bool m_reset_completed = false;
     std::string m_selected_backhaul; // "ETH" or "<RUID of the selected radio>"
-    std::unordered_map<std::string, beerocks_message::sVapsList> vaps_map;
 
     std::mutex mutex;
 };

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -524,17 +524,20 @@ void backhaul_manager::after_select(bool timeout)
     // 60 seconds a Topology Discovery message from it. If not, remove this neighbor from our list
     // and send a Topology Notification message.
     bool neighbors_list_changed = false;
-    for (auto it = m_1905_neighbor_devices.begin(); it != m_1905_neighbor_devices.end();) {
-        const auto &last_topology_discovery = it->second.timestamp;
-        if (last_topology_discovery + std::chrono::seconds(DISCOVERY_NEIGHBOUR_REMOVAL_TIMEOUT) <
-            std::chrono::steady_clock::now()) {
-            const auto &device_al_mac = it->first;
-            LOG(INFO) << "Removed 1905.1 device " << device_al_mac << " from neighbors list";
-            it                     = m_1905_neighbor_devices.erase(it);
-            neighbors_list_changed = true;
-            continue;
+    for (auto &neighbors_on_local_iface_entry : db->neighbor_devices) {
+        auto &neighbors_on_local_iface = neighbors_on_local_iface_entry.second;
+        for (auto it = neighbors_on_local_iface.begin(); it != neighbors_on_local_iface.end();) {
+            auto &last_topology_discovery = it->second.timestamp;
+            if (now - last_topology_discovery >
+                std::chrono::seconds(DISCOVERY_NEIGHBOUR_REMOVAL_TIMEOUT)) {
+                auto &device_al_mac = it->first;
+                LOG(INFO) << "Removed 1905.1 device " << device_al_mac << " from neighbors list";
+                it                     = neighbors_on_local_iface.erase(it);
+                neighbors_list_changed = true;
+                continue;
+            }
+            it++;
         }
-        it++;
     }
 
     if (neighbors_list_changed) {
@@ -3028,27 +3031,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
      * a map which key is the name of the local interface and the value is the list of neighbor
      * devices inferred from that interface.
      */
-    std::unordered_map<std::string, std::vector<sNeighborDevice>> neighbor_devices_by_local_iface;
-    for (const auto &entry : m_1905_neighbor_devices) {
-        const auto &neighbor_device = entry.second;
-        auto &neighbor_devices      = neighbor_devices_by_local_iface[neighbor_device.if_name];
-
-        neighbor_devices.emplace_back(neighbor_device);
-    }
-
-    /**
-     * Second, create a tlv1905NeighborDevice for every local interface on which a 1905 neighbor
-     * is visible, and then add the list of neighbors visible on that interface
-     */
-    for (const auto &entry : neighbor_devices_by_local_iface) {
-        const auto &iface_name       = entry.first;
-        const auto &neighbor_devices = entry.second;
-
-        sMacAddr iface_mac;
-        if (!get_iface_mac(iface_name, iface_mac)) {
-            return false;
-        }
-
+    for (auto &neighbors_on_local_iface_entry : db->neighbor_devices) {
         auto tlv1905NeighborDevice = cmdu_tx.addClass<ieee1905_1::tlv1905NeighborDevice>();
         if (!tlv1905NeighborDevice) {
             LOG(ERROR) << "addClass ieee1905_1::tlv1905NeighborDevice failed, mid=" << std::hex
@@ -3056,15 +3039,18 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
             return false;
         }
 
-        tlv1905NeighborDevice->mac_local_iface() = iface_mac;
+        tlv1905NeighborDevice->mac_local_iface() = neighbors_on_local_iface_entry.first;
+        auto &neighbors_on_local_iface           = neighbors_on_local_iface_entry.second;
 
-        if (!tlv1905NeighborDevice->alloc_mac_al_1905_device(neighbor_devices.size())) {
+        if (!tlv1905NeighborDevice->alloc_mac_al_1905_device(neighbors_on_local_iface.size())) {
             LOG(ERROR) << "alloc_mac_al_1905_device() has failed";
-            return true;
+            return false;
         }
 
         size_t index = 0;
-        for (const auto &neighbor_device : neighbor_devices) {
+        for (const auto &neighbor_on_local_iface_entry : neighbors_on_local_iface) {
+            auto &neighbor_al_mac = neighbor_on_local_iface_entry.first;
+
             auto mac_al_1905_device_tuple = tlv1905NeighborDevice->mac_al_1905_device(index);
             if (!std::get<0>(mac_al_1905_device_tuple)) {
                 LOG(ERROR) << "getting mac_al_1905_device element has failed";
@@ -3072,7 +3058,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
             }
 
             auto &mac_al_1905_device = std::get<1>(mac_al_1905_device_tuple);
-            mac_al_1905_device.mac   = neighbor_device.al_mac;
+            mac_al_1905_device.mac   = neighbor_al_mac;
             mac_al_1905_device.bridges_exist =
                 ieee1905_1::tlv1905NeighborDevice::eBridgesExist::AT_LEAST_ONE_BRIDGES_EXIST;
             index++;
@@ -3434,7 +3420,7 @@ bool backhaul_manager::handle_1905_topology_discovery(const std::string &src_mac
 
     auto mid = cmdu_rx.getMessageId();
     LOG(INFO) << "Received TOPOLOGY_DISCOVERY_MESSAGE from AL MAC=" << tlvAlMac->mac()
-              << ", mid=" << std::hex << int(mid);
+              << ", mid=" << std::hex << mid;
 
     auto tlvMac = cmdu_rx.getClass<ieee1905_1::tlvMacAddress>();
     if (!tlvMac) {
@@ -3442,24 +3428,38 @@ bool backhaul_manager::handle_1905_topology_discovery(const std::string &src_mac
         return false;
     }
 
-    uint32_t if_index   = message_com::get_uds_header(cmdu_rx)->if_index;
-    std::string if_name = network_utils::linux_get_iface_name(if_index);
-    if (if_name.empty()) {
+    uint32_t if_index                      = message_com::get_uds_header(cmdu_rx)->if_index;
+    std::string local_receiving_iface_name = network_utils::linux_get_iface_name(if_index);
+    if (local_receiving_iface_name.empty()) {
         LOG(ERROR) << "Failed getting interface name for index: " << if_index;
         return false;
     }
 
-    auto new_device =
-        m_1905_neighbor_devices.find(tlvAlMac->mac()) == m_1905_neighbor_devices.end();
+    std::string local_receiving_iface_mac_str;
+    if (!network_utils::linux_iface_get_mac(local_receiving_iface_name,
+                                            local_receiving_iface_mac_str)) {
+        LOG(ERROR) << "Failed getting MAC address for interface: " << local_receiving_iface_name;
+        return false;
+    }
+
+    // Check if it is a new device so if it does, we will send Topology Notification.
+    bool new_device = false;
+    for (auto &neighbors_on_local_iface_entry : db->neighbor_devices) {
+        auto &neighbors_on_local_iface = neighbors_on_local_iface_entry.second;
+        new_device =
+            neighbors_on_local_iface.find(tlvAlMac->mac()) == neighbors_on_local_iface.end();
+        if (new_device) {
+            break;
+        }
+    }
 
     // Add/Update the device on our list.
-    sNeighborDevice neighbor_device;
-    neighbor_device.al_mac    = tlvAlMac->mac();
-    neighbor_device.mac       = tlvMac->mac();
-    neighbor_device.if_name   = if_name;
-    neighbor_device.timestamp = std::chrono::steady_clock::now();
+    auto &neighbor_devices_by_al_mac =
+        db->neighbor_devices[tlvf::mac_from_string(local_receiving_iface_mac_str)];
 
-    m_1905_neighbor_devices[tlvAlMac->mac()] = neighbor_device;
+    // Update an exist neighbor.
+    neighbor_devices_by_al_mac[tlvAlMac->mac()].transmitting_iface_mac = tlvMac->mac();
+    neighbor_devices_by_al_mac[tlvAlMac->mac()].timestamp = std::chrono::steady_clock::now();
 
     // If it is a new device, then our 1905.1 neighbors list has changed and we are required to send
     // Topology Notification Message.
@@ -4311,13 +4311,16 @@ bool backhaul_manager::get_neighbor_links(
         return false;
     }
 
-    for (const auto &entry : m_1905_neighbor_devices) {
-        sLinkNeighbor neighbor;
-        neighbor.al_mac    = entry.first;
-        neighbor.iface_mac = neighbor.al_mac;
-        if ((neighbor_mac_filter == network_utils::ZERO_MAC) ||
-            (neighbor_mac_filter == neighbor.al_mac)) {
-            neighbor_links_map[wired_interface].push_back(neighbor);
+    for (const auto &neighbors_on_local_iface : db->neighbor_devices) {
+        auto &neighbors = neighbors_on_local_iface.second;
+        for (const auto &neighbor_entry : neighbors) {
+            sLinkNeighbor neighbor;
+            neighbor.al_mac    = neighbor_entry.first;
+            neighbor.iface_mac = neighbor_entry.second.transmitting_iface_mac;
+            if ((neighbor_mac_filter == network_utils::ZERO_MAC) ||
+                (neighbor_mac_filter == neighbor.al_mac)) {
+                neighbor_links_map[wired_interface].push_back(neighbor);
+            }
         }
     }
 

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1060,16 +1060,6 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
             if (elapsed_time_s >= ap_metrics_reporting_info.reporting_interval_s) {
                 ap_metrics_reporting_info.last_reporting_time_point = now;
 
-                std::vector<sMacAddr> bssid_list;
-                for (const auto &socket : slaves_sockets) {
-                    if (socket) {
-                        for (int i = 0; i < beerocks::IFACE_TOTAL_VAPS; ++i) {
-                            if (socket->vaps_list.vaps[i].mac != network_utils::ZERO_MAC) {
-                                bssid_list.push_back(socket->vaps_list.vaps[i].mac);
-                            }
-                        }
-                    }
-                }
                 // We must generate a new MID for the periodic AP Metrics Response messages that
                 // do not correspond to an AP Metrics Query message.
                 // We cannot set MID to 0 here because we must also differentiate periodic
@@ -1077,11 +1067,9 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
                 // due to channel utilization crossed configured threshold value.
                 // As a temporary solution, set MID to UINT16_MAX here.
                 // TODO: to be fixed as part of #1328
-                if (!bssid_list.empty()) {
-                    send_slave_ap_metric_query_message(UINT16_MAX, bssid_list);
-                } else {
-                    LOG(DEBUG) << "Skipping AP_METRICS_QUERY for slave, empty BSSID list";
-                }
+
+                // Send ap_metrics query on all bssids exists on the Agent.
+                send_slave_ap_metric_query_message(UINT16_MAX);
             }
         }
 
@@ -1149,7 +1137,7 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
     }
 
     return (true);
-}
+} // namespace beerocks
 
 bool backhaul_manager::send_1905_topology_discovery_message()
 {
@@ -1309,53 +1297,58 @@ bool backhaul_manager::send_autoconfig_search_message(const std::string &front_r
                                tlvf::mac_to_string(db->bridge.mac));
 }
 
-bool backhaul_manager::send_slave_ap_metric_query_message(uint16_t mid,
-                                                          const std::vector<sMacAddr> &bssid_list)
+bool backhaul_manager::send_slave_ap_metric_query_message(
+    uint16_t mid, const std::unordered_set<sMacAddr> &bssid_list)
 {
-    bool ret = false;
-    for (auto socket : slaves_sockets) {
-        for (const auto &mac : bssid_list) {
-            int i = 0;
-            if (mac == socket->vaps_list.vaps[i].mac) {
-                LOG(DEBUG) << "Forwarding AP_METRICS_QUERY_MESSAGE message to son_slave, bssid: "
-                           << std::hex << tlvf::mac_to_string(mac);
+    auto db = AgentDB::get();
 
-                auto forward =
-                    cmdu_tx.create(mid, ieee1905_1::eMessageType::AP_METRICS_QUERY_MESSAGE);
-                if (!forward) {
-                    LOG(ERROR) << "Failed to create AP_METRICS_QUERY_MESSAGE";
-                    return false;
-                }
-
-                auto query = cmdu_tx.addClass<wfa_map::tlvApMetricQuery>();
-                if (!query) {
-                    LOG(ERROR) << "Failed addClass<wfa_map::tlvApMetricQuery>";
-                    return false;
-                }
-
-                if (!query->alloc_bssid_list(1)) {
-                    LOG(ERROR) << "Failed allocate memory for bssid_list";
-                    return false;
-                }
-
-                auto list         = query->bssid_list(0);
-                std::get<0>(list) = true;
-                std::get<1>(list) = mac;
-
-                if (!message_com::send_cmdu(socket->slave, cmdu_tx)) {
-                    LOG(ERROR) << "Failed forwarding AP_METRICS_QUERY_MESSAGE message to son_slave";
-                    ret = false;
-                    continue;
-                } else {
-                    ret = true;
-                    // Fill a query vector
-                    m_ap_metric_query.push_back({socket->slave, mac});
-                }
+    for (const auto &radio : db->get_radios_list()) {
+        if (!radio) {
+            continue;
+        }
+        for (const auto &bssid : radio->front.bssids) {
+            if (!bssid_list.empty() && bssid_list.find(bssid.mac) == bssid_list.end()) {
+                continue;
             }
-            i++;
+            LOG(DEBUG) << "Forwarding AP_METRICS_QUERY_MESSAGE message to son_slave, bssid: "
+                       << bssid.mac;
+
+            if (!cmdu_tx.create(mid, ieee1905_1::eMessageType::AP_METRICS_QUERY_MESSAGE)) {
+                LOG(ERROR) << "Failed to create AP_METRICS_QUERY_MESSAGE";
+                return false;
+            }
+
+            auto query = cmdu_tx.addClass<wfa_map::tlvApMetricQuery>();
+            if (!query) {
+                LOG(ERROR) << "Failed addClass<wfa_map::tlvApMetricQuery>";
+                return false;
+            }
+
+            if (!query->alloc_bssid_list(1)) {
+                LOG(ERROR) << "Failed to allocate memory for bssid_list";
+                return false;
+            }
+
+            auto list = query->bssid_list(0);
+            if (!std::get<0>(list)) {
+                LOG(ERROR) << "Failed to get element of bssid_list";
+            }
+            std::get<1>(list) = bssid.mac;
+
+            auto radio_info = get_radio(radio->front.iface_mac);
+            if (!radio_info) {
+                LOG(ERROR) << "Failed to get radio info for " << radio->front.iface_mac;
+                return false;
+            }
+
+            if (!message_com::send_cmdu(radio_info->slave, cmdu_tx)) {
+                LOG(ERROR) << "Failed forwarding AP_METRICS_QUERY_MESSAGE message to son_slave";
+            }
+
+            m_ap_metric_query.push_back({radio_info->slave, bssid.mac});
         }
     }
-    return ret;
+    return true;
 }
 
 bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
@@ -2159,10 +2152,19 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
             return false;
         }
 
-        soc->vaps_list = msg->params();
-        if (m_agent_ucc_listener) {
-            m_agent_ucc_listener->update_vaps_list(tlvf::mac_to_string(soc->radio_mac),
-                                                   msg->params());
+        // Create a local copy on this process database instance. Will be removed on PPM-83 phase 5
+        auto db    = AgentDB::get();
+        auto radio = db->radio(soc->hostap_iface);
+        if (!radio) {
+            LOG(DEBUG) << "Radio of iface " << soc->hostap_iface << " does not exist on the db";
+            return false;
+        }
+        for (uint8_t vap_idx = 0; vap_idx < eBeeRocksIfaceIds::IFACE_TOTAL_VAPS; vap_idx++) {
+            radio->front.bssids[vap_idx].mac  = msg->params().vaps[vap_idx].mac;
+            radio->front.bssids[vap_idx].ssid = msg->params().vaps[vap_idx].ssid;
+            radio->front.bssids[vap_idx].type = msg->params().vaps[vap_idx].backhaul_vap
+                                                    ? AgentDB::sRadio::sFront::sBssid::eType::bAP
+                                                    : AgentDB::sRadio::sFront::sBssid::eType::fAP;
         }
         break;
     }
@@ -2675,25 +2677,26 @@ bool backhaul_manager::handle_ap_capability_query(ieee1905_1::CmduMessageRx &cmd
 bool backhaul_manager::handle_ap_metrics_query(ieee1905_1::CmduMessageRx &cmdu_rx,
                                                const std::string &src_mac)
 {
-    std::vector<sMacAddr> bssid;
     const auto mid           = cmdu_rx.getMessageId();
     auto ap_metric_query_tlv = cmdu_rx.getClass<wfa_map::tlvApMetricQuery>();
     if (!ap_metric_query_tlv) {
         LOG(ERROR) << "AP Metrics Query CMDU mid=" << mid << " does not have AP Metric Query TLV";
         return false;
     }
+
+    std::unordered_set<sMacAddr> bssids;
     for (size_t bssid_idx = 0; bssid_idx < ap_metric_query_tlv->bssid_list_length(); bssid_idx++) {
         auto bssid_tuple = ap_metric_query_tlv->bssid_list(bssid_idx);
         if (!std::get<0>(bssid_tuple)) {
             LOG(ERROR) << "Failed to get bssid " << bssid_idx << " from AP_METRICS_QUERY";
             return false;
         }
-        bssid.push_back(std::get<1>(bssid_tuple));
+        bssids.insert(std::get<1>(bssid_tuple));
         LOG(DEBUG) << "Received AP_METRICS_QUERY_MESSAGE, mid=" << std::hex << int(mid)
                    << "  bssid " << std::get<1>(bssid_tuple);
     }
 
-    if (!send_slave_ap_metric_query_message(mid, bssid)) {
+    if (!send_slave_ap_metric_query_message(mid, bssids)) {
         LOG(ERROR) << "Failed to forward AP_METRICS_RESPONSE to the son_slave_thread";
         return false;
     }
@@ -3139,22 +3142,24 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
         return false;
     }
 
-    for (const auto &slave : slaves_sockets) {
-        // TODO skip slaves that are not operational
-        auto vaps_list = slave->vaps_list;
+    for (const auto &radio : db->get_radios_list()) {
+        if (!radio) {
+            continue;
+        }
 
         auto radio_list         = tlvApOperationalBSS->create_radio_list();
-        radio_list->radio_uid() = slave->radio_mac;
-        for (const auto &vap : vaps_list.vaps) {
-            if (vap.mac == network_utils::ZERO_MAC)
+        radio_list->radio_uid() = radio->front.iface_mac;
+        for (const auto &bssid : radio->front.bssids) {
+            if (bssid.mac == network_utils::ZERO_MAC) {
                 continue;
-            if (vap.ssid[0] == '\0')
+            }
+            if (bssid.ssid.empty()) {
                 continue;
+            }
             auto radio_bss_list           = radio_list->create_radio_bss_list();
-            radio_bss_list->radio_bssid() = vap.mac;
-            auto ssid =
-                std::string(vap.ssid, strnlen(vap.ssid, beerocks::message::WIFI_SSID_MAX_LENGTH));
-            radio_bss_list->set_ssid(ssid);
+            radio_bss_list->radio_bssid() = bssid.mac;
+            radio_bss_list->set_ssid(bssid.ssid);
+
             radio_list->add_radio_bss_list(radio_bss_list);
         }
         tlvApOperationalBSS->add_radio_list(radio_list);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -572,7 +572,6 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
 
         auto db = AgentDB::get();
 
-        std::string strIface;
         network_utils::iface_info iface_info;
         bool backhaul_manager_exist = false;
 
@@ -580,15 +579,9 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
         notification->params().controller_bridge_mac = tlvf::mac_from_string(controller_bridge_mac);
 
         if (!db->device_conf.local_gw) {
-
-            if (db->backhaul.connection_type == AgentDB::sBackhaul::eConnectionType::Wired) {
-                strIface = db->ethernet.iface_name;
-            } else {
-                strIface = m_sConfig.wireless_iface;
-            }
             // Read the IP addresses of the bridge interface
-            if (network_utils::get_iface_info(iface_info, strIface) != 0) {
-                LOG(ERROR) << "Failed reading addresses for: " << strIface;
+            if (network_utils::get_iface_info(iface_info, db->backhaul.selected_iface_name) != 0) {
+                LOG(ERROR) << "Failed reading addresses for: " << db->backhaul.selected_iface_name;
                 return false;
             }
 
@@ -625,7 +618,7 @@ bool backhaul_manager::finalize_slaves_connect_state(bool fConnected,
 
                 // Find the slave handling the wireless interface
                 for (auto soc : slaves_sockets) {
-                    if (soc->sta_iface == m_sConfig.wireless_iface) {
+                    if (soc->sta_iface == db->backhaul.selected_iface_name) {
 
                         // Mark the slave as the backhaul manager
                         soc->slave_is_backhaul_manager = true;
@@ -846,6 +839,8 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
         if (db->device_conf.local_controller && db->device_conf.local_gw) {
             LOG(DEBUG) << "local controller && local gw";
             FSM_MOVE_STATE(MASTER_DISCOVERY);
+            db->backhaul.connection_type = AgentDB::sBackhaul::eConnectionType::Invalid;
+            db->backhaul.selected_iface_name.clear();
         } else { // link establish
 
             auto ifaces = network_utils::linux_get_iface_list_from_bridge(db->bridge.iface_name);
@@ -872,7 +867,8 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
                 }
 
                 // Mark the connection as WIRED
-                db->backhaul.connection_type = AgentDB::sBackhaul::eConnectionType::Wired;
+                db->backhaul.connection_type     = AgentDB::sBackhaul::eConnectionType::Wired;
+                db->backhaul.selected_iface_name = db->ethernet.iface_name;
 
             } else {
                 auto selected_ruid_it = std::find_if(
@@ -1422,9 +1418,9 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
 
                 /**
                  * This code was disabled as part of the effort to pass certification flow 
-                 * (PR #1469), and broke wirless backhual flow.
+                 * (PR #1469), and broke wireless backhual flow.
                  * If a connected backhual interface has been discovered, the backhaul fsm was set
-                 * to MASTER_DISCOVERY state, otherwise, to INITIATE_SCAN.
+                 * to MASTER_DISCOVERY state, otherwise to INITIATE_SCAN.
                  */
 
                 // if (!roam_flag && soc->sta_wlan_hal->is_connected()) {
@@ -1623,6 +1619,8 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
             }
         }
 
+        auto db = AgentDB::get();
+
         if (hidden_ssid) {
             std::string iface;
 
@@ -1652,8 +1650,8 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
                 break;
             }
 
-            m_sConfig.wireless_iface = iface;
-            active_hal               = get_wireless_hal();
+            db->backhaul.selected_iface_name = iface;
+            active_hal                       = get_wireless_hal();
         }
 
         if (active_hal->connect(m_sConfig.ssid, m_sConfig.pass, m_sConfig.security_type,
@@ -1661,9 +1659,9 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
                                 hidden_ssid)) {
             LOG(DEBUG) << "successful call to active_hal->connect(), bssid=" << selected_bssid
                        << ", channel=" << selected_bssid_channel
-                       << ", iface=" << m_sConfig.wireless_iface;
+                       << ", iface=" << db->backhaul.selected_iface_name;
         } else {
-            LOG(ERROR) << "connect command failed for iface " << m_sConfig.wireless_iface;
+            LOG(ERROR) << "connect command failed for iface " << db->backhaul.selected_iface_name;
             FSM_MOVE_STATE(INITIATE_SCAN);
             break;
         }
@@ -1677,6 +1675,7 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
     }
     case EState::WIRELESS_ASSOCIATE_4ADDR_WAIT: {
 
+        auto db  = AgentDB::get();
         auto now = std::chrono::steady_clock::now();
         if (now > state_time_stamp_timeout) {
             LOG(ERROR) << "associate wait timeout";
@@ -1702,7 +1701,7 @@ bool backhaul_manager::backhaul_fsm_wireless(bool &skip_select)
                 stop_on_failure_attempts--;
                 platform_notify_error(bpl::eErrorCode::BH_ASSOCIATE_4ADDR_TIMEOUT,
                                       "SSID='" + m_sConfig.ssid + "', iface='" +
-                                          m_sConfig.wireless_iface + "'");
+                                          db->backhaul.selected_iface_name + "'");
 
                 if (!selected_bssid.empty()) {
                     ap_blacklist_entry &entry = ap_blacklist[selected_bssid];
@@ -2974,7 +2973,7 @@ bool backhaul_manager::handle_1905_topology_query(ieee1905_1::CmduMessageRx &cmd
                 db->backhaul.connection_type == AgentDB::sBackhaul::eConnectionType::Wired ||
                 front_iface ||
                 (db->backhaul.connection_type == AgentDB::sBackhaul::eConnectionType::Wireless &&
-                 soc->sta_iface != m_sConfig.wireless_iface)) {
+                 soc->sta_iface != db->backhaul.selected_iface_name)) {
                 media_info.network_membership = network_utils::ZERO_MAC;
             } else {
                 media_info.network_membership =
@@ -3686,6 +3685,7 @@ bool backhaul_manager::send_slaves_enable()
 {
     auto iface_hal = get_wireless_hal();
 
+    auto db = AgentDB::get();
     for (auto soc : slaves_sockets) {
         auto notification =
             message_com::create_vs_message<beerocks_message::cACTION_BACKHAUL_ENABLE_APS_REQUEST>(
@@ -3696,7 +3696,7 @@ bool backhaul_manager::send_slaves_enable()
             return false;
         }
 
-        if (soc->sta_iface == m_sConfig.wireless_iface) {
+        if (soc->sta_iface == db->backhaul.selected_iface_name) {
             notification->channel() = iface_hal->get_channel();
         }
         LOG(DEBUG) << "Sending enable to slave " << soc->hostap_iface
@@ -3751,12 +3751,12 @@ bool backhaul_manager::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t eve
 
         auto db = AgentDB::get();
 
-        if (iface == m_sConfig.wireless_iface && !hidden_ssid) {
+        if (iface == db->backhaul.selected_iface_name && !hidden_ssid) {
             //this is generally not supposed to happen
             LOG(WARNING) << "event iface != wireless iface!";
         }
         if (FSM_IS_IN_STATE(WAIT_WPS)) {
-            m_sConfig.wireless_iface = iface;
+            db->backhaul.selected_iface_name = iface;
             FSM_MOVE_STATE(MASTER_DISCOVERY);
         }
         if (FSM_IS_IN_STATE(WIRELESS_ASSOCIATE_4ADDR_WAIT)) {
@@ -3825,7 +3825,8 @@ bool backhaul_manager::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t eve
         if (FSM_IS_IN_STATE(WAIT_WPS)) {
             return true;
         }
-        if (iface == m_sConfig.wireless_iface) {
+        auto db = AgentDB::get();
+        if (iface == db->backhaul.selected_iface_name) {
             if (FSM_IS_IN_STATE(OPERATIONAL) || FSM_IS_IN_STATE(CONNECTED)) {
                 platform_notify_error(bpl::eErrorCode::BH_DISCONNECTED,
                                       "Backhaul disconnected on operational state");
@@ -3979,6 +3980,8 @@ bool backhaul_manager::select_bssid()
     // Support up to 256 scan results
     std::vector<bwl::SScanResult> scan_results;
 
+    auto db = AgentDB::get();
+
     LOG(DEBUG) << "select_bssid: SSID = " << m_sConfig.ssid;
 
     for (auto soc : slaves_sockets) {
@@ -4020,14 +4023,14 @@ bool backhaul_manager::select_bssid()
                     LOG(DEBUG) << "roaming flag on  - found bssid match = " << roam_selected_bssid
                                << " roam_selected_bssid_channel = "
                                << int(roam_selected_bssid_channel);
-                    m_sConfig.wireless_iface = iface;
+                    db->backhaul.selected_iface_name = iface;
                     return true;
                 }
             } else if (!m_sConfig.preferred_bssid.empty() && bssid == m_sConfig.preferred_bssid) {
                 LOG(DEBUG) << "preferred bssid - found bssid match = " << bssid;
-                selected_bssid_channel   = scan_result.channel;
-                selected_bssid           = bssid;
-                m_sConfig.wireless_iface = iface;
+                selected_bssid_channel           = scan_result.channel;
+                selected_bssid                   = bssid;
+                db->backhaul.selected_iface_name = iface;
                 return true;
             } else if (son::wireless_utils::which_freq(scan_result.channel) == eFreqType::FREQ_5G) {
                 if (soc->sta_iface_filter_low &&
@@ -4140,29 +4143,29 @@ bool backhaul_manager::select_bssid()
         // TODO: ???
         return false;
     } else if (max_rssi_24 == beerocks::RSSI_INVALID) {
-        selected_bssid           = best_bssid_5;
-        selected_bssid_channel   = best_bssid_channel_5;
-        m_sConfig.wireless_iface = best_5_sta_iface;
+        selected_bssid                   = best_bssid_5;
+        selected_bssid_channel           = best_bssid_channel_5;
+        db->backhaul.selected_iface_name = best_5_sta_iface;
     } else if (max_rssi_5_best == beerocks::RSSI_INVALID) {
-        selected_bssid           = best_bssid_24;
-        selected_bssid_channel   = best_bssid_channel_24;
-        m_sConfig.wireless_iface = best_24_sta_iface;
+        selected_bssid                   = best_bssid_24;
+        selected_bssid_channel           = best_bssid_channel_24;
+        db->backhaul.selected_iface_name = best_24_sta_iface;
     } else if ((max_rssi_5_best > RSSI_THRESHOLD_5GHZ)) {
-        selected_bssid           = best_bssid_5;
-        selected_bssid_channel   = best_bssid_channel_5;
-        m_sConfig.wireless_iface = best_5_sta_iface;
+        selected_bssid                   = best_bssid_5;
+        selected_bssid_channel           = best_bssid_channel_5;
+        db->backhaul.selected_iface_name = best_5_sta_iface;
     } else if (max_rssi_24 < max_rssi_5_best + RSSI_BAND_DELTA_THRESHOLD) {
-        selected_bssid           = best_bssid_5;
-        selected_bssid_channel   = best_bssid_channel_5;
-        m_sConfig.wireless_iface = best_5_sta_iface;
+        selected_bssid                   = best_bssid_5;
+        selected_bssid_channel           = best_bssid_channel_5;
+        db->backhaul.selected_iface_name = best_5_sta_iface;
     } else {
-        selected_bssid           = best_bssid_24;
-        selected_bssid_channel   = best_bssid_channel_24;
-        m_sConfig.wireless_iface = best_24_sta_iface;
+        selected_bssid                   = best_bssid_24;
+        selected_bssid_channel           = best_bssid_channel_24;
+        db->backhaul.selected_iface_name = best_24_sta_iface;
     }
 
     if (!get_wireless_hal()) {
-        LOG(ERROR) << "Slave for interface " << m_sConfig.wireless_iface << " NOT found!";
+        LOG(ERROR) << "Slave for interface " << db->backhaul.selected_iface_name << " NOT found!";
         return false;
     }
 
@@ -4232,8 +4235,9 @@ void backhaul_manager::get_scan_measurement()
 std::shared_ptr<bwl::sta_wlan_hal> backhaul_manager::get_wireless_hal(std::string iface)
 {
     // If the iface argument is empty, use the default wireless interface
+    auto db = AgentDB::get();
     if (iface.empty()) {
-        iface = m_sConfig.wireless_iface;
+        iface = db->backhaul.selected_iface_name;
     }
 
     auto slave_sk = m_sConfig.slave_iface_socket.find(iface);

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -1851,6 +1851,8 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
 
         soc->sta_iface.assign(request->sta_iface(message::IFACE_NAME_LENGTH));
         soc->hostap_iface.assign(request->hostap_iface(message::IFACE_NAME_LENGTH));
+        // Create a local copy on this process database instance. Will be removed on PPM-83 phase 5
+        db->add_radio(request->hostap_iface(), request->sta_iface());
         soc->sta_iface_filter_low = request->sta_iface_filter_low();
         onboarding                = request->onboarding();
 
@@ -1892,7 +1894,12 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
             return false;
         }
 
-        auto db = AgentDB::get();
+        auto db    = AgentDB::get();
+        auto radio = db->radio(soc->hostap_iface);
+        if (!radio) {
+            LOG(DEBUG) << "Radio of iface " << soc->hostap_iface << " does not exist on the db";
+            return false;
+        }
 
         auto tuple_preferred_channels = request->preferred_channels(0);
         if (!std::get<0>(tuple_preferred_channels)) {
@@ -1904,7 +1911,10 @@ bool backhaul_manager::handle_slave_backhaul_message(std::shared_ptr<sRadioInfo>
 
         std::copy_n(channels, request->preferred_channels_size(), soc->preferred_channels.begin());
 
-        soc->radio_mac             = request->iface_mac();
+        soc->radio_mac = request->iface_mac();
+        // Create a local copy on this process database instance. Will be removed on PPM-83 phase 5
+        radio->front.iface_mac = soc->radio_mac;
+
         soc->freq_type             = request->frequency_band();
         soc->controller_discovered = false;
         soc->max_bandwidth         = request->max_bandwidth();

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -175,15 +175,6 @@ private:
     SocketClient *master_discovery_socket = nullptr;
 
     struct SBackhaulConfig {
-
-        // Current connection type
-        enum class EType {
-            Invalid = 0, //!< Invalid connection
-            Wired,       //!< Wired connection
-            Wireless     //!< Wireless connection
-
-        } eType;
-
         std::string ssid;
         std::string pass;
         std::string wireless_iface;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -429,33 +429,6 @@ private:
                        std::map<sLinkInterface, std::vector<sLinkNeighbor>> &neighbor_links_map);
 
     /**
-     * @brief 1905.1 Neighbor device information
-     *
-     * Information gathered from a neighbor device upon reception of a Topology Discovery message.
-     */
-    struct sNeighborDevice {
-        sMacAddr al_mac = beerocks::net::network_utils::
-            ZERO_MAC; /**< 1905.1 AL MAC address of the Topology Discovery message transmitting device. */
-        sMacAddr mac = beerocks::net::network_utils::
-            ZERO_MAC; /**< MAC address of the interface on which the Topology Discovery message is transmitted. */
-        std::string
-            if_name; /**< Name of the network interface the Topology Discovery message was received on */
-        std::chrono::steady_clock::time_point
-            timestamp; /**< Timestamp of the last Topology Discovery message received from this neighbor device. */
-    };
-
-    /*
-     * @brief List of known 1905 neighbor devices
-     * 
-     * key:     1905.1 device AL-MAC
-     * value:   1905.1 device information
-     * Devices are being added to the list when receiving a 1905.1 Topology Discovery message from
-     * an unknown 1905.1 device. Every 1905.1 device shall send this message every 60 seconds, and
-     * we update the time stamp in which the message is received.
-     */
-    std::unordered_map<sMacAddr, sNeighborDevice> m_1905_neighbor_devices;
-
-    /**
      * @brief Adds an AP HT Capabilities TLV to AP Capability Report message.
      *
      * TLV is added to message only if given radio supports HT capabilities.

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -94,7 +94,7 @@ private:
     finalize_slaves_connect_state(bool fConnected,
                                   std::shared_ptr<sRadioInfo> pSocket = nullptr); // cmdu_duplicate
 
-    bool send_autoconfig_search_message(std::shared_ptr<sRadioInfo> soc);
+    bool send_autoconfig_search_message(const std::string &front_radio_iface_name);
     bool send_1905_topology_discovery_message();
 
     /**

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -175,8 +175,6 @@ private:
     void platform_notify_error(bpl::eErrorCode code, const std::string &error_data);
     bool send_slaves_enable();
 
-    void remove_client_from_all_radios(sMacAddr &client_mac);
-
     std::shared_ptr<bwl::sta_wlan_hal> get_wireless_hal(std::string iface = "");
 
 private:
@@ -311,44 +309,6 @@ private:
      */
     sApMetricsReportingInfo ap_metrics_reporting_info;
 
-    struct sClientInfo {
-        sMacAddr client_mac;
-        sMacAddr bssid; // VAP mac
-        std::chrono::steady_clock::time_point time_stamp;
-        size_t asso_len;
-        uint8_t assoc_req[ASSOCIATION_FRAME_SIZE];
-    };
-
-    /**
-     * @brief Type definition for associated clients information.
-     *
-     * Associated client information consists of sClientInfo strucrt, which has the 
-     * following fields:
-     * - The MAC address of the 802.11 client that associates to a BSS.
-     * - Timestamp of the 802.11 client's last association to this Multi-AP device.
-     * - The length of the association frame.
-     * - the association frame itself.
-     *
-     * Associated client information is gathered from
-     * ACTION_BACKHAUL_CLIENT_ASSOCIATED_NOTIFICATION events received from slave threads.
-     *
-     * Associated client information is later used to fill in the Associated Clients TLV
-     * in the Topology Response message and Client Capability Response message.
-     */
-
-    typedef std::unordered_map<sMacAddr, sClientInfo> associated_clients_t;
-
-    /**
-     * @brief Gets BSSID to which STA with given MAC is connected
-     *
-     * @param[in] clients_map Associated client map to seach
-     * @param[in] sta_mac MAC address of the STA
-     * @return BSSID in case of success or network_utils::ZERO_MAC otherwise
-     */
-    static sMacAddr
-    get_sta_bssid(const std::unordered_map<sMacAddr, associated_clients_t> &clients_map,
-                  const sMacAddr &sta_mac);
-
     /**
      * @brief Information gathered about a radio (= slave).
      *
@@ -382,8 +342,6 @@ private:
         bool he_supported = false; /**< Is HE supported flag */
         std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
             preferred_channels; /**< Array of supported channels in radio. */
-        std::unordered_map<sMacAddr, associated_clients_t>
-            associated_clients_map; /**< Associated clients grouped by BSSID. */
     };
 
     /**
@@ -393,14 +351,6 @@ private:
      * @return shared pointer to radio info in case of success or nullptr otherwise
      */
     std::shared_ptr<sRadioInfo> get_radio(const sMacAddr &radio_mac) const;
-
-    /**
-     * @brief Gets radio info for the STA with given MAC address
-     *
-     * @param[in] sta_mac MAC address of the STA
-     * @return shared pointer to radio info in case of success or nullptr otherwise
-     */
-    std::shared_ptr<sRadioInfo> get_sta_radio(const sMacAddr &sta_mac);
 
     /**
      * @brief Interface in this device which connects to an interface in one or more neighbors.

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -186,7 +186,6 @@ private:
 
         std::string ssid;
         std::string pass;
-        std::string wire_iface;
         std::string wireless_iface;
         std::string preferred_bssid;
         std::string vendor;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -224,9 +224,7 @@ private:
     const std::string config_const_bh_slave;
 
     int stop_on_failure_attempts;
-    bool local_master = false;
-    bool local_gw     = false;
-    bool onboarding   = true;
+    bool onboarding = true;
 
     //backlist bssid and timers (remove con(or wrong passphrase) ap from select bssid for limited time )
     struct ap_blacklist_entry {

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -177,7 +177,6 @@ private:
     struct SBackhaulConfig {
         std::string ssid;
         std::string pass;
-        std::string wireless_iface;
         std::string preferred_bssid;
         std::string vendor;
         std::string model;

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -105,7 +105,17 @@ private:
      */
     bool send_1905_topology_discovery_message(const std::string &iface_name);
 
-    bool send_slave_ap_metric_query_message(uint16_t mid, std::vector<sMacAddr> const &bssid_list);
+    /**
+     * @brief Sends an AP Metrics Query message for each bssid on 'bssid_list' to the son_slaves.
+     * If the 'bssid_list' is empty, sends a query on each bssid that exists on the Agent.
+     * 
+     * @param mid MID of the message to be sent.
+     * @param bssid_list List of bssids to send a query on.
+     * @return true on success, otherwise false.
+     */
+    bool send_slave_ap_metric_query_message(
+        uint16_t mid,
+        const std::unordered_set<sMacAddr> &bssid_list = std::unordered_set<sMacAddr>());
 
     /**
      * @brief Creates Backhaul STA Steering Response message with 2 tlvs Steering Response
@@ -369,8 +379,7 @@ private:
         uint32_t vht_capability = 0;     /**< VHT capabilities */
         std::array<uint8_t, beerocks::message::VHT_MCS_SET_SIZE>
             vht_mcs_set; /**< 32-byte attribute containing the MCS set as defined in 802.11ac */
-        bool he_supported = false;             /**< Is HE supported flag */
-        beerocks_message::sVapsList vaps_list; /**< List of VAPs in radio. */
+        bool he_supported = false; /**< Is HE supported flag */
         std::array<beerocks::message::sWifiChannel, beerocks::message::SUPPORTED_CHANNELS_LENGTH>
             preferred_channels; /**< Array of supported channels in radio. */
         std::unordered_map<sMacAddr, associated_clients_t>

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.h
@@ -186,7 +186,6 @@ private:
 
         std::string ssid;
         std::string pass;
-        std::string bridge_iface;
         std::string wire_iface;
         std::string wireless_iface;
         std::string preferred_bssid;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3390,10 +3390,13 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                                   config.backhaul_wireless_iface.c_str(),
                                   message::IFACE_NAME_LENGTH);
 
-        bh_enable->frequency_band() = hostap_params.frequency_band;
-        bh_enable->max_bandwidth()  = hostap_params.max_bandwidth;
-        bh_enable->ht_supported()   = hostap_params.ht_supported;
-        bh_enable->ht_capability()  = hostap_params.ht_capability;
+        bh_enable->frequency_band()   = hostap_params.frequency_band;
+        radio->front.freq_type        = hostap_params.frequency_band;
+        bh_enable->max_bandwidth()    = hostap_params.max_bandwidth;
+        radio->front.max_supported_bw = hostap_params.max_bandwidth;
+
+        bh_enable->ht_supported()  = hostap_params.ht_supported;
+        bh_enable->ht_capability() = hostap_params.ht_capability;
         std::copy_n(hostap_params.ht_mcs_set, beerocks::message::HT_MCS_SET_SIZE,
                     bh_enable->ht_mcs_set());
         bh_enable->vht_supported()  = hostap_params.vht_supported;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -198,6 +198,7 @@ private:
 
     Socket *monitor_socket    = nullptr;
     Socket *ap_manager_socket = nullptr;
+    std::string m_fronthaul_iface;
 
     std::chrono::steady_clock::time_point master_last_seen;
     std::chrono::steady_clock::time_point monitor_last_seen;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -59,8 +59,6 @@ public:
         std::string gw_bridge_mac;
         std::string controller_bridge_mac;
         bool is_prplmesh_controller;
-        std::string bridge_iface;
-        std::string bridge_mac;
         std::string bridge_ipv4;
         std::string backhaul_iface;
         std::string backhaul_mac;

--- a/ci/cppcheck/cppcheck_existing_issues.txt
+++ b/ci/cppcheck/cppcheck_existing_issues.txt
@@ -6,33 +6,25 @@ agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp: style: The if c
 agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp: style: Variable 'id' is assigned a value that is never used. [unreadVariable]        int id        = 0;
 agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp: style: Variable 'iface' is assigned a value that is never used. [unreadVariable]        std::string iface = radio_node->get_iface();
 agent/src/beerocks/fronthaul_manager/monitor/rdkb/monitor_rdkb_hal.cpp: style: Consecutive return, break, continue, goto or throw statements are unnecessary. [duplicateBreak]        break;
-agent/src/beerocks/slave/agent_ucc_listener.cpp: style: struct member 'sVapElement::backhaul_vap' is never used. [unusedStructMember]    bool backhaul_vap;
-agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]                    if (soc->hostap_iface == config_const_bh_slave) {
-agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]                if (soc_iter->slave == sd) {
 agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp: style: Local variable 'iface_hal' shadows outer variable [shadowVariable]                            auto iface_hal = get_wireless_hal(sta_iface);
 agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp: style: Local variable 'local_interface_name' shadows outer variable [shadowVariable]        std::string local_interface_name = soc->hostap_iface;
 agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp: style: Local variable 'supportedServiceTuple' shadows outer variable [shadowVariable]        auto supportedServiceTuple = tlvSupportedService->supported_service_list(1);
 agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp: style: Variable 'p_cmdu_header' is assigned a value that is never used. [unreadVariable]    auto p_cmdu_header =
 agent/src/beerocks/slave/beerocks_slave_main.cpp: style: Parameter 'beerocks_slave_conf' can be declared with const [constParameter]static int run_son_slave(int slave_num, beerocks::config_file::sConfigSlave &beerocks_slave_conf,
+agent/src/beerocks/slave/gate/unit_tests/gate_test.cpp: error: syntax error [syntaxError]TEST(gate_beacon_query_test, loading_vs_from_1905_beacon_query)
 agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp: warning: Comparison of a boolean expression with an integer. [compareBoolExpressionWithInt]    if (bpl::dhcp_mon_stop() == false) {
 agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp: warning: Redundant assignment of '*(volatile char*)pass' to itself. [selfAssignment]            *(volatile char *)pass = *(volatile char *)pass;
 agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp: warning: Redundant assignment of '*(volatile char*)pass' to itself. [selfAssignment]        *(volatile char *)pass = *(volatile char *)pass;
-agent/src/beerocks/slave/son_slave_thread.cpp: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]        if (channel_to_check == ch.channel) {
 agent/src/beerocks/slave/son_slave_thread.cpp: style: Local variable 'notification' shadows outer variable [shadowVariable]        auto notification = message_com::create_vs_message<
 common/beerocks/bcl/include/bcl/beerocks_logging.h: style: Class 'logging' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]    logging(const std::string &module_name, const std::string &config_path = std::string(),
-common/beerocks/bcl/source/beerocks_logging.cpp: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]        str += elt + ", ";
 common/beerocks/bcl/source/beerocks_logging.cpp: style: The class 'NetLogger' does not have a constructor although it has private member variables. [noConstructor]class NetLogger : public el::LogDispatchCallback {
-common/beerocks/bcl/source/beerocks_ucc_listener.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]                          validate_binary_notation(value) || validate_decimal_notation(value))) {
-common/beerocks/bcl/source/beerocks_ucc_listener.cpp: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]        mandatory_params.push_back(param_name.first);
 common/beerocks/bcl/source/beerocks_ucc_listener.cpp: style: Parameter 'tlv_hex_list' can be declared with const [constParameter]bool tlvPrefilledData::add_tlvs_from_list(std::list<beerocks_ucc_listener::tlv_hex_t> &tlv_hex_list,
 common/beerocks/bcl/source/beerocks_ucc_listener.cpp: style: Variable 'command_type_str' can be declared with const [constVariable]    auto &command_type_str = *cmd_tokens_vec.begin();
 common/beerocks/bcl/source/network/network_utils.cpp: information: Skipping configuration 'SIOCBRADDIF' since the value of 'SIOCBRADDIF' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly. [ConfigurationNotChecked]    err             = ioctl(br_socket_fd, SIOCBRADDIF, &ifr);
 common/beerocks/bcl/source/network/network_utils.cpp: information: Skipping configuration 'SIOCBRDELIF' since the value of 'SIOCBRDELIF' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly. [ConfigurationNotChecked]    err             = ioctl(br_socket_fd, SIOCBRDELIF, &ifr);
 common/beerocks/bcl/source/network/network_utils.cpp: style: Condition '!up' is always true [knownConditionTrueFalse]    while (!up) {
-common/beerocks/bcl/source/network/network_utils.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]        if (ip_info.iface == iface_name) {
 common/beerocks/bcl/source/network/network_utils.cpp: style: Local variable 'ecmd' shadows outer variable [shadowVariable]            struct ethtool_cmd ecmd;
 common/beerocks/bcl/source/network/network_utils.cpp: style: The scope of the variable 'rtInfo_ret' can be reduced. [variableScope]    int rtInfo_ret;
-common/beerocks/bcl/source/network/socket.cpp: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]        if (soc == s) {
 common/beerocks/bcl/source/network/socket.cpp: style: The scope of the variable 'i' can be reduced. [variableScope]    unsigned i;
 common/beerocks/bcl/source/network/socket.cpp: style: Unused variable: it [unusedVariable]        std::vector<Socket *>::iterator it;
 common/beerocks/bcl/source/son/son_wireless_utils.cpp: style: Condition 'prev_bw<=bw' is always true [knownConditionTrueFalse]    } else if (prev_bw <= bw) {
@@ -44,7 +36,6 @@ common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp: style: struct member 'DUMMY_acs
 common/beerocks/bwl/dummy/ap_wlan_hal_dummy.cpp: style: struct member 'DUMMY_acs_report_get::bss' is never used. [unusedStructMember]    int bss;
 common/beerocks/bwl/dummy/mon_wlan_hal_dummy.cpp: style: The scope of the variable 'tmp_int' can be reduced. [variableScope]    int64_t tmp_int;
 common/beerocks/bwl/dwpal/ap_wlan_hal_dwpal.cpp: information: This file is not analyzed. Cppcheck failed to extract a valid configuration. Use -v for more details. [noValidConfiguration]
-common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp: style: Consider using std::count_if algorithm instead of a raw loop. [useStlAlgorithm]                        attached++;
 common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp: style: The scope of the variable 'rate_kbs' can be reduced. [variableScope]    uint32_t rate_kbs;
 common/beerocks/bwl/dwpal/mon_wlan_hal_dwpal.cpp: style: The scope of the variable 'rate_mbs_fp_8_1' can be reduced. [variableScope]    uint8_t rate_mbs_fp_8_1;
 common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp: style: A pointer can not be negative so it is either pointless or an error to check if it is. [pointerLessThanZero]    if (err < 0) {
@@ -70,7 +61,6 @@ controller/src/beerocks/cli/beerocks_cli_bml.cpp: performance: Function paramete
 controller/src/beerocks/cli/beerocks_cli_bml.cpp: performance: Function parameter 'ind' should be passed by const reference. [passedByValue]    const std::string &parent_bssid, const std::string ind, std::stringstream &ss)
 controller/src/beerocks/cli/beerocks_cli_bml.h: performance: Function parameter 'iface' should be passed by const reference. [passedByValue]    int wps_onboarding(const std::string iface = std::string());
 controller/src/beerocks/cli/beerocks_cli_main.cpp: performance: Function parameter 'temp_path' should be passed by const reference. [passedByValue]static void cli_tcp_proxy(std::string temp_path)
-controller/src/beerocks/cli/beerocks_cli_main.cpp: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]        cmd += token + " ";
 controller/src/beerocks/cli/beerocks_cli_main.cpp: style: Redundant initialization for 'cli_ptr'. The initialized value is overwritten before it is read. [redundantInitialization]    beerocks::cli *cli_ptr = &cli_soc;
 controller/src/beerocks/cli/beerocks_cli_main.cpp: style: Variable 'cli_ptr' is assigned a value that is never used. [unreadVariable]    beerocks::cli *cli_ptr = &cli_soc;
 controller/src/beerocks/cli/beerocks_cli_main.cpp: style: Variable 'pos' is assigned a value that is never used. [unreadVariable]        } else if ((pos = token->find("!")) != std::string::npos) {
@@ -87,9 +77,6 @@ controller/src/beerocks/master/db/db.cpp: performance: Function parameter 'iface
 controller/src/beerocks/master/db/db.cpp: performance: Function parameter 'name' should be passed by const reference. [passedByValue]bool db::set_node_name(const std::string &mac, std::string name)
 controller/src/beerocks/master/db/db.cpp: performance: Function parameter 'ssid' should be passed by const reference. [passedByValue]bool db::add_vap(const std::string &radio_mac, int vap_id, std::string bssid, std::string ssid,
 controller/src/beerocks/master/db/db.cpp: performance: Function parameter 'version' should be passed by const reference. [passedByValue]bool db::set_hostap_driver_version(const std::string &mac, std::string version)
-controller/src/beerocks/master/db/db.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]            get_node_state(hostap) == beerocks::STATE_CONNECTED) {
-controller/src/beerocks/master/db/db.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]        if (it.second.mac == mac) {
-controller/src/beerocks/master/db/db.cpp: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]        neighbors_al_macs.push_back(tlvf::mac_from_string(sibling));
 controller/src/beerocks/master/db/db.cpp: style: Non-boolean value returned from function returning bool [returnNonBoolInBooleanFunction]        return -1;
 controller/src/beerocks/master/db/db.cpp: style: Parameter 'n' can be declared with const [constParameter]int db::get_node_bw_int(std::shared_ptr<node> &n)
 controller/src/beerocks/master/db/db.cpp: style: The scope of the variable 'listener_exist' can be reduced. [variableScope]    bool listener_exist;
@@ -107,7 +94,6 @@ controller/src/beerocks/master/db/network_map.cpp: style: Variable 'size' is ass
 controller/src/beerocks/master/son_actions.cpp: performance: Function parameter 'bssid' should be passed by const reference. [passedByValue]                                                     std::string sta_mac, std::string bssid)
 controller/src/beerocks/master/son_actions.cpp: performance: Function parameter 'hostap_mac' should be passed by const reference. [passedByValue]void son_actions::handle_dead_node(std::string mac, std::string hostap_mac, db &database,
 controller/src/beerocks/master/son_actions.cpp: performance: Function parameter 'sta_mac' should be passed by const reference. [passedByValue]                                                     std::string sta_mac, std::string bssid)
-controller/src/beerocks/master/son_actions.cpp: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]            if (operating_class == operating_class_info.operating_class()) {
 controller/src/beerocks/master/son_actions.cpp: style: Local variable 'prev_task_id' shadows outer variable [shadowVariable]        int prev_task_id = database.get_association_handling_task_id(mac);
 controller/src/beerocks/master/son_actions.cpp: style: The scope of the variable 'prev_task_id' can be reduced. [variableScope]    int prev_task_id;
 controller/src/beerocks/master/son_management.cpp: style: Variable 'op_error_code' is assigned a value that is never used. [unreadVariable]            op_error_code = eChannelScanOperationCode::SCAN_IN_PROGRESS;
@@ -145,8 +131,6 @@ controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: C-style 
 controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: C-style pointer casting [cstyleCast]            auto new_event        = CHANNEL_SELECTION_ALLOCATE_EVENT(sDfsCacPendinghostap_event);
 controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: C-style pointer casting [cstyleCast]        auto new_event = CHANNEL_SELECTION_ALLOCATE_EVENT(sDfsReEntrySampleSteeredClients_event);
 controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: C-style pointer casting [cstyleCast]    auto new_event             = CHANNEL_SELECTION_ALLOCATE_EVENT(sDfsCacPendinghostap_event);
-controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]            if (database.is_hostap_backhaul_manager(sibling)) {
-controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]        if (database.is_node_5ghz(gw_slave)) {
 controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: Redundant initialization for 'hostap_parent_type'. The initialized value is overwritten before it is read. [redundantInitialization]        auto hostap_parent_type = database.get_node_type(hostap_parent_mac);
 controller/src/beerocks/master/tasks/channel_selection_task.cpp: style: The scope of the variable 'channel_80Mhz_step' can be reduced. [variableScope]    auto channel_80Mhz_step = CHANNEL_80MHZ_STEP;
 controller/src/beerocks/master/tasks/client_locating_task.cpp: performance: Function parameter 'client_mac_' should be passed by const reference. [passedByValue]                                           task_pool &tasks_, std::string client_mac_,
@@ -201,7 +185,6 @@ framework/platform/bpl/uci/cfg/bpl_cfg_uci.cpp: style: The scope of the variable
 framework/platform/bpl/uci/db/bpl_db.cpp: style: Parameter 'nested_params' can be declared with const [constParameter]    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> &nested_params)
 framework/platform/bpl/uci/db/bpl_db.cpp: style: Parameter 'params' can be declared with const [constParameter]                  std::unordered_map<std::string, std::string> &params)
 framework/platform/bpl/uci/dhcp/bpl_dhcp.cpp: style: struct member 'dhcp_event_request::data' is never used. [unusedStructMember]    char data[];
-framework/tlvf/src/src/ClassList.cpp: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]        msg_len += c->getLen();
 framework/tlvf/test/tlvf_test.cpp: style: Local variable 'cmplx' shadows outer variable [shadowVariable]            auto cmplx = std::get<1>(tlv4->complex_list(0));
 framework/tlvf/test/tlvf_test.cpp: style: Local variable 'cmplx' shadows outer variable [shadowVariable]            auto cmplx = std::get<1>(tlv4->complex_list(1));
 framework/tlvf/test/tlvf_test.cpp: style: Local variable 'cmplx' shadows outer variable [shadowVariable]        auto cmplx = std::get<1>(tlv4->complex_list(i));

--- a/tools/docker/static-analysis/suppressions.txt
+++ b/tools/docker/static-analysis/suppressions.txt
@@ -3,3 +3,6 @@ uninitMemberVar
 
 // Suppress performance: Variable 'X' is assigned in constructor body. Consider performing initialization in initialization list.
 useInitializationList
+
+// Suppress style: Consider using std::find_if algorithm instead of a raw loop.
+useStlAlgorithm


### PR DESCRIPTION
To create a topology task it is needed that all the topology related will use data from the AgentDB, instead of local class members.
This PR defines all the required data on the AgentDB needed for moving the topology related code to a separate task,
and makes sure it is being used instead of the class member data and removes the messaging dependency of the data.

Currently, since the son_slave are not under the same process as the backhaul manager, I had to save the same data on two different instances of the AgentDB.
On a follow-up PR, I will move the son_slaves to be the main Agent thread, and do some cleanups to the mess I did here.

Edit:
I ran a certification test on 4.7.4 and 4.7.5 but it was broken on the master. So I ran 4.5.3 which passed on master and it passed here too. Since this PR is delicate and can easily break on rebase, I've decided to merge it.
If there will be problems with it, it will be fixed in a hotfix PR.
https://gitlab.com/prpl-foundation/prplMesh/-/pipelines/168628249