### PR TITLE
deploy_firmware.py: don't fail on EOF when device is not reachable

### DIFF
--- a/tools/deploy_firmware.py
+++ b/tools/deploy_firmware.py
@@ -104,7 +104,7 @@ class PrplwrtDevice:
             print(diff_str)
         return bool(diff_str)
 
-    def reach(self, attempts: int = 5, wait: int = 5):
+    def reach(self, attempts: int = 5, wait: int = 5) -> bool:
         """Check if the device is reachable via SSH (and optionally try multiple times).
 
         Parameters
@@ -124,7 +124,7 @@ class PrplwrtDevice:
                 with pexpect.pxssh.pxssh() as shell:
                     shell.login(self.name, self.username, login_timeout=5)
                     return True
-            except pexpect.pxssh.ExceptionPxssh:
+            except (pexpect.pxssh.ExceptionPxssh, pexpect.exceptions.EOF):
                 print("Waiting for the device to be reachable")
                 time.sleep(wait)
         return False


### PR DESCRIPTION
After a successful upgrade and when the device is not yet reachable,
the script sometimes reaches a pexpect.exceptions.EOF and fail.

See for example:
https://gitlab.com/prpl-foundation/prplMesh/-/jobs/626283944

If a pexpect.exceptions.EOF is raised in reach(), just continue to
loop.

Fixes https://jira.prplfoundation.org/browse/PPM-228

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>