### PR TITLE
[PPM-10] Replace if_indextoname to network_utils::linux_get_iface_name

### DIFF
--- a/agent/src/beerocks/slave/backhaul_manager/wan_monitor.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/wan_monitor.cpp
@@ -130,20 +130,21 @@ wan_monitor::ELinkState wan_monitor::process()
 
         // LINK related message
         if (hnl->nlmsg_type == RTM_NEWLINK || hnl->nlmsg_type == RTM_DELLINK) {
-            char name[IFNAMSIZ]   = {0};
+
             struct ifinfomsg *ifi = (struct ifinfomsg *)NLMSG_DATA(hnl);
 
             // Convert the interface index to name
-            if_indextoname(ifi->ifi_index, name);
+            auto iface_name = network_utils::linux_get_iface_name(ifi->ifi_index);
 
             // Skip events for other interfaces
-            if (m_strWanIfaceName.compare(name) != 0) {
-                LOG(DEBUG) << "Link detected for non-WAN interface '" << name << "'. Skipping...";
+            if (m_strWanIfaceName != iface_name) {
+                LOG(DEBUG) << "Link detected for non-WAN interface '" << iface_name
+                           << "'. Skipping...";
 
                 continue;
             }
 
-            LOG(DEBUG) << "Interface '" << name << "', msg_type: " << int(hnl->nlmsg_type)
+            LOG(DEBUG) << "Interface '" << iface_name << "', msg_type: " << int(hnl->nlmsg_type)
                        << ", running: " << int(ifi->ifi_flags & IFF_RUNNING);
 
             // Return WAN interface link state

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -338,9 +338,12 @@ static int parseRoutes(struct nlmsghdr *nlHdr, std::shared_ptr<route_info> rtInf
     rtLen  = RTM_PAYLOAD(nlHdr);
     for (; RTA_OK(rtAttr, rtLen); rtAttr = RTA_NEXT(rtAttr, rtLen)) {
         switch (rtAttr->rta_type) {
-        case RTA_OIF:
-            if_indextoname(*(int *)RTA_DATA(rtAttr), rtInfo->ifName);
+        case RTA_OIF: {
+            auto index            = *(int *)RTA_DATA(rtAttr);
+            auto iface_index_name = network_utils::linux_get_iface_name(index);
+            std::copy_n(iface_index_name.begin(), iface_index_name.length(), rtInfo->ifName);
             break;
+        }
         case RTA_GATEWAY:
             rtInfo->gateWay.s_addr = *(u_int *)RTA_DATA(rtAttr);
             break;

--- a/common/beerocks/bcl/source/network/network_utils.cpp
+++ b/common/beerocks/bcl/source/network/network_utils.cpp
@@ -541,6 +541,8 @@ std::string network_utils::linux_get_iface_name(uint32_t iface_index)
         return "";
     }
 
+    iface_name[IF_NAMESIZE - 1] = '\0';
+
     return iface_name;
 }
 


### PR DESCRIPTION
Need to replace `if_indextoname()` to the wrapper `network_utils::linux_get_iface_name`. For all prplmesh source code.

https://jira.prplfoundation.org/browse/PPM-10