### PR TITLE
common: bwl: Fix building nl80211 for linux

### DIFF
--- a/common/beerocks/bwl/CMakeLists.txt
+++ b/common/beerocks/bwl/CMakeLists.txt
@@ -28,11 +28,6 @@ elseif(TARGET_PLATFORM STREQUAL "openwrt")
         set(BWL_TYPE "NL80211")
     endif()
 
-    # hostapd directory
-    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd*/hostapd-*")
-    find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS ${HOSTAPD_SEARCH_PATHS} NO_CMAKE_FIND_ROOT_PATH)
-    set(HOSTAPD_DIR "${HOSTAPD_INCLUDE_DIR}")
-
 endif()
 
 set(BWL_TYPE ${BWL_TYPE} CACHE STRING "Which BWL backend to use")
@@ -43,6 +38,10 @@ set(BWL_TYPE ${BWL_TYPE} CACHE STRING "Which BWL backend to use")
 
 if(BWL_TYPE STREQUAL "DWPAL")
     
+    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd*/hostapd-*")
+    find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS ${HOSTAPD_SEARCH_PATHS} NO_CMAKE_FIND_ROOT_PATH)
+    set(HOSTAPD_DIR "${HOSTAPD_INCLUDE_DIR}")
+
     include_directories(
         ${HOSTAPD_DIR}/src/drivers
         ${PLATFORM_BUILD_DIR}/iwlwav-iw-4.14
@@ -75,6 +74,10 @@ if(BWL_TYPE STREQUAL "DWPAL")
     endif()
 
 elseif(BWL_TYPE STREQUAL "NL80211")
+
+    file(GLOB HOSTAPD_SEARCH_PATHS "${PLATFORM_BUILD_DIR}/hostapd*/hostapd-*")
+    find_path(HOSTAPD_INCLUDE_DIR NAMES "src/common/wpa_ctrl.h" PATHS ${HOSTAPD_SEARCH_PATHS} NO_CMAKE_FIND_ROOT_PATH)
+    set(HOSTAPD_DIR "${HOSTAPD_INCLUDE_DIR}")
 
     find_package(nl-genl-3 REQUIRED)
     list(APPEND BWL_LIBS nl-genl-3)


### PR DESCRIPTION

If run build with BWL_TYPE=NL80211 for TARGET_PLATFORM linux:

```
./tools/docker/build.sh -f BWL_TYPE=NL80211 TARGET_PLATFORM=linux
```
then next compilation errors happen:

```
/home/mutespirit/inango/prplmesh/prplmesh_root/prplMesh/common/beerocks/bwl/shared/netlink_socket.cpp:11:10: fatal error: netlink/msg.h: No such file or directory
     #include <netlink/msg.h>
               ^~~~~~~~~~~~~~~
               compilation terminated.

    /home/mutespirit/inango/prplmesh/prplmesh_root/prplMesh/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp:20:10: fatal error: wpa_ctrl.h: No such file or directory
     #include <wpa_ctrl.h>
              ^~~~~~~~~~~~
```

For fixing build nl80211 for linux platform need to create new variable NEEDS_HOSTAPD_PATH and add a condition for linux platform. NEEDS_HOSTAPD_PATH variable should be true when it is built for rdkb, ugw, openwrt and linux. For dummy it should be turned off.

Original PR is #1355
https://jira.prplfoundation.org/browse/PPM-269
