### PR TITLE
.gitlab-ci.yml: boardfarm-tests: add missing dependency on image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,6 +241,7 @@ boardfarm-tests:
       - results
   needs:
     - job: build-in-docker
+    - job: image-build-boardfarm-ci
   tags:
     - boardfarm
 


### PR DESCRIPTION
We need an explicit dependency on image-build-boardfarm-ci, since it's
not implied by build-in-docker. In most cases, image-build-boardfarm-ci
will be finished before build-in-docker is even started, but there's no
guarantee (as observed at least once).