### PR TITLE
controller: db: rename ePersistentParamBool to eTriStateBool

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2599,18 +2599,18 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
     }
 
     node->client_stay_on_initial_radio =
-        (stay_on_initial_radio) ? ePersistentParamBool::ENABLE : ePersistentParamBool::DISABLE;
+        (stay_on_initial_radio) ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
     node->client_parameters_last_edit = timestamp;
 
     return true;
 }
 
-ePersistentParamBool db::get_client_stay_on_initial_radio(const sMacAddr &mac)
+eTriStateBool db::get_client_stay_on_initial_radio(const sMacAddr &mac)
 {
     auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
     if (!node) {
         LOG(ERROR) << "client node not found for mac " << mac;
-        return ePersistentParamBool::NOT_CONFIGURED;
+        return eTriStateBool::NOT_CONFIGURED;
     }
 
     return node->client_stay_on_initial_radio;
@@ -2686,18 +2686,18 @@ bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_sele
     }
 
     node->client_stay_on_selected_band =
-        (stay_on_selected_band) ? ePersistentParamBool::ENABLE : ePersistentParamBool::DISABLE;
+        (stay_on_selected_band) ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
     node->client_parameters_last_edit = timestamp;
 
     return true;
 }
 
-ePersistentParamBool db::get_client_stay_on_selected_band(const sMacAddr &mac)
+eTriStateBool db::get_client_stay_on_selected_band(const sMacAddr &mac)
 {
     auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
     if (!node) {
         LOG(ERROR) << "client node not found for mac " << mac;
-        return ePersistentParamBool::NOT_CONFIGURED;
+        return eTriStateBool::NOT_CONFIGURED;
     }
 
     return node->client_stay_on_selected_band;
@@ -2758,9 +2758,9 @@ bool db::clear_client_persistent_db(const sMacAddr &mac)
 
     node->client_parameters_last_edit  = std::chrono::steady_clock::time_point::min();
     node->client_time_life_delay_sec   = std::chrono::seconds::zero();
-    node->client_stay_on_initial_radio = ePersistentParamBool::NOT_CONFIGURED;
+    node->client_stay_on_initial_radio = eTriStateBool::NOT_CONFIGURED;
     node->client_initial_radio         = network_utils::ZERO_MAC;
-    node->client_stay_on_selected_band = ePersistentParamBool::NOT_CONFIGURED;
+    node->client_stay_on_selected_band = eTriStateBool::NOT_CONFIGURED;
     node->client_selected_bands        = beerocks::eFreqType::FREQ_UNKNOWN;
 
     LOG(DEBUG) << "removing client " << mac << " from persistent db";
@@ -2807,8 +2807,8 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
             std::to_string(node->client_time_life_delay_sec.count());
     }
 
-    if (node->client_stay_on_initial_radio != ePersistentParamBool::NOT_CONFIGURED) {
-        auto enable = (node->client_stay_on_initial_radio == ePersistentParamBool::ENABLE);
+    if (node->client_stay_on_initial_radio != eTriStateBool::NOT_CONFIGURED) {
+        auto enable = (node->client_stay_on_initial_radio == eTriStateBool::ENABLE);
         LOG(DEBUG) << "setting client stay-on-initial-radio in persistent-db to for " << mac
                    << " to " << enable;
         values_map.at(initial_radio_enable_str) = std::to_string(enable);
@@ -2820,8 +2820,8 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
         values_map.at(initial_radio_str) = tlvf::mac_to_string(node->client_initial_radio);
     }
 
-    if (node->client_stay_on_selected_band != ePersistentParamBool::NOT_CONFIGURED) {
-        auto enable = (node->client_stay_on_selected_band == ePersistentParamBool::ENABLE);
+    if (node->client_stay_on_selected_band != eTriStateBool::NOT_CONFIGURED) {
+        auto enable = (node->client_stay_on_selected_band == eTriStateBool::ENABLE);
         LOG(DEBUG) << "setting client stay-on-selected-band in persistent-db to for " << mac
                    << " to " << enable;
         values_map.at(selected_band_enable_str) = std::to_string(enable);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -702,7 +702,7 @@ public:
      * @param mac MAC address of a client.
      * @return Enable client stay on the radio it initially connected to.
      */
-    ePersistentParamBool get_client_stay_on_initial_radio(const sMacAddr &mac);
+    eTriStateBool get_client_stay_on_initial_radio(const sMacAddr &mac);
 
     /**
      * @brief Set the client's initial-radio.
@@ -740,7 +740,7 @@ public:
      * @param mac MAC address of a client.
      * @return Enable client stay on the selected band/bands.
      */
-    ePersistentParamBool get_client_stay_on_selected_band(const sMacAddr &mac);
+    eTriStateBool get_client_stay_on_selected_band(const sMacAddr &mac);
 
     /**
      * @brief Set the client's selected-bands.

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -29,11 +29,11 @@ node::node(beerocks::eType type_, const std::string &mac_)
 }
 
 namespace son {
-std::ostream &operator<<(std::ostream &os, ePersistentParamBool value)
+std::ostream &operator<<(std::ostream &os, eTriStateBool value)
 {
-    if (value == ePersistentParamBool::DISABLE) {
+    if (value == eTriStateBool::DISABLE) {
         os << "Disabled";
-    } else if (value == ePersistentParamBool::ENABLE) {
+    } else if (value == eTriStateBool::ENABLE) {
         os << "Enabled";
     } else {
         os << "Not-Configured";

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -36,12 +36,12 @@ typedef struct {
 } sVapElement;
 
 /**
- * @brief Extended boolean parameter to support "not configured" value for persistent configuration.
+ * @brief Extended boolean parameter to support "not configured" value for configuration.
  * For persistent data, it is important to differ between configured enable/disable to uncofigured value.
  */
-enum class ePersistentParamBool : int8_t { NOT_CONFIGURED = -1, DISABLE = 0, ENABLE = 1 };
+enum class eTriStateBool : int8_t { NOT_CONFIGURED = -1, DISABLE = 0, ENABLE = 1 };
 
-std::ostream &operator<<(std::ostream &os, ePersistentParamBool value);
+std::ostream &operator<<(std::ostream &os, eTriStateBool value);
 
 class node {
 public:
@@ -290,14 +290,14 @@ public:
     std::chrono::seconds client_time_life_delay_sec = std::chrono::seconds::zero();
 
     // If enabled, the client will be steered to the initial radio it connected to - save at client_initial_radio.
-    ePersistentParamBool client_stay_on_initial_radio = ePersistentParamBool::NOT_CONFIGURED;
+    eTriStateBool client_stay_on_initial_radio = eTriStateBool::NOT_CONFIGURED;
 
     // The client_initial_radio bssid must be set.
     sMacAddr client_initial_radio;
 
     // If enabled, the client will be steered to pre-selected-bands defined by client_selected_bands.
     // Not enforced if client_selected_bands is not set.
-    ePersistentParamBool client_stay_on_selected_band = ePersistentParamBool::NOT_CONFIGURED;
+    eTriStateBool client_stay_on_selected_band = eTriStateBool::NOT_CONFIGURED;
 
     // The selected bands the client should be steered to if the client_stay_on_selected_band is set.
     // Default value is FREQ_UNKNOWN (also indicates value is not configured)


### PR DESCRIPTION
The extension of not-configured value to a boolean can be useful for
non-persistent and persistent configurations alike. Thus, limiting the
parameter to describe persistent-configurations is flawed.

Renamed to a more suitable name that doesn't limit the use to persistent
configuration.

Signed-off-by: Adam Dov <adamx.dov@intel.com>