### PR TITLE
[PPM-275] Replace CLIENT_BEACON_11K_REQUEST/RESPONSE on the standard one

### DIFF
--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
@@ -18,6 +18,7 @@
 #include <beerocks/tlvf/beerocks_message.h>
 
 #include <tlvf/wfa_map/tlvApMetricQuery.h>
+#include <tlvf/wfa_map/tlvBeaconMetricsQuery.h>
 
 #include <cmath>
 #include <vector>
@@ -1381,6 +1382,8 @@ bool monitor_thread::handle_cmdu_ieee1905_1_message(Socket &sd, ieee1905_1::Cmdu
         return handle_ap_metrics_query(sd, cmdu_rx);
     case ieee1905_1::eMessageType::MULTI_AP_POLICY_CONFIG_REQUEST_MESSAGE:
         return handle_multi_ap_policy_config_request(sd, cmdu_rx);
+    case ieee1905_1::eMessageType::BEACON_METRICS_QUERY_MESSAGE:
+        return handle_beacon_metrics_query(sd, cmdu_rx);
     default:
         LOG(ERROR) << "Unknown CMDU message type: " << std::hex << int(cmdu_message_type);
     }
@@ -1478,6 +1481,88 @@ bool monitor_thread::handle_ap_metrics_query(Socket &sd, ieee1905_1::CmduMessage
     LOG(DEBUG) << "Sending AP_METRICS_RESPONSE_MESSAGE to slave_socket, mid=" << std::hex
                << int(mid);
     return message_com::send_cmdu(slave_socket, cmdu_tx);
+}
+
+bool monitor_thread::handle_beacon_metrics_query(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx)
+{
+    const auto mid = cmdu_rx.getMessageId();
+    int dialog_token;
+    auto beacon_metrics_query_tlv = cmdu_rx.getClass<wfa_map::tlvBeaconMetricsQuery>();
+    if (!beacon_metrics_query_tlv) {
+        LOG(ERROR) << "Beacon Metrics Query CMDU mid=" << mid
+                   << " does not have Beacon Metric Query TLV";
+        return false;
+    }
+
+    bwl::SBeaconRequest11k bwl_request;
+
+    bwl_request.measurement_mode = beerocks::MEASURE_MODE_ACTIVE;
+    bwl_request.channel          = beacon_metrics_query_tlv->channel_number();
+    bwl_request.op_class         = beacon_metrics_query_tlv->operating_class();
+    bwl_request.repeats          = 0;
+    bwl_request.rand_ival        = beerocks::BEACON_MEASURE_DEFAULT_RANDOMIZATION_INTERVAL;
+
+    bwl_request.duration = beerocks::BEACON_MEASURE_DEFAULT_ACTIVE_DURATION;
+
+    std::copy_n(beacon_metrics_query_tlv->associated_sta_mac().oct, sizeof(bwl_request.sta_mac.oct),
+                bwl_request.sta_mac.oct);
+
+    std::copy_n(beacon_metrics_query_tlv->bssid().oct, sizeof(bwl_request.bssid.oct),
+                bwl_request.bssid.oct);
+
+    bwl_request.parallel               = 0;
+    bwl_request.enable                 = 0;
+    bwl_request.request                = 1;
+    bwl_request.report                 = beacon_metrics_query_tlv->reporting_detail_value();
+    bwl_request.mandatory_duration     = 0;
+    bwl_request.expected_reports_count = 1;
+    bwl_request.use_optional_ssid      = 0;
+
+    auto ap_ch_report_length = beacon_metrics_query_tlv->ap_channel_reports_list_length();
+
+    if (ap_ch_report_length != 0 && bwl_request.channel != 255) {
+        LOG(ERROR) << "inconsistency between channel report length and channel number. please take "
+                      "look at the specification. v1 17.2.27";
+        return false;
+    }
+
+    if (ap_ch_report_length > 1) {
+        // the reason we support only 1 channel list is that the hostapd does not support more
+        // there is no way to tell it for which operating class which channels to use
+        LOG(ERROR)
+            << "too many channles requested (the maximum is 237, current support is only for 1): "
+            << +ap_ch_report_length;
+        return false;
+    }
+
+    // we support only one
+    if (1 == ap_ch_report_length) {
+
+        // get the first (and currently only) structure from the list
+        auto channel = beacon_metrics_query_tlv->ap_channel_reports_list(0);
+        if (!std::get<0>(channel)) {
+            LOG(ERROR) << "there should be a structure at index 0, but it wasn't found";
+            return false;
+        }
+
+        // the number of channels, excluding the first operating class
+        bwl_request.use_optional_ap_ch_report =
+            std::get<1>(channel).ap_channel_report_list_length() - 1;
+
+        // the first index in the tlv's channel-report-list is the operating class,
+        // we skip it. using pointer arithmethics and copying one element less from the source (we skip the operation class)
+        for (int idx = 0; idx < bwl_request.use_optional_ap_ch_report; ++idx) {
+            bwl_request.ap_ch_report[idx] = *std::get<1>(channel).ap_channel_report_list(idx + 1);
+        }
+
+        auto request = mon_wlan_hal->sta_beacon_11k_request(bwl_request, dialog_token);
+
+        if (!request) {
+            LOG(ERROR) << "BWL method sta_beacon_11k_request failed.";
+            return false;
+        }
+    }
+    return true;
 }
 
 bool monitor_thread::hal_event_handler(bwl::base_wlan_hal::hal_event_ptr_t event_ptr)

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.cpp
@@ -19,6 +19,7 @@
 
 #include <tlvf/wfa_map/tlvApMetricQuery.h>
 #include <tlvf/wfa_map/tlvBeaconMetricsQuery.h>
