### PR TITLE
PPM-251 tests/run_bf.sh must return non-zero when tests fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,6 +239,7 @@ boardfarm-tests:
     paths:
       - logs
       - results
+    when: always
   needs:
     - job: build-in-docker
     - job: image-build-boardfarm-ci

--- a/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
+++ b/tests/boardfarm_plugins/boardfarm_prplmesh/testsuites.cfg
@@ -5,6 +5,4 @@
 
 [test_flows]
 InitialApConfig
-ApConfigRenew
 ClientAssociationLinkMetrics
-LinkMetricQuery

--- a/tools/docker/boardfarm-ci/Dockerfile
+++ b/tools/docker/boardfarm-ci/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     git \
     gnupg \
     gnupg-agent \
+    jq \
     libsnmp-dev \
     netcat \
     software-properties-common \


### PR DESCRIPTION
We tell bft to output test results in a JSON file and then we read that file to determine if any tests failed.

Previously bft was run with "exec", probably to have the script exit with whatever exit code bft returns. I had to remove it of course but that behavior is preserved and we return non-zero exit code when bft itself fails.

I think it is a nice addition to have boardfarm's test results in a file, may be we can use that information in other places in CI.

I used jq to parse the JSON file. I could have grepped and parsed with regular shell utils but I think jq is great to deal with JSON data and it is a must have for any sys-admin in these times.