### PR TITLE
Feature/persistent db integration

### DIFF
--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -1383,6 +1383,8 @@ typedef struct sClient {
     uint32_t timestamp_sec;
     //1 for true, 0 for false, -1 for "not configured".
     int8_t stay_on_initial_radio;
+    //Initial radio stored for the client, set to network_utils::ZERO_MAC if not configured.
+    sMacAddr initial_radio;
     //1 for true, 0 for false, -1 for "not configured".
     int8_t stay_on_selected_device;
     //Bitset of selected bands supported by the client according to eClientSelectedBands
@@ -1397,6 +1399,7 @@ typedef struct sClient {
     void struct_swap(){
         sta_mac.struct_swap();
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&timestamp_sec));
+        initial_radio.struct_swap();
         tlvf_swap(32, reinterpret_cast<uint8_t*>(&time_life_delay_days));
     }
     void struct_init(){

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -1013,6 +1013,9 @@ sClient:
     _type: int8_t
     _value: -1
     _comment: 1 for true, 0 for false, -1 for "not configured".
+  initial_radio:
+    _type: sMacAddr
+    _comment: Initial radio stored for the client, set to network_utils::ZERO_MAC if not configured.
   stay_on_selected_device:
     _type: int8_t
     _value: -1

--- a/controller/src/beerocks/bml/bml_defs.h
+++ b/controller/src/beerocks/bml/bml_defs.h
@@ -615,7 +615,7 @@ struct BML_CLIENT {
     // Determines the period of time after which the client configuration should be cleared,
     //   0 - Never age.
     //  -1 - Not Configured.
-    uint32_t time_life_delay_days;
+    int32_t time_life_delay_days;
 };
 
 /****************************************************************************/

--- a/controller/src/beerocks/bml/bml_defs.h
+++ b/controller/src/beerocks/bml/bml_defs.h
@@ -607,6 +607,9 @@ struct BML_CLIENT {
     // 1 for true, 0 for false, -1 for "not configured".
     int8_t stay_on_initial_radio;
 
+    // Initial radio stored for the client, Zeroed out if not configured (00:00:00:00:00:00).
+    uint8_t initial_radio[BML_MAC_ADDR_LEN];
+
     // Bitwise value of selected bands for the client.
     // Correlates to BML_CLIENT_SELECTED_BANDS
     int8_t selected_bands;

--- a/controller/src/beerocks/bml/internal/bml_internal.cpp
+++ b/controller/src/beerocks/bml/internal/bml_internal.cpp
@@ -1237,6 +1237,8 @@ int bml_internal::process_cmdu_header(std::shared_ptr<beerocks_header> beerocks_
             std::copy_n(response->client().sta_mac.oct, BML_MAC_ADDR_LEN, m_client->sta_mac);
             m_client->timestamp_sec         = response->client().timestamp_sec;
             m_client->stay_on_initial_radio = response->client().stay_on_initial_radio;
+            std::copy_n(response->client().initial_radio.oct, BML_MAC_ADDR_LEN,
+                        m_client->initial_radio);
             // TODO: add stay_on_selected_device to BML_CLIENT when support is added
             //m_client->stay_on_selected_device = response->client().stay_on_selected_device;
             m_client->selected_bands       = response->client().selected_bands;

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -2281,7 +2281,11 @@ int cli_bml::client_get_client(const std::string &sta_mac)
                   << " selected_bands: " << client_selected_bands_print(client.selected_bands)
                   << std::endl
                   << " single_band: " << client_bool_print(client.single_band) << std::endl
-                  << " time_life_delay_days:" << client.time_life_delay_days << std::endl;
+                  << " time_life_delay_days: "
+                  << ((client.time_life_delay_days == PARAMETER_NOT_CONFIGURED)
+                          ? "not-configred"
+                          : std::to_string(client.time_life_delay_days))
+                  << std::endl;
     }
 
     printBmlReturnVals("bml_client_get_client", ret);

--- a/controller/src/beerocks/cli/beerocks_cli_bml.cpp
+++ b/controller/src/beerocks/cli/beerocks_cli_bml.cpp
@@ -2274,10 +2274,19 @@ int cli_bml::client_get_client(const std::string &sta_mac)
 
             return ret;
         };
+        auto print_configured_mac = [](uint8_t *mac) -> std::string {
+            uint8_t ZERO_MAC[BML_MAC_ADDR_LEN] = {0};
+            if (std::equal(mac, mac + BML_MAC_ADDR_LEN, ZERO_MAC)) {
+                return "Not configured";
+            }
+            return tlvf::mac_to_string(mac);
+        };
+
         std::cout << "client: " << tlvf::mac_to_string(client.sta_mac) << std::endl
                   << " timestamp_sec: " << client.timestamp_sec << std::endl
                   << " stay_on_initial_radio: " << client_bool_print(client.stay_on_initial_radio)
                   << std::endl
+                  << " initial_radio: " << print_configured_mac(client.initial_radio) << std::endl
                   << " selected_bands: " << client_selected_bands_print(client.selected_bands)
                   << std::endl
                   << " single_band: " << client_bool_print(client.single_band) << std::endl

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2412,7 +2412,9 @@ bool db::add_client_to_persistent_db(const sMacAddr &mac, const ValuesMap &param
     while (m_persistent_db_clients_count >= config.clients_persistent_db_max_size) {
         LOG(DEBUG) << "reached max clients size in persistent db - removing a client before adding "
                       "new client";
-        if (!remove_candidate_client()) {
+        // Remove a candidate but skip the current client and not select it as candidate
+        // for removal.
+        if (!remove_candidate_client(mac)) {
             LOG(ERROR) << "failed to remove next-to-be-aged client entry " << db_entry
                        << "from persistent db (due to full persistent db)";
             return false;
@@ -4385,11 +4387,11 @@ bool db::remove_client_entry_and_update_counter(const std::string &entry_name)
     return true;
 }
 
-bool db::remove_candidate_client()
+bool db::remove_candidate_client(sMacAddr client_to_skip)
 {
 
     // find cadidate client to be removed
-    sMacAddr client_to_remove = get_candidate_client_for_removal();
+    sMacAddr client_to_remove = get_candidate_client_for_removal(client_to_skip);
     if (client_to_remove == network_utils::ZERO_MAC) {
         LOG(ERROR) << "failed to find client to be removed, number of persistent db clients is "
                    << m_persistent_db_clients_count;
@@ -4405,7 +4407,7 @@ bool db::remove_candidate_client()
     return true;
 }
 
-sMacAddr db::get_candidate_client_for_removal()
+sMacAddr db::get_candidate_client_for_removal(sMacAddr client_to_skip)
 {
     const auto max_timelife_delay_sec =
         std::chrono::seconds(config.max_timelife_delay_days * 24 * 3600);
@@ -4417,44 +4419,50 @@ sMacAddr db::get_candidate_client_for_removal()
     for (const auto &node_map : nodes) {
         for (const auto &key_value : node_map) {
             const auto client = key_value.second;
-            if (client->get_type() == beerocks::eType::TYPE_CLIENT) {
-                //TODO: improvement - stop search if "already-aged" candidate is found (don't-care of connectivity status)
+            if (client->get_type() != beerocks::eType::TYPE_CLIENT) {
+                continue;
+            }
+            const auto client_mac = tlvf::mac_from_string(key_value.first);
 
-                // Skip clients which have no persistent information.
-                if (client->client_parameters_last_edit ==
-                    std::chrono::steady_clock::time_point::min()) {
-                    continue;
+            // skip client if matches the provided client to skip
+            if (client_mac == client_to_skip) {
+                continue;
+            }
+            //TODO: improvement - stop search if "already-aged" candidate is found (don't-care of connectivity status)
+
+            // Skip clients which have no persistent information.
+            if (client->client_parameters_last_edit ==
+                std::chrono::steady_clock::time_point::min()) {
+                continue;
+            }
+
+            // Preferring disconnected clients over connected ones (even if less aged).
+            if (is_disconnected_candidate_available &&
+                client->state != beerocks::STATE_DISCONNECTED) {
+                continue;
+            }
+
+            // Client timelife delay
+            //TODO: use max_timelife_delay_sec/unfriendly_max_timelife_delay_sec according to "is_unfriendly" check which is yet-to-be-defined
+            auto timelife_delay =
+                (client->client_time_life_delay_sec != std::chrono::seconds::zero())
+                    ? client->client_time_life_delay_sec
+                    : max_timelife_delay_sec;
+
+            // Calculate client expiry due time
+            auto current_client_expiry_due = client->client_parameters_last_edit + timelife_delay;
+
+            // Compare to currently chosen candidate expiry due time.
+            // The case where a client is connected and we already found a disconnected cadidate
+            // is handled above - meaning we can assume that either we didn't find any candidate
+            // yet or the candidate found is connected (meaning only the remaining timelife
+            // should be compared)
+            if (current_client_expiry_due < candidate_client_expiry_due_time) {
+                candidate_client_expiry_due_time = current_client_expiry_due;
+                if (client->state == beerocks::STATE_DISCONNECTED) {
+                    is_disconnected_candidate_available = true;
                 }
-
-                // Preferring disconnected clients over connected ones (even if less aged).
-                if (is_disconnected_candidate_available &&
-                    client->state != beerocks::STATE_DISCONNECTED) {
-                    continue;
-                }
-
-                // Client timelife delay
-                //TODO: use max_timelife_delay_sec/unfriendly_max_timelife_delay_sec according to "is_unfriendly" check which is yet-to-be-defined
-                auto timelife_delay =
-                    (client->client_time_life_delay_sec != std::chrono::seconds::zero())
-                        ? client->client_time_life_delay_sec
-                        : max_timelife_delay_sec;
-
-                // Calculate client expiry due time
-                auto current_client_expiry_due =
-                    client->client_parameters_last_edit + timelife_delay;
-
-                // Compare to currently chosen candidate expiry due time.
-                // The case where a client is connected and we already found a disconnected cadidate
-                // is handled above - meaning we can assume that either we didn't find any candidate
-                // yet or the candidate found is connected (meaning only the remaining timelife
-                // should be compared)
-                if (current_client_expiry_due < candidate_client_expiry_due_time) {
-                    candidate_client_expiry_due_time = current_client_expiry_due;
-                    if (client->state == beerocks::STATE_DISCONNECTED) {
-                        is_disconnected_candidate_available = true;
-                    }
-                    candidate_client_to_be_removed = tlvf::mac_from_string(key_value.first);
-                }
+                candidate_client_to_be_removed = client_mac;
             }
         }
     }

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2387,6 +2387,12 @@ bool db::add_client_to_persistent_db(const sMacAddr &mac, const ValuesMap &param
         return false;
     }
 
+    if (config.clients_persistent_db_max_size <= 0) {
+        LOG(ERROR) << "Invalid max clients persistent db size: "
+                   << config.clients_persistent_db_max_size;
+        return false;
+    }
+
     auto db_entry = client_db_entry_from_mac(mac);
 
     if (bpl::db_has_entry(type_to_string(beerocks::eType::TYPE_CLIENT), db_entry)) {
@@ -2403,7 +2409,7 @@ bool db::add_client_to_persistent_db(const sMacAddr &mac, const ValuesMap &param
         return false;
     }
 
-    if (m_persistent_db_clients_count >= config.clients_persistent_db_max_size) {
+    while (m_persistent_db_clients_count >= config.clients_persistent_db_max_size) {
         LOG(DEBUG) << "reached max clients size in persistent db - removing a client before adding "
                       "new client";
         if (!remove_candidate_client()) {

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2842,6 +2842,9 @@ bool db::load_persistent_db_clients()
                        << " added successfully to node-list with parameters: " << values_map;
 
             ++clients_added_no_error;
+
+            // Update the number of clients in persistent DB
+            ++m_persistent_db_clients_count;
             return true;
         };
 

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -24,7 +24,6 @@ const std::string db::TIMESTAMP_STR            = "timestamp";
 const std::string db::TIMELIFE_DELAY_STR       = "timelife";
 const std::string db::INITIAL_RADIO_ENABLE_STR = "initial_radio_enable";
 const std::string db::INITIAL_RADIO_STR        = "initial_radio";
-const std::string db::SELECTED_BAND_ENABLE_STR = "selected_band_enable";
 const std::string db::SELECTED_BANDS_STR       = "selected_bands";
 
 // static
@@ -2604,56 +2603,6 @@ sMacAddr db::get_client_initial_radio(const sMacAddr &mac)
     return node->client_initial_radio;
 }
 
-bool db::set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_selected_band,
-                                          bool save_to_persistent_db)
-{
-    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
-    if (!node) {
-        LOG(ERROR) << "client node not found for mac " << mac;
-        return false;
-    }
-
-    LOG(DEBUG) << "stay_on_selected_band = " << stay_on_selected_band;
-
-    auto timestamp = std::chrono::steady_clock::now();
-    if (save_to_persistent_db) {
-        // if persistent db is disabled
-        if (!config.persistent_db) {
-            LOG(DEBUG) << "persistent db is disabled";
-        } else {
-            LOG(DEBUG) << "configuring persistent-db, selected_band_enable = "
-                       << stay_on_selected_band;
-
-            ValuesMap values_map;
-            values_map[TIMESTAMP_STR]            = timestamp_to_string_seconds(timestamp);
-            values_map[SELECTED_BAND_ENABLE_STR] = std::to_string(stay_on_selected_band);
-
-            // update the persistent db
-            if (!update_client_entry_in_persistent_db(mac, values_map)) {
-                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
-                return false;
-            }
-        }
-    }
-
-    node->client_stay_on_selected_band =
-        (stay_on_selected_band) ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
-    node->client_parameters_last_edit = timestamp;
-
-    return true;
-}
-
-eTriStateBool db::get_client_stay_on_selected_band(const sMacAddr &mac)
-{
-    auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
-    if (!node) {
-        LOG(ERROR) << "client node not found for mac " << mac;
-        return eTriStateBool::NOT_CONFIGURED;
-    }
-
-    return node->client_stay_on_selected_band;
-}
-
 bool db::set_client_selected_bands(const sMacAddr &mac, int8_t selected_bands,
                                    bool save_to_persistent_db)
 {
@@ -2716,7 +2665,6 @@ bool db::clear_client_persistent_db(const sMacAddr &mac)
     node->client_time_life_delay_sec   = std::chrono::seconds::zero();
     node->client_stay_on_initial_radio = eTriStateBool::NOT_CONFIGURED;
     node->client_initial_radio         = network_utils::ZERO_MAC;
-    node->client_stay_on_selected_band = eTriStateBool::NOT_CONFIGURED;
     node->client_selected_bands        = PARAMETER_NOT_CONFIGURED;
 
     // if persistent db is enabled
@@ -2797,13 +2745,6 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
         LOG(DEBUG) << "setting client initial-radio in persistent-db to for " << mac << " to "
                    << node->client_initial_radio;
         values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(node->client_initial_radio);
-    }
-
-    if (node->client_stay_on_selected_band != eTriStateBool::NOT_CONFIGURED) {
-        auto enable = (node->client_stay_on_selected_band == eTriStateBool::ENABLE);
-        LOG(DEBUG) << "setting client stay-on-selected-band in persistent-db to for " << mac
-                   << " to " << enable;
-        values_map[SELECTED_BAND_ENABLE_STR] = std::to_string(enable);
     }
 
     if (node->client_selected_bands != PARAMETER_NOT_CONFIGURED) {
@@ -4392,12 +4333,6 @@ bool db::set_node_params_from_map(const sMacAddr &mac, const ValuesMap &values_m
             LOG(DEBUG) << "setting node client_initial_radio to " << param.second << " for " << mac;
 
             node->client_initial_radio = tlvf::mac_from_string(param.second);
-        } else if (param.first == SELECTED_BAND_ENABLE_STR) {
-            LOG(DEBUG) << "setting node client_stay_on_selected_band to " << param.second << " for "
-                       << mac;
-
-            node->client_stay_on_selected_band =
-                (param.second == "1") ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
         } else if (param.first == SELECTED_BANDS_STR) {
             LOG(DEBUG) << "setting node client_selected_bands to " << param.second << " for "
                        << mac;

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2503,19 +2503,19 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
         return false;
     }
 
-    LOG(DEBUG) << "stay_on_initial_radio = " << stay_on_initial_radio;
+    LOG(DEBUG) << "stay_on_initial_radio=" << stay_on_initial_radio;
 
     auto is_client_connected = (node->state == STATE_CONNECTED);
     LOG(DEBUG) << "client "
-               << " state=" << ((stay_on_initial_radio) ? "connected" : "disconnected");
+               << " state=" << ((is_client_connected) ? "connected" : "disconnected");
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
         // if persistent db is disabled
         if (!config.persistent_db) {
-            LOG(DEBUG) << "persistent db is disabled";
+            LOG(DEBUG) << "Persistent db is disabled";
         } else {
-            LOG(DEBUG) << "configuring persistent-db, initial_radio_enable = "
+            LOG(DEBUG) << "Configuring persistent-db, initial_radio_enable = "
                        << stay_on_initial_radio;
 
             ValuesMap values_map;
@@ -2523,16 +2523,20 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
             values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(stay_on_initial_radio);
             // clear initial-radio data on disabling of stay_on_initial_radio
             if (!stay_on_initial_radio) {
+                LOG(DEBUG) << "Clearing initial_radio in persistent DB";
                 values_map[INITIAL_RADIO_STR] = std::string();
             } else if (is_client_connected) {
                 // if enabling stay-on-initial-radio and client is already connected, update the initial_radio as well
-                auto bssid                    = node->parent_mac;
-                values_map[INITIAL_RADIO_STR] = get_node_parent_radio(bssid);
+                auto bssid            = node->parent_mac;
+                auto parent_radio_mac = get_node_parent_radio(bssid);
+                LOG(DEBUG) << "Persistent DB, Setting client " << mac << " initial-radio to "
+                           << parent_radio_mac;
+                values_map[INITIAL_RADIO_STR] = parent_radio_mac;
             }
 
             // update the persistent db
             if (!update_client_entry_in_persistent_db(mac, values_map)) {
-                LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+                LOG(ERROR) << "Failed to update client entry in persistent-db to for " << mac;
                 return false;
             }
         }
@@ -2542,6 +2546,7 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
         (stay_on_initial_radio) ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
     // clear initial-radio data on disabling of stay_on_initial_radio
     if (!stay_on_initial_radio) {
+        LOG(DEBUG) << "Clearing initial_radio in runtime DB";
         node->client_initial_radio = network_utils::ZERO_MAC;
         // if enabling stay-on-initial-radio and client is already connected, update the initial_radio as well
     } else if (is_client_connected) {
@@ -2560,7 +2565,7 @@ eTriStateBool db::get_client_stay_on_initial_radio(const sMacAddr &mac)
 {
     auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
     if (!node) {
-        LOG(ERROR) << "client node not found for mac " << mac;
+        LOG(ERROR) << "Client node not found for mac " << mac;
         return eTriStateBool::NOT_CONFIGURED;
     }
 
@@ -2572,24 +2577,33 @@ bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_r
 {
     auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
     if (!node) {
-        LOG(ERROR) << "client node not found for mac " << mac;
+        LOG(ERROR) << "Client node not found for mac " << mac;
         return false;
     }
 
-    LOG(DEBUG) << "initial_radio = " << initial_radio_mac;
+    LOG(DEBUG) << "initial_radio=" << initial_radio_mac;
 
-    auto timestamp = std::chrono::steady_clock::now();
+    // Since the initial radio is an internal parameter (not configured by the user), its value
+    // is only relevant if the stay_on_initial_radio is set and although we want its value to be
+    // persistent, we don't want it to affect the client's aging.
+    // This means:
+    // 1. We do not update the timestamp when we update only the initial_radio.
+    // 2. We only set the initial_radio if the stay_on_initial_radio is set.
+    if (node->client_stay_on_initial_radio == eTriStateBool::NOT_CONFIGURED) {
+        LOG(ERROR) << "Configuring initial-radio to " << initial_radio_mac
+                   << " aborted: stay-on-initial-radio is not configured yet";
+        return false;
+    }
+
     if (save_to_persistent_db) {
         // if persistent db is disabled
         if (!config.persistent_db) {
-            LOG(DEBUG) << "persistent db is disabled";
+            LOG(DEBUG) << "Persistent db is disabled";
         } else {
-            LOG(DEBUG) << "configuring persistent-db, initial_radio = " << initial_radio_mac;
+            LOG(DEBUG) << "Configuring persistent-db, initial_radio = " << initial_radio_mac;
 
             ValuesMap values_map;
-            values_map[TIMESTAMP_STR]     = timestamp_to_string_seconds(timestamp);
             values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(initial_radio_mac);
-
             // update the persistent db
             if (!update_client_entry_in_persistent_db(mac, values_map)) {
                 LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
@@ -2598,8 +2612,7 @@ bool db::set_client_initial_radio(const sMacAddr &mac, const sMacAddr &initial_r
         }
     }
 
-    node->client_initial_radio        = initial_radio_mac;
-    node->client_parameters_last_edit = timestamp;
+    node->client_initial_radio = initial_radio_mac;
 
     return true;
 }
@@ -2751,12 +2764,12 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
         LOG(DEBUG) << "Setting client stay-on-initial-radio in persistent-db to " << enable
                    << " for " << mac;
         values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(enable);
-    }
-
-    if (node->client_initial_radio != network_utils::ZERO_MAC) {
-        LOG(DEBUG) << "Setting client initial-radio in persistent-db to "
-                   << node->client_initial_radio << " for " << mac;
-        values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(node->client_initial_radio);
+        // initial radio should be configured only if the stay_on_initial_radio is set
+        if (node->client_initial_radio != network_utils::ZERO_MAC) {
+            LOG(DEBUG) << "Setting client initial-radio in persistent-db to "
+                       << node->client_initial_radio << " for " << mac;
+            values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(node->client_initial_radio);
+        }
     }
 
     if (node->client_selected_bands != PARAMETER_NOT_CONFIGURED) {
@@ -4314,46 +4327,55 @@ bool db::set_node_params_from_map(const sMacAddr &mac, const ValuesMap &values_m
         return false;
     }
 
+    auto initial_radio = network_utils::ZERO_MAC;
+
     for (const auto &param : values_map) {
         if (param.first == TIMESTAMP_STR) {
-            LOG(DEBUG) << "setting node client_parameters_last_edit to " << param.second << " for "
+            LOG(DEBUG) << "Setting node client_parameters_last_edit to " << param.second << " for "
                        << mac;
             node->client_parameters_last_edit =
                 timestamp_from_seconds(string_utils::stoi(param.second));
         } else if (param.first == TIMELIFE_DELAY_STR) {
-            LOG(DEBUG) << "setting node client_time_life_delay_sec to " << param.second << " for "
+            LOG(DEBUG) << "Setting node client_time_life_delay_sec to " << param.second << " for "
                        << mac;
             node->client_time_life_delay_sec =
                 std::chrono::seconds(string_utils::stoi(param.second));
         } else if (param.first == INITIAL_RADIO_ENABLE_STR) {
-            LOG(DEBUG) << "setting node client_stay_on_initial_radio to " << param.second << " for "
+            LOG(DEBUG) << "Setting node client_stay_on_initial_radio to " << param.second << " for "
                        << mac;
-            auto stay_on_initial_radio = (param.second == "1");
             node->client_stay_on_initial_radio =
                 (param.second == "1") ? eTriStateBool::ENABLE : eTriStateBool::DISABLE;
-
-            // clear initial-radio data on disabling of stay_on_initial_radio
-            if (!stay_on_initial_radio) {
-                node->client_initial_radio = network_utils::ZERO_MAC;
-                // if enabling stay-on-initial-radio and client is already connected, update the initial_radio as well
-            } else if (node->state == STATE_CONNECTED) {
-                auto bssid                 = node->parent_mac;
-                auto parent_radio_mac      = get_node_parent_radio(bssid);
-                node->client_initial_radio = tlvf::mac_from_string(parent_radio_mac);
-                LOG(DEBUG) << "Setting client " << mac << " initial-radio to "
-                           << node->client_initial_radio;
-            }
         } else if (param.first == INITIAL_RADIO_STR) {
-            LOG(DEBUG) << "setting node client_initial_radio to " << param.second << " for " << mac;
-
-            node->client_initial_radio = tlvf::mac_from_string(param.second);
+            LOG(DEBUG) << "Received client_initial_radio=" << param.second << " for " << mac;
+            initial_radio = tlvf::mac_from_string(param.second);
         } else if (param.first == SELECTED_BANDS_STR) {
-            LOG(DEBUG) << "setting node client_selected_bands to " << param.second << " for "
+            LOG(DEBUG) << "Setting node client_selected_bands to " << param.second << " for "
                        << mac;
             node->client_selected_bands = string_utils::stoi(param.second);
         } else {
             LOG(WARNING) << "Unknown parameter, skipping: " << param.first << " for " << mac;
         }
+    }
+
+    // After configuring the values we can determine if the client_initial_radio should be set as well.
+    // Since its value is only relevant if client_stay_on_initial_radio is set.
+    // clear initial-radio data on disabling of stay_on_initial_radio.
+    if (node->client_stay_on_initial_radio != eTriStateBool::ENABLE) {
+        LOG_IF((initial_radio != network_utils::ZERO_MAC), WARNING)
+            << "ignoring initial-radio=" << initial_radio
+            << " since stay-on-initial-radio is not enabled";
+        node->client_initial_radio = network_utils::ZERO_MAC;
+    } else if (initial_radio != network_utils::ZERO_MAC) {
+        // If stay-on-initial-radio is set to enable and initial_radio is provided.
+        node->client_initial_radio = initial_radio;
+    } else if (node->state == STATE_CONNECTED) {
+        // If stay-on-initial-radio is enabled and initial_radio is not set and client is already connected:
+        // Set the initial_radio from parent radio mac (not bssid).
+        auto bssid                 = node->parent_mac;
+        auto parent_radio_mac      = get_node_parent_radio(bssid);
+        node->client_initial_radio = tlvf::mac_from_string(parent_radio_mac);
+        LOG(DEBUG) << "Setting client " << mac << " initial-radio to "
+                   << node->client_initial_radio;
     }
 
     return true;

--- a/controller/src/beerocks/master/db/db.cpp
+++ b/controller/src/beerocks/master/db/db.cpp
@@ -2498,6 +2498,8 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
     LOG(DEBUG) << "stay_on_initial_radio = " << stay_on_initial_radio;
 
     auto is_client_connected = (node->state == STATE_CONNECTED);
+    LOG(DEBUG) << "client "
+               << " state=" << ((stay_on_initial_radio) ? "connected" : "disconnected");
 
     auto timestamp = std::chrono::steady_clock::now();
     if (save_to_persistent_db) {
@@ -2538,6 +2540,8 @@ bool db::set_client_stay_on_initial_radio(const sMacAddr &mac, bool stay_on_init
         auto bssid                 = node->parent_mac;
         auto parent_radio_mac      = get_node_parent_radio(bssid);
         node->client_initial_radio = tlvf::mac_from_string(parent_radio_mac);
+        LOG(DEBUG) << "Setting client " << mac << " initial-radio to "
+                   << node->client_initial_radio;
     }
     node->client_parameters_last_edit = timestamp;
 
@@ -2705,20 +2709,20 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
 {
     // if persistent db is disabled
     if (!config.persistent_db) {
-        LOG(ERROR) << "persistent db is disabled";
+        LOG(ERROR) << "Persistent db is disabled";
         return false;
     }
 
     auto node = get_node_verify_type(mac, beerocks::TYPE_CLIENT);
     if (!node) {
-        LOG(ERROR) << "client node not found for mac " << mac;
+        LOG(ERROR) << "Client node not found for mac " << mac;
         return false;
     }
 
     // any persistent parameter update also sets the last-edit timestamp
     // if it is with default value - no other persistent configuration was performed
     if (node->client_parameters_last_edit == std::chrono::steady_clock::time_point::min()) {
-        LOG(DEBUG) << "persistent client parameters are empty for " << mac
+        LOG(DEBUG) << "Persistent client parameters are empty for " << mac
                    << ", no need to update persistent-db";
         return true;
     }
@@ -2729,37 +2733,37 @@ bool db::update_client_persistent_db(const sMacAddr &mac)
     values_map[TIMESTAMP_STR] = timestamp_to_string_seconds(node->client_parameters_last_edit);
 
     if (node->client_time_life_delay_sec != std::chrono::seconds::zero()) {
-        LOG(DEBUG) << "setting client time-life-delay in persistent-db to for " << mac << " to "
-                   << node->client_time_life_delay_sec.count();
+        LOG(DEBUG) << "Setting client time-life-delay in persistent-db to "
+                   << node->client_time_life_delay_sec.count() << " for " << mac;
         values_map[TIMELIFE_DELAY_STR] = std::to_string(node->client_time_life_delay_sec.count());
     }
 
     if (node->client_stay_on_initial_radio != eTriStateBool::NOT_CONFIGURED) {
         auto enable = (node->client_stay_on_initial_radio == eTriStateBool::ENABLE);
-        LOG(DEBUG) << "setting client stay-on-initial-radio in persistent-db to for " << mac
-                   << " to " << enable;
+        LOG(DEBUG) << "Setting client stay-on-initial-radio in persistent-db to " << enable
+                   << " for " << mac;
         values_map[INITIAL_RADIO_ENABLE_STR] = std::to_string(enable);
     }
 
     if (node->client_initial_radio != network_utils::ZERO_MAC) {
-        LOG(DEBUG) << "setting client initial-radio in persistent-db to for " << mac << " to "
-                   << node->client_initial_radio;
+        LOG(DEBUG) << "Setting client initial-radio in persistent-db to "
+                   << node->client_initial_radio << " for " << mac;
         values_map[INITIAL_RADIO_STR] = tlvf::mac_to_string(node->client_initial_radio);
     }
 
     if (node->client_selected_bands != PARAMETER_NOT_CONFIGURED) {
-        LOG(DEBUG) << "setting client selected-bands in persistent-db to for " << mac << " to "
-                   << node->client_selected_bands;
+        LOG(DEBUG) << "Setting client selected-bands in persistent-db to "
+                   << node->client_selected_bands << " for " << mac;
         values_map[SELECTED_BANDS_STR] = std::to_string(node->client_selected_bands);
     }
 
     // update the persistent db
     if (!update_client_entry_in_persistent_db(mac, values_map)) {
-        LOG(ERROR) << "failed to update client entry in persistent-db to for " << mac;
+        LOG(ERROR) << "Failed to update client entry in persistent-db for " << mac;
         return false;
     }
 
-    LOG(DEBUG) << "client successfully updated in persistent-db for " << mac;
+    LOG(DEBUG) << "Client successfully updated in persistent-db for " << mac;
 
     return true;
 }
@@ -4328,6 +4332,8 @@ bool db::set_node_params_from_map(const sMacAddr &mac, const ValuesMap &values_m
                 auto bssid                 = node->parent_mac;
                 auto parent_radio_mac      = get_node_parent_radio(bssid);
                 node->client_initial_radio = tlvf::mac_from_string(parent_radio_mac);
+                LOG(DEBUG) << "Setting client " << mac << " initial-radio to "
+                           << node->client_initial_radio;
             }
         } else if (param.first == INITIAL_RADIO_STR) {
             LOG(DEBUG) << "setting node client_initial_radio to " << param.second << " for " << mac;
@@ -4365,6 +4371,10 @@ bool db::remove_client_entry_and_update_counter(const std::string &entry_name)
         return false;
     }
     --m_persistent_db_clients_count;
+
+    LOG(DEBUG) << "Removed client entry " << entry_name
+               << " from persistent db, total clients count in persisttent-db: "
+               << m_persistent_db_clients_count;
 
     return true;
 }
@@ -4446,7 +4456,8 @@ sMacAddr db::get_candidate_client_for_removal()
     if (candidate_client_to_be_removed == network_utils::ZERO_MAC) {
         LOG(DEBUG) << "no client to be removed is found";
     } else {
-        LOG(DEBUG) << "candidate client to be removed is currently "
+        LOG(DEBUG) << "candidate client to be removed " << candidate_client_to_be_removed
+                   << " is currently "
                    << ((is_disconnected_candidate_available) ? "disconnected" : "connected");
     }
 

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -59,7 +59,6 @@ public:
     static const std::string TIMELIFE_DELAY_STR;
     static const std::string INITIAL_RADIO_ENABLE_STR;
     static const std::string INITIAL_RADIO_STR;
-    static const std::string SELECTED_BAND_ENABLE_STR;
     static const std::string SELECTED_BANDS_STR;
 
     // VAPs info list type
@@ -727,25 +726,6 @@ public:
      * @return MAC adddress of the radio that the client has initially connected to.
      */
     sMacAddr get_client_initial_radio(const sMacAddr &mac);
-
-    /**
-     * @brief Set the client's stay-on-selected-band.
-     * 
-     * @param mac MAC address of a client.
-     * @param stay_on_selected_band Enable client stay on the selected band/bands.
-     * @param save_to_persistent_db If set to true, update the persistent-db (write-through), default is true.
-     * @return true on success, otherwise false.
-     */
-    bool set_client_stay_on_selected_band(const sMacAddr &mac, bool stay_on_selected_band,
-                                          bool save_to_persistent_db = true);
-
-    /**
-     * @brief Get the client's stay-on-selected-band.
-     * 
-     * @param mac MAC address of a client.
-     * @return Enable client stay on the selected band/bands.
-     */
-    eTriStateBool get_client_stay_on_selected_band(const sMacAddr &mac);
 
     /**
      * @brief Set the client's selected-bands.

--- a/controller/src/beerocks/master/db/db.h
+++ b/controller/src/beerocks/master/db/db.h
@@ -1122,19 +1122,22 @@ private:
     /**
      * @brief Removes client with least timelife remaining from persistent db (with preference to disconnected clients).
      * 
+     * @param[in] client_to_skip A client mac that should not be selected as cadidate. This is to prevent currently added node as candidate.
      * @return true on success, otherwise false.
      */
-    bool remove_candidate_client();
+    bool remove_candidate_client(sMacAddr client_to_skip = beerocks::net::network_utils::ZERO_MAC);
 
     /**
      * @brief Returns the preferred client to be removed.
      * Preference is determined as follows:
      * - Prefer disconnected clients over connected ones.
      * - According to above, the client with least time left before aging.
-     *
+     
+     * @param[in] client_to_skip A client mac that should not be selected as cadidate. This is to prevent currently added node as candidate.
      * @return sMacAddr mac of candidate client to be removed - if not found, string_utils::ZERO_MAC is returned.
      */
-    sMacAddr get_candidate_client_for_removal();
+    sMacAddr get_candidate_client_for_removal(
+        sMacAddr client_to_skip = beerocks::net::network_utils::ZERO_MAC);
 
     int network_optimization_task_id = -1;
     int channel_selection_task_id    = -1;

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -26,6 +26,7 @@ node::node(beerocks::eType type_, const std::string &mac_)
     }
     m_sta_5ghz_capabilities.valid  = false;
     m_sta_24ghz_capabilities.valid = false;
+    client_initial_radio           = net::network_utils::ZERO_MAC;
 }
 
 namespace son {

--- a/controller/src/beerocks/master/db/node.cpp
+++ b/controller/src/beerocks/master/db/node.cpp
@@ -150,7 +150,6 @@ std::ostream &operator<<(std::ostream &os, const node &n)
                << (client_time_life_delay_hours % 24) << " hours" << std::endl
                << "   ClientStayOnInitialRadio: " << n.client_stay_on_initial_radio << std::endl
                << "   ClientInitialRadio: " << n.client_initial_radio << std::endl
-               << "   ClientStayOnSelectedBand: " << n.client_stay_on_selected_band << std::endl
                << "   ClientSelectedBands: " << n.client_selected_bands << std::endl;
         }
 

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -284,7 +284,7 @@ public:
     // If enabled, the client will be steered to the initial radio it connected to - save at client_initial_radio.
     eTriStateBool client_stay_on_initial_radio = eTriStateBool::NOT_CONFIGURED;
 
-    // The client_initial_radio bssid must be set.
+    // The client_initial_radio mac must be set, default value is network_utils::ZERO_MAC.
     sMacAddr client_initial_radio;
 
     // If enabled, the client will be steered to pre-selected-bands defined by client_selected_bands.

--- a/controller/src/beerocks/master/db/node.h
+++ b/controller/src/beerocks/master/db/node.h
@@ -287,12 +287,8 @@ public:
     // The client_initial_radio mac must be set, default value is network_utils::ZERO_MAC.
     sMacAddr client_initial_radio;
 
-    // If enabled, the client will be steered to pre-selected-bands defined by client_selected_bands.
-    // Not enforced if client_selected_bands is not set.
-    eTriStateBool client_stay_on_selected_band = eTriStateBool::NOT_CONFIGURED;
-
-    // The selected bands the client should be steered to if the client_stay_on_selected_band is set.
-    // Default value is PARAMETER_NOT_CONFIGURED.
+    // The selected bands that the client should be steered to.
+    // Default value is PARAMETER_NOT_CONFIGURED - which means no limitation on bands.
     // Possible values are bitwise options of eClientSelectedBands.
     int8_t client_selected_bands = beerocks::PARAMETER_NOT_CONFIGURED;
 

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -2238,6 +2238,8 @@ void son_management::handle_bml_message(Socket *sd,
         // Stay on initial radio
         response->client().stay_on_initial_radio =
             int(database.get_client_stay_on_initial_radio(client_mac));
+        // Initial radio
+        response->client().initial_radio = database.get_client_initial_radio(client_mac);
         // Selected bands
         response->client().selected_bands = database.get_client_selected_bands(client_mac);
         // Timelife Delay - scaled from seconds to days

--- a/controller/src/beerocks/master/son_management.cpp
+++ b/controller/src/beerocks/master/son_management.cpp
@@ -2171,20 +2171,9 @@ void son_management::handle_bml_message(Socket *sd,
             // }
         }
 
-        // Set stay_on_selected_bands and selected_bands if requested.
+        // Set selected_bands if requested.
         if (request->client_config().selected_bands != PARAMETER_NOT_CONFIGURED) {
             auto selected_bands = eClientSelectedBands(request->client_config().selected_bands);
-            auto stay_on_selected_band =
-                (selected_bands != eClientSelectedBands::eSelectedBands_Disabled);
-            // Set stay_on_selected_bands.
-            if (!database.set_client_stay_on_selected_band(client_mac, stay_on_selected_band,
-                                                           false)) {
-                LOG(ERROR) << " Failed to stay_on_selected_band to " << stay_on_selected_band
-                           << " for client " << client_mac;
-                send_response(false);
-                break;
-            }
-            // Set selected_bands.
             if (!database.set_client_selected_bands(client_mac, selected_bands, false)) {
                 LOG(ERROR) << " Failed to set selected-bands to " << selected_bands
                            << " for client " << client_mac;
@@ -2250,12 +2239,7 @@ void son_management::handle_bml_message(Socket *sd,
         response->client().stay_on_initial_radio =
             int(database.get_client_stay_on_initial_radio(client_mac));
         // Selected bands
-        auto selected_band_enable = database.get_client_stay_on_selected_band(client_mac);
-        if (selected_band_enable == eTriStateBool::NOT_CONFIGURED) {
-            response->client().selected_bands = PARAMETER_NOT_CONFIGURED;
-        } else {
-            response->client().selected_bands = database.get_client_selected_bands(client_mac);
-        }
+        response->client().selected_bands = database.get_client_selected_bands(client_mac);
         // Timelife Delay - scaled from seconds to days
         auto timelife_delay_sec = database.get_client_time_life_delay(client_mac);
         response->client().time_life_delay_days =

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -259,7 +259,9 @@ void optimal_path_task::work()
                               << " is not on the candidate ap list, continue as usual.";
         }
 
-        if (database.get_client_stay_on_selected_band(client) == eTriStateBool::ENABLE) {
+        auto selected_bands = database.get_client_selected_bands(client);
+        if ((selected_bands != PARAMETER_NOT_CONFIGURED) &&
+            (selected_bands != eClientSelectedBands::eSelectedBands_Disabled)) {
             TASK_LOG(INFO) << "Client stay on selected bands enabled";
             if (!database.is_hostap_on_client_selected_bands(
                     client, tlvf::mac_from_string(current_hostap))) {
@@ -1023,7 +1025,9 @@ void optimal_path_task::work()
                               << " is not on the candidate ap list, continue as usual.";
         }
 
-        if (database.get_client_stay_on_selected_band(client) == eTriStateBool::ENABLE) {
+        auto selected_bands = database.get_client_selected_bands(client);
+        if ((selected_bands != PARAMETER_NOT_CONFIGURED) &&
+            (selected_bands != eClientSelectedBands::eSelectedBands_Disabled)) {
             TASK_LOG(INFO) << "Client stay on selected bands enabled";
             if (!database.is_hostap_on_client_selected_bands(
                     client, tlvf::mac_from_string(current_hostap))) {


### PR DESCRIPTION
This branch in this PR is rebased to the https://github.com/prplfoundation/prplMesh/tree/dev/use-client-steering-persistent-info-in-optimal-path which is handled by #1560 
This means this PR will be merged after #1560 

Included in this:
- fixing several log prints.
- fix bug where initial-radio wasn't set to its expected default value of `ZERO_MAC`
- removed unneeded db parameter of "stay-on-selected-band" (the functionality is implemented directly by using the "selected_bands" and using an additional boolean parameter is not required.
- change the `time_life_delay_days` type from uint32_t to int32_t to support the -1 value for not-configured
- add initial-radio to the get-client response flow: extend the messaging infrastructure, fill the response with the value read from the DB, parse it on the BML side and add it to the debug prints in the bml-cli. Extend the BML_CLIENT struct to used by the bml_client_get_client() API.
- extend the remove-candidate APIs to get mac-to-skip parameter - this is in order to prevent the new client which its node is already been added (but not yet added to persistent DB) to be selected as a candidate - the assumption is that the currently added client (in runtime flow, not when loading from DB at boot) is less aged than existing clients already in DB.
- set the initial-radio value only if the stay-on-initial-radio is set, it is meaningless otherwise.

PPM-5