+#include <tlvf/wfa_map/tlvBeaconMetricsResponse.h>
 
 #include <cmath>
 #include <vector>
@@ -656,6 +657,33 @@ bool monitor_thread::create_ap_metrics_response(uint16_t mid,
             }
         }
     }
+
+    return true;
+}
+
+bool monitor_thread::create_beacon_metrics_response(uint16_t mid,
+                                                    const bwl::SBeaconResponse11k &hal_data)
+{
+    auto beacon_response =
+        cmdu_tx.create(mid, ieee1905_1::eMessageType::BEACON_METRICS_RESPONSE_MESSAGE);
+
+    if (!beacon_response) {
+        LOG(ERROR) << "Failed to create BEACON_METRICS_RESPONSE_MESSAGE";
+        return false;
+    }
+
+    auto beacon_metrics_response_tlv = cmdu_tx.addClass<wfa_map::tlvBeaconMetricsResponse>();
+
+    if (!beacon_metrics_response_tlv) {
+        LOG(ERROR) << "Failed addClass<wfa_map::tlvBeaconMetricsResponse>";
+        return false;
+    }
+
+    // TODO: Add filling up the correct data according to the specification.
+
+    std::copy_n(hal_data.sta_mac.oct, sizeof(hal_data.sta_mac.oct),
+                beacon_metrics_response_tlv->associated_sta_mac().oct);
+    beacon_response->finalize();
 
     return true;
 }

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.h
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.h
@@ -146,6 +146,7 @@ private:
 
     bool handle_multi_ap_policy_config_request(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_ap_metrics_query(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_beacon_metrics_query(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx);
 };
 } // namespace son
 

--- a/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.h
+++ b/agent/src/beerocks/fronthaul_manager/monitor/monitor_thread.h
@@ -82,6 +82,15 @@ private:
      */
     bool create_ap_metrics_response(uint16_t mid, const std::vector<sMacAddr> &bssid_list);
 
