### PR TITLE
agent: ucc_listener: take the ssid into account when looking for "mac…

### DIFF
--- a/agent/src/beerocks/slave/agent_db.cpp
+++ b/agent/src/beerocks/slave/agent_db.cpp
@@ -96,4 +96,22 @@ void AgentDB::erase_client(const sMacAddr &client_mac, sMacAddr bssid)
     }
 }
 
+bool AgentDB::get_mac_by_ssid(const sMacAddr &ruid, const std::string &ssid, sMacAddr &value)
+{
+    value      = net::network_utils::ZERO_MAC;
+    auto radio = get_radio_by_mac(ruid, AgentDB::eMacType::RADIO);
+    if (!radio) {
+        LOG(ERROR) << "No radio with ruid '" << ruid << "' found!";
+        return false;
+    }
+
+    for (const auto &bssid : radio->front.bssids) {
+        if (bssid.ssid == ssid) {
+            value = bssid.mac;
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace beerocks

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -210,6 +210,16 @@ public:
     void erase_client(const sMacAddr &client_mac, sMacAddr bssid = net::network_utils::ZERO_MAC);
 
     /**
+     * @brief Get the MAC address (or bssid) of an AP based on the ruid and ssid.
+     *
+     * @param[in] ruid The Radio UID.
+     * @param[in] ssid The ssid of the AP.
+     * @param[out] value The mac address/bssid if found, else an invalid MAC (zero).
+     * @return true if the mac/bssid was found, false otherwise.
+     */
+    bool get_mac_by_ssid(const sMacAddr &ruid, const std::string &ssid, sMacAddr &value);
+
+    /**
      * @brief 1905.1 Neighbor device information
      * Information gathered from a neighbor device upon reception of a Topology Discovery message.
      */


### PR DESCRIPTION


Commit 96e22fbb6b698b2e80f72274510260a5e3a89a54 split the handling of
"macaddr" and "bssid". In the "macaddr" case, the ruid (which
correspond to the radio MAC)  was returned unconditionally.

However, there are some cases where the UCC asks for a "macaddr" by
also specifying an "ssid". In those cases, we have to lookup the MAC
address of the VAP with the matching ssid and return it (like we do in
the "bssid" case).

Move the code that gets the MAC/bssid to the get_mac_by_ssid()
function and use it in the "bssid" case.

In the "macaddr" case: if an "ssid" was given, use get_mac_by_ssid()
to find and return the MAC of the VAP instead of returning the MAC of
the radio.

Fixes https://jira.prplfoundation.org/browse/PPM-317

MAP-4.2.1:netgear-rax40

