### PR TITLE
hotfix/Revert "tools: Change testflows repeater operational check to use BML"

### DIFF
--- a/common/beerocks/scripts/prplmesh_utils.sh.in
+++ b/common/beerocks/scripts/prplmesh_utils.sh.in
@@ -296,19 +296,10 @@ status_function() {
     pgrep -l beerocks
     pgrep -l ieee1905_transport
 
-    # Use the given argument as birdge mac if it filled with something, otherwise get the bridge mac
-    # of the local platform.
-    ARGUMENT_LEN=${#1}
-    if [ "$ARGUMENT_LEN" -ne "0" ]; then
-        BRIDGE_MAC=$1
-    else 
-        BRIDGE_MAC="$(ip link show dev @BEEROCKS_BRIDGE_IFACE@ | awk '/^ *link\/ether / {print $2}')"
-    fi
-
-    bml_cmd="bml_get_device_operational_radios $BRIDGE_MAC"
+    bridge_mac="$(ip link show dev @BEEROCKS_BRIDGE_IFACE@ | awk '/^ *link\/ether / {print $2}')"
+    bml_cmd="bml_get_device_operational_radios $bridge_mac"
 
     if  pgrep -l beerocks_cont ; then
-        echo "executing operational test using bml"
         if execute_beerocks_command "$bml_cmd" ; then
             # Expecting
             # > OK Main radio agent operational
@@ -328,7 +319,6 @@ status_function() {
             exit 1
         fi
     else
-        echo "executing operational test using grep on log files"
         # check for operational status
         LOGS_PATH=@BEEROCKS_LOG_FILES_PATH@
 
@@ -397,7 +387,7 @@ main() {
             start_function
             ;;
         "status")
-            status_function "$2"
+            status_function
             ;;
         "roll_logs")
             roll_logs_function

--- a/tests/test_gw_repeater.sh
+++ b/tests/test_gw_repeater.sh
@@ -55,13 +55,6 @@ check_wsl() {
     RP_EXTRA_OPT=(--expose "${RP_UCC_PORT}" --publish "127.0.0.1::${RP_UCC_PORT}")
 }
 
-get_repater_bridge_mac() {
-    if [ "$#" -eq 1 ]; then
-        REPEATER_BRIDGE_MAC=$(run docker container exec "$1" ifconfig br-lan | grep ether | tr -s ' ' | cut --delimiter=' ' -f 3)
-        echo "$REPEATER_BRIDGE_MAC"
-    fi
-}
-
 main() {
     if ! OPTS=$(getopt -o 'hvd:fg:r:t:u:' --long help,verbose,rm,gateway-only,repeater-only,delay:,force,gateway:,repeater:,tag:,unique-id: -n 'parse-options' -- "$@"); then
         err "Failed parsing options." >&2 ; usage; exit 1 ;
@@ -135,9 +128,8 @@ main() {
     [ "$START_REPEATER" = "true" ] && {
         for repeater in $REPEATER_NAMES
         do
-            REPEATER_BRIDGE_MAC=$(get_repater_bridge_mac "${repeater}")
             report "Repeater $repeater operational" \
-            "${rootdir}"/tools/docker/test.sh ${VERBOSE_OPT} -n "${GW_NAME}" -b "${REPEATER_BRIDGE_MAC}"
+            "${rootdir}"/tools/docker/test.sh ${VERBOSE_OPT} -n "${repeater}"
         done
     }
 

--- a/tools/docker/test.sh
+++ b/tools/docker/test.sh
@@ -13,16 +13,15 @@ rootdir="${scriptdir%/*/*}"
 . "${rootdir}/tools/functions.sh"
 
 usage() {
-    echo "usage: $(basename "$0") [-hv] [-n name [-b bridge_mac]]"
+    echo "usage: $(basename "$0") [-hv] [-n name]"
     echo "  options:"
     echo "      -h|--help - show this help menu"
     echo "      -v|--verbose - verbosity on"
     echo "      -n|--name - container name for which to attach"
-    echo "      -b|--bridge_mac - bridge mac to get operational status on"
 }
 
 main() {
-    if ! OPTS=$(getopt -o 'hvn:b:' --long verbose,help,name,bridge_mac -n 'parse-options' -- "$@"); then
+    if ! OPTS=$(getopt -o 'hvn:' --long verbose,help,name -n 'parse-options' -- "$@"); then
         err "Failed parsing options." >&2
         usage
         exit 1
@@ -32,26 +31,18 @@ main() {
 
     while true; do
         case "$1" in
-            -v | --verbose)    VERBOSE=true; OPT="-v"; shift ;;
-            -h | --help)       usage; exit 0; shift ;;
-            -n | --name)       NAME="$2"; shift; shift ;;
-            -b | --bridge_mac) BRIDGE_MAC="$2"; shift; shift ;;
+            -v | --verbose) VERBOSE=true; OPT="-v"; shift ;;
+            -h | --help)    usage; exit 0; shift ;;
+            -n | --name)    NAME="$2"; shift; shift ;;
             -- ) shift; break ;;
             * ) err "unsupported argument $1"; usage; exit 1 ;;
         esac
     done
 
-    if [ -z "$BRIDGE_MAC" ]; then 
-        run docker container exec "${NAME}" "${rootdir}/build/install/scripts/prplmesh_utils.sh" status $OPT
-    else
-        run docker container exec "${NAME}" "${rootdir}/build/install/scripts/prplmesh_utils.sh" status "$BRIDGE_MAC" $OPT
-    fi
-
-    
+    run docker container exec "${NAME}" "${rootdir}/build/install/scripts/prplmesh_utils.sh" status $OPT
 }
 
 VERBOSE=false
 NAME=prplMesh
-declare BRIDGE_MAC
 
 main "$@"


### PR DESCRIPTION
This reverts commit 408b6039c4c9b4e2c475c54744f3b8d8e529d72b.

It breaks UGW build because:
```bash
Applying ./patches/003-increase-prplmesh-utils-watchdog-sleep.patch using plaintext: 
patching file common/beerocks/scripts/prplmesh_utils.sh.in
Hunk #1 FAILED at 27.
Hunk #2 FAILED at 146.
2 out of 2 hunks FAILED -- saving rejects to file common/beerocks/scripts/prplmesh_utils.sh.in.rej
Patch failed!  Please fix ./patches/003-increase-prplmesh-utils-watchdog-sleep.patch!
```