### PR TITLE
PPM-338 Move UCI configuration to Agent DB

### DIFF
--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -110,6 +110,12 @@ public:
         uint8_t load_balancing_enabled;
         uint8_t service_fairness_enabled;
         uint8_t rdkb_extensions_enabled;
+
+        struct sWlanSettings {
+            uint8_t band_enabled;
+            uint8_t channel;
+        } wlan_settings;
+
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -102,6 +102,8 @@ public:
         uint8_t management_mode;
         uint8_t certification_mode;
         uint8_t stop_on_failure_attempts;
+
+        uint8_t client_band_steering_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -107,6 +107,7 @@ public:
         uint8_t client_optimal_path_roaming_enabled;
         uint8_t dfs_reentry_enabled;
         uint8_t client_optimal_path_roaming_prefer_signal_strength_enabled;
+        uint8_t client_11k_roaming_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -81,7 +81,9 @@ public:
     /* Agent Configuration */
     struct sDeviceConf {
         struct sFrontRadio {
-
+            char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
+            char pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
+            char security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
         } front_radio;
 
         struct sBackRadio {

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -106,6 +106,7 @@ public:
         uint8_t client_band_steering_enabled;
         uint8_t client_optimal_path_roaming_enabled;
         uint8_t dfs_reentry_enabled;
+        uint8_t client_optimal_path_roaming_prefer_signal_strength_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -92,6 +92,7 @@ public:
             char security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
             uint8_t mem_only_psk;
             uint8_t backhaul_max_vaps;
+            uint8_t backhaul_network_enabled;
         } back_radio;
 
         bool local_gw;

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -99,6 +99,7 @@ public:
         bool local_gw;
         bool local_controller;
         uint8_t operating_mode;
+        uint8_t management_mode;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -105,6 +105,7 @@ public:
 
         uint8_t client_band_steering_enabled;
         uint8_t client_optimal_path_roaming_enabled;
+        uint8_t dfs_reentry_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -91,6 +91,7 @@ public:
             char pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
             char security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
             uint8_t mem_only_psk;
+            uint8_t backhaul_max_vaps;
         } back_radio;
 
         bool local_gw;

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -87,7 +87,9 @@ public:
         } front_radio;
 
         struct sBackRadio {
-
+            char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
+            char pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
+            char security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
         } back_radio;
 
         bool local_gw;

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -100,6 +100,7 @@ public:
         bool local_controller;
         uint8_t operating_mode;
         uint8_t management_mode;
+        uint8_t certification_mode;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -93,6 +93,7 @@ public:
             uint8_t mem_only_psk;
             uint8_t backhaul_max_vaps;
             uint8_t backhaul_network_enabled;
+            uint8_t backhaul_preferred_radio_band;
         } back_radio;
 
         bool local_gw;

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -101,6 +101,7 @@ public:
         uint8_t operating_mode;
         uint8_t management_mode;
         uint8_t certification_mode;
+        uint8_t stop_on_failure_attempts;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -109,6 +109,7 @@ public:
         uint8_t client_optimal_path_roaming_prefer_signal_strength_enabled;
         uint8_t client_11k_roaming_enabled;
         uint8_t load_balancing_enabled;
+        uint8_t service_fairness_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -90,6 +90,7 @@ public:
             char ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
             char pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
             char security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
+            uint8_t mem_only_psk;
         } back_radio;
 
         bool local_gw;

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -104,6 +104,7 @@ public:
         uint8_t stop_on_failure_attempts;
 
         uint8_t client_band_steering_enabled;
+        uint8_t client_optimal_path_roaming_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -108,6 +108,7 @@ public:
         uint8_t dfs_reentry_enabled;
         uint8_t client_optimal_path_roaming_prefer_signal_strength_enabled;
         uint8_t client_11k_roaming_enabled;
+        uint8_t load_balancing_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -102,7 +102,6 @@ public:
         uint8_t management_mode;
         uint8_t certification_mode;
         uint8_t stop_on_failure_attempts;
-
         uint8_t client_band_steering_enabled;
         uint8_t client_optimal_path_roaming_enabled;
         uint8_t dfs_reentry_enabled;
@@ -110,6 +109,7 @@ public:
         uint8_t client_11k_roaming_enabled;
         uint8_t load_balancing_enabled;
         uint8_t service_fairness_enabled;
+        uint8_t rdkb_extensions_enabled;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/agent_db.h
+++ b/agent/src/beerocks/slave/agent_db.h
@@ -98,6 +98,7 @@ public:
 
         bool local_gw;
         bool local_controller;
