### PR TITLE
Feature/ppm 5 change get client list response to return list of mac addresses instead of a string

### DIFF
--- a/ci/cppcheck/cppcheck_existing_issues.txt
+++ b/ci/cppcheck/cppcheck_existing_issues.txt
@@ -96,6 +96,7 @@ controller/src/beerocks/master/son_actions.cpp: performance: Function parameter 
 controller/src/beerocks/master/son_actions.cpp: performance: Function parameter 'sta_mac' should be passed by const reference. [passedByValue]                                                     std::string sta_mac, std::string bssid)
 controller/src/beerocks/master/son_actions.cpp: style: Local variable 'prev_task_id' shadows outer variable [shadowVariable]        int prev_task_id = database.get_association_handling_task_id(mac);
 controller/src/beerocks/master/son_actions.cpp: style: The scope of the variable 'prev_task_id' can be reduced. [variableScope]    int prev_task_id;
+controller/src/beerocks/master/son_management.cpp: style: Condition '!client_list.size()' is always true [knownConditionTrueFalse]        if (!client_list.size()) {
 controller/src/beerocks/master/son_management.cpp: style: Variable 'op_error_code' is assigned a value that is never used. [unreadVariable]            op_error_code = eChannelScanOperationCode::SCAN_IN_PROGRESS;
 controller/src/beerocks/master/son_management.cpp: style: Variable 'op_error_code' is assigned a value that is never used. [unreadVariable]        auto op_error_code = eChannelScanOperationCode::SUCCESS;
 controller/src/beerocks/master/son_management.cpp: style: Variable 'result_status' is assigned a value that is never used. [unreadVariable]            result_status = last_scan_success;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_bml.h
@@ -2248,11 +2248,9 @@ class cACTION_BML_CLIENT_GET_CLIENT_LIST_RESPONSE : public BaseClass
         static eActionOp_BML get_action_op(){
             return (eActionOp_BML)(ACTION_BML_CLIENT_GET_CLIENT_LIST_RESPONSE);
         }
+        uint8_t& result();
         uint32_t& client_list_size();
-        std::string client_list_str();
-        char* client_list(size_t length = 0);
-        bool set_client_list(const std::string& str);
-        bool set_client_list(const char buffer[], size_t size);
+        std::tuple<bool, sMacAddr&> client_list(size_t idx);
         bool alloc_client_list(size_t count = 1);
         void class_swap() override;
         bool finalize() override;
@@ -2261,8 +2259,9 @@ class cACTION_BML_CLIENT_GET_CLIENT_LIST_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_BML* m_action_op = nullptr;
+        uint8_t* m_result = nullptr;
         uint32_t* m_client_list_size = nullptr;
-        char* m_client_list = nullptr;
+        sMacAddr* m_client_list = nullptr;
         size_t m_client_list_idx__ = 0;
         int m_lock_order_counter__ = 0;
 };

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_bml.yaml
@@ -498,11 +498,14 @@ cACTION_BML_CLIENT_GET_CLIENT_LIST_REQUEST:
 
 cACTION_BML_CLIENT_GET_CLIENT_LIST_RESPONSE:
   _type: class
+  result:
+    _type: uint8_t
+    _comment: # 0 - Failure, 1 - Success
   client_list_size:
     _type: uint32_t
     _length_var: True
   client_list:
-    _type: char
+    _type: sMacAddr
     _length: [client_list_size]
 
 cACTION_BML_CLIENT_SET_CLIENT_REQUEST:

--- a/controller/src/beerocks/bml/bml.cpp
+++ b/controller/src/beerocks/bml/bml.cpp
@@ -691,14 +691,7 @@ int bml_client_get_client_list(BML_CTX ctx, char *client_list, unsigned int *cli
     }
 
     auto pBML = static_cast<bml_internal *>(ctx);
-    std::string temp_client_list;
-    int ret = pBML->client_get_client_list(temp_client_list, client_list_size);
-    if (ret == BML_RET_OK) {
-        beerocks::string_utils::copy_string(client_list, temp_client_list.c_str(),
-                                            *client_list_size);
-    }
-
-    return ret;
+    return pBML->client_get_client_list(client_list, client_list_size);
 }
 
 int bml_client_set_client(BML_CTX ctx, const char *sta_mac,

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -1817,12 +1817,12 @@ int bml_internal::start_dcs_single_scan(const sMacAddr &mac, int dwell_time_ms,
     return BML_RET_OK;
 }
 
-int bml_internal::client_get_client_list(std::string &client_list, unsigned int *client_list_size)
+int bml_internal::client_get_client_list(char *client_list, unsigned int *client_list_size)
 {
     LOG(DEBUG) << "client_get_client_list";
 
-    if (!client_list_size) {
-        LOG(ERROR) << "Size param must be initialized";
+    if (!client_list || !client_list_size) {
+        LOG(ERROR) << "Invalid input: null pointers";
         return (-BML_RET_INVALID_DATA);
     }
 
@@ -2304,8 +2304,8 @@ int bml_internal::register_event_cb(BML_EVENT_CB pCB)
     }
 
     if (!message_com::send_cmdu(m_sockMaster, cmdu_tx)) {
-        LOG(ERROR)
-            << "Failed sending ACTION_BML_REGISTER/UNREGISTER_TO_EVENTS_UPDATES_REQUEST message!";
+        LOG(ERROR) << "Failed sending ACTION_BML_REGISTER/UNREGISTER_TO_EVENTS_UPDATES_REQUEST "
+                      "message!";
         return (-BML_RET_OP_FAILED);
     }
 

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -381,13 +381,13 @@ private:
     //m_scan_results_status is used to store the results' latest status
     uint8_t *m_scan_results_status = nullptr;
     //m_scan_results_maxsize is used to indicate the maximum capacity of the requested results
-    uint32_t *m_scan_results_maxsize = nullptr;
-    std::string *m_client_list       = nullptr;
-    uint32_t *m_client_list_size     = nullptr;
-    BML_CLIENT *m_client             = nullptr;
-    BML_VAP_INFO *m_vaps             = nullptr;
-    uint8_t *m_pvaps_list_size       = nullptr;
-    uint16_t id                      = 0;
+    uint32_t *m_scan_results_maxsize   = nullptr;
+    std::list<sMacAddr> *m_client_list = nullptr;
+    uint32_t *m_client_list_size       = nullptr;
+    BML_CLIENT *m_client               = nullptr;
+    BML_VAP_INFO *m_vaps               = nullptr;
+    uint8_t *m_pvaps_list_size         = nullptr;
+    uint16_t id                        = 0;
     static bool s_fExtLogContext;
 };
 

--- a/controller/src/beerocks/bml/internal/bml_internal.h
+++ b/controller/src/beerocks/bml/internal/bml_internal.h
@@ -268,7 +268,7 @@ public:
      * @param [in,out] client_list_size Size of client list.
      * @return BML_RET_OK on success.
      */
-    int client_get_client_list(std::string &client_list, unsigned int *client_list_size);
+    int client_get_client_list(char *client_list, unsigned int *client_list_size);
 
     /**
      * Set client configuration.


### PR DESCRIPTION
The current implementation returns an `std::string` which tightly
couples the way the son_management returns the information to the BML
and the interface the BML provides to external users.
From a messaging perspective as well as generic and extendable design
the response should contain a list of MAC addresses and not a string.
    
Changed the cACTION_BML_CLIENT_GET_CLIENT_LIST_RESPONSE to return a list
of sMacAddr instead of a string.

While at it, moved the translation of the response from the bml.cpp to the bml_internal as done for the rest of the responses.