### PR TITLE
CODEOWNERS: add Mario as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @tomereli @arnout @morantr @rmelotte @vitalybu @kantera800
+*   @tomereli @arnout @mariomaz @morantr @rmelotte @vitalybu @kantera800


### PR DESCRIPTION
With Tomer leaving, we need an additional code owner for final approval
of PRs.