### PR TITLE
update_vap_stats() fails for wlan0.0 in Gl.Inet B1300

### DIFF
--- a/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/ap_manager/ap_manager_thread.cpp
@@ -948,9 +948,12 @@ bool ap_manager_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_
                                    return element.second.mac == bssid;
                                });
 
-        auto vap_id   = it->first;
-        auto vap_name = utils::get_iface_string_from_iface_vap_ids(
-            ap_wlan_hal->get_radio_info().iface_name, vap_id);
+        if (vap_unordered_map.end() == it) {
+            LOG(ERROR) << "BSSID " << bssid << " not found";
+            return false;
+        }
+
+        auto vap_name = it->second.bss;
 
         if (!request->params().remove) {
             if (!ap_wlan_hal->sta_softblock_add(

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
@@ -2241,8 +2241,7 @@ void monitor_thread::update_vaps_in_db()
 
         // if vap exist in HAL, update it in the local db.
         if (radio_vaps.find(vap_id) != radio_vaps.end()) {
-            auto iface_name = beerocks::utils::get_iface_string_from_iface_vap_ids(
-                mon_wlan_hal->get_radio_info().iface_name, vap_id);
+            auto iface_name = radio_vaps.at(vap_id).bss;
 
             auto curr_vap = radio_vaps.at(vap_id);
 

--- a/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
+++ b/common/beerocks/bwl/dwpal/base_wlan_hal_dwpal.cpp
@@ -969,6 +969,7 @@ bool base_wlan_hal_dwpal::refresh_vap_info(int vap_id)
     // New VAP Element
     VAPElement vapElement;
 
+    vapElement.bss  = ifname;
     vapElement.mac  = std::string(bssid);
     vapElement.ssid = std::string(ssid);
     if (!get_vap_type(ifname, vapElement.fronthaul, vapElement.backhaul)) {

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -46,17 +46,21 @@ enum class AntMode { Invalid = 0, ANT_1X1, ANT_2X2, ANT_3X3, ANT_4X4 };
 enum class WiFiChanBW { Invalid = 0, BW_20 = 20, BW_40 = 40, BW_80 = 80 };
 
 struct VAPElement {
+    /**
+     * Basic Service Set (i.e.: VAP name, e.g.: wlan0.0, wlan0.1, wlan0.2, ...).
+     */
+    std::string bss;
     std::string ssid;
     std::string mac;
     bool fronthaul;
     bool backhaul;
 
-    virtual bool operator==(const VAPElement &other) const
+    bool operator==(const VAPElement &other) const
     {
         return (ssid == other.ssid && mac == other.mac);
     }
 
-    virtual bool operator!=(const VAPElement &other) const
+    bool operator!=(const VAPElement &other) const
     {
         return (ssid != other.ssid || mac != other.mac);
     }

--- a/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
+++ b/common/beerocks/bwl/include/bwl/base_wlan_hal_types.h
@@ -57,13 +57,10 @@ struct VAPElement {
 
     bool operator==(const VAPElement &other) const
     {
-        return (ssid == other.ssid && mac == other.mac);
+        return (bss == other.bss && ssid == other.ssid && mac == other.mac);
     }
 
-    bool operator!=(const VAPElement &other) const
-    {
-        return (ssid != other.ssid || mac != other.mac);
-    }
+    bool operator!=(const VAPElement &other) const { return !(*this == other); }
 };
 
 enum class ChanSwReason { Unknown = 0, Radar = 1, CoEx_20 = 2, CoEx_40 = 3 };

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -764,6 +764,7 @@ bool base_wlan_hal_nl80211::refresh_vaps_info(int id)
             VAPElement vap_element;
 
             // Try reading the BSSID and SSID of the requested VAP
+            vap_element.bss  = reply["bss[" + std::to_string(vap_id) + "]"];
             vap_element.mac  = reply["bssid[" + std::to_string(vap_id) + "]"];
             vap_element.ssid = reply["ssid[" + std::to_string(vap_id) + "]"];
             // TODO https://github.com/prplfoundation/prplMesh/issues/1175
@@ -780,7 +781,7 @@ bool base_wlan_hal_nl80211::refresh_vaps_info(int id)
 
             // Store the VAP element
             LOG(DEBUG) << "Detected VAP ID (" << vap_id << ") - MAC: " << vap_element.mac
-                       << ", SSID: " << vap_element.ssid;
+                       << ", SSID: " << vap_element.ssid << ", BSS: " << vap_element.bss;
 
             m_radio_info.available_vaps[vap_id] = vap_element;
         }
@@ -789,6 +790,7 @@ bool base_wlan_hal_nl80211::refresh_vaps_info(int id)
         VAPElement vap_element;
 
         // Try reading the BSSID and SSID of the requested VAP
+        vap_element.bss  = reply["bss[" + std::to_string(id) + "]"];
         vap_element.mac  = reply["bssid[" + std::to_string(id) + "]"];
         vap_element.ssid = reply["ssid[" + std::to_string(id) + "]"];
         // TODO https://github.com/prplfoundation/prplMesh/issues/1175

--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -763,7 +763,7 @@ bool base_wlan_hal_nl80211::refresh_vaps_info(int id)
              vap_id++) {
             VAPElement vap_element;
 
-            // Try reading the BSSID and SSID of the requested VAP
+            // Try reading values of the requested VAP
             vap_element.bss  = reply["bss[" + std::to_string(vap_id) + "]"];
             vap_element.mac  = reply["bssid[" + std::to_string(vap_id) + "]"];
             vap_element.ssid = reply["ssid[" + std::to_string(vap_id) + "]"];
@@ -789,7 +789,7 @@ bool base_wlan_hal_nl80211::refresh_vaps_info(int id)
 
         VAPElement vap_element;
 
-        // Try reading the BSSID and SSID of the requested VAP
+        // Try reading values of the requested VAP
         vap_element.bss  = reply["bss[" + std::to_string(id) + "]"];
         vap_element.mac  = reply["bssid[" + std::to_string(id) + "]"];
         vap_element.ssid = reply["ssid[" + std::to_string(id) + "]"];


### PR DESCRIPTION
PPM-311

Method `beerocks::utils::get_iface_string_from_iface_vap_ids` computes VAP name from interface name and VAP id using a hardcoded formula that produces names like "wlan0.0", "wlan0.1" and so on. While this is working fine for devices like RAX40, it does not work with Gl.Inet B1300, where there's only one VAP and it has the same name as the interface, so the computed VAP name does not exist. 

To fix the problem, BSS (or name) of the VAP is now read from the device instead of computing it.