### PR TITLE
Hotfix/dev reset disconnect backhaul

### DIFF
--- a/agent/src/beerocks/slave/agent_ucc_listener.cpp
+++ b/agent/src/beerocks/slave/agent_ucc_listener.cpp
@@ -216,6 +216,16 @@ bool agent_ucc_listener::handle_dev_set_config(std::unordered_map<std::string, s
     std::transform(backhaul_param.begin(), backhaul_param.end(), backhaul_param.begin(), ::tolower);
     if (backhaul_param == DEV_SET_ETH) {
         m_selected_backhaul = DEV_SET_ETH;
+        // add the iface to the bridge
+        auto db        = AgentDB::get();
+        auto bridge    = db->bridge.iface_name;
+        auto eth_iface = db->ethernet.iface_name;
+        if (!network_utils::linux_add_iface_to_bridge(bridge, eth_iface)) {
+            LOG(ERROR) << "Failed to add iface '" << eth_iface << "' to bridge '" << bridge
+                       << "' !";
+            return false;
+        }
+
     } else {
         // backhaul param must be a radio UID, in hex, starting with 0x
         if (backhaul_param.substr(0, 2) != "0x" || backhaul_param.size() != 14 ||

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -656,6 +656,19 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
 
     // UCC FSM. If UCC is in RESET, we have to stay in (or move to) ENABLED state.
     if (m_agent_ucc_listener && m_agent_ucc_listener->is_in_reset()) {
+        auto db            = AgentDB::get();
+        auto bridge        = db->bridge.iface_name;
+        auto bridge_ifaces = network_utils::linux_get_iface_list_from_bridge(bridge);
+        auto eth_iface     = db->ethernet.iface_name;
+        // remove the wired interface from the bridge, it will be added on dev_set_config.
+        if (std::find(bridge_ifaces.begin(), bridge_ifaces.end(), eth_iface) !=
+            bridge_ifaces.end()) {
+            if (!network_utils::linux_remove_iface_from_bridge(bridge, eth_iface)) {
+                LOG(ERROR) << "Failed to remove iface '" << eth_iface << "' from bridge '" << bridge
+                           << "' !";
+                return false;
+            }
+        }
         if (m_eFSMState == EState::ENABLED) {
             m_agent_ucc_listener->reset_completed();
             // Stay in ENABLE state until onboarding_state will change

--- a/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
+++ b/agent/src/beerocks/slave/backhaul_manager/backhaul_manager_thread.cpp
@@ -656,6 +656,11 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
 
     // UCC FSM. If UCC is in RESET, we have to stay in (or move to) ENABLED state.
     if (m_agent_ucc_listener && m_agent_ucc_listener->is_in_reset()) {
+        auto active_hal = get_wireless_hal();
+        if (active_hal) {
+            active_hal->disconnect();
+        }
+
         auto db            = AgentDB::get();
         auto bridge        = db->bridge.iface_name;
         auto bridge_ifaces = network_utils::linux_get_iface_list_from_bridge(bridge);
@@ -674,10 +679,6 @@ bool backhaul_manager::backhaul_fsm_main(bool &skip_select)
             // Stay in ENABLE state until onboarding_state will change
             return true;
         } else if (m_eFSMState > EState::ENABLED) {
-            auto active_hal = get_wireless_hal();
-            if (active_hal) {
-                active_hal->disconnect();
-            }
             FSM_MOVE_STATE(RESTART);
         }
     }


### PR DESCRIPTION
When running wireless backhaul tests, we have to remove the wired
interface from the bridge to avoid creating a loop.

Dynamic backhaul switching is not implemented yet, but we can get away
with it in certification.

When we receive dev_reset_default from the UCC, remove the wired
interface from the bridge. Then, when we get dev_set_config, only add
the wired interface back in the bridge if the test uses wired backhaul.

---
Also:

Previously the wireless hal was only disconnected in dev_reset if the
FSM state was already is something that comes after ENABLE.

There are some cases however where the disconnect didn't happen.

For example, if the connection is active and we stop and restart
prplMesh, the next dev_reset will not disconnect the wireless
link.

When we are in dev_reset, disconnect the wireless hal if it's active,
regardless of the FSM state.
