### PR TITLE
Feature/ppm 5 add persistent db global configurations to bpl cfg

### DIFF
--- a/controller/src/beerocks/master/beerocks_master_main.cpp
+++ b/controller/src/beerocks/master/beerocks_master_main.cpp
@@ -218,6 +218,34 @@ static void fill_master_config(son::db::sDbMasterConfig &master_conf,
     } else {
         master_conf.load_steer_on_vaps = std::string(load_steer_on_vaps);
     }
+
+    if (!beerocks::bpl::cfg_get_persistent_db_enable(master_conf.persistent_db)) {
+        LOG(DEBUG) << "failed to read persistent db enable, setting to default value: "
+                   << bool(beerocks::bpl::DEFAULT_PERSISTENT_DB);
+        master_conf.persistent_db = bool(beerocks::bpl::DEFAULT_PERSISTENT_DB);
+    }
+    if (!beerocks::bpl::cfg_get_clients_persistent_db_max_size(
+            master_conf.clients_persistent_db_max_size)) {
+        LOG(DEBUG)
+            << "failed to read max number of clients in persistent db, setting to default value: "
+            << beerocks::bpl::DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE;
+        master_conf.clients_persistent_db_max_size =
+            beerocks::bpl::DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE;
+    }
+    if (!beerocks::bpl::cfg_get_max_timelife_delay_days(master_conf.max_timelife_delay_days)) {
+        LOG(DEBUG)
+            << "failed to read max lifetime of clients in persistent db, setting to default value: "
+            << beerocks::bpl::DEFAULT_MAX_TIMELIFE_DELAY_DAYS << " days";
+        master_conf.max_timelife_delay_days = beerocks::bpl::DEFAULT_MAX_TIMELIFE_DELAY_DAYS;
+    }
+    if (!beerocks::bpl::cfg_get_unfriendly_device_max_timelife_delay_days(
+            master_conf.unfriendly_device_max_timelife_delay_days)) {
+        LOG(DEBUG) << "failed to read max lifetime of unfriendly clients in persistent db, setting "
+                      "to default value: "
+                   << beerocks::bpl::DEFAULT_UNFRIENDLY_DEVICE_MAX_TIMELIFE_DELAY_DAYS << " days";
+        master_conf.unfriendly_device_max_timelife_delay_days =
+            beerocks::bpl::DEFAULT_UNFRIENDLY_DEVICE_MAX_TIMELIFE_DELAY_DAYS;
+    }
 }
 
 int main(int argc, char *argv[])

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -75,6 +75,7 @@ public:
         bool load_health_check;
         bool load_monitor_on_vaps;
         bool certification_mode;
+        bool persistent_db;
         int roaming_5ghz_failed_attemps_threshold;
         int roaming_24ghz_failed_attemps_threshold;
         int roaming_11v_failed_attemps_threshold;
@@ -107,6 +108,9 @@ public:
         int blacklist_channel_remove_timeout;
         int failed_roaming_counter_threshold;
         int roaming_sticky_client_rssi_threshold;
+        int clients_persistent_db_max_size;
+        int max_timelife_delay_days;
+        int unfriendly_device_max_timelife_delay_days;
 
     } sDbMasterConfig;
 

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -98,6 +98,9 @@ constexpr int DEFAULT_PERSISTENT_DB = 0;
 // this is configurable to enable flexibility and support for low-memory platforms
 // by default, the number of clients's configuration to be cached is limited to 256
 constexpr int DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE = 256;
+// the persistent data of clients has aging limit
+// by default, the limit is 365 days, but it is configurable via the UCI
+constexpr int DEFAULT_MAX_TIMELIFE_DELAY_DAYS = 365;
 
 /****************************************************************************/
 /******************************* Structures *********************************/
@@ -512,6 +515,14 @@ bool cfg_get_persistent_db_enable(bool &enable);
  * @return true on success, otherwise false.
  */
 bool cfg_get_clients_persistent_db_max_size(int &max_size);