+        uint8_t operating_mode;
     } device_conf;
 
     /** 

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -90,12 +90,12 @@ static bool fill_platform_settings(
         return false;
     }
 
-    msg->platform_settings().mem_only_psk = mem_only_psk;
+    db->device_conf.back_radio.mem_only_psk = mem_only_psk;
 
     LOG(DEBUG) << "Back Credentials:"
                << " ssid=" << db->device_conf.back_radio.ssid
                << " sec=" << db->device_conf.back_radio.security_type
-               << " mem_only_psk=" << int(msg->platform_settings().mem_only_psk) << " pass=***";
+               << " mem_only_psk=" << int(db->device_conf.back_radio.mem_only_psk) << " pass=***";
 
     bpl::BPL_WLAN_PARAMS params;
     if (bpl::cfg_get_wifi_params(iface_name.c_str(), &params) < 0) {

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -191,7 +191,6 @@ static bool fill_platform_settings(
     db->device_conf.local_gw = (platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY ||
                                 platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY_WISP);
 
-    msg->platform_settings().onboarding          = uint8_t(platform_common_conf.onboarding);
     db->device_conf.dfs_reentry_enabled          = uint8_t(platform_common_conf.dfs_reentry);
     db->device_conf.rdkb_extensions_enabled      = uint8_t(platform_common_conf.rdkb_extensions);
     db->device_conf.client_band_steering_enabled = uint8_t(platform_common_conf.band_steering);
@@ -216,7 +215,7 @@ static bool fill_platform_settings(
     db->device_conf.service_fairness_enabled = 0; // for v1.3 TODO read from CAL DB
 
     LOG(DEBUG) << "iface " << iface_name << " settings:";
-    LOG(DEBUG) << "onboarding: " << (unsigned)msg->platform_settings().onboarding;
+    LOG(DEBUG) << "onboarding: " << (unsigned)0;
     LOG(DEBUG) << "client_band_steering_enabled: "
                << (unsigned)db->device_conf.client_band_steering_enabled;
     LOG(DEBUG) << "client_optimal_path_roaming_enabled: "

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -191,13 +191,14 @@ static bool fill_platform_settings(
     db->device_conf.local_gw = (platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY ||
                                 platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY_WISP);
 
-    msg->platform_settings().onboarding          = uint8_t(platform_common_conf.onboarding);
+    msg->platform_settings().onboarding = uint8_t(platform_common_conf.onboarding);
     db->device_conf.dfs_reentry_enabled = uint8_t(platform_common_conf.dfs_reentry);
     msg->platform_settings().rdkb_extensions_enabled =
         uint8_t(platform_common_conf.rdkb_extensions);
     db->device_conf.client_band_steering_enabled = uint8_t(platform_common_conf.band_steering);
-    db->device_conf.client_optimal_path_roaming_enabled = uint8_t(platform_common_conf.client_roaming);
-    msg->platform_settings().client_optimal_path_roaming_prefer_signal_strength_enabled =
+    db->device_conf.client_optimal_path_roaming_enabled =
+        uint8_t(platform_common_conf.client_roaming);
+    db->device_conf.client_optimal_path_roaming_prefer_signal_strength_enabled =
         0; // TODO add platform DB flag
     msg->platform_settings().client_11k_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming || platform_common_conf.band_steering);
@@ -222,8 +223,8 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "client_optimal_path_roaming_enabled: "
                << (unsigned)db->device_conf.client_optimal_path_roaming_enabled;
     LOG(DEBUG) << "client_optimal_path_roaming_prefer_signal_strength_enabled: "
-               << (unsigned)msg->platform_settings()
-                      .client_optimal_path_roaming_prefer_signal_strength_enabled;
+               << (unsigned)
+                      db->device_conf.client_optimal_path_roaming_prefer_signal_strength_enabled;
     LOG(DEBUG) << "band_enabled: " << (unsigned)msg->wlan_settings().band_enabled;
     LOG(DEBUG) << "local_gw: " << db->device_conf.local_gw;
     LOG(DEBUG) << "local_controller: " << db->device_conf.local_controller;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -203,7 +203,7 @@ static bool fill_platform_settings(
         0; // TODO add platform DB flag
     msg->platform_settings().client_11k_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming || platform_common_conf.band_steering);
-    msg->platform_settings().operating_mode     = uint8_t(platform_common_conf.operating_mode);
+    db->device_conf.operating_mode              = uint8_t(platform_common_conf.operating_mode);
     msg->platform_settings().management_mode    = uint8_t(platform_common_conf.management_mode);
     msg->platform_settings().certification_mode = uint8_t(platform_common_conf.certification_mode);
     msg->platform_settings().stop_on_failure_attempts =

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -200,7 +200,7 @@ static bool fill_platform_settings(
         uint8_t(platform_common_conf.client_roaming);
     db->device_conf.client_optimal_path_roaming_prefer_signal_strength_enabled =
         0; // TODO add platform DB flag
-    msg->platform_settings().client_11k_roaming_enabled =
+    db->device_conf.client_11k_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming || platform_common_conf.band_steering);
     db->device_conf.operating_mode     = uint8_t(platform_common_conf.operating_mode);
     db->device_conf.management_mode    = uint8_t(platform_common_conf.management_mode);

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -57,9 +57,7 @@ static beerocks::eFreqType bpl_band_to_freq_type(int bpl_band)
 }
 
 static bool fill_platform_settings(
-    std::string iface_name,
-    std::shared_ptr<beerocks_message::cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE> msg,
-    main_thread::platform_common_conf_t &platform_common_conf,
+    std::string iface_name, main_thread::platform_common_conf_t &platform_common_conf,
     std::unordered_map<std::string, std::shared_ptr<beerocks_message::sWlanSettings>>
         &iface_wlan_params_map,
     Socket *sd)
@@ -103,12 +101,13 @@ static bool fill_platform_settings(
         return false;
     }
     /* update message */
-    msg->wlan_settings().band_enabled = params.enabled;
-    msg->wlan_settings().channel      = params.channel;
+    db->device_conf.wlan_settings.band_enabled = params.enabled;
+    db->device_conf.wlan_settings.channel      = params.channel;
 
     LOG(DEBUG) << "wlan settings:"
-               << " band_enabled=" << string_utils::bool_str(msg->wlan_settings().band_enabled)
-               << " channel=" << int(msg->wlan_settings().channel);
+               << " band_enabled="
+               << string_utils::bool_str(db->device_conf.wlan_settings.band_enabled)
+               << " channel=" << int(db->device_conf.wlan_settings.channel);
 
     // initialize wlan params cache
     //erase interface cache from map if exists
