### PR TITLE
increase 11k responsiveness threshold to 80% in optimal path task

### DIFF
--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -31,6 +31,18 @@ using namespace son;
 #define ONE_PERCENT 0.01f
 #define EIGHTY_PERCENT 0.80f
 
+/*
+* Responsiveness may be less than 100% since the station might refuse to the measurement
+* request or failed to measure it due to incapability (to measure in another band for
+* example), missed the probe or due to the AP bad reception.
+* There is a high probability to get responsiveness less than 100% and therefore, the
+* threshold was changed to 50% as part of demo optimizations.
+* This hardcoded threshold is temporary and shall be revised in the future. 
+* update: increasing to 80% since in bandsteering scenario there are only 2 radios
+* and 50% means optimal path always will fail to find an additional candidate.
+*/
+static constexpr uint8_t RESPONSIVENESS_PRECENT_11K_THRESHOLD = 80;
+
 /////////////// FOR DEBUG ONLY ////////////////
 int optimal_path_task::cli_beacon_request_duration  = -1;
 int optimal_path_task::cli_beacon_request_rand_ival = -1;
@@ -357,16 +369,9 @@ void optimal_path_task::work()
         TASK_LOG(DEBUG) << "responsiveness_precentage_11k: " << int(responsiveness_precentage_11k)
                         << "%";
 
-        /*
-         * Responsiveness may be less than 100% since the station might refuse to the measurement
-         * request or failed to measure it due to incapability (to measure in another band for
-         * example), missed the probe or due to the AP bad reception.
-         * There is a high probability to get responsiveness less than 100% and therefore, the
-         * threshold was changed to 50% as part of demo optimizations.
-         * This hardcoded threshold is temporary and shall be revised in the future. 
-         */
-        if (responsiveness_precentage_11k < 50) {
-            TASK_LOG(DEBUG) << "11k measurement request responsiveness is less than 50%";
+        if (responsiveness_precentage_11k < RESPONSIVENESS_PRECENT_11K_THRESHOLD) {
+            TASK_LOG(DEBUG) << "11k measurement request responsiveness is less than "
+                            << RESPONSIVENESS_PRECENT_11K_THRESHOLD << "%";
             if (database.settings_front_measurements()) {
                 /////////////// FOR DEBUG ONLY ////////////////
                 if (use_cli_value) {


### PR DESCRIPTION
Beacon measurement responsiveness threshold is currently set to 50%
below that optimal path task flags the client as 11k non responsive
and switch to legacy cross rssi measurement algorithm.
In case of band steering scenario where there are only 2 radio
candidates, 50% responsiveness means only 1 candidate for optimal
path task  to decide from which ends the task.

Increase to responsiveness threshold to 80%.