+    /**
+     * @brief Creates Beacon Metrics Response message
+     *
+     * @param mid Message ID.
+     * @param hal_data Data received from hostapd.
+     * @return True on success and false otherwise.
+     */
+    bool create_beacon_metrics_response(uint16_t mid, const bwl::SBeaconResponse11k &hal_data);
+
     bool update_ap_stats();
     bool update_sta_stats();
 

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -225,6 +225,7 @@ private:
     bool send_operating_channel_report();
     bool handle_ap_metrics_query(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_monitor_ap_metrics_response(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx);
+    bool handle_monitor_beacon_metrics_response(Socket &sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_preference_query(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool handle_channel_selection_request(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx);
     bool channel_selection_get_channel_preference(ieee1905_1::CmduMessageRx &cmdu_rx);

--- a/controller/src/beerocks/master/son_actions.h
+++ b/controller/src/beerocks/master/son_actions.h
@@ -18,6 +18,7 @@
 #include <tlvf/ieee_1905_1/tlvLinkMetricQuery.h>
 #include <tlvf/ieee_1905_1/tlvSupportedFreqBand.h>
 #include <tlvf/ieee_1905_1/tlvSupportedRole.h>
+#include <tlvf/wfa_map/tlvBeaconMetricsQuery.h>
 
 #define CLI_LOG(a) LOG(a)
 
@@ -59,6 +60,8 @@ public:
                                    db &database, const std::string &radio_mac = std::string());
     static bool send_ap_config_renew_msg(ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
                                          const sMacAddr &al_mac);
+    static bool send_beacon_metrics_query_msg(ieee1905_1::CmduMessageTx &cmdu_tx, db &database,
+                                              const sMacAddr &sta_mac);
 
 private:
     static bool

--- a/controller/src/beerocks/master/tasks/optimal_path_task.cpp
+++ b/controller/src/beerocks/master/tasks/optimal_path_task.cpp
@@ -37,7 +37,7 @@ using namespace son;
 * example), missed the probe or due to the AP bad reception.
 * There is a high probability to get responsiveness less than 100% and therefore, the
 * threshold was changed to 50% as part of demo optimizations.
-* This hardcoded threshold is temporary and shall be revised in the future. 
+* This hardcoded threshold is temporary and shall be revised in the future.
 * update: increasing to 80% since in bandsteering scenario there are only 2 radios
 * and 50% means optimal path always will fail to find an additional candidate.
 */
@@ -328,20 +328,11 @@ void optimal_path_task::work()
                     TASK_LOG(DEBUG)
                         << "requested 11K beacon measurement request from sta: " << sta_mac
                         << " on bssid: " << vap_mac;
-                    auto request = message_com::create_vs_message<
-                        beerocks_message::cACTION_CONTROL_CLIENT_BEACON_11K_REQUEST>(cmdu_tx, id);
 
-                    if (request == nullptr) {
-                        LOG(ERROR)
-                            << "Failed building ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST message!";
-                        break;
+                    if (!son::son_actions::send_beacon_metrics_query_msg(
+                            cmdu_tx, database, tlvf::mac_from_string(sta_mac))) {
+                        LOG(ERROR) << "Failed sending BEACON_METRICS_QUERY_MESSAGE";
                     }
-                    request->params() = measurement_request;
-
-                    son_actions::send_cmdu_to_agent(current_agent_mac, cmdu_tx, database,
-                                                    current_hostap);
-
-                    set_responses_timeout(BEACON_MEASUREMENT_REQUEST_TIMEOUT_MSEC);
 
                     iterator_element_counter++;
                     potential_ap_iter++;

--- a/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvBeaconMetricsQuery.h
+++ b/framework/tlvf/AutoGenerated/include/tlvf/wfa_map/tlvBeaconMetricsQuery.h
@@ -49,6 +49,7 @@ class tlvBeaconMetricsQuery : public BaseClass
         bool set_ssid(const std::string& str);
         bool set_ssid(const char buffer[], size_t size);
         bool alloc_ssid(size_t count = 1);
+        uint8_t& ap_channel_reports_num();
         uint8_t& ap_channel_reports_list_length();
         std::tuple<bool, cApChannelReports&> ap_channel_reports_list(size_t idx);
         std::shared_ptr<cApChannelReports> create_ap_channel_reports_list();
@@ -74,6 +75,7 @@ class tlvBeaconMetricsQuery : public BaseClass
         char* m_ssid = nullptr;
         size_t m_ssid_idx__ = 0;
         int m_lock_order_counter__ = 0;
+        uint8_t* m_ap_channel_reports_num = nullptr;
         uint8_t* m_ap_channel_reports_list_length = nullptr;
         cApChannelReports* m_ap_channel_reports_list = nullptr;
         size_t m_ap_channel_reports_list_idx__ = 0;

--- a/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvBeaconMetricsQuery.cpp
+++ b/framework/tlvf/AutoGenerated/src/tlvf/wfa_map/tlvBeaconMetricsQuery.cpp
@@ -98,6 +98,7 @@ bool tlvBeaconMetricsQuery::alloc_ssid(size_t count) {
         size_t move_length = getBuffRemainingBytes(src) - len;
         std::copy_n(src, move_length, dst);
     }
+    m_ap_channel_reports_num = (uint8_t *)((uint8_t *)(m_ap_channel_reports_num) + len);
     m_ap_channel_reports_list_length = (uint8_t *)((uint8_t *)(m_ap_channel_reports_list_length) + len);
     m_ap_channel_reports_list = (cApChannelReports *)((uint8_t *)(m_ap_channel_reports_list) + len);
     m_elemnt_id_list_length = (uint8_t *)((uint8_t *)(m_elemnt_id_list_length) + len);
@@ -110,6 +111,10 @@ bool tlvBeaconMetricsQuery::alloc_ssid(size_t count) {
     }
     if(m_length){ (*m_length) += len; }
     return true;
+}
+
+uint8_t& tlvBeaconMetricsQuery::ap_channel_reports_num() {
+    return (uint8_t&)(*m_ap_channel_reports_num);
 }
 
 uint8_t& tlvBeaconMetricsQuery::ap_channel_reports_list_length() {
@@ -284,6 +289,7 @@ size_t tlvBeaconMetricsQuery::get_initial_size()
     class_size += sizeof(sMacAddr); // bssid
     class_size += sizeof(uint8_t); // reporting_detail_value
     class_size += sizeof(uint8_t); // ssid_length
+    class_size += sizeof(uint8_t); // ap_channel_reports_num
     class_size += sizeof(uint8_t); // ap_channel_reports_list_length
     class_size += sizeof(uint8_t); // elemnt_id_list_length
     return class_size;
@@ -353,6 +359,12 @@ bool tlvBeaconMetricsQuery::init()
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(char) * (ssid_length) << ") Failed!";
         return false;
     }
+    m_ap_channel_reports_num = reinterpret_cast<uint8_t*>(m_buff_ptr__);
+    if (!buffPtrIncrementSafe(sizeof(uint8_t))) {
+        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint8_t) << ") Failed!";
+        return false;
+    }
+    if(m_length && !m_parse__){ (*m_length) += sizeof(uint8_t); }
     m_ap_channel_reports_list_length = reinterpret_cast<uint8_t*>(m_buff_ptr__);
     if (!m_parse__) *m_ap_channel_reports_list_length = 0;
     if (!buffPtrIncrementSafe(sizeof(uint8_t))) {

--- a/framework/tlvf/yaml/tlvf/wfa_map/tlvBeaconMetricsQuery.yaml
+++ b/framework/tlvf/yaml/tlvf/wfa_map/tlvBeaconMetricsQuery.yaml
@@ -20,6 +20,7 @@ tlvBeaconMetricsQuery:
   ssid:
     _type: char
     _length: [ ssid_length ]
+  ap_channel_reports_num: uint8_t
   ap_channel_reports_list_length:
     _type: uint8_t
     _length_var: True


### PR DESCRIPTION
As part of the issue for replacing vendor-specific messages on the standard one (PPM-273) need to replace next messages 
on the standard one

_Vendor-specific messages:_
```
ACTION_CONTROL_CLIENT_BEACON_11K_REQUEST
ACTION_CONTROL_CLIENT_BEACON_11K_RESPONSE
``` 

_Easy-mesh messages:_
```
BEACON_METRICS_QUERY_MESSAGE 
BEACON_METRICS_RESPONSE_MESSAGE 
```