@@ -223,7 +222,7 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "client_optimal_path_roaming_prefer_signal_strength_enabled: "
                << (unsigned)
                       db->device_conf.client_optimal_path_roaming_prefer_signal_strength_enabled;
-    LOG(DEBUG) << "band_enabled: " << (unsigned)msg->wlan_settings().band_enabled;
+    LOG(DEBUG) << "band_enabled: " << (unsigned)db->device_conf.wlan_settings.band_enabled;
     LOG(DEBUG) << "local_gw: " << db->device_conf.local_gw;
     LOG(DEBUG) << "local_controller: " << db->device_conf.local_controller;
     LOG(DEBUG) << "dfs_reentry_enabled: " << (unsigned)db->device_conf.dfs_reentry_enabled;
@@ -649,7 +648,7 @@ bool main_thread::handle_cmdu(Socket *sd, ieee1905_1::CmduMessageRx &cmdu_rx)
             do {
                 LOG(TRACE) << "Trying to read settings of iface:" << strIfaceName
                            << ", attempt=" << int(retry_cnt);
-                if (fill_platform_settings(strIfaceName, register_response, platform_common_conf,
+                if (fill_platform_settings(strIfaceName, platform_common_conf,
                                            bpl_iface_wlan_params_map, sd)) {
                     register_response->valid() = 1;
                 } else {

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -208,7 +208,7 @@ static bool fill_platform_settings(
     msg->platform_settings().certification_mode = uint8_t(platform_common_conf.certification_mode);
     msg->platform_settings().stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);
-    msg->platform_settings().backhaul_max_vaps = uint8_t(platform_common_conf.backhaul_max_vaps);
+    db->device_conf.back_radio.backhaul_max_vaps = uint8_t(platform_common_conf.backhaul_max_vaps);
     msg->platform_settings().backhaul_network_enabled =
         uint8_t(platform_common_conf.backhaul_network_enabled);
     msg->platform_settings().backhaul_preferred_radio_band =

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -206,7 +206,7 @@ static bool fill_platform_settings(
     db->device_conf.operating_mode     = uint8_t(platform_common_conf.operating_mode);
     db->device_conf.management_mode    = uint8_t(platform_common_conf.management_mode);
     db->device_conf.certification_mode = uint8_t(platform_common_conf.certification_mode);
-    msg->platform_settings().stop_on_failure_attempts =
+    db->device_conf.stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);
     db->device_conf.back_radio.backhaul_max_vaps = uint8_t(platform_common_conf.backhaul_max_vaps);
     db->device_conf.back_radio.backhaul_network_enabled =

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -191,10 +191,9 @@ static bool fill_platform_settings(
     db->device_conf.local_gw = (platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY ||
                                 platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY_WISP);
 
-    msg->platform_settings().onboarding = uint8_t(platform_common_conf.onboarding);
-    db->device_conf.dfs_reentry_enabled = uint8_t(platform_common_conf.dfs_reentry);
-    msg->platform_settings().rdkb_extensions_enabled =
-        uint8_t(platform_common_conf.rdkb_extensions);
+    msg->platform_settings().onboarding          = uint8_t(platform_common_conf.onboarding);
+    db->device_conf.dfs_reentry_enabled          = uint8_t(platform_common_conf.dfs_reentry);
+    db->device_conf.rdkb_extensions_enabled      = uint8_t(platform_common_conf.rdkb_extensions);
     db->device_conf.client_band_steering_enabled = uint8_t(platform_common_conf.band_steering);
     db->device_conf.client_optimal_path_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming);
@@ -231,7 +230,7 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "dfs_reentry_enabled: " << (unsigned)db->device_conf.dfs_reentry_enabled;
     LOG(DEBUG) << "backhaul_preferred_radio_band: "
                << (unsigned)db->device_conf.back_radio.backhaul_preferred_radio_band;
-    LOG(DEBUG) << "rdkb_extensions: " << (unsigned)msg->platform_settings().rdkb_extensions_enabled;
+    LOG(DEBUG) << "rdkb_extensions: " << (unsigned)db->device_conf.rdkb_extensions_enabled;
 
     return true;
 }

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -213,8 +213,8 @@ static bool fill_platform_settings(
     db->device_conf.back_radio.backhaul_preferred_radio_band =
         uint8_t(bpl_band_to_freq_type(platform_common_conf.backhaul_preferred_radio_band));
 
-    db->device_conf.load_balancing_enabled            = 0; // for v1.3 TODO read from CAL DB
-    msg->platform_settings().service_fairness_enabled = 0; // for v1.3 TODO read from CAL DB
+    db->device_conf.load_balancing_enabled   = 0; // for v1.3 TODO read from CAL DB
+    db->device_conf.service_fairness_enabled = 0; // for v1.3 TODO read from CAL DB
 
     LOG(DEBUG) << "iface " << iface_name << " settings:";
     LOG(DEBUG) << "onboarding: " << (unsigned)msg->platform_settings().onboarding;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -209,7 +209,7 @@ static bool fill_platform_settings(
     msg->platform_settings().stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);
     db->device_conf.back_radio.backhaul_max_vaps = uint8_t(platform_common_conf.backhaul_max_vaps);
-    msg->platform_settings().backhaul_network_enabled =
+    db->device_conf.back_radio.backhaul_network_enabled =
         uint8_t(platform_common_conf.backhaul_network_enabled);
     msg->platform_settings().backhaul_preferred_radio_band =
         uint8_t(bpl_band_to_freq_type(platform_common_conf.backhaul_preferred_radio_band));

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -196,8 +196,7 @@ static bool fill_platform_settings(
     msg->platform_settings().rdkb_extensions_enabled =
         uint8_t(platform_common_conf.rdkb_extensions);
     db->device_conf.client_band_steering_enabled = uint8_t(platform_common_conf.band_steering);
-    msg->platform_settings().client_optimal_path_roaming_enabled =
-        uint8_t(platform_common_conf.client_roaming);
+    db->device_conf.client_optimal_path_roaming_enabled = uint8_t(platform_common_conf.client_roaming);
     msg->platform_settings().client_optimal_path_roaming_prefer_signal_strength_enabled =
         0; // TODO add platform DB flag
     msg->platform_settings().client_11k_roaming_enabled =
@@ -221,7 +220,7 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "client_band_steering_enabled: "
                << (unsigned)db->device_conf.client_band_steering_enabled;
     LOG(DEBUG) << "client_optimal_path_roaming_enabled: "
-               << (unsigned)msg->platform_settings().client_optimal_path_roaming_enabled;
+               << (unsigned)db->device_conf.client_optimal_path_roaming_enabled;
     LOG(DEBUG) << "client_optimal_path_roaming_prefer_signal_strength_enabled: "
                << (unsigned)msg->platform_settings()
                       .client_optimal_path_roaming_prefer_signal_strength_enabled;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -192,7 +192,7 @@ static bool fill_platform_settings(
                                 platform_common_conf.operating_mode == BPL_OPER_MODE_GATEWAY_WISP);
 
     msg->platform_settings().onboarding          = uint8_t(platform_common_conf.onboarding);
-    msg->platform_settings().dfs_reentry_enabled = uint8_t(platform_common_conf.dfs_reentry);
+    db->device_conf.dfs_reentry_enabled = uint8_t(platform_common_conf.dfs_reentry);
     msg->platform_settings().rdkb_extensions_enabled =
         uint8_t(platform_common_conf.rdkb_extensions);
     db->device_conf.client_band_steering_enabled = uint8_t(platform_common_conf.band_steering);
@@ -227,7 +227,7 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "band_enabled: " << (unsigned)msg->wlan_settings().band_enabled;
     LOG(DEBUG) << "local_gw: " << db->device_conf.local_gw;
     LOG(DEBUG) << "local_controller: " << db->device_conf.local_controller;
-    LOG(DEBUG) << "dfs_reentry_enabled: " << (unsigned)msg->platform_settings().dfs_reentry_enabled;
+    LOG(DEBUG) << "dfs_reentry_enabled: " << (unsigned)db->device_conf.dfs_reentry_enabled;
     LOG(DEBUG) << "backhaul_preferred_radio_band: "
                << (unsigned)db->device_conf.back_radio.backhaul_preferred_radio_band;
     LOG(DEBUG) << "rdkb_extensions: " << (unsigned)msg->platform_settings().rdkb_extensions_enabled;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -77,9 +77,9 @@ static bool fill_platform_settings(
                << " ssid=" << db->device_conf.front_radio.ssid
                << " sec=" << db->device_conf.front_radio.security_type << " pass=***";
 
-    if (bpl::cfg_get_beerocks_credentials(BPL_RADIO_BACK, msg->platform_settings().back_ssid,
-                                          msg->platform_settings().back_pass,
-                                          msg->platform_settings().back_security_type) < 0) {
+    if (bpl::cfg_get_beerocks_credentials(BPL_RADIO_BACK, db->device_conf.back_radio.ssid,
+                                          db->device_conf.back_radio.pass,
+                                          db->device_conf.back_radio.security_type) < 0) {
         LOG(ERROR) << "Failed reading Wi-Fi back credentials!";
         return false;
     }
@@ -93,8 +93,8 @@ static bool fill_platform_settings(
     msg->platform_settings().mem_only_psk = mem_only_psk;
 
     LOG(DEBUG) << "Back Credentials:"
-               << " ssid=" << msg->platform_settings().back_ssid
-               << " sec=" << msg->platform_settings().back_security_type
+               << " ssid=" << db->device_conf.back_radio.ssid
+               << " sec=" << db->device_conf.back_radio.security_type
                << " mem_only_psk=" << int(msg->platform_settings().mem_only_psk) << " pass=***";
 
     bpl::BPL_WLAN_PARAMS params;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -195,8 +195,7 @@ static bool fill_platform_settings(
     msg->platform_settings().dfs_reentry_enabled = uint8_t(platform_common_conf.dfs_reentry);
     msg->platform_settings().rdkb_extensions_enabled =
         uint8_t(platform_common_conf.rdkb_extensions);
-    msg->platform_settings().client_band_steering_enabled =
-        uint8_t(platform_common_conf.band_steering);
+    db->device_conf.client_band_steering_enabled = uint8_t(platform_common_conf.band_steering);
     msg->platform_settings().client_optimal_path_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming);
     msg->platform_settings().client_optimal_path_roaming_prefer_signal_strength_enabled =
@@ -220,7 +219,7 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "iface " << iface_name << " settings:";
     LOG(DEBUG) << "onboarding: " << (unsigned)msg->platform_settings().onboarding;
     LOG(DEBUG) << "client_band_steering_enabled: "
-               << (unsigned)msg->platform_settings().client_band_steering_enabled;
+               << (unsigned)db->device_conf.client_band_steering_enabled;
     LOG(DEBUG) << "client_optimal_path_roaming_enabled: "
                << (unsigned)msg->platform_settings().client_optimal_path_roaming_enabled;
     LOG(DEBUG) << "client_optimal_path_roaming_prefer_signal_strength_enabled: "

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -66,16 +66,16 @@ static bool fill_platform_settings(
 {
     auto db = AgentDB::get();
 
-    if (bpl::cfg_get_beerocks_credentials(BPL_RADIO_FRONT, msg->platform_settings().front_ssid,
-                                          msg->platform_settings().front_pass,
-                                          msg->platform_settings().front_security_type) < 0) {
+    if (bpl::cfg_get_beerocks_credentials(BPL_RADIO_FRONT, db->device_conf.front_radio.ssid,
+                                          db->device_conf.front_radio.pass,
+                                          db->device_conf.front_radio.security_type) < 0) {
         LOG(ERROR) << "Failed reading front Wi-Fi credentials!";
         return false;
     }
 
     LOG(DEBUG) << "Front Credentials:"
-               << " ssid=" << msg->platform_settings().front_ssid
-               << " sec=" << msg->platform_settings().front_security_type << " pass=***";
+               << " ssid=" << db->device_conf.front_radio.ssid
+               << " sec=" << db->device_conf.front_radio.security_type << " pass=***";
 
     if (bpl::cfg_get_beerocks_credentials(BPL_RADIO_BACK, msg->platform_settings().back_ssid,
                                           msg->platform_settings().back_pass,

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -213,7 +213,7 @@ static bool fill_platform_settings(
     db->device_conf.back_radio.backhaul_preferred_radio_band =
         uint8_t(bpl_band_to_freq_type(platform_common_conf.backhaul_preferred_radio_band));
 
-    msg->platform_settings().load_balancing_enabled   = 0; // for v1.3 TODO read from CAL DB
+    db->device_conf.load_balancing_enabled            = 0; // for v1.3 TODO read from CAL DB
     msg->platform_settings().service_fairness_enabled = 0; // for v1.3 TODO read from CAL DB
 
     LOG(DEBUG) << "iface " << iface_name << " settings:";

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -211,7 +211,7 @@ static bool fill_platform_settings(
     db->device_conf.back_radio.backhaul_max_vaps = uint8_t(platform_common_conf.backhaul_max_vaps);
     db->device_conf.back_radio.backhaul_network_enabled =
         uint8_t(platform_common_conf.backhaul_network_enabled);
-    msg->platform_settings().backhaul_preferred_radio_band =
+    db->device_conf.back_radio.backhaul_preferred_radio_band =
         uint8_t(bpl_band_to_freq_type(platform_common_conf.backhaul_preferred_radio_band));
 
     msg->platform_settings().load_balancing_enabled   = 0; // for v1.3 TODO read from CAL DB
@@ -231,7 +231,7 @@ static bool fill_platform_settings(
     LOG(DEBUG) << "local_controller: " << db->device_conf.local_controller;
     LOG(DEBUG) << "dfs_reentry_enabled: " << (unsigned)msg->platform_settings().dfs_reentry_enabled;
     LOG(DEBUG) << "backhaul_preferred_radio_band: "
-               << (unsigned)msg->platform_settings().backhaul_preferred_radio_band;
+               << (unsigned)db->device_conf.back_radio.backhaul_preferred_radio_band;
     LOG(DEBUG) << "rdkb_extensions: " << (unsigned)msg->platform_settings().rdkb_extensions_enabled;
 
     return true;

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -203,9 +203,9 @@ static bool fill_platform_settings(
         0; // TODO add platform DB flag
     msg->platform_settings().client_11k_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming || platform_common_conf.band_steering);
-    db->device_conf.operating_mode              = uint8_t(platform_common_conf.operating_mode);
-    db->device_conf.management_mode             = uint8_t(platform_common_conf.management_mode);
-    msg->platform_settings().certification_mode = uint8_t(platform_common_conf.certification_mode);
+    db->device_conf.operating_mode     = uint8_t(platform_common_conf.operating_mode);
+    db->device_conf.management_mode    = uint8_t(platform_common_conf.management_mode);
+    db->device_conf.certification_mode = uint8_t(platform_common_conf.certification_mode);
     msg->platform_settings().stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);
     db->device_conf.back_radio.backhaul_max_vaps = uint8_t(platform_common_conf.backhaul_max_vaps);

--- a/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
+++ b/agent/src/beerocks/slave/platform_manager/platform_manager_thread.cpp
@@ -204,7 +204,7 @@ static bool fill_platform_settings(
     msg->platform_settings().client_11k_roaming_enabled =
         uint8_t(platform_common_conf.client_roaming || platform_common_conf.band_steering);
     db->device_conf.operating_mode              = uint8_t(platform_common_conf.operating_mode);
-    msg->platform_settings().management_mode    = uint8_t(platform_common_conf.management_mode);
+    db->device_conf.management_mode             = uint8_t(platform_common_conf.management_mode);
     msg->platform_settings().certification_mode = uint8_t(platform_common_conf.certification_mode);
     msg->platform_settings().stop_on_failure_attempts =
         uint8_t(platform_common_conf.stop_on_failure_attempts);

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3112,7 +3112,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                                       message::WIFI_PASS_MAX_LENGTH);
             bh_enable->security_type() = static_cast<uint32_t>(
                 platform_to_bwl_security(db->device_conf.back_radio.security_type));
-            bh_enable->mem_only_psk() = platform_settings.mem_only_psk;
+            bh_enable->mem_only_psk() = db->device_conf.back_radio.mem_only_psk;
             bh_enable->backhaul_preferred_radio_band() =
                 platform_settings.backhaul_preferred_radio_band;
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1336,9 +1336,8 @@ bool slave_thread::handle_cmdu_platform_manager_message(
                 db->ethernet.mac = network_utils::ZERO_MAC;
             }
 
-            configuration_stop_on_failure_attempts =
-                response->platform_settings().stop_on_failure_attempts;
-            stop_on_failure_attempts = configuration_stop_on_failure_attempts;
+            configuration_stop_on_failure_attempts = db->device_conf.stop_on_failure_attempts;
+            stop_on_failure_attempts               = configuration_stop_on_failure_attempts;
 
             LOG(TRACE) << "goto STATE_CONNECT_TO_BACKHAUL_MANAGER";
             slave_state = STATE_CONNECT_TO_BACKHAUL_MANAGER;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3114,7 +3114,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 platform_to_bwl_security(db->device_conf.back_radio.security_type));
             bh_enable->mem_only_psk() = db->device_conf.back_radio.mem_only_psk;
             bh_enable->backhaul_preferred_radio_band() =
-                platform_settings.backhaul_preferred_radio_band;
+                db->device_conf.back_radio.backhaul_preferred_radio_band;
 
             string_utils::copy_string(bh_enable->wire_iface(message::IFACE_NAME_LENGTH),
                                       db->ethernet.iface_name.c_str(), message::IFACE_NAME_LENGTH);

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2977,7 +2977,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                                   config.hostap_iface.c_str(), message::IFACE_NAME_LENGTH);
 
         request->sta_iface_filter_low() = config.backhaul_wireless_iface_filter_low;
-        request->onboarding()           = platform_settings.onboarding;
+        request->onboarding()           = 0;
         request->certification_mode()   = db->device_conf.certification_mode;
 
         LOG(INFO) << "ACTION_BACKHAUL_REGISTER_REQUEST "
@@ -3006,12 +3006,8 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
     case STATE_JOIN_INIT: {
 
         auto db = AgentDB::get();
-        LOG(DEBUG) << "onboarding: " << int(platform_settings.onboarding);
-        if (platform_settings.onboarding) {
-            LOG(TRACE) << "goto STATE_ONBOARDING";
-            slave_state = STATE_ONBOARDING;
-            break;
-        } else if (!wlan_settings.band_enabled) {
+        LOG(DEBUG) << "onboarding: " << int(0);
+        if (!wlan_settings.band_enabled) {
             LOG(DEBUG) << "wlan_settings.band_enabled=false";
             LOG(TRACE) << "goto STATE_BACKHAUL_ENABLE";
             slave_state = STATE_BACKHAUL_ENABLE;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -794,7 +794,7 @@ bool slave_thread::handle_cmdu_control_message(Socket *sd,
         if (request_in->params().use_optional_ssid &&
             std::string((char *)request_in->params().ssid).empty()) {
             //LOG(DEBUG) << "ssid field is empty! using slave ssid -> " << config.ssid;
-            string_utils::copy_string(request_in->params().ssid, platform_settings.front_ssid,
+            string_utils::copy_string(request_in->params().ssid, db->device_conf.front_radio.ssid,
                                       message::WIFI_SSID_MAX_LENGTH);
         }
 

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -1320,8 +1320,7 @@ bool slave_thread::handle_cmdu_platform_manager_message(
                 return true;
             }
 
-            platform_settings = response->platform_settings();
-            wlan_settings     = response->wlan_settings();
+            wlan_settings = response->wlan_settings();
 
             auto db = AgentDB::get();
 
@@ -3364,7 +3363,24 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
                 }
 
                 //Platform Settings
-                notification->platform_settings()              = platform_settings;
+                notification->platform_settings().client_band_steering_enabled =
+                    db->device_conf.client_band_steering_enabled;
+                notification->platform_settings().client_optimal_path_roaming_enabled =
+                    db->device_conf.client_optimal_path_roaming_enabled;
+                notification->platform_settings().dfs_reentry_enabled =
+                    db->device_conf.dfs_reentry_enabled;
+                notification->platform_settings()
+                    .client_optimal_path_roaming_prefer_signal_strength_enabled =
+                    db->device_conf.client_optimal_path_roaming_prefer_signal_strength_enabled;
+                notification->platform_settings().client_11k_roaming_enabled =
+                    db->device_conf.client_11k_roaming_enabled;
+                notification->platform_settings().load_balancing_enabled =
+                    db->device_conf.load_balancing_enabled;
+                notification->platform_settings().service_fairness_enabled =
+                    db->device_conf.service_fairness_enabled;
+                notification->platform_settings().rdkb_extensions_enabled =
+                    db->device_conf.rdkb_extensions_enabled;
+
                 notification->platform_settings().local_master = db->device_conf.local_controller;
 
                 //Wlan Settings

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3105,11 +3105,13 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
             // to the backhaul manager will no longer be necessary, and therefore should be be
             // removed completely from beerocks including the BPL.
             string_utils::copy_string(bh_enable->ssid(message::WIFI_SSID_MAX_LENGTH),
-                                      platform_settings.back_ssid, message::WIFI_SSID_MAX_LENGTH);
+                                      db->device_conf.back_radio.ssid,
+                                      message::WIFI_SSID_MAX_LENGTH);
             string_utils::copy_string(bh_enable->pass(message::WIFI_PASS_MAX_LENGTH),
-                                      platform_settings.back_pass, message::WIFI_PASS_MAX_LENGTH);
+                                      db->device_conf.back_radio.pass,
+                                      message::WIFI_PASS_MAX_LENGTH);
             bh_enable->security_type() = static_cast<uint32_t>(
-                platform_to_bwl_security(platform_settings.back_security_type));
+                platform_to_bwl_security(db->device_conf.back_radio.security_type));
             bh_enable->mem_only_psk() = platform_settings.mem_only_psk;
             bh_enable->backhaul_preferred_radio_band() =
                 platform_settings.backhaul_preferred_radio_band;

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -2979,7 +2979,7 @@ bool slave_thread::slave_fsm(bool &call_slave_select)
 
         request->sta_iface_filter_low() = config.backhaul_wireless_iface_filter_low;
         request->onboarding()           = platform_settings.onboarding;
-        request->certification_mode()   = platform_settings.certification_mode;
+        request->certification_mode()   = db->device_conf.certification_mode;
 
         LOG(INFO) << "ACTION_BACKHAUL_REGISTER_REQUEST "
                   << " hostap_iface=" << request->hostap_iface(message::IFACE_NAME_LENGTH)

--- a/agent/src/beerocks/slave/son_slave_thread.cpp
+++ b/agent/src/beerocks/slave/son_slave_thread.cpp
@@ -3950,7 +3950,7 @@ bool slave_thread::handle_autoconfiguration_wsc(Socket *sd, ieee1905_1::CmduMess
     // All EasyMesh VAPs will be stored in the platform DB.
     // All other VAPs are manual, AKA should not be modified by prplMesh
     ////////////////////////////////////////////////////////////////////
-    if (platform_settings.management_mode != BPL_MGMT_MODE_NOT_MULTIAP) {
+    if (db->device_conf.management_mode != BPL_MGMT_MODE_NOT_MULTIAP) {
         message_com::send_cmdu(ap_manager_socket, cmdu_tx);
     } else {
         LOG(WARNING) << "non-EasyMesh mode - skip updating VAP credentials";
@@ -4713,7 +4713,7 @@ bool slave_thread::handle_channel_selection_request(Socket *sd, ieee1905_1::Cmdu
     // and in this case don't switch channel
     //
     ////////////////////////////////////////////////////////////////////
-    if (platform_settings.management_mode != BPL_MGMT_MODE_NOT_MULTIAP) {
+    if (db->device_conf.management_mode != BPL_MGMT_MODE_NOT_MULTIAP) {
         message_com::send_cmdu(ap_manager_socket, cmdu_tx);
     } else {
         LOG(WARNING) << "non-EasyMesh mode - skip channel switch";

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -160,8 +160,7 @@ private:
     std::string backhaul_manager_uds;
     std::string platform_manager_uds;
     sSlaveConfig config;
-    beerocks_message::sPlatformSettings platform_settings; // from platform manager //
-    beerocks_message::sWlanSettings wlan_settings;         // from platform manager //
+    beerocks_message::sWlanSettings wlan_settings; // from platform manager //
     beerocks_message::sSonConfig son_config;
     beerocks::logging &logger;
     std::string master_version;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -160,6 +160,7 @@ private:
     std::string backhaul_manager_uds;
     std::string platform_manager_uds;
     sSlaveConfig config;
+    beerocks_message::sWlanSettings wlan_settings; // from platform manager //
     beerocks_message::sSonConfig son_config;
     beerocks::logging &logger;
     std::string master_version;

--- a/agent/src/beerocks/slave/son_slave_thread.h
+++ b/agent/src/beerocks/slave/son_slave_thread.h
@@ -160,7 +160,6 @@ private:
     std::string backhaul_manager_uds;
     std::string platform_manager_uds;
     sSlaveConfig config;
-    beerocks_message::sWlanSettings wlan_settings; // from platform manager //
     beerocks_message::sSonConfig son_config;
     beerocks::logging &logger;
     std::string master_version;

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_common.h
@@ -72,20 +72,7 @@ typedef struct sSonConfig {
 } __attribute__((packed)) sSonConfig;
 
 typedef struct sPlatformSettings {
-    char front_ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
-    char front_pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
-    char front_security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
-    char back_ssid[beerocks::message::WIFI_SSID_MAX_LENGTH];
-    char back_pass[beerocks::message::WIFI_PASS_MAX_LENGTH];
-    char back_security_type[beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH];
-    uint8_t onboarding;
     uint8_t local_master;
-    uint8_t local_gw;
-    uint8_t operating_mode;
-    uint8_t management_mode;
-    uint8_t mem_only_psk;
-    uint8_t certification_mode;
-    uint8_t stop_on_failure_attempts;
     uint8_t client_band_steering_enabled;
     uint8_t client_optimal_path_roaming_enabled;
     uint8_t dfs_reentry_enabled;
@@ -94,9 +81,6 @@ typedef struct sPlatformSettings {
     uint8_t load_balancing_enabled;
     uint8_t service_fairness_enabled;
     uint8_t rdkb_extensions_enabled;
-    uint8_t backhaul_max_vaps;
-    uint8_t backhaul_network_enabled;
-    uint8_t backhaul_preferred_radio_band;
     void struct_swap(){
     }
     void struct_init(){

--- a/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_platform.h
+++ b/common/beerocks/tlvf/AutoGenerated/include/beerocks/tlvf/beerocks_message_platform.h
@@ -83,8 +83,6 @@ class cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE : public BaseClass
         static eActionOp_PLATFORM get_action_op(){
             return (eActionOp_PLATFORM)(ACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE);
         }
-        sPlatformSettings& platform_settings();
-        sWlanSettings& wlan_settings();
         uint32_t& valid();
         void class_swap() override;
         bool finalize() override;
@@ -93,8 +91,6 @@ class cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE : public BaseClass
     private:
         bool init();
         eActionOp_PLATFORM* m_action_op = nullptr;
-        sPlatformSettings* m_platform_settings = nullptr;
-        sWlanSettings* m_wlan_settings = nullptr;
         uint32_t* m_valid = nullptr;
 };
 

--- a/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
+++ b/common/beerocks/tlvf/AutoGenerated/src/beerocks/tlvf/beerocks_message_platform.cpp
@@ -185,14 +185,6 @@ BaseClass(base->getBuffPtr(), base->getBuffRemainingBytes(), parse){
 }
 cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::~cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE() {
 }
-sPlatformSettings& cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::platform_settings() {
-    return (sPlatformSettings&)(*m_platform_settings);
-}
-
-sWlanSettings& cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::wlan_settings() {
-    return (sWlanSettings&)(*m_wlan_settings);
-}
-
 uint32_t& cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::valid() {
     return (uint32_t&)(*m_valid);
 }
@@ -200,8 +192,6 @@ uint32_t& cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::valid() {
 void cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::class_swap()
 {
     tlvf_swap(8*sizeof(eActionOp_PLATFORM), reinterpret_cast<uint8_t*>(m_action_op));
-    m_platform_settings->struct_swap();
-    m_wlan_settings->struct_swap();
     tlvf_swap(32, reinterpret_cast<uint8_t*>(m_valid));
 }
 
@@ -235,8 +225,6 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::finalize()
 size_t cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::get_initial_size()
 {
     size_t class_size = 0;
-    class_size += sizeof(sPlatformSettings); // platform_settings
-    class_size += sizeof(sWlanSettings); // wlan_settings
     class_size += sizeof(uint32_t); // valid
     return class_size;
 }
@@ -247,18 +235,6 @@ bool cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE::init()
         TLVF_LOG(ERROR) << "Not enough available space on buffer. Class init failed";
         return false;
     }
-    m_platform_settings = reinterpret_cast<sPlatformSettings*>(m_buff_ptr__);
-    if (!buffPtrIncrementSafe(sizeof(sPlatformSettings))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sPlatformSettings) << ") Failed!";
-        return false;
-    }
-    if (!m_parse__) { m_platform_settings->struct_init(); }
-    m_wlan_settings = reinterpret_cast<sWlanSettings*>(m_buff_ptr__);
-    if (!buffPtrIncrementSafe(sizeof(sWlanSettings))) {
-        LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(sWlanSettings) << ") Failed!";
-        return false;
-    }
-    if (!m_parse__) { m_wlan_settings->struct_init(); }
     m_valid = reinterpret_cast<uint32_t*>(m_buff_ptr__);
     if (!buffPtrIncrementSafe(sizeof(uint32_t))) {
         LOG(ERROR) << "buffPtrIncrementSafe(" << std::dec << sizeof(uint32_t) << ") Failed!";

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_common.yaml
@@ -50,33 +50,7 @@ sSonConfig:
 
 sPlatformSettings:
   _type: struct
-  front_ssid:
-    _type: char
-    _length: ["beerocks::message::WIFI_SSID_MAX_LENGTH"]
-  front_pass:
-    _type: char
-    _length: ["beerocks::message::WIFI_PASS_MAX_LENGTH"]
-  front_security_type:
-    _type: char
-    _length: ["beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH"]
-  back_ssid:
-    _type: char
-    _length: ["beerocks::message::WIFI_SSID_MAX_LENGTH"]
-  back_pass:
-    _type: char
-    _length: ["beerocks::message::WIFI_PASS_MAX_LENGTH"]
-  back_security_type:
-    _type: char
-    _length: ["beerocks::message::WIFI_SECURITY_TYPE_MAX_LENGTH"]
-  onboarding: uint8_t
   local_master: uint8_t
-  local_gw: uint8_t
-  operating_mode: uint8_t
-  management_mode: uint8_t
-  mem_only_psk: uint8_t
-
-  certification_mode: uint8_t
-  stop_on_failure_attempts: uint8_t
 
   client_band_steering_enabled: uint8_t
   client_optimal_path_roaming_enabled: uint8_t
@@ -88,10 +62,6 @@ sPlatformSettings:
   service_fairness_enabled: uint8_t
 
   rdkb_extensions_enabled: uint8_t
-
-  backhaul_max_vaps: uint8_t
-  backhaul_network_enabled: uint8_t
-  backhaul_preferred_radio_band: uint8_t
 
 sWlanSettings:
   _type: struct

--- a/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_platform.yaml
+++ b/common/beerocks/tlvf/yaml/beerocks/tlvf/beerocks_message_platform.yaml
@@ -24,11 +24,9 @@ cACTION_PLATFORM_SON_SLAVE_REGISTER_REQUEST:
 
 cACTION_PLATFORM_SON_SLAVE_REGISTER_RESPONSE:
   _type: class
-  platform_settings: sPlatformSettings
-  wlan_settings: sWlanSettings
   valid:
     _type: uint32_t
-    _comment: #Marks whether the settings are valid
+    _comment: # Marks whether the settings received into agent_db
 
 cACTION_PLATFORM_ARP_MONITOR_NOTIFICATION:
   _type: class


### PR DESCRIPTION
This PR moves agent configuration from the local "sPlatformSettings" struct to the AgentDB.
Preparation for unified agent task.