### PR TITLE
PPM-297 Implement missing dev_get_parameter for macaddr

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -115,7 +115,16 @@ bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, st
     if (parameter == "alid") {
         value = m_bridge_mac;
         return true;
-    } else if (parameter == "macaddr" || parameter == "bssid") {
+    } else if (parameter == "macaddr") {
+        if (params.find("ruid") == params.end()) {
+            value = "missing ruid";
+            return false;
+        }
+        auto ruid = tlvf::mac_to_string(std::strtoull(params["ruid"].c_str(), nullptr, 16));
+        // We use MAC address as Radio UID, so we can just return it here.
+        value = ruid;
+        return true;
+    } else if (parameter == "bssid") {
         if (params.find("ruid") == params.end()) {
             value = "missing ruid";
             return false;
@@ -138,7 +147,7 @@ bool agent_ucc_listener::handle_dev_get_param(std::unordered_map<std::string, st
                 return true;
             }
         }
-        value = "macaddr/bssid not found for ruid " + ruid + " ssid " + ssid;
+        value = "bssid not found for ruid " + ruid + " ssid " + ssid;
         return false;
     }
     value = "parameter " + parameter + " not supported";

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -332,14 +332,18 @@ class TestFlows:
         # Step 2: config
         env.checkpoint()
         agent.cmd_reply("dev_set_config,backhaul,0x{}".format(agent.radios[0].mac.replace(':', '')))
-        # TODO
+
         # At this point, the wired backhaul should be removed from the bridge so autoconfig search
         # should still not come through.
         time.sleep(2)
-        # self.check_no_cmdu_type("autoconfig search while awaiting onboarding", 0x0007, agent.mac)
+        self.check_no_cmdu_type("autoconfig search while awaiting onboarding", 0x0007, agent.mac)
 
         # Step 3: start WPS
-        # TODO do backhaul onboarding
+        agent.cmd_reply("start_wps_registration,band,24G,WpsConfigMethod,PBC")
+
+        # TODO start WPS on CTT agent as well to complete onboarding
+        # On dummy, it does nothing anyway
+        time.sleep(2)
 
         # Clean up: reset to ethernet backhaul
         self.test_dev_reset_default()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -345,6 +345,13 @@ class TestFlows:
         # On dummy, it does nothing anyway
         time.sleep(2)
 
+        backhaul_mac = agent.cmd_reply(
+            "dev_get_parameter,program,map,ruid,0x{},parameter,macaddr".format(
+                agent.radios[0].mac.replace(':', ''))).get('macaddr')
+
+        # prplMesh uses the radio MAC as the backhaul MAC
+        assert backhaul_mac == agent.radios[0].mac
+
         # Clean up: reset to ethernet backhaul
         self.test_dev_reset_default()
 


### PR DESCRIPTION
The dev_get_parameter command is overloaded with a few different functions. Apparently one of them is to get the backhaul STA MAC address:

```    
dev_get_parameter,program,map,ruid,<ruid>,parameter,macaddr
```
    
We had already implemented this, but in commit 65b625d0a0 it was changed to behave the same as when requesting and SSID.
    
Reimplement the request for macaddr. Since we now use the MAC address as radio UID, we can simply return the RUID given as a parameter directly.