### PR TITLE
Feature/ppm 5 read clients persistent db at controller init

### DIFF
--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -4303,6 +4303,26 @@ bool db::remove_client_entry_and_update_counter(const std::string &entry_name)
     return false;
 }
 
+bool db::remove_candidate_client()
+{
+
+    // find cadidate client to be removed
+    sMacAddr client_to_remove = get_candidate_client_for_removal();
+    if (client_to_remove == network_utils::ZERO_MAC) {
+        LOG(ERROR) << "failed to find client to be removed, number of persistent db clients is "
+                   << m_persistent_db_clients_count;
+        return false;
+    }
+
+    // clear persistent data in runtime db and remove from persistent db
+    if (!clear_client_persistent_db(client_to_remove)) {
+        LOG(ERROR) << "failed to clear client persistent data and remove it from persistent db";
+        return false;
+    }
+
+    return true;
+}
+
 sMacAddr db::get_candidate_client_for_removal()
 {
     const auto max_timelife_delay_sec =

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -20,12 +20,12 @@ using namespace beerocks_message;
 using namespace son;
 using namespace net;
 
-static const std::string timestamp_str            = "timestamp";
-static const std::string timelife_delay_str       = "timelife";
-static const std::string initial_radio_enable_str = "initial_radio_enable";
-static const std::string initial_radio_str        = "initial_radio";
-static const std::string selected_band_enable_str = "selected_band_enable";
-static const std::string selected_bands_str       = "selected_bands";
+const std::string db::TIMESTAMP_STR            = "timestamp";
+const std::string db::TIMELIFE_DELAY_STR       = "timelife";
+const std::string db::INITIAL_RADIO_ENABLE_STR = "initial_radio_enable";
+const std::string db::INITIAL_RADIO_STR        = "initial_radio";
+const std::string db::SELECTED_BAND_ENABLE_STR = "selected_band_enable";
+const std::string db::SELECTED_BANDS_STR       = "selected_bands";
 
 // static
 std::string db::type_to_string(beerocks::eType type)
@@ -2545,8 +2545,8 @@ bool db::set_client_time_life_delay(const sMacAddr &mac,
         LOG(DEBUG) << "configuring persistent-db, timelife = " << time_life_delay_sec.count();
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(timestamp_str)      = timestamp_to_string_seconds(timestamp);
-        values_map.at(timelife_delay_str) = std::to_string(time_life_delay_sec.count());
+        values_map.at(TIMESTAMP_STR)      = timestamp_to_string_seconds(timestamp);
+        values_map.at(TIMELIFE_DELAY_STR) = std::to_string(time_life_delay_sec.count());
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2588,8 +2588,8 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
         LOG(DEBUG) << "configuring persistent-db, initial_radio_enable = " << stay_on_initial_radio;
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(timestamp_str)            = timestamp_to_string_seconds(timestamp);
-        values_map.at(initial_radio_enable_str) = std::to_string(stay_on_initial_radio);
+        values_map.at(TIMESTAMP_STR)            = timestamp_to_string_seconds(timestamp);
+        values_map.at(INITIAL_RADIO_ENABLE_STR) = std::to_string(stay_on_initial_radio);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2632,8 +2632,8 @@ bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_r
         LOG(DEBUG) << "configuring persistent-db, initial_radio = " << initial_radio_mac;
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(timestamp_str)     = timestamp_to_string_seconds(timestamp);
-        values_map.at(initial_radio_str) = tlvf::mac_to_string(initial_radio_mac);
+        values_map.at(TIMESTAMP_STR)     = timestamp_to_string_seconds(timestamp);
+        values_map.at(INITIAL_RADIO_STR) = tlvf::mac_to_string(initial_radio_mac);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2675,8 +2675,8 @@ bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_sele
         LOG(DEBUG) << "configuring persistent-db, selected_band_enable = " << stay_on_selected_band;
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(timestamp_str)            = timestamp_to_string_seconds(timestamp);
-        values_map.at(selected_band_enable_str) = std::to_string(stay_on_selected_band);
+        values_map.at(TIMESTAMP_STR)            = timestamp_to_string_seconds(timestamp);
+        values_map.at(SELECTED_BAND_ENABLE_STR) = std::to_string(stay_on_selected_band);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2719,8 +2719,8 @@ bool db::set_client_selected_bands(const sMacAddr &mac, beerocks::eFreqType sele
         LOG(DEBUG) << ", configuring persistent-db, selected_bands = " << int(selected_bands);
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(timestamp_str)      = timestamp_to_string_seconds(timestamp);
-        values_map.at(selected_bands_str) = std::to_string(selected_bands);
+        values_map.at(TIMESTAMP_STR)      = timestamp_to_string_seconds(timestamp);
+        values_map.at(SELECTED_BANDS_STR) = std::to_string(selected_bands);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2798,12 +2798,12 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
     std::unordered_map<std::string, std::string> values_map;
 
     //fill values map of client persistent params
-    values_map.at(timestamp_str) = timestamp_to_string_seconds(node->client_parameters_last_edit);
+    values_map.at(TIMESTAMP_STR) = timestamp_to_string_seconds(node->client_parameters_last_edit);
 
     if (node->client_time_life_delay_sec != std::chrono::seconds::zero()) {
         LOG(DEBUG) << "setting client time-life-delay in persistent-db to for " << mac << " to "
                    << node->client_time_life_delay_sec.count();
-        values_map.at(timelife_delay_str) =
+        values_map.at(TIMELIFE_DELAY_STR) =
             std::to_string(node->client_time_life_delay_sec.count());
     }
 
@@ -2811,26 +2811,26 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
         auto enable = (node->client_stay_on_initial_radio == eTriStateBool::ENABLE);
         LOG(DEBUG) << "setting client stay-on-initial-radio in persistent-db to for " << mac
                    << " to " << enable;
-        values_map.at(initial_radio_enable_str) = std::to_string(enable);
+        values_map.at(INITIAL_RADIO_ENABLE_STR) = std::to_string(enable);
     }
 
     if (node->client_initial_radio != network_utils::ZERO_MAC) {
         LOG(DEBUG) << "setting client initial-radio in persistent-db to for " << mac << " to "
                    << node->client_initial_radio;
-        values_map.at(initial_radio_str) = tlvf::mac_to_string(node->client_initial_radio);
+        values_map.at(INITIAL_RADIO_STR) = tlvf::mac_to_string(node->client_initial_radio);
     }
 
     if (node->client_stay_on_selected_band != eTriStateBool::NOT_CONFIGURED) {
         auto enable = (node->client_stay_on_selected_band == eTriStateBool::ENABLE);
         LOG(DEBUG) << "setting client stay-on-selected-band in persistent-db to for " << mac
                    << " to " << enable;
-        values_map.at(selected_band_enable_str) = std::to_string(enable);
+        values_map.at(SELECTED_BAND_ENABLE_STR) = std::to_string(enable);
     }
 
     if (node->client_selected_bands != beerocks::eFreqType::FREQ_UNKNOWN) {
         LOG(DEBUG) << "setting client selected-bands in persistent-db to for " << mac << " to "
                    << node->client_selected_bands;
-        values_map.at(selected_bands_str) = std::to_string(node->client_selected_bands);
+        values_map.at(SELECTED_BANDS_STR) = std::to_string(node->client_selected_bands);
     }
 
     // update the persistent db

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2492,6 +2492,12 @@ bool db::is_client_in_persistent_db(const sMacAddr &mac)
 bool db::add_client_to_persistent_db(const sMacAddr &mac,
                                      std::unordered_map<std::string, std::string> params)
 {
+    // if persistent db is disabled
+    if (!config.persistent_db) {
+        LOG(ERROR) << "persistent db is disabled";
+        return false;
+    }
+
     auto db_entry = client_db_entry_from_mac(mac);
 
     if (!bpl::db_has_entry(std::string("type"), db_entry)) {
@@ -2542,16 +2548,21 @@ bool db::set_client_time_life_delay(const sMacAddr &mac,
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
-        LOG(DEBUG) << "configuring persistent-db, timelife = " << time_life_delay_sec.count();
+        // if persistent db is disabled
+        if (!config.persistent_db) {
+            LOG(DEBUG) << "persistent db is disabled";
+        } else {
+            LOG(DEBUG) << "configuring persistent-db, timelife = " << time_life_delay_sec.count();
 
-        std::unordered_map<std::string, std::string> values_map;
-        values_map[TIMESTAMP_STR]      = timestamp_to_string_seconds(timestamp);
-        values_map[TIMELIFE_DELAY_STR] = std::to_string(time_life_delay_sec.count());
+            std::unordered_map<std::string, std::string> values_map;
+            values_map[TIMESTAMP_STR]      = timestamp_to_string_seconds(timestamp);
+            values_map[TIMELIFE_DELAY_STR] = std::to_string(time_life_delay_sec.count());
 
-        // update the persistent db
-        if (!update_client_entry_in_persistent_db(mac, values_map)) {
-            LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
-            return false;
+            // update the persistent db
+            if (!update_client_entry_in_persistent_db(mac, values_map)) {
+                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+                return false;
+            }
         }
     }
 
@@ -2585,16 +2596,22 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
-        LOG(DEBUG) << "configuring persistent-db, initial_radio_enable = " << stay_on_initial_radio;
+        // if persistent db is disabled
+        if (!config.persistent_db) {
+            LOG(DEBUG) << "persistent db is disabled";
+        } else {
+            LOG(DEBUG) << "configuring persistent-db, initial_radio_enable = "
+                       << stay_on_initial_radio;
 
-        std::unordered_map<std::string, std::string> values_map;
-        values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
-        values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(stay_on_initial_radio);
+            std::unordered_map<std::string, std::string> values_map;
+            values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
+            values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(stay_on_initial_radio);
 
-        // update the persistent db
-        if (!update_client_entry_in_persistent_db(mac, values_map)) {
-            LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
-            return false;
+            // update the persistent db
+            if (!update_client_entry_in_persistent_db(mac, values_map)) {
+                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+                return false;
+            }
         }
     }
 
@@ -2629,16 +2646,21 @@ bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_r
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
-        LOG(DEBUG) << "configuring persistent-db, initial_radio = " << initial_radio_mac;
+        // if persistent db is disabled
+        if (!config.persistent_db) {
+            LOG(DEBUG) << "persistent db is disabled";
+        } else {
+            LOG(DEBUG) << "configuring persistent-db, initial_radio = " << initial_radio_mac;
 
-        std::unordered_map<std::string, std::string> values_map;
-        values_map[TIMESTAMP_STR]     = timestamp_to_string_seconds(timestamp);
-        values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(initial_radio_mac);
+            std::unordered_map<std::string, std::string> values_map;
+            values_map[TIMESTAMP_STR]     = timestamp_to_string_seconds(timestamp);
+            values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(initial_radio_mac);
 
-        // update the persistent db
-        if (!update_client_entry_in_persistent_db(mac, values_map)) {
-            LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
-            return false;
+            // update the persistent db
+            if (!update_client_entry_in_persistent_db(mac, values_map)) {
+                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+                return false;
+            }
         }
     }
 
@@ -2672,16 +2694,22 @@ bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_sele
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
-        LOG(DEBUG) << "configuring persistent-db, selected_band_enable = " << stay_on_selected_band;
+        // if persistent db is disabled
+        if (!config.persistent_db) {
+            LOG(DEBUG) << "persistent db is disabled";
+        } else {
+            LOG(DEBUG) << "configuring persistent-db, selected_band_enable = "
+                       << stay_on_selected_band;
 
-        std::unordered_map<std::string, std::string> values_map;
-        values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
-        values_map[SELECTED_BAND_ENABLE_STR] = std::to_string(stay_on_selected_band);
+            std::unordered_map<std::string, std::string> values_map;
+            values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
+            values_map[SELECTED_BAND_ENABLE_STR] = std::to_string(stay_on_selected_band);
 
-        // update the persistent db
-        if (!update_client_entry_in_persistent_db(mac, values_map)) {
-            LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
-            return false;
+            // update the persistent db
+            if (!update_client_entry_in_persistent_db(mac, values_map)) {
+                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+                return false;
+            }
         }
     }
 
@@ -2716,16 +2744,21 @@ bool db::set_client_selected_bands(const sMacAddr &mac, beerocks::eFreqType sele
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
-        LOG(DEBUG) << ", configuring persistent-db, selected_bands = " << int(selected_bands);
+        // if persistent db is disabled
+        if (!config.persistent_db) {
+            LOG(DEBUG) << "persistent db is disabled";
+        } else {
+            LOG(DEBUG) << ", configuring persistent-db, selected_bands = " << int(selected_bands);
 
-        std::unordered_map<std::string, std::string> values_map;
-        values_map[TIMESTAMP_STR]      = timestamp_to_string_seconds(timestamp);
-        values_map[SELECTED_BANDS_STR] = std::to_string(selected_bands);
+            std::unordered_map<std::string, std::string> values_map;
+            values_map[TIMESTAMP_STR]      = timestamp_to_string_seconds(timestamp);
+            values_map[SELECTED_BANDS_STR] = std::to_string(selected_bands);
 
-        // update the persistent db
-        if (!update_client_entry_in_persistent_db(mac, values_map)) {
-            LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
-            return false;
+            // update the persistent db
+            if (!update_client_entry_in_persistent_db(mac, values_map)) {
+                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+                return false;
+            }
         }
     }
 
@@ -2763,17 +2796,19 @@ bool db::clear_client_persistent_db(const sMacAddr &mac)
     node->client_stay_on_selected_band = eTriStateBool::NOT_CONFIGURED;
     node->client_selected_bands        = beerocks::eFreqType::FREQ_UNKNOWN;
 
-    LOG(DEBUG) << "removing client " << mac << " from persistent db";
-    auto db_entry        = client_db_entry_from_mac(mac);
-    auto type_client_str = type_to_string(beerocks::eType::TYPE_CLIENT);
-    if (!bpl::db_has_entry(type_client_str, db_entry)) {
-        LOG(DEBUG) << "client entry does not exist in persistent-db for " << db_entry;
-        return true;
-    }
+    // if persistent db is enabled
+    if (config.persistent_db) {
+        auto db_entry        = client_db_entry_from_mac(mac);
+        auto type_client_str = type_to_string(beerocks::eType::TYPE_CLIENT);
+        if (!bpl::db_has_entry(type_client_str, db_entry)) {
+            LOG(DEBUG) << "client entry does not exist in persistent-db for " << db_entry;
+            return true;
+        }
 
-    if (!bpl::db_remove_entry(type_client_str, db_entry)) {
-        LOG(ERROR) << "failed to remove client entry " << db_entry;
-        return false;
+        if (!bpl::db_remove_entry(type_client_str, db_entry)) {
+            LOG(ERROR) << "failed to remove client entry " << db_entry;
+            return false;
+        }
     }
 
     return true;
@@ -2781,6 +2816,12 @@ bool db::clear_client_persistent_db(const sMacAddr &mac)
 
 bool db::update_client_persistent_db(const sMacAddr &mac)
 {
+    // if persistent db is disabled
+    if (!config.persistent_db) {
+        LOG(ERROR) << "persistent db is disabled";
+        return false;
+    }
+
     auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
     if (!node) {
         LOG(ERROR) << "client node not found for mac " << mac;
@@ -2846,6 +2887,12 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
 std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
 db::load_persistent_db_clients()
 {
+    // if persistent db is disabled
+    if (!config.persistent_db) {
+        LOG(ERROR) << "persistent db is disabled";
+        return {};
+    }
+
     std::unordered_map<std::string, std::unordered_map<std::string, std::string>> clients;
     if (!bpl::db_get_entries_by_type(type_to_string(beerocks::eType::TYPE_CLIENT), clients)) {
         LOG(ERROR) << "failed to get all clients from persistent DB";

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2513,6 +2513,17 @@ bool db::add_client_to_persistent_db(const sMacAddr &mac,
                    << " already exists but with different type";
         return false;
     }
+
+    if (m_persistent_db_clients_count >= config.clients_persistent_db_max_size) {
+        LOG(DEBUG) << "reached max clients size in persistent db - removing a client before adding "
+                      "new client";
+        if (!remove_candidate_client()) {
+            LOG(ERROR) << "failed to remove next-to-be-aged client entry " << db_entry
+                       << "from persistent db (due to full persistent db)";
+            return false;
+        }
+    }
+
     // add entry to the persistent db
     if (!add_client_entry_and_update_counter(db_entry, params)) {
         LOG(ERROR) << "failed to add client entry " << db_entry << " to persistent db";

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2545,8 +2545,8 @@ bool db::set_client_time_life_delay(const sMacAddr &mac,
         LOG(DEBUG) << "configuring persistent-db, timelife = " << time_life_delay_sec.count();
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(TIMESTAMP_STR)      = timestamp_to_string_seconds(timestamp);
-        values_map.at(TIMELIFE_DELAY_STR) = std::to_string(time_life_delay_sec.count());
+        values_map[TIMESTAMP_STR]      = timestamp_to_string_seconds(timestamp);
+        values_map[TIMELIFE_DELAY_STR] = std::to_string(time_life_delay_sec.count());
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2588,8 +2588,8 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
         LOG(DEBUG) << "configuring persistent-db, initial_radio_enable = " << stay_on_initial_radio;
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(TIMESTAMP_STR)            = timestamp_to_string_seconds(timestamp);
-        values_map.at(INITIAL_RADIO_ENABLE_STR) = std::to_string(stay_on_initial_radio);
+        values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
+        values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(stay_on_initial_radio);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2632,8 +2632,8 @@ bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_r
         LOG(DEBUG) << "configuring persistent-db, initial_radio = " << initial_radio_mac;
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(TIMESTAMP_STR)     = timestamp_to_string_seconds(timestamp);
-        values_map.at(INITIAL_RADIO_STR) = tlvf::mac_to_string(initial_radio_mac);
+        values_map[TIMESTAMP_STR]     = timestamp_to_string_seconds(timestamp);
+        values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(initial_radio_mac);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2675,8 +2675,8 @@ bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_sele
         LOG(DEBUG) << "configuring persistent-db, selected_band_enable = " << stay_on_selected_band;
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(TIMESTAMP_STR)            = timestamp_to_string_seconds(timestamp);
-        values_map.at(SELECTED_BAND_ENABLE_STR) = std::to_string(stay_on_selected_band);
+        values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
+        values_map[SELECTED_BAND_ENABLE_STR] = std::to_string(stay_on_selected_band);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2719,8 +2719,8 @@ bool db::set_client_selected_bands(const sMacAddr &mac, beerocks::eFreqType sele
         LOG(DEBUG) << ", configuring persistent-db, selected_bands = " << int(selected_bands);
 
         std::unordered_map<std::string, std::string> values_map;
-        values_map.at(TIMESTAMP_STR)      = timestamp_to_string_seconds(timestamp);
-        values_map.at(SELECTED_BANDS_STR) = std::to_string(selected_bands);
+        values_map[TIMESTAMP_STR]      = timestamp_to_string_seconds(timestamp);
+        values_map[SELECTED_BANDS_STR] = std::to_string(selected_bands);
 
         // update the persistent db
         if (!update_client_entry_in_persistent_db(mac, values_map)) {
@@ -2798,39 +2798,38 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
     std::unordered_map<std::string, std::string> values_map;
 
     //fill values map of client persistent params
-    values_map.at(TIMESTAMP_STR) = timestamp_to_string_seconds(node->client_parameters_last_edit);
+    values_map[TIMESTAMP_STR] = timestamp_to_string_seconds(node->client_parameters_last_edit);
 
     if (node->client_time_life_delay_sec != std::chrono::seconds::zero()) {
         LOG(DEBUG) << "setting client time-life-delay in persistent-db to for " << mac << " to "
                    << node->client_time_life_delay_sec.count();
-        values_map.at(TIMELIFE_DELAY_STR) =
-            std::to_string(node->client_time_life_delay_sec.count());
+        values_map[TIMELIFE_DELAY_STR] = std::to_string(node->client_time_life_delay_sec.count());
     }
 
     if (node->client_stay_on_initial_radio != eTriStateBool::NOT_CONFIGURED) {
         auto enable = (node->client_stay_on_initial_radio == eTriStateBool::ENABLE);
         LOG(DEBUG) << "setting client stay-on-initial-radio in persistent-db to for " << mac
                    << " to " << enable;
-        values_map.at(INITIAL_RADIO_ENABLE_STR) = std::to_string(enable);
+        values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(enable);
     }
 
     if (node->client_initial_radio != network_utils::ZERO_MAC) {
         LOG(DEBUG) << "setting client initial-radio in persistent-db to for " << mac << " to "
                    << node->client_initial_radio;
-        values_map.at(INITIAL_RADIO_STR) = tlvf::mac_to_string(node->client_initial_radio);
+        values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(node->client_initial_radio);
     }
 
     if (node->client_stay_on_selected_band != eTriStateBool::NOT_CONFIGURED) {
         auto enable = (node->client_stay_on_selected_band == eTriStateBool::ENABLE);
         LOG(DEBUG) << "setting client stay-on-selected-band in persistent-db to for " << mac
                    << " to " << enable;
-        values_map.at(SELECTED_BAND_ENABLE_STR) = std::to_string(enable);
+        values_map[SELECTED_BAND_ENABLE_STR] = std::to_string(enable);
     }
 
     if (node->client_selected_bands != beerocks::eFreqType::FREQ_UNKNOWN) {
         LOG(DEBUG) << "setting client selected-bands in persistent-db to for " << mac << " to "
                    << node->client_selected_bands;
-        values_map.at(SELECTED_BANDS_STR) = std::to_string(node->client_selected_bands);
+        values_map[SELECTED_BANDS_STR] = std::to_string(node->client_selected_bands);
     }
 
     // update the persistent db

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -4227,3 +4227,28 @@ bool db::update_client_entry_in_persistent_db(
 
     return true;
 }
+
+bool db::add_client_entry_and_update_counter(
+    const std::string &entry_name, const std::unordered_map<std::string, std::string> &values_map)
+{
+    if (!bpl::db_add_entry(type_to_string(beerocks::eType::TYPE_CLIENT), entry_name, values_map)) {
+        LOG(ERROR) << "failed to add client entry " << entry_name << " to persistent db";
+        return false;
+    }
+
+    ++m_persistent_db_clients_count;
+
+    return true;
+}
+
+bool db::remove_client_entry_and_update_counter(const std::string &entry_name)
+{
+    if (!bpl::db_remove_entry(type_to_string(beerocks::eType::TYPE_CLIENT), entry_name)) {
+        LOG(ERROR) << "failed to remove entry " << entry_name << "from persistent db";
+        return false;
+    }
+    --m_persistent_db_clients_count;
+
+    return false;
+}
+

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -4231,6 +4231,54 @@ bool db::update_client_entry_in_persistent_db(
     return true;
 }
 
+bool db::set_node_params_from_map(const sMacAddr &mac,
+                                  const std::unordered_map<std::string, std::string> &values_map)
+{
+    auto node = get_node(mac);
+    if (!node) {
+        LOG(WARNING) << " - node " << mac << " does not exist!";
+        return false;
+    }
+
+    for (const auto &param : values_map) {
+        if (param.first == TIMESTAMP_STR) {
+            LOG(DEBUG) << "setting node client_parameters_last_edit to " << param.second << " for "
+                       << mac;
+            node->client_parameters_last_edit =
+                timestamp_from_seconds(string_utils::stoi(param.second));
+        } else if (param.first == TIMELIFE_DELAY_STR) {
+            LOG(DEBUG) << "setting node client_time_life_delay_sec to " << param.second << " for "
+                       << mac;
+            node->client_time_life_delay_sec =
+                std::chrono::seconds(string_utils::stoi(param.second));
+        } else if (param.first == INITIAL_RADIO_ENABLE_STR) {
+            LOG(DEBUG) << "setting node client_stay_on_initial_radio to " << param.second << " for "
+                       << mac;
+
+            node->client_stay_on_initial_radio =
+                (param.second == "1") ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
+        } else if (param.first == INITIAL_RADIO_STR) {
+            LOG(DEBUG) << "setting node client_initial_radio to " << param.second << " for " << mac;
+
+            node->client_initial_radio = tlvf::mac_from_string(param.second);
+        } else if (param.first == SELECTED_BAND_ENABLE_STR) {
+            LOG(DEBUG) << "setting node client_stay_on_selected_band to " << param.second << " for "
+                       << mac;
+
+            node->client_stay_on_selected_band =
+                (param.second == "1") ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
+        } else if (param.first == SELECTED_BANDS_STR) {
+            LOG(DEBUG) << "setting node client_selected_bands to " << param.second << " for "
+                       << mac;
+            node->client_selected_bands = beerocks::eFreqType(string_utils::stoi(param.second));
+        } else {
+            LOG(WARNING) << "Unknown parameter, skipping: " << param.first << " for " << mac;
+        }
+    }
+
+    return true;
+}
+
 bool db::add_client_entry_and_update_counter(
     const std::string &entry_name, const std::unordered_map<std::string, std::string> &values_map)
 {

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1133,6 +1133,16 @@ private:
      */
     bool remove_client_entry_and_update_counter(const std::string &entry_name);
 
+    /**
+     * @brief Returns the preferred client to be removed.
+     * Preference is determined as follows:
+     * - Prefer disconnected clients over connected ones.
+     * - According to above, the client with least time left before aging.
+     *
+     * @return sMacAddr mac of candidate client to be removed - if not found, string_utils::ZERO_MAC is returned.
+     */
+    sMacAddr get_candidate_client_for_removal();
+
     int network_optimization_task_id = -1;
     int channel_selection_task_id    = -1;
     int bml_task_id                  = -1;

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1134,6 +1134,13 @@ private:
     bool remove_client_entry_and_update_counter(const std::string &entry_name);
 
     /**
+     * @brief Removes client with least timelife remaining from persistent db (with preference to disconnected clients).
+     * 
+     * @return true on success, otherwise false.
+     */
+    bool remove_candidate_client();
+
+    /**
      * @brief Returns the preferred client to be removed.
      * Preference is determined as follows:
      * - Prefer disconnected clients over connected ones.

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1093,6 +1093,14 @@ private:
     void rewind();
     bool get_next_node(std::shared_ptr<node> &n, int &hierarchy);
     bool get_next_node(std::shared_ptr<node> &n);
+
+    /**
+     * @brief Updates the client values in the persistent db.
+     * 
+     * @param mac MAC address of a client.
+     * @param values_map A map of client params and their values.
+     * @return true on success, otherwise false.
+     */
     bool
     update_client_entry_in_persistent_db(const sMacAddr &mac,
                                          std::unordered_map<std::string, std::string> values_map);

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -666,7 +666,7 @@ public:
      * @return true on success, otherwise false.
      */
     bool add_client_to_persistent_db(const sMacAddr &mac,
-                                     std::unordered_map<std::string, std::string> params =
+                                     const std::unordered_map<std::string, std::string> &params =
                                          std::unordered_map<std::string, std::string>());
 
     /**
@@ -1101,9 +1101,8 @@ private:
      * @param values_map A map of client params and their values.
      * @return true on success, otherwise false.
      */
-    bool
-    update_client_entry_in_persistent_db(const sMacAddr &mac,
-                                         std::unordered_map<std::string, std::string> values_map);
+    bool update_client_entry_in_persistent_db(
+        const sMacAddr &mac, const std::unordered_map<std::string, std::string> &values_map);
 
     /**
      * @brief Adds a client entry to persistent_db with configured parameters and increments clients counter.

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1105,6 +1105,25 @@ private:
     update_client_entry_in_persistent_db(const sMacAddr &mac,
                                          std::unordered_map<std::string, std::string> values_map);
 
+    /**
+     * @brief Adds a client entry to persistent_db with configured parameters and increments clients counter.
+     * 
+     * @param entry_name Client entry name in persistent db.
+     * @param values_map A map of client params and their values.
+     * @return true on success, otherwise false.
+     */
+    bool add_client_entry_and_update_counter(
+        const std::string &entry_name,
+        const std::unordered_map<std::string, std::string> &values_map);
+
+    /**
+     * @brief Removes a client entry from persistent_db and decrements clients counter.
+     * 
+     * @param entry_name Client entry name in persistent db.
+     * @return true on success, otherwise false.
+     */
+    bool remove_client_entry_and_update_counter(const std::string &entry_name);
+
     int network_optimization_task_id = -1;
     int channel_selection_task_id    = -1;
     int bml_task_id                  = -1;
@@ -1165,6 +1184,8 @@ private:
 
     master_thread *m_master_thread_ctx = nullptr;
     const std::string m_local_bridge_mac;
+
+    int m_persistent_db_clients_count = 0;
 };
 
 } // namespace son

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1105,6 +1105,16 @@ private:
         const sMacAddr &mac, const std::unordered_map<std::string, std::string> &values_map);
 
     /**
+     * @brief Sets the node params (runtime db) from a param-value map.
+     * 
+     * @param mac MAC address of node to be updated.
+     * @param values_map A map of client params and their values.
+     * @return true on success, otherwise false.
+     */
+    bool set_node_params_from_map(const sMacAddr &mac,
+                                  const std::unordered_map<std::string, std::string> &values_map);
+
+    /**
      * @brief Adds a client entry to persistent_db with configured parameters and increments clients counter.
      * 
      * @param entry_name Client entry name in persistent db.

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -45,6 +45,18 @@ class db {
     } sBmlListener;
 
 public:
+    /**
+     * @brief Client parameter names.
+     * The parameter names can be used to set/get multiple parameters in one-shot.
+     * This is done using key-value map (where key is the param name and value is it value)
+     */
+    static const std::string TIMESTAMP_STR;
+    static const std::string TIMELIFE_DELAY_STR;
+    static const std::string INITIAL_RADIO_ENABLE_STR;
+    static const std::string INITIAL_RADIO_STR;
+    static const std::string SELECTED_BAND_ENABLE_STR;
+    static const std::string SELECTED_BANDS_STR;
+
     // VAPs info list type
     typedef std::list<std::shared_ptr<beerocks_message::sConfigVapInfo>> vaps_list_t;
 

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -187,6 +187,7 @@ public:
      * 
      * @param mac MAC address of a client.
      * @return std::string the string representation of the MAC address with ':' replaced with '_' removed.
+     * @return An empty string is returned on failure.
      */
     static std::string client_db_entry_from_mac(const sMacAddr &mac);
 
@@ -194,7 +195,7 @@ public:
      * @brief Get client MAC address from db entry.
      * 
      * @param db_entry Client entry name in persistent db.
-     * @return sMacAddr MAC address of the client the db_entry is representing.
+     * @return sMacAddr MAC address of the client the db_entry is representing. On failure ZERO_MAC is returned.
      */
     static sMacAddr client_db_entry_to_mac(const std::string &db_entry);
 
@@ -791,12 +792,12 @@ public:
 
     /**
      * @brief Load all clients from persistent db.
+     * Creates nodes for the clients in runtime-db and set persistent parameters values accordingly.
+     * Aged Clients and Clients with invalid data are filtered-out and removed from persistent-DB.
      * 
-     * @return An unordered map of clients, for each client unordered map of params as key-value.
-     * @return An empty map of clients is returned if the persistent db is empty.
+     * @return true on success, otherwise false.
      */
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
-    load_persistent_db_clients();
+    bool load_persistent_db_clients();
 
     //
     // CLI

--- a/controller/src/beerocks/master/son_master_thread.cpp
+++ b/controller/src/beerocks/master/son_master_thread.cpp
@@ -88,6 +88,16 @@ bool master_thread::init()
     set_server_max_connections(SOCKET_MAX_CONNECTIONS);
     set_select_timeout(SOCKETS_SELECT_TIMEOUT_MSEC);
 
+    LOG(DEBUG) << "persistent db enable=" << database.config.persistent_db;
+    if (database.config.persistent_db) {
+        LOG(DEBUG) << "loading clients from persistent db";
+        if (!database.load_persistent_db_clients()) {
+            LOG(WARNING) << "failed to load clients from persistent db";
+        } else {
+            LOG(DEBUG) << "load clients from persistent db finished successfully";
+        }
+    }
+
     if (!transport_socket_thread::init()) {
         LOG(ERROR) << "Failed init of transport_socket_thread";
         stop();


### PR DESCRIPTION
This PR introduces the flow of reading clients from the persistent DB as part of the controller init flow.

As part of this PR the following improvements/changes were introduced:
- persistent DB param-names are public to `db` class users (required for efficient update of the multiple parameters at once).
- In existing db APIs verify persistent-db is enabled before accessing the BPL.
- missing function description was added.
- added a client-aging and removal functionality (both for runtime DB parameters and for persistent DB).
- added a counter of clients in persistent-db and moved all BPL add/remove client operation to use private `db` class APIs that encapsulates the counter update.
- added a "remove-a-client-before-add" functionality if persistent DB is full.
- refactored the load_persistent_db_clients() to handle the filtering of aged and invalid client entries.
- added a call to load_persistent_db_clients() from the controller init flow - if the persistent DB is enabled.

relates to PPM-5