### PR TITLE
prplmesh utils: increase prplmesh_watchdog sleep time

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -159,7 +159,7 @@ prplmesh_watchdog() {
 
     # Monitor the number of running processes
     while [ "$CURR_PIDS" -ge "$PREV_PIDS" ]; do
-        sleep 1
+        sleep 5
         CURR_PIDS="$(pgrep 'beerocks_(agent|controller)' | wc -l)"
         if [ "$CURR_PIDS" -gt "$PREV_PIDS" ]; then
             PREV_PIDS=$CURR_PIDS


### PR DESCRIPTION
High CPU  was noticed in platforms that use prplmesh_watchdog.
Currently polling time is configured to 1 sec which is too frequent
and can be optimized.
Watchdog serves 2 purposes:
1. on boot – make sure wlan is up and running before prplmesh.
2. on run time- make sure all processes gets closed properly.

Testing show that increasing to 5 sec is more optimal and still
serves the same purpose.