### PR TITLE
Hotfix/ci make jobs interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 variables:
   PYTHONUNBUFFERED: "1"
+default:
+  interruptible: true
 
 stages:
   - containers
@@ -325,6 +327,7 @@ test-on-netgear-rax40:
   needs: ["build-for-netgear-rax40"]
 
 run-certification-tests:
+  interruptible: false
   stage: test
   variables:
     # TESTS_TO_RUN needs to be set by the user (or the pipeline schedule)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,6 +330,7 @@ run-certification-tests:
   interruptible: false
   stage: test
   variables:
+    GIT_STRATEGY: clone
     # TESTS_TO_RUN needs to be set by the user (or the pipeline schedule)
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplmesh/prplMesh/"
     # device to test with: prplmesh for dummy bwl, axepoint for dwpal on axepoint

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -1,4 +1,5 @@
 .certification-generic:
+  interruptible: false
   variables:
     # DEVICE_UNDER_TEST need to be set when extending the job
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplmesh/prplMesh/"

--- a/ci/certification/generic.yml
+++ b/ci/certification/generic.yml
@@ -1,10 +1,10 @@
 .certification-generic:
   interruptible: false
   variables:
+    GIT_STRATEGY: clone
     # DEVICE_UNDER_TEST need to be set when extending the job
     GIT_CLONE_PATH: "/builds/prpl-foundation/prplmesh/prplMesh/"
   script:
-      - echo $CI_COMMIT_DESCRIPTION
       - ci/git-clean-reset.sh /easymesh_cert "$(<"ci/easymesh_cert_version")"
       - sudo /easymesh_cert/run_test_file.py -v -o logs -d $DEVICE_UNDER_TEST "${CI_JOB_NAME%%:*}"
   artifacts:


### PR DESCRIPTION
Essentially 2 things:
- Make the CI jobs interruptible.
  This should hopefully make it overall faster, because redundant pipelines will get cancelled (a pipeline is redundant when there is a more recent one for the same branch).
  Only the latest pipeline for each branch will get completed.
- Cleanup the certification tests manually, this should hopefully improving the situation when a job is cancelled (the next ones should no longer fail).