### PR TITLE
openwrt: wlan_wave_feed: bump to include the fix for DFS-CAC-COMPLETED

### DIFF
--- a/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
+++ b/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
@@ -15,7 +15,7 @@
   hash: af078af5408654ca2e759ea7afcf92163282e86e
 - name: feed_wlan_6x
   uri: https://intel.prpl.dev/prplmesh/feed_wlan_6x.git
-  hash: 1acf2f19c489c72478d3ae74ee59b5fb06a6ee7e
+  hash: c7d701102bcfed7f3c75683a6d05ae8ce762a764
 - name: feed_prpl
   uri: https://git.prpl.dev/prplmesh/feed-prpl.git
   hash: 89e6602655713f8487c72d8d636daa610d76a468


### PR DESCRIPTION
Bump the revision to include the patch from:
https://jira.prplfoundation.org/projects/PPM/issues/PPM-233

Fixes https://jira.prplfoundation.org/projects/PPM/issues/PPM-233

MAP-4.8.1_ETH_FH5GH:axepoint

Depends on:
https://intel.prpl.dev/prplmesh/feed_wlan_6x/-/merge_requests/2/diffs
https://intel.prpl.dev/prplmesh/iwlwav-hostap/-/merge_requests/1

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>