### PR TITLE
PPM-268: Add SAH feed to prplwrt builds

### DIFF
--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -13,7 +13,7 @@ FROM ubuntu:18.04 as openwrt-prerequisites
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
     build-essential libncurses5 libncurses5-dev python python3 \
-    unzip git ca-certificates gawk wget file bash \
+    unzip git ca-certificates gawk wget file bash fakeroot \
     python-yaml python3-yaml rsync less vim gnupg software-properties-common \
     #   yq is available in a separate ppa (needs gnupg and software-properties-common):
     && if [ -n "$HTTP_PROXY" ]; then KEYSERVER_OPTIONS="--keyserver-options http-proxy=$HTTP_PROXY"; fi \

--- a/tools/docker/builder/openwrt/Dockerfile
+++ b/tools/docker/builder/openwrt/Dockerfile
@@ -51,6 +51,9 @@ ENV PRPLMESH_VARIANT=$PRPLMESH_VARIANT
 # The feed to use to build prplMesh.
 ARG PRPL_FEED
 ENV PRPL_FEED=$PRPL_FEED
+# The feed to use to build HLAPI.
+ARG SAH_FEED
+ENV SAH_FEED=$SAH_FEED
 # optional: intel feed to use.
 ARG INTEL_FEED
 ENV INTEL_FEED=$INTEL_FEED

--- a/tools/docker/builder/openwrt/build.sh
+++ b/tools/docker/builder/openwrt/build.sh
@@ -28,6 +28,8 @@ usage() {
     echo "The following environment variables will affect the build:"
     echo " - PRPL_FEED: the prpl feed that will be used to install prplMesh."
     echo "   default: $PRPL_FEED"
+    echo " - SAH_FEED: the SAH feed that will be used to install bus agnostic API."
+    echo "   default: $SAH_FEED"
 
 }
 
@@ -41,6 +43,7 @@ build_image() {
            --build-arg TARGET_DEVICE="$TARGET_DEVICE" \
            --build-arg TARGET_PROFILE="$TARGET_PROFILE" \
            --build-arg PRPL_FEED="$PRPL_FEED" \
+           --build-arg SAH_FEED="$SAH_FEED" \
            --build-arg PRPLMESH_VARIANT="$PRPLMESH_VARIANT" \
            --target="$DOCKER_TARGET_STAGE" \
            "$scriptdir/"
@@ -131,6 +134,7 @@ main() {
     dbg "OPENWRT_REPOSITORY=$OPENWRT_REPOSITORY"
     dbg "OPENWRT_VERSION=$OPENWRT_VERSION"
     dbg "PRPL_FEED=$PRPL_FEED"
+    dbg "SAH_FEED=$SAH_FEED"
     dbg "IMAGE_ONLY=$IMAGE_ONLY"
     dbg "TARGET_DEVICE=$TARGET_DEVICE"
     dbg "TAG=$TAG"
@@ -158,6 +162,7 @@ main() {
     PRPLMESH_VERSION="$(git describe --always --dirty | sed -e 's/.*-g//')"
     export PRPLMESH_VERSION
     export PRPL_FEED
+    export SAH_FEED
     export PRPLMESH_VARIANT
 
     if [ $IMAGE_ONLY = true ] ; then
@@ -175,6 +180,7 @@ IMAGE_ONLY=false
 OPENWRT_REPOSITORY='https://git.prpl.dev/prplmesh/prplwrt.git'
 OPENWRT_VERSION='3d511d477e72bd1845c75101a7f3d4e00780991d'
 PRPL_FEED='https://git.prpl.dev/prplmesh/feed-prpl.git^89e6602655713f8487c72d8d636daa610d76a468'
+SAH_FEED='https://gitlab.com/soft.at.home/buildsystems/openwrt/sah-packages.git'
 PRPLMESH_VARIANT="-nl80211"
 DOCKER_TARGET_STAGE="prplmesh-builder"
 

--- a/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
+++ b/tools/docker/builder/openwrt/profiles_feeds/netgear-rax40.yml
@@ -25,3 +25,5 @@
 - name: feed_pending
   uri: https://intel.prpl.dev/intel/feed-pending.git
   hash: 352365b31f968ab37e772b23c30ea32dbff9e337
+- name: sah
+  uri: https://gitlab.com/soft.at.home/buildsystems/openwrt/sah-packages.git

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -22,6 +22,7 @@ case $TARGET_DEVICE in
     *)
         cp feeds.conf.default feeds.conf
         echo "src-git prpl $PRPL_FEED" >> feeds.conf
+        echo "src-git sah  $SAH_FEED" >> feeds.conf
         scripts/feeds update -a
         scripts/feeds install -a
         {

--- a/tools/docker/builder/openwrt/scripts/build-openwrt.sh
+++ b/tools/docker/builder/openwrt/scripts/build-openwrt.sh
@@ -35,6 +35,23 @@ case $TARGET_DEVICE in
             echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}=y"
             echo "CONFIG_TARGET_${TARGET_SYSTEM}_${SUBTARGET}_${TARGET_PROFILE}=y"
             echo "CONFIG_PACKAGE_prplmesh${PRPLMESH_VARIANT}=y"
+            # AMBIORIX modules to work with u-bus
+            echo "CONFIG_PACKAGE_amxb-ubus=y"
+            # AMBIORIX applications for debug
+            echo "CONFIG_PACKAGE_amxb-inspect=y"
+            echo "CONFIG_PACKAGE_amxo-cg=y"
+            echo "CONFIG_PACKAGE_amxrt=y"
+            # AMBIORIX libs
+            echo "CONFIG_PACKAGE_libamxb=y"
+            echo "CONFIG_PACKAGE_libamxc=y"
+            echo "CONFIG_PACKAGE_libamxd=y"
+            echo "CONFIG_PACKAGE_libamxj=y"
+            echo "CONFIG_PACKAGE_libamxo=y"
+            echo "CONFIG_PACKAGE_libamxp=y"
+            echo "CONFIG_PACKAGE_libevent2=y"
+            # Dependencies of AMBIORIX
+            echo "CONFIG_PACKAGE_uriparser=y"
+            echo "CONFIG_PACKAGE_yajl=y"
         } >> .config
         make defconfig
         printf '%s=%s\n' "PRPL_FEED" "$PRPL_FEED" >> files/etc/prplwrt-version


### PR DESCRIPTION
## Description

This  PR adds [AMBIORIX](https://gitlab.com/soft.at.home/ambiorix) (aka Bus Agnostic API) to the prplWRT builds in CI.

## Changes

1. Add [Soft-at-Home OpenWrt feed](https://gitlab.com/soft.at.home/buildsystems/openwrt/sah-packages/-/tree/master) to the Netgear RAX40 prplWRT build (it uses `netgear-rax40.yml` instead of usual `feeds.conf`)
2. Add [Soft-at-Home OpenWrt feed](https://gitlab.com/soft.at.home/buildsystems/openwrt/sah-packages/-/tree/master) to other builds (Turris Omnia, GL.inet B1300)
3. Enable `libevent2`, `uriparser`, `yajl` (dependencies of AMBIORIX), `libamxb`, `libamxc`, `libamd`, `libamxj`, `libamxo`, `libamxp` (AMBIORIX libs), `amxb-ubus` (module to work with Ubus), `amxo-cg`, `amxrt` (applications which may be useful for HLAPI debug).

## Notes

We don't yet use HLAPI anywhere, so there isn't much sense in building prplMesh with `-DENABLE_HLAPI` yet.

-----

Jira link: https://jira.prplfoundation.org/browse/PPM-268