### PR TITLE
operating class not used in 11k beacon requests

### DIFF
--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -146,6 +146,8 @@ void association_handling_task::work()
         measurement_request->params().measurement_mode =
             beerocks::MEASURE_MODE_ACTIVE; // son::eMeasurementMode11K "passive"/"active"/"table"
         measurement_request->params().channel = database.get_node_channel(bssid);
+        measurement_request->params().op_class =
+            database.get_hostap_operating_class(tlvf::mac_from_string(bssid));
         measurement_request->params().rand_ival = beerocks::
             BEACON_MEASURE_DEFAULT_RANDOMIZATION_INTERVAL; // random interval - specifies the upper bound of the random delay to be used prior to making the measurement, expressed in units of TUs [=1024usec]
         measurement_request->params().duration = beerocks::

--- a/controller/src/beerocks/master/tasks/association_handling_task.cpp
+++ b/controller/src/beerocks/master/tasks/association_handling_task.cpp
@@ -132,9 +132,9 @@ void association_handling_task::work()
         TASK_LOG(DEBUG) << "started association_handling_task, looking for beacon measurement "
                            "capabilities on "
                         << sta_mac;
-        std::string parent_mac = database.get_node_parent(sta_mac);
-        std::string radio_mac  = database.get_node_parent_radio(parent_mac);
-        auto agent_mac         = database.get_node_parent_ire(parent_mac);
+        std::string bssid     = database.get_node_parent(sta_mac);
+        std::string radio_mac = database.get_node_parent_radio(bssid);
+        auto agent_mac        = database.get_node_parent_ire(bssid);
 
         auto measurement_request = message_com::create_vs_message<
             beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>(cmdu_tx, id);
@@ -145,20 +145,19 @@ void association_handling_task::work()
         }
         measurement_request->params().measurement_mode =
             beerocks::MEASURE_MODE_ACTIVE; // son::eMeasurementMode11K "passive"/"active"/"table"
-        measurement_request->params().channel   = database.get_node_channel(parent_mac);
+        measurement_request->params().channel = database.get_node_channel(bssid);
         measurement_request->params().rand_ival = beerocks::
             BEACON_MEASURE_DEFAULT_RANDOMIZATION_INTERVAL; // random interval - specifies the upper bound of the random delay to be used prior to making the measurement, expressed in units of TUs [=1024usec]
         measurement_request->params().duration = beerocks::
             BEACON_MEASURE_DEFAULT_ACTIVE_DURATION; // measurement duration, expressed in units of TUs [=1024usec]
         measurement_request->params().sta_mac = tlvf::mac_from_string(sta_mac);
-        measurement_request->params().bssid   = tlvf::mac_from_string(
-            parent_mac); // the bssid which will be reported. for all bssid, use wildcard "ff:ff:ff:ff:ff:ff"
+        measurement_request->params().bssid   = tlvf::mac_from_string(bssid);
         //measurement_request.params.use_optional_ssid = true;
         measurement_request->params().expected_reports_count = 1;
-        //string_utils::copy_string(measurement_request.params.ssid, database.get_hostap_vap_ssid(parent_mac).c_str(), sizeof(measurement_request.params.ssid));
+        //mapf::utils::copy_string(measurement_request.params.ssid, database.get_hostap_vap_ssid(bssid).c_str(), sizeof(measurement_request.params.ssid));
         add_pending_mac(radio_mac, beerocks_message::ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE);
         TASK_LOG(DEBUG) << "requested beacon measurement request from sta: " << sta_mac
-                        << " on hostap: " << parent_mac;
+                        << " on bssid: " << bssid;
 
         son_actions::send_cmdu_to_agent(agent_mac, cmdu_tx, database, radio_mac);
         set_responses_timeout(BEACON_MEASURE_REQ_TIME_SPAN);

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -278,7 +278,7 @@ void optimal_path_task::work()
                         measurement_request.duration =
                             beerocks::BEACON_MEASURE_DEFAULT_ACTIVE_DURATION;
                     }
-                    // ap_mac is a radio mac, but we need to request measurment on some vap since radio don't beacon
+                    // ap_mac is a radio mac, but we need to request measurement on some vap since radio don't beacon
                     const std::string vap_mac =
                         database.get_hostap_vap_with_ssid(ap_mac, current_hostap_ssid);
                     if (vap_mac.empty()) {
@@ -289,8 +289,10 @@ void optimal_path_task::work()
                         ++potential_ap_iter;
                         continue;
                     }
-                    measurement_request.bssid                  = tlvf::mac_from_string(vap_mac);
-                    measurement_request.channel                = database.get_node_channel(ap_mac);
+                    measurement_request.bssid   = tlvf::mac_from_string(vap_mac);
+                    measurement_request.channel = database.get_node_channel(ap_mac);
+                    measurement_request.op_class =
+                        database.get_hostap_operating_class(tlvf::mac_from_string(ap_mac));
                     measurement_request.expected_reports_count = 1;
 
                     /////////////// FOR DEBUG ONLY ////////////////


### PR DESCRIPTION
radio operation class is always 0 in beacon request message as a result hostapd message validation fails and messages are  not really sent to the air.

need to add operation class when creating the request.