### PR TITLE
nl80211: use the 5Ghz band for dual bands radio

### DIFF
--- a/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
+++ b/common/beerocks/bwl/nl80211/base_wlan_hal_nl80211.cpp
@@ -632,7 +632,27 @@ bool base_wlan_hal_nl80211::refresh_radio_info()
         nl80211_client::radio_info radio_info;
         if (m_nl80211_client->get_radio_info(get_iface_name(), radio_info)) {
             if (!radio_info.bands.empty()) {
-                nl80211_client::band_info band_info = radio_info.bands.at(0);
+                nl80211_client::band_info band_info;
+                /*
+                   If there are multiple bands, use the 5G one only.
+                   TODO: properly support dual bands radio:
+                   https://jira.prplfoundation.org/browse/PPM-366
+                 */
+                if (radio_info.bands.size() > 1) {
+                    auto band_5G = find_if(
+                        radio_info.bands.begin(), radio_info.bands.end(),
+                        [&](const nl80211_client::band_info &band) { return band.is_5ghz_band(); });
+                    if (band_5G == radio_info.bands.end()) {
+                        LOG(ERROR) << "Dual band radio has no 5Ghz band: " << get_iface_name();
+                        return false;
+                    }
+                    band_info = *band_5G;
+                } else if (radio_info.bands.size() == 1) {
+                    band_info = radio_info.bands.at(0);
+                } else {
+                    LOG(ERROR) << "Unable to find any band for the radio: " << get_iface_name();
+                    return false;
+                }
 
                 m_radio_info.frequency_band = band_info.get_frequency_band();
                 m_radio_info.max_bandwidth  = band_info.get_max_bandwidth();


### PR DESCRIPTION
The Turris Omnia comes with a 2.4Ghz and a dual band radio by default.

Up to now we've only been taking into account the first band of each
radio, which means we'll report two 2.4Ghz radios.

Supporting dual bands radio properly requires some refactoring, as the
users of the RadioInfo struct would need to take the bands into
account as well.

To allow the progress on the certification tests for the nl80211 bwl
to continue, when a radio is a dual-band radio assume it's a 5Ghz
radio only.

A Jira task has been added to properly support dual bands radios:
https://jira.prplfoundation.org/browse/PPM-366

Signed-off-by: Raphaël Mélotte <raphael.melotte@mind.be>