### PR TITLE
bml: rdkb hal: enum elements names conflict with RDKB WiFi HAL ones

### DIFF
--- a/controller/src/beerocks/bml/rdkb/bml_rdkb_defs.h
+++ b/controller/src/beerocks/bml/rdkb/bml_rdkb_defs.h
@@ -92,15 +92,15 @@ struct BML_STEERING_RRM_CAPS {
 };
 
 typedef enum {
-    DISCONNECT_SOURCE_UNKNOWN = 0, /**< Unknown source             */
-    DISCONNECT_SOURCE_LOCAL,       /**< Initiated locally          */
-    DISCONNECT_SOURCE_REMOTE       /**< Initiated remotely         */
+    BML_DISCONNECT_SOURCE_UNKNOWN = 0, /**< Unknown source             */
+    BML_DISCONNECT_SOURCE_LOCAL,       /**< Initiated locally          */
+    BML_DISCONNECT_SOURCE_REMOTE       /**< Initiated remotely         */
 } BML_DISCONNECT_SOURCE;
 
 typedef enum {
-    DISCONNECT_TYPE_UNKNOWN = 0, /**< Unknown type               */
-    DISCONNECT_TYPE_DISASSOC,    /**< Disassociation             */
-    DISCONNECT_TYPE_DEAUTH       /**< Deauthentication           */
+    BML_DISCONNECT_TYPE_UNKNOWN = 0, /**< Unknown type               */
+    BML_DISCONNECT_TYPE_DISASSOC,    /**< Disassociation             */
+    BML_DISCONNECT_TYPE_DEAUTH       /**< Deauthentication           */
 } BML_DISCONNECT_TYPE;
 
 /**


### PR DESCRIPTION
There are two enums in bml_rdkb_defs.h:
* BML_DISCONNECT_SOURCE
* BML_DISCONNECT_TYPE

which elements has the same names as next RDKB WiFi HAL enums
* wifi_disconnectSource_t
* wifi_disconnectType_t
and conflict with them as a result

See on GitHub:
    https://github.com/rdkcmf/rdkb-halinterface/blob/2fbb252ca52b81fa59edbe9b6461ab7d2eb33b23/wifi_hal.h#L7200

Add BML_ prefix for enum elements names

There are no places in prplMesh where these enums are used explicitly