### PR TITLE
PPM-303 Move link metric query test to boardfarm

### DIFF
--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -1,12 +1,12 @@
 {
     "prplmesh_docker": {
-        "name": "controller",
+        "name": "agent",
         "board_type": "prplmesh_docker",
         "role": "agent",
         "conn_cmd": "",
         "devices": [
             {
-                "name": "wan",
+                "name": "lan",
                 "type": "prplmesh_docker",
                 "role": "controller",
                 "conn_cmd": ""
@@ -27,7 +27,7 @@
         "conn_cmd": "cu -s 115200 -l /dev/ttyUSB0",
         "devices": [
             {
-            "name": "wan",
+            "name": "lan",
             "type": "prplmesh_docker",
             "role": "controller",
             "docker_network": "prplMesh-net-rax40-1",

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/prplmesh_config.json
@@ -12,6 +12,12 @@
                 "conn_cmd": ""
             },
             {
+                "name": "lan2",
+                "type": "prplmesh_docker",
+                "role": "agent",
+                "conn_cmd": ""
+            },
+            {
                 "name": "wifi",
                 "type": "STA_dummy",
                 "mac": "51:a1:10:20:00:01",

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/ap_config_renew.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/ap_config_renew.py
@@ -16,7 +16,7 @@ class ApConfigRenew(PrplMeshBaseTest):
     def runTest(self):
         # Locate test participants
         agent = self.dev.DUT.agent_entity
-        controller = self.dev.wan.controller_entity
+        controller = self.dev.lan.controller_entity
 
         self.dev.DUT.wired_sniffer.start(self.__class__.__name__ + "-" + self.dev.DUT.name)
         # Regression test: MAC address should be case insensitive

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/client_association_link_metrics.py
@@ -20,7 +20,7 @@ class ClientAssociationLinkMetrics(PrplMeshBaseTest):
     def runTest(self):
         # Locate test participants
         agent = self.dev.DUT.agent_entity
-        controller = self.dev.wan.controller_entity
+        controller = self.dev.lan.controller_entity
         sta = self.dev.wifi
 
         # Regression check

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/link_metric_query.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/link_metric_query.py
@@ -1,0 +1,102 @@
+import time
+from collections import Counter
+from boardfarm.exceptions import SkipTest
+from .prplmesh_base_test import PrplMeshBaseTest
+from capi import tlv
+from opts import debug
+
+
+class LinkMetricQuery(PrplMeshBaseTest):
+    """Check if an agent can report the links it formed with other devices properly
+
+    Devices used in test setup:
+    AP1 - Agent1 [DUT]
+    AP2 - Agent2
+    GW - Controller
+
+    Given:
+    Bi-directional link is formed between AP1 and GW
+    Bi-directional link is formed between AP2 and AP1
+    When:
+    GW controller is instructed; "Link metric query" (0x0005) is sent for "All neighbors" (0) and
+    for "Both Tx and Rx link metrics" (2) from GW controller to AP1 agent
+    Then:
+    Agent must return a "Link metric response" (0x0006) which contains:
+    - A "1905 transmitter link metric" TLV with AP1's local interface MAC address
+    and GW's interface MAC address
+    - A "1905 receiver link metric" TLV with AP1's local interface MAC address
+    and GW's interface MAC address
+    - A "1905 transmitter link metric" TLV with AP1's local interface MAC address
+    and AP2's interface MAC address
+    - A "1905 receiver link metric" TLV with AP1's local interface MAC address
+    and AP2's interface MAC address
+
+    Link's media type (ethernet, wifi), packet stats, RSSI (for wireless rx links) and phy rate
+    (for wireless tx links) are not checked in this test.
+    """
+    def runTest(self):
+        # skip this test if one of the components does not exist in setup
+        try:
+            agent1 = self.dev.DUT.agent_entity
+            agent2 = self.dev.lan2.agent_entity
+            controller = self.dev.lan.controller_entity
+        except AttributeError as ae:
+            raise SkipTest(ae)
+
+        sniffer = self.dev.DUT.wired_sniffer
+        sniffer.start(self.__class__.__name__ + "-" + self.dev.DUT.name)
+
+        mid = controller.ucc_socket.dev_send_1905(agent1.mac, 0x0005,
+                                                  tlv(0x08, 0x0002, "0x00 0x02"))
+        time.sleep(1)
+
+        query = self.check_cmdu_type_single("link metric query", 0x0005,
+                                            controller.mac, agent1.mac,
+                                            mid)
+        query_tlv = self.check_cmdu_has_tlv_single(query, 0x08)
+
+        debug("Checking query type and queried metrics are correct")
+        assert int(query_tlv.link_metric_query_type) == 0x00, "Query type is not 'All neighbors'"
+        assert int(query_tlv.link_metrics_requested) == 0x02, \
+            "Metrics for both Tx and Rx is not requested"
+
+        resp = self.check_cmdu_type_single("link metric response", 0x0006,
+                                           agent1.mac, controller.mac,
+                                           mid)
+
+        debug("Checking response contains expected links to/from agent and nothing else")
+        # neighbor macs are based on the setup in "launch_environment_docker" method
+        expected_tx_link_neighbors = [controller.mac, agent2.mac]
+        expected_rx_link_neighbors = [controller.mac, agent2.mac]
+        actual_tx_links = self.check_cmdu_has_tlvs(resp, 0x09)
+        actual_rx_links = self.check_cmdu_has_tlvs(resp, 0x0a)
+
+        def verify_links(links, expected_neighbors, link_type):
+            verified_neighbors = []
+            unexpected_neighbors = []
+            for link in links:
+                assert link.responder_mac_addr == agent1.mac, "Responder MAC address is wrong"
+                # a tshark (v3.2.4) bug causes "neighbor_mac_addr" field to
+                # show up as "responder_mac_addr_2"
+                if link.responder_mac_addr_2 in expected_neighbors:
+                    verified_neighbors += [link.responder_mac_addr_2]
+                else:
+                    unexpected_neighbors += [link.responder_mac_addr_2]
+
+            # we expect each neighbor to appear only once
+            dup_links = []
+            for neighbor, count in Counter(verified_neighbors).items():
+                if count != 1:
+                    dup_links.append((neighbor, count))
+            assert not dup_links, \
+                "Following {} links were expected to appear only once:\n".format(link_type)\
+                + "\n".join(dup_links)
+
+            # report any extra neighbors that show up
+            assert not unexpected_neighbors, \
+                "{} links to following neighbors were not expected:\n".format(link_type)\
+                + "\n".join(unexpected_neighbors)
+
+        # check responder mac is our own mac, neighbor is one of the expected macs for each link
+        verify_links(actual_tx_links, expected_tx_link_neighbors, "tx")
+        verify_links(actual_rx_links, expected_rx_link_neighbors, "rx")

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/tests/prplmesh_base_test.py
@@ -3,10 +3,12 @@
 # This code is subject to the terms of the BSD+Patent license.
 # See LICENSE file for more details.
 
-from typing import Union
+from typing import Union, Callable, NoReturn
 
 from boardfarm.tests import bft_base_test
+from opts import debug
 import environment as env
+import sniffer
 
 
 class PrplMeshBaseTest(bft_base_test.BftBaseTest):
@@ -30,3 +32,144 @@ class PrplMeshBaseTest(bft_base_test.BftBaseTest):
         if not result:
             raise Exception
         return result
+
+    def check_cmdu(
+        self, msg: str, match_function: Callable[[sniffer.Packet], bool]
+    ) -> [sniffer.Packet]:
+        """Verify that the wired_sniffer has captured a CMDU that satisfies match_function.
+
+        Mark failure if no satisfying packet is found.
+
+        Parameters
+        ----------
+        msg: str
+            Message to show in case of failure. It is formatted in a context like
+            "No CMDU <msg> found".
+
+        match_function: Callable[[sniffer.Packet], bool]
+            A function that returns True if it is the expected packet. It is called on every packet
+            returned by get_packet_capture.
+
+        Returns
+        -------
+        [sniffer.Packet]
+            The matching packets.
+        """
+        debug("Checking for CMDU {}".format(msg))
+        result = self.dev.DUT.wired_sniffer.get_cmdu_capture(match_function)
+        assert result, "No CMDU {} found".format(msg)
+        return result
+
+    def check_cmdu_type(
+        self, msg: str, msg_type: int, eth_src: str, eth_dst: str = None, mid: int = None
+    ) -> [sniffer.Packet]:
+        """Verify that the wired sniffer has captured a CMDU.
+
+        Mark failure if the CMDU is not found.
+
+        Parameters
+        ----------
+        msg: str
+            Message to show in case of failure. It is formatted in a context like
+            "No CMDU <msg> found".
+
+        msg_type: int
+            CMDU message type that is expected.
+
+        eth_src: str
+            MAC address of the sender that is expected.
+
+        eth_dst: str
+            MAC address of the destination that is expected. If omitted, the IEEE1905.1 multicast
+            MAC address is used.
+
+        mid: int
+            Message Identifier that is expected. If omitted, the MID is not checked.
+
+        Returns
+        -------
+        [sniffer.Packet]
+            The matching packets.
+        """
+        debug("Checking for CMDU {} (0x{:04x}) from {}".format(msg, msg_type, eth_src))
+        result = self.dev.DUT.wired_sniffer.get_cmdu_capture_type(msg_type, eth_src, eth_dst, mid)
+        assert result, "No CMDU {} found".format(msg)
+        return result
+
+    def check_cmdu_type_single(
+        self, msg: str, msg_type: int, eth_src: str, eth_dst: str = None, mid: int = None
+    ) -> sniffer.Packet:
+        '''Like check_cmdu_type, but also check that only a single CMDU is found.'''
+        debug("Checking for single CMDU {} (0x{:04x}) from {}".format(msg, msg_type, eth_src))
+        cmdus = self.check_cmdu_type(msg, msg_type, eth_src, eth_dst, mid)
+        assert len(cmdus) == 1, "Multiple CMDUs {} found".format(msg)
+        return cmdus[0]
+
+    def check_no_cmdu_type(
+        self, msg: str, msg_type: int, eth_src: str, eth_dst: str = None
+    ) -> NoReturn:
+        '''Like check_cmdu_type, but check that *no* machting CMDU is found.'''
+        debug("Checking for no CMDU {} (0x{:04x}) from {}".format(msg, msg_type, eth_src))
+        result = self.dev.DUT.wired_sniffer.get_cmdu_capture_type(msg_type, eth_src, eth_dst)
+        if result:
+            for packet in result:
+                debug("  {}".format(packet))
+            assert False, "Unexpected CMDU {}".format(msg)
+
+    def check_cmdu_has_tlvs(
+        self, packet: sniffer.Packet, tlv_type: int
+    ) -> [sniffer.Tlv]:
+        '''Check that the packet has at least one TLV of the given type.
+
+        Mark failure if no TLV of that type is found.
+
+        Parameters
+        ----------
+        packet: Union[sniffer.Packet]
+            The packet to verify. If it is empty or it is not an IEEE1905
+            packet, an AssertionError is raised.
+
+        tlv_type: int
+            The type of TLV to look for.
+
+        Returns
+        -------
+        [sniffer.Tlv]
+            List of TLVs of the requested type. An AssertionError is raised if
+            no TLV is found.
+        '''
+        assert packet, "No packet found"
+        assert packet.ieee1905, "Packet is not IEEE1905: {}".format(packet)
+        tlvs = [tlv for tlv in packet.ieee1905_tlvs if tlv.tlv_type == tlv_type]
+        if not tlvs:
+            debug("  {}".format(packet))
+            assert False, "No TLV of type 0x{:02x} found in packet".format(tlv_type)
+        return tlvs
+
+    def check_cmdu_has_tlv_single(
+        self, packet: Union[sniffer.Packet, None], tlv_type: int
+    ) -> sniffer.Tlv:
+        '''Like check_cmdu_has_tlvs, but also check that only one TLV of that type is found.'''
+        tlvs = self.check_cmdu_has_tlvs(packet, tlv_type)
+        if len(tlvs) > 1:
+            debug("  {}".format(packet))
+            assert False, "More than one ({}) TLVs of type 0x{:02x} found".format(
+                len(tlvs), tlv_type)
+        return tlvs[0]
+
+    def check_cmdu_has_tlvs_exact(
+        self, packet: Union[sniffer.Packet, None], tlvs: [sniffer.Tlv]
+    ) -> NoReturn:
+        '''Check that the CMDU has exactly the TLVs given.'''
+        assert packet, "Packet not found"
+        assert packet.ieee1905, "Packet is not IEEE1905: {}".format(packet)
+
+        packet_tlvs = list(packet.ieee1905_tlvs)
+        for t in tlvs:
+            if t in packet_tlvs:
+                packet_tlvs.remove(t)
+            else:
+                assert False, "Packet misses tlv:\n {}".format(str(t))
+
+        assert not packet_tlvs, "Packet has unexpected tlvs:\n {}".format(
+            "\n ".join(map(str, packet_tlvs)))

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
@@ -7,3 +7,4 @@
 InitialApConfig
 ApConfigRenew
 ClientAssociationLinkMetrics
+LinkMetricQuery

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -122,6 +122,7 @@ class TestFlows:
         self, msg: str, msg_type: int, eth_src: str, eth_dst: str = None, mid: int = None
     ) -> sniffer.Packet:
         '''Like check_cmdu_type, but also check that only a single CMDU is found.'''
+        debug("Checking for single CMDU {} (0x{:04x}) from {}".format(msg, msg_type, eth_src))
         cmdus = self.check_cmdu_type(msg, msg_type, eth_src, eth_dst, mid)
         if not cmdus:
             assert False  # Failure already reported by check_cmdu


### PR DESCRIPTION
Link metric test is the first test that checks CMDUs and TLVs so code is duplicated between test_flows.py and prplmesh_base_test.py. I didn't try to come up with a design to prevent that since test_flows.py is no longer developed and will be removed.

Test is modified since boardfarm tests exit when the test fails. In test_flows.py we were trying to give as much of the fail reasons as we can.

This test is skipped on RAX40 since that setup has only one agent and testing only controller / agent connection is underwhelming. I plan to discuss this and do another PR which adds a second dockerized agent to the RAX40 setup.

I didn't remove the test from test_flows.py (as @abelog suggested).