+
+/**
+ * @brief Returns the max time-life delay of clients (used for aging of client's persistent data).
+ * 
+ * @param [out] max_timelife_delay_days Max clients' timelife delay.
+ * @return true on success, otherwise false.
+ */
+bool cfg_get_max_timelife_delay_days(int &max_timelife_delay_days);
 
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -86,11 +86,11 @@ namespace bpl {
 #define BPL_GW_DB_OPER_MODE_LEN (127 + 1)   /* Maximal length of OPERATING MODE string */
 
 /* Default values */
-#define DEFAULT_STOP_ON_FAILURE_ATTEMPTS 1
-#define DEFAULT_RDKB_EXTENSIONS 0
-#define DEFAULT_BAND_STEERING 1
-#define DEFAULT_DFS_REENTRY 1
-#define DEFAULT_CLIENT_ROAMING 1
+constexpr int DEFAULT_STOP_ON_FAILURE_ATTEMPTS = 1;
+constexpr int DEFAULT_RDKB_EXTENSIONS          = 0;
+constexpr int DEFAULT_BAND_STEERING            = 1;
+constexpr int DEFAULT_DFS_REENTRY              = 1;
+constexpr int DEFAULT_CLIENT_ROAMING           = 1;
 // by-default the persistent DB is disabled to allow backwards compatability
 // if the parameter is not configured in the prplmesh config and set to 1, DB is disabled
 constexpr int DEFAULT_PERSISTENT_DB = 0;

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -91,6 +91,9 @@ namespace bpl {
 #define DEFAULT_BAND_STEERING 1
 #define DEFAULT_DFS_REENTRY 1
 #define DEFAULT_CLIENT_ROAMING 1
+// by-default the persistent DB is disabled to allow backwards compatability
+// if the parameter is not configured in the prplmesh config and set to 1, DB is disabled
+constexpr int DEFAULT_PERSISTENT_DB = 0;
 
 /****************************************************************************/
 /******************************* Structures *********************************/
@@ -489,6 +492,14 @@ int cfg_get_hostap_iface(int32_t radio_num, char hostap_iface[BPL_IFNAME_LEN]);
  * @return -1 Error, or no hostap_iface is configured.
  */
 int cfg_get_all_prplmesh_wifi_interfaces(BPL_WLAN_IFACE *interfaces, int *num_of_interfaces);
+
+/**
+ * @brief Returns whether the persistent DB is enabled.
+ * 
+ * @param [out] enable true if the DB is enabled and false otherwise.
+ * @return true on success, otherwise false.
+ */
+bool cfg_get_persistent_db_enable(bool &enable);
 
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -101,6 +101,10 @@ constexpr int DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE = 256;
 // the persistent data of clients has aging limit
 // by default, the limit is 365 days, but it is configurable via the UCI
 constexpr int DEFAULT_MAX_TIMELIFE_DELAY_DAYS = 365;
+// the timelife of unfriendly-devices is set separately and can be shorter than the timelife
+// TODO: add description of "unfriendly-device" and how it is determined
+// by default, the limit is 1 day, but it is configurable via the UCI
+constexpr int DEFAULT_UNFRIENDLY_DEVICE_MAX_TIMELIFE_DELAY_DAYS = 1;
 
 /****************************************************************************/
 /******************************* Structures *********************************/
@@ -523,6 +527,15 @@ bool cfg_get_clients_persistent_db_max_size(int &max_size);
  * @return true on success, otherwise false.
  */
 bool cfg_get_max_timelife_delay_days(int &max_timelife_delay_days);
+
+/**
+ * @brief Returns the max time-life delay for unfriendly clients.
+ * 
+ * @param [out] unfriendly_device_max_timelife_delay_days Max unfriendly clients' timelife delay.
+ * @return true on success, otherwise false.
+ */
+bool cfg_get_unfriendly_device_max_timelife_delay_days(
+    int &unfriendly_device_max_timelife_delay_days);
 
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/include/bpl/bpl_cfg.h
+++ b/framework/platform/bpl/include/bpl/bpl_cfg.h
@@ -94,6 +94,10 @@ namespace bpl {
 // by-default the persistent DB is disabled to allow backwards compatability
 // if the parameter is not configured in the prplmesh config and set to 1, DB is disabled
 constexpr int DEFAULT_PERSISTENT_DB = 0;
+// the DB of clients is limited in size to prevent high memory consumption
+// this is configurable to enable flexibility and support for low-memory platforms
+// by default, the number of clients's configuration to be cached is limited to 256
+constexpr int DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE = 256;
 
 /****************************************************************************/
 /******************************* Structures *********************************/
@@ -500,6 +504,14 @@ int cfg_get_all_prplmesh_wifi_interfaces(BPL_WLAN_IFACE *interfaces, int *num_of
  * @return true on success, otherwise false.
  */
 bool cfg_get_persistent_db_enable(bool &enable);
+
+/**
+ * @brief Returns the max number of clients in the persistent DB.
+ * 
+ * @param [out] max_size Max number of clients the persistent-db supports.
+ * @return true on success, otherwise false.
+ */
+bool cfg_get_clients_persistent_db_max_size(int &max_size);
 
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -363,5 +363,18 @@ bool cfg_get_clients_persistent_db_max_size(int &max_size)
     return true;
 }
 
+bool cfg_get_max_timelife_delay_days(int &max_timelife_delay_days)
+{
+    int val = -1;
+    if (cfg_get_param_int("max_timelife_delay_days=", val) == RETURN_ERR) {
+        MAPF_ERR("Failed to read max-timelife-delay-days parameter - setting default value");
+        val = DEFAULT_MAX_TIMELIFE_DELAY_DAYS;
+    }
+
+    max_timelife_delay_days = val;
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -335,5 +335,20 @@ int cfg_get_all_prplmesh_wifi_interfaces(BPL_WLAN_IFACE *interfaces, int *num_of
     return RETURN_OK;
 }
 
+bool cfg_get_persistent_db_enable(bool &enable)
+{
+    int persistent_db_enable = DEFAULT_PERSISTENT_DB;
+
+    // persistent db value is optional
+    if (cfg_get_param_int("persistent_db=", persistent_db_enable) < 0) {
+        MAPF_DBG("Failed to read persistent-db-enable parameter - setting default value");
+        persistent_db_enable = DEFAULT_PERSISTENT_DB;
+    }
+
+    enable = (persistent_db_enable == 1);
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -376,5 +376,20 @@ bool cfg_get_max_timelife_delay_days(int &max_timelife_delay_days)
     return true;
 }
 
+bool cfg_get_unfriendly_device_max_timelife_delay_days(
+    int &unfriendly_device_max_timelife_delay_days)
+{
+    int val = -1;
+    if (cfg_get_param_int("unfriendly_device_max_timelife_delay_days=", val) == RETURN_ERR) {
+        MAPF_ERR("Failed to read unfriendly-device-max-timelife-delay-days parameter - setting "
+                 "default value");
+        val = DEFAULT_MAX_TIMELIFE_DELAY_DAYS;
+    }
+
+    unfriendly_device_max_timelife_delay_days = val;
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/linux/bpl_cfg.cpp
+++ b/framework/platform/bpl/linux/bpl_cfg.cpp
@@ -350,5 +350,18 @@ bool cfg_get_persistent_db_enable(bool &enable)
     return true;
 }
 
+bool cfg_get_clients_persistent_db_max_size(int &max_size)
+{
+    int max_size_val = -1;
+    if (cfg_get_param_int("clients_persistent_db_max_size=", max_size_val) == RETURN_ERR) {
+        MAPF_ERR("Failed to read clients-persistent-db-max-size parameter - setting default value");
+        max_size_val = DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE;
+    }
+
+    max_size = max_size_val;
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -429,5 +429,19 @@ bool cfg_get_clients_persistent_db_max_size(int &max_size)
     return true;
 }
 
+bool cfg_get_max_timelife_delay_days(int &max_timelife_delay_days)
+{
+    int retVal = -1;
+    if (cfg_get_prplmesh_param_int_default("max_timelife_delay_days", &retVal,
+                                           DEFAULT_MAX_TIMELIFE_DELAY_DAYS) == RETURN_ERR) {
+        MAPF_ERR("Failed to read max-timelife-delay-days parameter");
+        return false;
+    }
+
+    max_timelife_delay_days = retVal;
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -415,5 +415,19 @@ bool cfg_get_persistent_db_enable(bool &enable)
     return true;
 }
 
+bool cfg_get_clients_persistent_db_max_size(int &max_size)
+{
+    int retVal = -1;
+    if (cfg_get_prplmesh_param_int_default("clients_persistent_db_max_size", &retVal,
+                                           DEFAULT_CLIENTS_PERSISTENT_DB_MAX_SIZE) == RETURN_ERR) {
+        MAPF_ERR("Failed to read clients-persistent-db-max-size parameter");
+        return false;
+    }
+
+    max_size = retVal;
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -443,5 +443,21 @@ bool cfg_get_max_timelife_delay_days(int &max_timelife_delay_days)
     return true;
 }
 
+bool cfg_get_unfriendly_device_max_timelife_delay_days(
+    int &unfriendly_device_max_timelife_delay_days)
+{
+    int retVal = -1;
+    if (cfg_get_prplmesh_param_int_default("unfriendly_device_max_timelife_delay_days", &retVal,
+                                           DEFAULT_UNFRIENDLY_DEVICE_MAX_TIMELIFE_DELAY_DAYS) ==
+        RETURN_ERR) {
+        MAPF_ERR("Failed to read unfriendly-device-max-timelife-delay-days parameter");
+        return false;
+    }
+
+    unfriendly_device_max_timelife_delay_days = retVal;
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks

--- a/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
+++ b/framework/platform/bpl/uci/cfg/bpl_cfg.cpp
@@ -401,5 +401,19 @@ int cfg_get_all_prplmesh_wifi_interfaces(BPL_WLAN_IFACE *interfaces, int *num_of
     return RETURN_OK;
 }
 
+bool cfg_get_persistent_db_enable(bool &enable)
+{
+    int retVal = -1;
+    if (cfg_get_prplmesh_param_int_default("persistent_db", &retVal, DEFAULT_PERSISTENT_DB) ==
+        RETURN_ERR) {
+        MAPF_ERR("Failed to read persistent-db-enable parameter");
+        return false;
+    }
+
+    enable = (retVal == 1);
+
+    return true;
+}
+
 } // namespace bpl
 } // namespace beerocks


### PR DESCRIPTION
PPM-5.

This PR adds the support of persistent db configurations and reading their values using `bpl_cfg` APIs.
The persistent db configurations are:
persistent_db - is persistent db enabled - default value false.
clients_persistent_db_max_size - max number of clients in persistent db - default value 256.
max_timelife_delay_days - max timelife delay for client (scale:days) - default value 365 days.
unfriendly_device_max_timelife_delay_days - max timelife delay for unfriendly clients (scale: days) - default value 1 day.

At this phase, the parameters are not configurable at runtime.
They can be updated using direct UCI access and prplmesh restart is required for their changes to take effect.