### PR TITLE
PPM-300: Add Bus agnostic API as optional dependency to the builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option (BUILD_AGENT "Build EasyMesh agent" ON)
 option (BUILD_CONTROLLER "Build EasyMesh controller" ON)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
+option (ENABLE_HLAPI "Build the northbound (high-level) API" OFF)
 
 ## Generic checks and defaults
 

--- a/cmake/Findamxb.cmake
+++ b/cmake/Findamxb.cmake
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(AMXB_LIBRARY "libamxb.so")
+find_path(AMXB_INCLUDE_DIRS
+    NAMES amxb/amxb.h
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(amxb DEFAULT_MSG
+    AMXB_LIBRARY
+    AMXB_INCLUDE_DIRS
+)
+
+if (amxb_FOUND)
+    add_library(amxb UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(amxb PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${AMXB_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(amxb PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${AMXB_LIBRARY}"
+    )
+
+endif()

--- a/cmake/Findamxc.cmake
+++ b/cmake/Findamxc.cmake
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(AMXC_LIBRARY "libamxc.so")
+find_path(AMXC_INCLUDE_DIRS
+    NAMES amxc/amxc.h
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(amxc DEFAULT_MSG
+    AMXC_LIBRARY
+    AMXC_INCLUDE_DIRS
+)
+
+if (amxc_FOUND)
+    add_library(amxc UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(amxc PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${AMXC_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(amxc PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${AMXC_LIBRARY}"
+    )
+
+endif()

--- a/cmake/Findamxd.cmake
+++ b/cmake/Findamxd.cmake
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(AMXD_LIBRARY "libamxd.so")
+find_path(AMXD_INCLUDE_DIRS
+    NAMES amxd_object_function.h amxd_object.h amxd_object_expression.h amxd_parameter_action.h amxd_object_parameter.h amxd_object_hierarchy.h amxd_action.h amxd_transaction.h amxd_function.h amxd_parameter.h amxd_object_event.h amxd_common.h amxd_object_action.h
+    PATH_SUFFIXES amxd
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(amxd DEFAULT_MSG
+    AMXD_LIBRARY
+    AMXD_INCLUDE_DIRS
+)
+
+if (amxd_FOUND)
+    add_library(amxd UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(amxd PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${AMXD_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(amxd PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${AMXD_LIBRARY}"
+    )
+
+endif()

--- a/cmake/Findamxj.cmake
+++ b/cmake/Findamxj.cmake
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(AMXJ_LIBRARY "libamxj.so")
+find_path(AMXJ_INCLUDE_DIRS
+    NAMES amxj/amxj_variant.h
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(amxj DEFAULT_MSG
+    AMXJ_LIBRARY
+    AMXJ_INCLUDE_DIRS
+)
+
+if (amxj_FOUND)
+    add_library(amxj UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(amxj PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${AMXJ_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(amxj PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${AMXJ_LIBRARY}"
+    )
+
+endif()

--- a/cmake/Findamxo.cmake
+++ b/cmake/Findamxo.cmake
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(AMXO_LIBRARY "libamxo.so")
+find_path(AMXO_INCLUDE_DIRS
+    NAMES amxo/amxo.h
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(amxo DEFAULT_MSG
+    AMXO_LIBRARY
+    AMXO_INCLUDE_DIRS
+)
+
+if (amxo_FOUND)
+    add_library(amxo UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(amxo PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${AMXO_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(amxo PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${AMXO_LIBRARY}"
+    )
+
+endif()

--- a/cmake/Findamxp.cmake
+++ b/cmake/Findamxp.cmake
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+#
+# This code is subject to the terms of the BSD+Patent license.
+# See LICENSE file for more details.
+
+find_library(AMXP_LIBRARY "libamxp.so")
+find_path(AMXP_INCLUDE_DIRS
+    NAMES amxp/amxp.h
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(amxp DEFAULT_MSG
+    AMXP_LIBRARY
+    AMXP_INCLUDE_DIRS
+)
+
+if (amxp_FOUND)
+    add_library(amxp UNKNOWN IMPORTED)
+
+    # Includes
+    set_target_properties(amxp PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${AMXP_INCLUDE_DIRS}/"
+    )
+
+    # Library
+    set_target_properties(amxp PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${AMXP_LIBRARY}"
+    )
+
+endif()

--- a/framework/platform/CMakeLists.txt
+++ b/framework/platform/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_subdirectory(bpl)
+if (ENABLE_HLAPI)
+    add_subdirectory(hlapi)
+endif()

--- a/framework/platform/hlapi/CMakeLists.txt
+++ b/framework/platform/hlapi/CMakeLists.txt
@@ -1,0 +1,39 @@
+project(hlapi VERSION ${prplmesh_VERSION})
+
+message("${BoldWhite}Preparing ${BoldGreen}${PROJECT_NAME}${BoldWhite} for the ${BoldGreen}${TARGET_PLATFORM}${BoldWhite} platform${ColourReset}")
+
+# Set the base path for the current module
+set(MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# Common Sources
+set(hlapi_sources ${MODULE_PATH}/hlapi.cpp)
+
+# Include AMBIORIX in the build
+message(STATUS "ENABLE_HLAPI: ${ENABLE_HLAPI}")
+find_package(amxb REQUIRED)
+find_package(amxc REQUIRED)
+find_package(amxd REQUIRED)
+find_package(amxj REQUIRED)
+find_package(amxo REQUIRED)
+find_package(amxp REQUIRED)
+list(APPEND HLAPI_LIBS amxb amxc amxd amxj amxo amxp)
+
+
+# Build the library
+add_library(${PROJECT_NAME} ${hlapi_sources})
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${prplmesh_VERSION} SOVERSION ${prplmesh_VERSION_MAJOR})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,-z,defs")
+target_link_libraries(${PROJECT_NAME} PRIVATE ${HLAPI_LIBS})
+
+# Install
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lib>
+    )
+
+install(TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )

--- a/framework/platform/hlapi/hlapi.cpp
+++ b/framework/platform/hlapi/hlapi.cpp
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * SPDX-FileCopyrightText: 2020 the prplMesh contributors (see AUTHORS.md)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+extern "C" {
+#include <amxc/amxc.h>
+}

--- a/framework/platform/hlapi/include/hlapi.h
+++ b/framework/platform/hlapi/include/hlapi.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ * SPDX-FileCopyrightText: 2016-2020 the prplMesh contributors (see AUTHORS.md)
+ *
+ * This code is subject to the terms of the BSD+Patent license.
+ * See LICENSE file for more details.
+ */
+
+#ifndef _HL_API_H
+#define _HL_API_H


### PR DESCRIPTION
## Description

This PR intention is to introduce new HLAPI lib (High Level API) which should which links all BAAPI (Bus Agnostic API) libs.
`hlapi` is yet optional for build, as we don't use it right now.
Tested for Dummy build on CI. Flag was added by 113da938feb78a3d520efd092b31f19f667e98be commit. [Job](https://gitlab.com/prpl-foundation/prplMesh/-/jobs/674038950) and [pipeline](https://gitlab.com/prpl-foundation/prplMesh/-/pipelines/174989701).

## Changes

- Add `Findamx?.cmake` files to locate each `amx(c/d/j...) lib.
- Add new `hlapi` lib and new flag `ENABLE_HLAPI` to build it.

## Note

As we don't need to build `hlapi` right now - `ENABLE_HLAPI` flag isn't required yet, so no changes to regular build procedure used by CI and developers is required. Build in CI was done just for verification.

Jira link: https://jira.prplfoundation.org/browse/PPM-300